### PR TITLE
JIT: Fix disasm of reg to reg SIMD narrowing/widening instructions

### DIFF
--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -13411,7 +13411,7 @@ void emitter::emitDispIns(
                 break;
             }
 
-            unsigned inputSize  = static_cast<unsigned>(GetInputSizeInBytes(id));
+            unsigned inputSize = static_cast<unsigned>(GetInputSizeInBytes(id));
 
             switch (tt)
             {
@@ -13734,7 +13734,7 @@ void emitter::emitDispIns(
 
                 case INS_vcvtps2ph:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, EA_SIZE_IN_BYTES(attr) / 2U));
+                    tgtAttr = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 2));
                     break;
                 }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -13479,7 +13479,7 @@ void emitter::emitDispIns(
                 case INS_vcvttps2uqqs:
                 case INS_vcvtudq2pd:
                 {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 2U));
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
                     break;
                 }
 
@@ -13493,14 +13493,14 @@ void emitter::emitDispIns(
                 case INS_vcvttph2qq:
                 case INS_vcvttph2uqq:
                 {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 4U));
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 4U));
                     break;
                 }
 
                 case INS_pmovsxbq:
                 case INS_pmovzxbq:
                 {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 8U));
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 8U));
                     break;
                 }
 
@@ -13526,7 +13526,7 @@ void emitter::emitDispIns(
                 case INS_vcvttpd2udq:
                 case INS_vcvttpd2udqs:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 2U));
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
                     break;
                 }
 
@@ -13540,7 +13540,7 @@ void emitter::emitDispIns(
                 case INS_vpmovusdb:
                 case INS_vpmovusqw:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 4U));
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 4U));
                     break;
                 }
 
@@ -13548,7 +13548,7 @@ void emitter::emitDispIns(
                 case INS_vpmovsqb:
                 case INS_vpmovusqb:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 8U));
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 8U));
                     break;
                 }
 
@@ -13732,7 +13732,7 @@ void emitter::emitDispIns(
 
                 case INS_vcvtps2ph:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>EA_SIZE(attr) / 2U));
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
                     break;
                 }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -13335,16 +13335,44 @@ void emitter::emitDispIns(
         }
 
         case IF_RRD_RRD:
+        {
+            if (ins == INS_bt)
+            {
+                // INS_bt operands are reversed. Display them in the normal order.
+                printf("%s, %s", emitRegName(id->idReg2(), attr), emitRegName(id->idReg1(), attr));
+                break;
+            }
+
+            FALLTHROUGH;
+        }
+
         case IF_RWR_RRD:
+        {
+            if ((ins == INS_rol) || (ins == INS_ror) || (ins == INS_rcl) || (ins == INS_rcr) || (ins == INS_shl) ||
+                (ins == INS_shr) || (ins == INS_sar))
+            {
+                // This is the APX NDD form of these instructions.
+                printf("%s", emitRegName(id->idReg1(), attr));
+                printf(", %s", emitRegName(id->idReg2(), attr));
+                emitDispShift(ins, (BYTE)0);
+                break;
+            }
+
+            FALLTHROUGH;
+        }
+
         case IF_RRW_RRD:
         case IF_RRW_RRW:
         {
+            emitAttr tgtAttr = attr;
+            emitAttr srcAttr = attr;
+
             switch (ins)
             {
                 case INS_pmovmskb:
                 {
                     assert(!id->idIsEvexAaaContextSet());
-                    printf("%s, %s", emitRegName(id->idReg1(), EA_4BYTE), emitRegName(id->idReg2(), attr));
+                    tgtAttr = EA_4BYTE;
                     break;
                 }
 
@@ -13354,7 +13382,7 @@ void emitter::emitDispIns(
                 case INS_cvtsi2sd64:
                 {
                     assert(!id->idIsEvexAaaContextSet());
-                    printf("%s, %s", emitRegName(id->idReg1(), EA_16BYTE), emitRegName(id->idReg2(), attr));
+                    tgtAttr = EA_16BYTE;
                     break;
                 }
 
@@ -13384,14 +13412,15 @@ void emitter::emitDispIns(
                 case INS_vcvttss2usis64:
                 {
                     assert(!id->idIsEvexAaaContextSet());
-                    printf("%s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), EA_16BYTE));
+                    srcAttr = EA_16BYTE;
                     break;
                 }
 
 #ifdef TARGET_AMD64
                 case INS_movsxd:
                 {
-                    printf("%s, %s", emitRegName(id->idReg1(), EA_8BYTE), emitRegName(id->idReg2(), EA_4BYTE));
+                    tgtAttr = EA_8BYTE;
+                    srcAttr = EA_4BYTE;
                     break;
                 }
 #endif // TARGET_AMD64
@@ -13399,14 +13428,7 @@ void emitter::emitDispIns(
                 case INS_movsx:
                 case INS_movzx:
                 {
-                    printf("%s, %s", emitRegName(id->idReg1(), EA_PTRSIZE), emitRegName(id->idReg2(), attr));
-                    break;
-                }
-
-                case INS_bt:
-                {
-                    // INS_bt operands are reversed. Display them in the normal order.
-                    printf("%s, %s", emitRegName(id->idReg2(), attr), emitRegName(id->idReg1(), attr));
+                    tgtAttr = EA_PTRSIZE;
                     break;
                 }
 
@@ -13416,11 +13438,7 @@ void emitter::emitDispIns(
                     {
                         // The idReg1 is always 4 bytes, but the size of idReg2 can vary.
                         // This logic ensures that we print `crc32 eax, bx` instead of `crc32 ax, bx`
-                        printf("%s, %s", emitRegName(id->idReg1(), EA_4BYTE), emitRegName(id->idReg2(), attr));
-                    }
-                    else
-                    {
-                        printf("%s, %s", emitRegName(id->idReg1(), attr), emitRegName(id->idReg2(), attr));
+                        tgtAttr = EA_4BYTE;
                     }
                     break;
                 }
@@ -13429,43 +13447,119 @@ void emitter::emitDispIns(
                 case INS_vpbroadcastd_gpr:
                 case INS_vpbroadcastw_gpr:
                 {
-                    printf("%s", emitRegName(id->idReg1(), attr));
-                    emitDispEmbMasking(id);
-                    printf(", %s", emitRegName(id->idReg2(), EA_4BYTE));
+                    srcAttr = EA_4BYTE;
                     break;
                 }
 
                 case INS_vpbroadcastq_gpr:
                 {
-                    printf("%s", emitRegName(id->idReg1(), attr));
-                    emitDispEmbMasking(id);
-                    printf(", %s", emitRegName(id->idReg2(), EA_8BYTE));
+                    srcAttr = EA_8BYTE;
                     break;
                 }
 
-                case INS_rol:
-                case INS_ror:
-                case INS_rcl:
-                case INS_rcr:
-                case INS_shl:
-                case INS_shr:
-                case INS_sar:
+                case INS_cvtdq2pd:
+                case INS_cvtps2pd:
+                case INS_pmovsxbw:
+                case INS_pmovsxdq:
+                case INS_pmovsxwd:
+                case INS_pmovzxbw:
+                case INS_pmovzxdq:
+                case INS_pmovzxwd:
+                case INS_vcvtph2dq:
+                case INS_vcvtph2ps:
+                case INS_vcvtph2psx:
+                case INS_vcvtph2udq:
+                case INS_vcvtps2qq:
+                case INS_vcvtps2uqq:
+                case INS_vcvttph2dq:
+                case INS_vcvttph2udq:
+                case INS_vcvttps2qq:
+                case INS_vcvttps2qqs:
+                case INS_vcvttps2uqq:
+                case INS_vcvttps2uqqs:
+                case INS_vcvtudq2pd:
                 {
-                    printf("%s", emitRegName(id->idReg1(), attr));
-                    printf(", %s", emitRegName(id->idReg2(), attr));
-                    emitDispShift(ins, (BYTE)0);
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 2U));
+                    break;
+                }
+
+                case INS_pmovsxbd:
+                case INS_pmovsxwq:
+                case INS_pmovzxbd:
+                case INS_pmovzxwq:
+                case INS_vcvtph2pd:
+                case INS_vcvtph2qq:
+                case INS_vcvtph2uqq:
+                case INS_vcvttph2qq:
+                case INS_vcvttph2uqq:
+                {
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 4U));
+                    break;
+                }
+
+                case INS_pmovsxbq:
+                case INS_pmovzxbq:
+                {
+                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 8U));
+                    break;
+                }
+
+                case INS_cvtpd2dq:
+                case INS_cvtpd2ps:
+                case INS_cvttpd2dq:
+                case INS_vpmovdw:
+                case INS_vpmovqd:
+                case INS_vpmovsdw:
+                case INS_vpmovsqd:
+                case INS_vpmovswb:
+                case INS_vpmovusdw:
+                case INS_vpmovusqd:
+                case INS_vpmovuswb:
+                case INS_vpmovwb:
+                case INS_vcvtdq2ph:
+                case INS_vcvtpd2udq:
+                case INS_vcvtps2phx:
+                case INS_vcvtqq2ps:
+                case INS_vcvtudq2ph:
+                case INS_vcvtuqq2ps:
+                case INS_vcvttpd2dqs:
+                case INS_vcvttpd2udq:
+                case INS_vcvttpd2udqs:
+                {
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 2U));
+                    break;
+                }
+
+                case INS_vcvtpd2ph:
+                case INS_vcvtqq2ph:
+                case INS_vcvtuqq2ph:
+                case INS_vpmovdb:
+                case INS_vpmovqw:
+                case INS_vpmovsdb:
+                case INS_vpmovsqw:
+                case INS_vpmovusdb:
+                case INS_vpmovusqw:
+                {
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 4U));
+                    break;
+                }
+
+                case INS_vpmovqb:
+                case INS_vpmovsqb:
+                case INS_vpmovusqb:
+                {
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t> EA_SIZE(attr) / 8U));
                     break;
                 }
 
                 default:
-                {
-                    printf("%s", emitRegName(id->idReg1(), attr));
-                    emitDispEmbMasking(id);
-                    printf(", %s", emitRegName(id->idReg2(), attr));
-                    emitDispEmbRounding(id);
                     break;
-                }
             }
+
+            printf("%s", emitRegName(id->idReg1(), tgtAttr));
+            emitDispEmbMasking(id);
+            printf(", %s", emitRegName(id->idReg2(), srcAttr));
+            emitDispEmbRounding(id);
             break;
         }
 
@@ -13633,6 +13727,12 @@ void emitter::emitDispIns(
                 case INS_pinsrq:
                 {
                     attr = EA_8BYTE;
+                    break;
+                }
+
+                case INS_vcvtps2ph:
+                {
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>EA_SIZE(attr) / 2U));
                     break;
                 }
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -13367,193 +13367,195 @@ void emitter::emitDispIns(
             emitAttr tgtAttr = attr;
             emitAttr srcAttr = attr;
 
-            switch (ins)
+            insTupleType tt = insTupleTypeInfo(ins);
+
+            if (tt == INS_TT_NONE)
             {
-                case INS_pmovmskb:
+                switch (ins)
                 {
-                    assert(!id->idIsEvexAaaContextSet());
-                    tgtAttr = EA_4BYTE;
-                    break;
-                }
-
-                case INS_cvtsi2ss32:
-                case INS_cvtsi2sd32:
-                case INS_cvtsi2ss64:
-                case INS_cvtsi2sd64:
-                {
-                    assert(!id->idIsEvexAaaContextSet());
-                    tgtAttr = EA_16BYTE;
-                    break;
-                }
-
-                case INS_cvttsd2si32:
-                case INS_cvttsd2si64:
-                case INS_cvtsd2si32:
-                case INS_cvtsd2si64:
-                case INS_cvtss2si32:
-                case INS_cvtss2si64:
-                case INS_cvttss2si32:
-                case INS_cvttss2si64:
-                case INS_vcvtsd2usi32:
-                case INS_vcvtsd2usi64:
-                case INS_vcvtss2usi32:
-                case INS_vcvtss2usi64:
-                case INS_vcvttsd2usi32:
-                case INS_vcvttsd2usi64:
-                case INS_vcvttss2usi32:
-                case INS_vcvttss2usi64:
-                case INS_vcvttsd2sis32:
-                case INS_vcvttsd2sis64:
-                case INS_vcvttss2sis32:
-                case INS_vcvttss2sis64:
-                case INS_vcvttsd2usis32:
-                case INS_vcvttsd2usis64:
-                case INS_vcvttss2usis32:
-                case INS_vcvttss2usis64:
-                {
-                    assert(!id->idIsEvexAaaContextSet());
-                    srcAttr = EA_16BYTE;
-                    break;
-                }
+                    case INS_pmovmskb:
+                    {
+                        assert(!id->idIsEvexAaaContextSet());
+                        tgtAttr = EA_4BYTE;
+                        break;
+                    }
 
 #ifdef TARGET_AMD64
-                case INS_movsxd:
-                {
-                    tgtAttr = EA_8BYTE;
-                    srcAttr = EA_4BYTE;
-                    break;
-                }
+                    case INS_movsxd:
+                    {
+                        tgtAttr = EA_8BYTE;
+                        srcAttr = EA_4BYTE;
+                        break;
+                    }
 #endif // TARGET_AMD64
 
-                case INS_movsx:
-                case INS_movzx:
-                {
-                    tgtAttr = EA_PTRSIZE;
-                    break;
+                    case INS_movsx:
+                    case INS_movzx:
+                    {
+                        tgtAttr = EA_PTRSIZE;
+                        break;
+                    }
+
+                    case INS_crc32:
+                    {
+                        tgtAttr = std::max(EA_4BYTE, EA_SIZE(attr));
+                        break;
+                    }
+
+                    default:
+                        break;
                 }
 
-                case INS_crc32:
+                printf("%s", emitRegName(id->idReg1(), tgtAttr));
+                printf(", %s", emitRegName(id->idReg2(), srcAttr));
+                break;
+            }
+
+            unsigned inputSize  = static_cast<unsigned>(GetInputSizeInBytes(id));
+
+            switch (tt)
+            {
+                case INS_TT_HALF:
+                case INS_TT_HALF_MEM:
                 {
-                    if (attr != EA_8BYTE)
+                    unsigned maskElemSize = XMM_REGSIZE_BYTES / CodeGenInterface::instKMaskBaseSize(ins);
+                    emitAttr halfSize     = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 2));
+
+                    if (inputSize < maskElemSize)
                     {
-                        // The idReg1 is always 4 bytes, but the size of idReg2 can vary.
-                        // This logic ensures that we print `crc32 eax, bx` instead of `crc32 ax, bx`
-                        tgtAttr = EA_4BYTE;
+                        assert(inputSize == (maskElemSize / 2));
+                        srcAttr = halfSize;
+                    }
+                    else
+                    {
+                        tgtAttr = halfSize;
                     }
                     break;
                 }
 
-                case INS_vpbroadcastb_gpr:
-                case INS_vpbroadcastd_gpr:
-                case INS_vpbroadcastw_gpr:
+                case INS_TT_QUARTER_MEM:
                 {
-                    srcAttr = EA_4BYTE;
+                    unsigned maskElemSize = XMM_REGSIZE_BYTES / CodeGenInterface::instKMaskBaseSize(ins);
+                    emitAttr quarterSize  = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 4));
+
+                    if (inputSize < maskElemSize)
+                    {
+                        assert(inputSize == (maskElemSize / 4));
+                        srcAttr = quarterSize;
+                    }
+                    else
+                    {
+                        tgtAttr = quarterSize;
+                    }
                     break;
                 }
 
-                case INS_vpbroadcastq_gpr:
+                case INS_TT_EIGHTH_MEM:
                 {
-                    srcAttr = EA_8BYTE;
-                    break;
-                }
+                    unsigned maskElemSize = XMM_REGSIZE_BYTES / CodeGenInterface::instKMaskBaseSize(ins);
+                    emitAttr eighthSize   = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 8));
 
-                case INS_cvtdq2pd:
-                case INS_cvtps2pd:
-                case INS_pmovsxbw:
-                case INS_pmovsxdq:
-                case INS_pmovsxwd:
-                case INS_pmovzxbw:
-                case INS_pmovzxdq:
-                case INS_pmovzxwd:
-                case INS_vcvtph2dq:
-                case INS_vcvtph2ps:
-                case INS_vcvtph2psx:
-                case INS_vcvtph2udq:
-                case INS_vcvtps2qq:
-                case INS_vcvtps2uqq:
-                case INS_vcvttph2dq:
-                case INS_vcvttph2udq:
-                case INS_vcvttps2qq:
-                case INS_vcvttps2qqs:
-                case INS_vcvttps2uqq:
-                case INS_vcvttps2uqqs:
-                case INS_vcvtudq2pd:
-                {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
-                    break;
-                }
-
-                case INS_pmovsxbd:
-                case INS_pmovsxwq:
-                case INS_pmovzxbd:
-                case INS_pmovzxwq:
-                case INS_vcvtph2pd:
-                case INS_vcvtph2qq:
-                case INS_vcvtph2uqq:
-                case INS_vcvttph2qq:
-                case INS_vcvttph2uqq:
-                {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 4U));
-                    break;
-                }
-
-                case INS_pmovsxbq:
-                case INS_pmovzxbq:
-                {
-                    srcAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 8U));
-                    break;
-                }
-
-                case INS_cvtpd2dq:
-                case INS_cvtpd2ps:
-                case INS_cvttpd2dq:
-                case INS_vpmovdw:
-                case INS_vpmovqd:
-                case INS_vpmovsdw:
-                case INS_vpmovsqd:
-                case INS_vpmovswb:
-                case INS_vpmovusdw:
-                case INS_vpmovusqd:
-                case INS_vpmovuswb:
-                case INS_vpmovwb:
-                case INS_vcvtdq2ph:
-                case INS_vcvtpd2udq:
-                case INS_vcvtps2phx:
-                case INS_vcvtqq2ps:
-                case INS_vcvtudq2ph:
-                case INS_vcvtuqq2ps:
-                case INS_vcvttpd2dqs:
-                case INS_vcvttpd2udq:
-                case INS_vcvttpd2udqs:
-                {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
-                    break;
-                }
-
-                case INS_vcvtpd2ph:
-                case INS_vcvtqq2ph:
-                case INS_vcvtuqq2ph:
-                case INS_vpmovdb:
-                case INS_vpmovqw:
-                case INS_vpmovsdb:
-                case INS_vpmovsqw:
-                case INS_vpmovusdb:
-                case INS_vpmovusqw:
-                {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 4U));
-                    break;
-                }
-
-                case INS_vpmovqb:
-                case INS_vpmovsqb:
-                case INS_vpmovusqb:
-                {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 8U));
+                    if (inputSize < maskElemSize)
+                    {
+                        assert(inputSize == (maskElemSize / 8));
+                        srcAttr = eighthSize;
+                    }
+                    else
+                    {
+                        tgtAttr = eighthSize;
+                    }
                     break;
                 }
 
                 default:
+                {
+                    switch (ins)
+                    {
+                        case INS_cvtsi2ss32:
+                        case INS_cvtsi2sd32:
+                        case INS_cvtsi2ss64:
+                        case INS_cvtsi2sd64:
+                        {
+                            assert(!id->idIsEvexAaaContextSet());
+                            tgtAttr = EA_16BYTE;
+                            break;
+                        }
+
+                        case INS_cvttsd2si32:
+                        case INS_cvttsd2si64:
+                        case INS_cvtsd2si32:
+                        case INS_cvtsd2si64:
+                        case INS_cvtss2si32:
+                        case INS_cvtss2si64:
+                        case INS_cvttss2si32:
+                        case INS_cvttss2si64:
+                        case INS_vcvtsd2usi32:
+                        case INS_vcvtsd2usi64:
+                        case INS_vcvtss2usi32:
+                        case INS_vcvtss2usi64:
+                        case INS_vcvttsd2usi32:
+                        case INS_vcvttsd2usi64:
+                        case INS_vcvttss2usi32:
+                        case INS_vcvttss2usi64:
+                        case INS_vcvttsd2sis32:
+                        case INS_vcvttsd2sis64:
+                        case INS_vcvttss2sis32:
+                        case INS_vcvttss2sis64:
+                        case INS_vcvttsd2usis32:
+                        case INS_vcvttsd2usis64:
+                        case INS_vcvttss2usis32:
+                        case INS_vcvttss2usis64:
+                        {
+                            assert(!id->idIsEvexAaaContextSet());
+                            srcAttr = EA_16BYTE;
+                            break;
+                        }
+
+                        case INS_vpbroadcastb_gpr:
+                        case INS_vpbroadcastd_gpr:
+                        case INS_vpbroadcastw_gpr:
+                        {
+                            srcAttr = EA_4BYTE;
+                            break;
+                        }
+
+                        case INS_vpbroadcastq_gpr:
+                        {
+                            srcAttr = EA_8BYTE;
+                            break;
+                        }
+
+                        case INS_cvtpd2dq:
+                        case INS_cvtpd2ps:
+                        case INS_cvttpd2dq:
+                        case INS_vcvtdq2ph:
+                        case INS_vcvtneps2bf16:
+                        case INS_vcvtpd2udq:
+                        case INS_vcvtps2phx:
+                        case INS_vcvtqq2ps:
+                        case INS_vcvttpd2dqs:
+                        case INS_vcvttpd2udq:
+                        case INS_vcvttpd2udqs:
+                        case INS_vcvtudq2ph:
+                        case INS_vcvtuqq2ps:
+                        {
+                            tgtAttr = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 2));
+                            break;
+                        }
+
+                        case INS_vcvtpd2ph:
+                        case INS_vcvtqq2ph:
+                        case INS_vcvtuqq2ph:
+                        {
+                            tgtAttr = std::max(EA_16BYTE, EA_ATTR(EA_SIZE_IN_BYTES(attr) / 4));
+                            break;
+                        }
+
+                        default:
+                            break;
+                    }
                     break;
+                }
             }
 
             printf("%s", emitRegName(id->idReg1(), tgtAttr));
@@ -13732,7 +13734,7 @@ void emitter::emitDispIns(
 
                 case INS_vcvtps2ph:
                 {
-                    tgtAttr = static_cast<emitAttr>(std::max(16U, static_cast<uint32_t>(EA_SIZE(attr)) / 2U));
+                    tgtAttr = static_cast<emitAttr>(std::max(16U, EA_SIZE_IN_BYTES(attr) / 2U));
                     break;
                 }
 


### PR DESCRIPTION
Fixes #126363

This re-works the disasm for reg to reg instructions to cover some additional cases and make it a bit more consistent.

Many of the widening and narrowing instructions were showing the same size for source and target register.

Diff for the current vector byte multiply implementation:

```diff
        62F17C481002         vmovups  zmm0, zmmword ptr [rdx]
        62F17C4828C8         vmovaps  zmm1, zmm0
-       62F27D4820C9         vpmovsxbw zmm1, zmm1
+       62F27D4820C9         vpmovsxbw zmm1, ymm1
        62D17C481010         vmovups  zmm2, zmmword ptr [r8]
        62F17C4828DA         vmovaps  zmm3, zmm2
-       62F27D4820DB         vpmovsxbw zmm3, zmm3
+       62F27D4820DB         vpmovsxbw zmm3, ymm3
        62F16548D5C9         vpmullw  zmm1, zmm3, zmm1
-       62F27E4830C9         vpmovwb  zmm1, zmm1
+       62F27E4830C9         vpmovwb  ymm1, zmm1
        62F37D483BC001       vextracti32x8 ymm0, zmm0, 1
-       62F27D4820C0         vpmovsxbw zmm0, zmm0
+       62F27D4820C0         vpmovsxbw zmm0, ymm0
        62F37D483BD201       vextracti32x8 ymm2, zmm2, 1
-       62F27D4820D2         vpmovsxbw zmm2, zmm2
+       62F27D4820D2         vpmovsxbw zmm2, ymm2
        62F16D48D5C0         vpmullw  zmm0, zmm2, zmm0
-       62F27E4830C0         vpmovwb  zmm0, zmm0
+       62F27E4830C0         vpmovwb  ymm0, zmm0
        62F375483AC001       vinserti32x8 zmm0, zmm1, ymm0, 1
        62F17C481101         vmovups  zmmword ptr [rcx], zmm0
        488BC1               mov      rax, rcx
        C5F877               vzeroupper 
        C3                   ret      
```

This also catches a few cases where embedded rounding was not included in the disasm.  ex:

```diff
-    vcvtss2si eax, xmm0
+    vcvtss2si eax, xmm0 {rd-sae}
```

Confirmed with local `jit-diff` that there are no text changes aside from the above intended ones.