### PR TITLE
Avoid reordering when reading continuation state in AsyncOperation.SignalCompletion

### DIFF
--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -203,7 +203,8 @@ namespace System.Threading.Tasks.Sources
             }
             _completed = true;
 
-            if (_continuation != null || Interlocked.CompareExchange(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel, null) != null)
+            if (Volatile.Read(ref _continuation) != null ||
+                Interlocked.CompareExchange(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel, null) != null)
             {
                 if (_executionContext != null)
                 {

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -203,7 +203,11 @@ namespace System.Threading.Channels
             // be a nop, as its TrySetCanceled will return false and the callback will exit without doing further work.
             Unregister(_cancellationRegistration);
 
-            if (_continuation is not null || Interlocked.CompareExchange(ref _continuation, s_completedSentinel, null) is not null)
+            // NB: Assigning _continuation happens after assigning continuation dependencies (_capturedContext, _continuationState)
+            //     and effectively "commits" the entire continuation state as ready for invocation.
+            //     We must read _continuation before accessing its dependencies.
+            if (Volatile.Read(ref _continuation) is not null ||
+                Interlocked.CompareExchange(ref _continuation, s_completedSentinel, null) is not null)
             {
                 Debug.Assert(_continuation != s_completedSentinel, $"The continuation was the completion sentinel.");
                 Debug.Assert(_continuation != s_availableSentinel, $"The continuation was the available sentinel.");
@@ -260,6 +264,8 @@ namespace System.Threading.Channels
 
         private void SetCompletionAndInvokeContinuation()
         {
+            Debug.Assert(_continuation is not null);
+
             object? ctx = _capturedContext;
             ExecutionContext? ec =
                 ctx is null ? null :


### PR DESCRIPTION
Fixes: #125015

Missing Read barrier.
The fix is roughly the same as in https://github.com/dotnet/runtime/pull/72657, but in `AsyncOperation`
