### PR TITLE
[Wasm RyuJIT] Set wasm's vector width to 128 bits

### DIFF
--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -156,7 +156,7 @@ namespace ILCompiler
             }
             else if (_targetArchitecture == TargetArchitecture.Wasm32)
             {
-                return SimdVectorLength.None; // TODO-WASM-CQ: packed SIMD (128 bit vectors).
+                return SimdVectorLength.Vector128Bit;
             }
             else
             {

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -87,7 +87,7 @@ namespace ILCompiler
             TargetOS targetOS = Get(_command.TargetOS);
             bool allowOptimistic = _command.OptimizationMode != OptimizationMode.PreferSize;
 
-            if (targetOS is TargetOS.iOS or TargetOS.tvOS or TargetOS.iOSSimulator or TargetOS.tvOSSimulator or TargetOS.MacCatalyst)
+            if (targetOS is TargetOS.iOS or TargetOS.tvOS or TargetOS.iOSSimulator or TargetOS.tvOSSimulator or TargetOS.MacCatalyst or TargetOS.Browser)
             {
                 // These platforms do not support jitted code, so we want to ensure that we don't
                 // need to fall back to the interpreter for any hardware-intrinsic optimizations.


### PR DESCRIPTION
This fixes a late compilation failure in crossgen when doing dependency analysis for `Vector<T>` in S.P.CoreLib:

```
Unhandled exception. System.InvalidOperationException: Operation is not valid due to the current state of the object.
   at Internal.TypeSystem.LayoutInt.get_AsInt()
   at Internal.JitInterface.WasmLowering.LowerToAbiType(TypeDesc type)
   at Internal.JitInterface.WasmLowering.GetSignature(MethodSignature signature, LoweringFlags flags)
   at Internal.JitInterface.WasmLowering.GetSignature(MethodDesc method)
   at ILCompiler.DependencyAnalysis.NodeFactory.WasmTypeNode(MethodDesc method)
   at ILCompiler.DependencyAnalysis.ObjectNode.GetStaticDependencies(NodeFactory factory)
   at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.GetStaticDependenciesImpl(DependencyNodeCore`1 node)
   at ILCompiler.DependencyAnalysisFramework.DependencyAnalyzer`2.ComputeMarkedNodes()
   at ILCompiler.ReadyToRunCodegenCompilation.Compile(String outputFile)
   at ILCompiler.Program.RunSingleCompilation(Dictionary`2 inFilePaths, InstructionSetSupport instructionSetSupport, String compositeRootPath, Dictionary`2 unrootedInputFilePaths, HashSet`1 versionBubbleModulesHash, ReadyToRunCompilerContext typeSystemContext, Logger logger) in Z:\runtime\src\coreclr\tools\aot\crossgen2\Program.cs:line 669
   at ILCompiler.Program.Run() in Z:\runtime\src\coreclr\tools\aot\crossgen2\Program.cs:line 314
   at ILCompiler.Crossgen2RootCommand.<>c__DisplayClass217_0.<.ctor>b__0(ParseResult result) in Z:\runtime\src\coreclr\tools\aot\crossgen2\Crossgen2RootCommand.cs:line 274
   at System.CommandLine.Invocation.InvocationPipeline.Invoke(ParseResult parseResult)
   at ILCompiler.Program.Main(String[] args) in Z:\runtime\src\coreclr\tools\aot\crossgen2\Program.cs:line 946
```

Also includes a related change Andy suggested to disable being optimistic about instruction sets, since we don't have a Wasm client-side jit.

See also #125756