### PR TITLE
Fix libraries-interpreter Linux failures: Configuration case mismatch

### DIFF
--- a/eng/pipelines/coreclr/libraries-interpreter.yml
+++ b/eng/pipelines/coreclr/libraries-interpreter.yml
@@ -22,7 +22,7 @@ extends:
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
+          buildConfig: Release
           platforms:
           - windows_x64
           - osx_arm64


### PR DESCRIPTION
## Summary

The `runtime-libraries-interpreter` pipeline has been **100% red** across all 13 retained builds (Mar 2–30). The Linux leg fails with:

```
dotnet: No such file or directory
```

## Root Cause

`buildConfig: release` (lowercase) flows through to SendToHelix as `/p:Configuration=release`, but the build step produces artifacts under PascalCase `Release`. On Linux's case-sensitive filesystem:

| Step | `NetCoreAppCurrentTestHostPath` |
|------|---|
| **Build** (`-c Release`) | `testhost/net11.0-linux-**R**elease-x64/` |
| **SendToHelix** (`/p:Configuration=release`) | `testhost/net11.0-linux-**r**elease-x64/` |

SendToHelix zips an empty directory → Helix work items can't find `dotnet`.

Windows/macOS are case-insensitive so they find the binary (but then timeout under InterpMode=3 — separate issue).

## Fix

Change `buildConfig: release` → `buildConfig: Release` to match the convention used by other working pipelines (`libraries-jitstress`, `libraries-gcstress-extra`, `runtime-nativeaot-outerloop`).

## Confirmed via binlog analysis

Downloaded Build.binlog and SendToHelix.binlog from [build 1358001](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1358001). The `NetCoreAppCurrentTestHostPath` property differs in casing between the two binlogs.

## Note

Other pipelines (`gc-longrunning`, `r2r`, `superpmi-diffs`) also use lowercase `buildConfig` and may have the same latent bug on Linux legs.