### PR TITLE
Keep the trimming target type around if there's a template type layout for the trimming target

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
@@ -43,15 +43,15 @@ namespace ILCompiler.DependencyAnalysis
                         context.NecessaryTypeSymbol(trimmingTargetType),
                         "Type in external type map is cast target");
 
-                    // If the key type has a canonical form, it could be created at runtime by the type loader.
+                    // If the trimming target type has a canonical form, it could be created at runtime by the type loader.
                     // If there is a type loader template for it, create the generic type instantiation eagerly.
-                    TypeDesc canonKey = trimmingTargetType.ConvertToCanonForm(CanonicalFormKind.Specific);
-                    if (canonKey != trimmingTargetType)
+                    TypeDesc canonTrimmingType = trimmingTargetType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonTrimmingType != trimmingTargetType)
                     {
                         yield return new CombinedDependencyListEntry(
                             context.NecessaryTypeSymbol(trimmingTargetType),
-                            context.NativeLayout.TemplateTypeLayout(canonKey),
-                            "External type map entry that could be loaded at runtime");
+                            context.NativeLayout.TemplateTypeLayout(canonTrimmingType),
+                            "External type map trim target that could be loaded at runtime");
                     }
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.DependencyAnalysis
                     // If the trimming target type has a canonical form, it could be created at runtime by the type loader.
                     // If there is a type loader template for it, create the generic type instantiation eagerly.
                     TypeDesc canonTrimmingType = trimmingTargetType.ConvertToCanonForm(CanonicalFormKind.Specific);
-                    if (canonTrimmingType != trimmingTargetType)
+                    if (canonTrimmingType != trimmingTargetType && GenericTypesTemplateMap.IsEligibleToHaveATemplate(canonTrimmingType))
                     {
                         yield return new CombinedDependencyListEntry(
                             context.NecessaryTypeSymbol(trimmingTargetType),

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ExternalTypeMapNode.cs
@@ -42,6 +42,17 @@ namespace ILCompiler.DependencyAnalysis
                         context.MetadataTypeSymbol(targetType),
                         context.NecessaryTypeSymbol(trimmingTargetType),
                         "Type in external type map is cast target");
+
+                    // If the key type has a canonical form, it could be created at runtime by the type loader.
+                    // If there is a type loader template for it, create the generic type instantiation eagerly.
+                    TypeDesc canonKey = trimmingTargetType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                    if (canonKey != trimmingTargetType)
+                    {
+                        yield return new CombinedDependencyListEntry(
+                            context.NecessaryTypeSymbol(trimmingTargetType),
+                            context.NativeLayout.TemplateTypeLayout(canonKey),
+                            "External type map entry that could be loaded at runtime");
+                    }
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ProxyTypeMapNode.cs
@@ -50,7 +50,7 @@ namespace ILCompiler.DependencyAnalysis
                 // If the key type has a canonical form, it could be created at runtime by the type loader.
                 // If there is a type loader template for it, create the generic type instantiation eagerly.
                 TypeDesc canonKey = key.ConvertToCanonForm(CanonicalFormKind.Specific);
-                if (canonKey != key)
+                if (canonKey != key && GenericTypesTemplateMap.IsEligibleToHaveATemplate(canonKey))
                 {
                     yield return new CombinedDependencyListEntry(
                         context.MaximallyConstructableType(key),

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -10,8 +10,10 @@ using System.Runtime.InteropServices;
 
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("Foo", typeof(DeadCodeElimination.TestInteropMapTrimming.ConditionalTypeMapEntry), typeof(DeadCodeElimination.TestInteropMapTrimming.TypeMapTrimTarget))]
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("Bar", typeof(DeadCodeElimination.TestInteropMapTrimming.UnconditionalTypeMapEntry))]
+[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUsedForExternal", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForExternal<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUsed))]
+[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUnused", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUnused))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.SourceType), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyType))]
-[assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsed<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUsed))]
+[assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForProxy<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUsedForProxy))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUnused))]
 
 class DeadCodeElimination
@@ -1282,20 +1284,26 @@ class DeadCodeElimination
         internal class ConditionalTypeMapEntry;
         internal class UnconditionalTypeMapEntry;
         internal class TypeMapTrimTarget;
+        internal class GenUsedForExternal<T> where T : class;
+        internal class ExternalEntryFromGenUsed;
 
         internal class SourceType;
         internal class ProxyType;
 
-        internal class GenUsed<T> where T : class;
-        internal class ProxyFromGenUsed;
+        internal class GenUsedForProxy<T> where T : class;
+        internal class ExternalEntryFromGenUsedForProxy;
         internal class GenUnused<T> where T : class;
         internal class ProxyFromGenUnused;
+        internal class ExternalEntryFromGenUnused;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static object GetUnknown() => null;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Consume(object o) { }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool TypeCheckUnknown<T>() => GetUnknown() is GenUsedForExternal<T>;
 
         public static void Run()
         {
@@ -1310,6 +1318,16 @@ class DeadCodeElimination
                 var mappedType = map["Foo"];
                 ThrowIfUsableMethodTable(mappedType);
                 if (mappedType.Name != nameof(ConditionalTypeMapEntry))
+                    throw new Exception();
+                
+                if ((bool)typeof(TestInteropMapTrimming).GetMethod(nameof(TypeCheckUnknown)).MakeGenericMethod(GetObjectType()).Invoke(null, null))
+                {
+                    Console.WriteLine("Unexpected!");
+                }
+
+                var mappedTypeConstructed = map["GenUsedForExternal"];
+                ThrowIfUsableMethodTable(mappedTypeConstructed);
+                if (mappedTypeConstructed.Name != nameof(ExternalEntryFromGenUsed))
                     throw new Exception();
             }
 
@@ -1334,10 +1352,10 @@ class DeadCodeElimination
             {
                 var mappedType = (Type)typeof(TestInteropMapTrimming).GetMethod(nameof(GetProxyGeneric)).MakeGenericMethod(GetObjectType()).Invoke(null, [ proxyMap ]);
                 ThrowIfUsableMethodTable(mappedType);
-                if (mappedType.Name != nameof(ProxyFromGenUsed))
+                if (mappedType.Name != nameof(ProxyFromGenUsedForProxy))
                     throw new Exception();
 
-                ThrowIfNotPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUsed));
+                ThrowIfNotPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUsedForProxy));
                 ThrowIfPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUnused));
 
                 [MethodImpl(MethodImplOptions.NoInlining)]
@@ -1347,7 +1365,7 @@ class DeadCodeElimination
 
         public static Type GetProxyGeneric<T>(IReadOnlyDictionary<Type, Type> map) where T : class
         {
-            return map.GetValueOrDefault(new GenUsed<T>().GetType());
+            return map.GetValueOrDefault(new GenUsedForProxy<T>().GetType());
         }
     }
 

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -10,8 +10,8 @@ using System.Runtime.InteropServices;
 
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("Foo", typeof(DeadCodeElimination.TestInteropMapTrimming.ConditionalTypeMapEntry), typeof(DeadCodeElimination.TestInteropMapTrimming.TypeMapTrimTarget))]
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("Bar", typeof(DeadCodeElimination.TestInteropMapTrimming.UnconditionalTypeMapEntry))]
-[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUsedForExternal", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForExternal<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUsed))]
-[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUnused", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUnused))]
+[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUsedForExternal", typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUsed), typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForExternal<object>))]
+[assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUnused", typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUnused), typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.SourceType), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyType))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForProxy<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUsed))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUnused))]

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -13,7 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUsedForExternal", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForExternal<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUsed))]
 [assembly: TypeMap<DeadCodeElimination.TestInteropMapTrimming.Universe>("GenUnused", typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ExternalEntryFromGenUnused))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.SourceType), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyType))]
-[assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForProxy<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUsedForProxy))]
+[assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUsedForProxy<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUsed))]
 [assembly: TypeMapAssociation<DeadCodeElimination.TestInteropMapTrimming.Universe>(typeof(DeadCodeElimination.TestInteropMapTrimming.GenUnused<object>), typeof(DeadCodeElimination.TestInteropMapTrimming.ProxyFromGenUnused))]
 
 class DeadCodeElimination
@@ -1291,7 +1291,7 @@ class DeadCodeElimination
         internal class ProxyType;
 
         internal class GenUsedForProxy<T> where T : class;
-        internal class ExternalEntryFromGenUsedForProxy;
+        internal class ProxyFromGenUsed;
         internal class GenUnused<T> where T : class;
         internal class ProxyFromGenUnused;
         internal class ExternalEntryFromGenUnused;
@@ -1352,10 +1352,10 @@ class DeadCodeElimination
             {
                 var mappedType = (Type)typeof(TestInteropMapTrimming).GetMethod(nameof(GetProxyGeneric)).MakeGenericMethod(GetObjectType()).Invoke(null, [ proxyMap ]);
                 ThrowIfUsableMethodTable(mappedType);
-                if (mappedType.Name != nameof(ProxyFromGenUsedForProxy))
+                if (mappedType.Name != nameof(ProxyFromGenUsed))
                     throw new Exception();
 
-                ThrowIfNotPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUsedForProxy));
+                ThrowIfNotPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUsed));
                 ThrowIfPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUnused));
 
                 [MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -1354,10 +1354,10 @@ class DeadCodeElimination
 
                 ThrowIfNotPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUsed));
                 ThrowIfPresent(typeof(TestInteropMapTrimming), nameof(ProxyFromGenUnused));
-
-                [MethodImpl(MethodImplOptions.NoInlining)]
-                static Type GetObjectType() => typeof(object);
             }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static Type GetObjectType() => typeof(object);
         }
 
         public static Type GetProxyGeneric<T>(IReadOnlyDictionary<Type, Type> map) where T : class

--- a/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
+++ b/src/tests/nativeaot/SmokeTests/TrimmingBehaviors/DeadCodeElimination.cs
@@ -1302,9 +1302,6 @@ class DeadCodeElimination
         [MethodImpl(MethodImplOptions.NoInlining)]
         static void Consume(object o) { }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        static bool TypeCheckUnknown<T>() => GetUnknown() is GenUsedForExternal<T>;
-
         public static void Run()
         {
             var map = TypeMapping.GetOrCreateExternalTypeMapping<Universe>();
@@ -1319,7 +1316,7 @@ class DeadCodeElimination
                 ThrowIfUsableMethodTable(mappedType);
                 if (mappedType.Name != nameof(ConditionalTypeMapEntry))
                     throw new Exception();
-                
+
                 if ((bool)typeof(TestInteropMapTrimming).GetMethod(nameof(TypeCheckUnknown)).MakeGenericMethod(GetObjectType()).Invoke(null, null))
                 {
                     Console.WriteLine("Unexpected!");
@@ -1367,6 +1364,9 @@ class DeadCodeElimination
         {
             return map.GetValueOrDefault(new GenUsedForProxy<T>().GetType());
         }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public static bool TypeCheckUnknown<T>() where T : class => GetUnknown() is GenUsedForExternal<T>;
     }
 
     [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2070:UnrecognizedReflectionPattern",


### PR DESCRIPTION


Contributes to https://github.com/dotnet/runtime/issues/126177