### PR TITLE
Add update-os-coverage skill for Helix queue OS version updates

### DIFF
--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -67,7 +67,7 @@ Where:
 - `<HostQueue>` — physical host queue, e.g. `AzureLinux.3.Amd64.Open`
 - `<image-tag>` — container image tag, e.g. `fedora-44-helix-amd64`
 
-Most distro variables also have `_internal` counterparts (e.g. `helix_linux_x64_<distro>_oldest_internal`) that use the same queue/image but drop the `.Open` suffix. When updating a distro version, update both the `.Open` and `_internal` entries.
+Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_<distro>_oldest_internal`) that use the same queue/image but drop the `.Open` suffix. When an `_internal` counterpart exists, update both the `.Open` and `_internal` entries.
 
 ### helix-queues-setup.yml files
 
@@ -167,9 +167,9 @@ For each reference found in step 3:
    | openSUSE | `openSUSE.<ver>.Amd64.Open` | `opensuse-<ver>-helix-amd64` |
    | Ubuntu | `Ubuntu.<ver-no-dots>.Amd64.Open` | `ubuntu-<ver>-helix-amd64` |
 
-   Architecture suffixes vary: `Amd64`, `Arm64`, `Arm32` for queue names; `amd64`, `arm64v8`, `arm32v7` for image tags.
+   Architecture suffixes vary: `Amd64`, `Arm64`, `ArmArch`, `Arm32` for queue names; `amd64`, `arm64v8`, `arm32v7` for image tags.
 
-   For ARM-based queues, the host queue is typically `Ubuntu.2204.ArmArch.Open` (not AzureLinux).
+   For ARM-based queues, host queues are often `Ubuntu.2204.ArmArch.Open`, but some queues (for example `helix_linux_arm64_oldest`) use AzureLinux-based host queues such as `AzureLinux.3.Arm64.Open`. Follow the existing pattern for the specific queue in `eng/pipelines/helix-platforms.yml` when updating versions.
 
 ### 5. Validate changes
 
@@ -196,7 +196,7 @@ After editing, verify:
 After updating `main`, check whether release branches also need updates:
 
 ```bash
-for branch in $(git branch -r | grep -E 'origin/release/' | head -10); do
+for branch in $(git branch -r | grep -E 'origin/release/'); do
   echo "=== $branch ==="
   git show "$branch:eng/pipelines/helix-platforms.yml" 2>/dev/null | grep -n -i "<distro>" || echo "(no matches or file not found)"
 done
@@ -210,7 +210,7 @@ Note: Release branch updates should be done in separate PRs.
 
 ### 7. Cross-reference with supported-os
 
-Check if the [supported-os.json](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json) in dotnet/core needs corresponding updates. If a new version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
+Check if the relevant `supported-os.json` in dotnet/core needs corresponding updates. The file lives under the pattern `release-notes/<version>/supported-os.json` (for example, `release-notes/8.0/supported-os.json`) in the [release-notes directory](https://github.com/dotnet/core/tree/main/release-notes). If a new version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
 
 ### 8. Create PR
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -236,6 +236,8 @@ gh pr comment <pr-number> --body "/azp run runtime-extra-platforms"
 
 Tell the user you've triggered the pipeline and which distros required it.
 
+> **Note:** The `outerloop` pipeline (`libraries/outerloop.yml`) does not add Linux distro coverage beyond the default pipeline — the extra-platforms distros (Fedora, Debian, openSUSE) are explicitly excluded from outerloop runs. Do **not** trigger outerloop for Linux distro version changes unless the user explicitly requests it.
+
 ### 7. Check other branches
 
 After updating `main`, check whether release branches also need updates:

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -36,7 +36,7 @@ OS version references appear in these pipeline files:
 
 | File | Purpose |
 |------|---------|
-| `eng/pipelines/helix-platforms.yml` | **Primary target.** Central platform definitions — defines `latest` and `oldest` version variables for all OS/arch combinations |
+| `eng/pipelines/helix-platforms.yml` | Central platform definitions — a useful starting point for many `latest` and `oldest` OS version variables, but not the sole source of truth |
 | `eng/pipelines/libraries/helix-queues-setup.yml` | Libraries Helix queue assignments — inline OS version references per platform |
 | `eng/pipelines/coreclr/templates/helix-queues-setup.yml` | CoreCLR Helix queue assignments — inline OS version references |
 | `eng/pipelines/installer/helix-queues-setup.yml` | Installer Helix queue assignments |
@@ -45,7 +45,7 @@ OS version references appear in these pipeline files:
 
 ### helix-platforms.yml structure
 
-This file defines named variables following a consistent pattern:
+Many Linux container-backed entries in this file use a pattern like:
 
 ```yaml
 # <Distro> <arch>
@@ -55,6 +55,8 @@ This file defines named variables following a consistent pattern:
 ```
 
 Where `<QueueName>` is the Helix queue identifier (e.g. `Fedora.44.Amd64.Open`), `<HostQueue>` is the physical host queue (e.g. `AzureLinux.3.Amd64.Open`), and `<image-tag>` is the container image tag (e.g. `fedora-44-helix-amd64`).
+
+Other entries in the same file are plain queue values (for example Windows, macOS, and some Linux VM queues) rather than `(<QueueName>)<HostQueue>@<image>`. When the target entry is queue-only, preserve that format and update only the versioned queue string.
 
 Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_oldest_internal`, `helix_linux_musl_arm32_latest_internal`) that use the same queue/image but drop the `.Open` suffix. When an `_internal` counterpart exists, update both the `.Open` and `_internal` entries.
 
@@ -78,18 +80,18 @@ If the user provides only a distro name without specifying slots, determine the 
 
 ## Process
 
-Requires `curl` and `jq` for the verification and audit steps below.
+Use the repo tools that fit the environment. The shell snippets below are reference commands, not a required literal script; equivalent `gh`, `git`, or search-based workflows are fine.
 
 ### 1. Verify container image availability
 
-Before making any changes, confirm the target container image exists. Check the [image-info JSON](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json) for published images:
+Before making any changes, confirm the target container image exists. One convenient way is to check the [image-info JSON](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json) for published images:
 
 ```bash
 curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
   | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("<distro>-<version>"))) | sort | .[]'
 ```
 
-If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an open issue or PR already exists:
+If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an open issue or PR already exists, for example:
 
 ```bash
 gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
@@ -107,7 +109,7 @@ The `<distro-id>` matches [endoflife.date](https://endoflife.date) product IDs (
 
 ### 3. Scan current references
 
-Search for all current references to the distro being updated:
+Search for all current references to the distro being updated. For example:
 
 ```bash
 grep -rn -i "<distro>" \
@@ -125,10 +127,11 @@ Note every occurrence — the same distro may appear in multiple sections (x64, 
 
 For each reference found in step 3:
 
-1. **Update `helix-platforms.yml`** — this is the primary file
+1. **Start with `helix-platforms.yml`** — it is a convenient central catalog for many Linux container-backed entries, but it is not the source of truth by itself
    - Update the version comment (e.g. `# Latest: 43` → `# Latest: 44`)
-   - Update the variable value — adjust the queue name and image tag to use the new version
+   - Update the variable value — adjust the queue name and image tag to use the new version when the entry uses the container-backed format
    - Preserve the existing host queue (e.g. `AzureLinux.3.Amd64.Open`) — this does not change with distro version updates
+   - Then continue through the other files until every matching reference is updated consistently
 
 2. **Update `helix-queues-setup.yml` files** — libraries, coreclr, and installer templates
    - Search for inline references to the old version and update them

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -67,6 +67,8 @@ Where:
 - `<HostQueue>` — physical host queue, e.g. `AzureLinux.3.Amd64.Open`
 - `<image-tag>` — container image tag, e.g. `fedora-44-helix-amd64`
 
+Most distro variables also have `_internal` counterparts (e.g. `helix_linux_x64_<distro>_oldest_internal`) that use the same queue/image but drop the `.Open` suffix. When updating a distro version, update both the `.Open` and `_internal` entries.
+
 ### helix-queues-setup.yml files
 
 These files reference OS versions directly (not via variables) in conditional blocks per platform. Each inline reference follows the same `(<QueueName>)<HostQueue>@<image>` format.
@@ -158,6 +160,7 @@ For each reference found in step 3:
    | Distro | Queue name pattern | Image tag pattern |
    |--------|--------------------|-------------------|
    | Alpine | `Alpine.<ver-no-dots>.Amd64.Open` | `alpine-<ver>-helix-amd64` |
+   | Alpine (edge) | `Alpine.edge.Amd64.Open` | `alpine-edge-helix-amd64` |
    | CentOS Stream | `Centos.<ver>.Amd64.Open` | `centos-stream-<ver>-helix-amd64` |
    | Debian | `Debian.<ver>.Amd64.Open` | `debian-<ver>-helix-amd64` |
    | Fedora | `Fedora.<ver>.Amd64.Open` | `fedora-<ver>-helix-amd64` |
@@ -228,6 +231,8 @@ Check if the [supported-os.json](https://github.com/dotnet/core/blob/main/releas
    - Confirmation that container images are available
    - Link to the [os-onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
    - Link to tracking issue if applicable (e.g. [dotnet/core#9638](https://github.com/dotnet/core/issues/9638))
+
+> 📝 **AI-generated content disclosure:** When posting any content to GitHub (PR descriptions, comments) under a user's credentials — i.e., the account is **not** a dedicated "copilot" or "bot" account/app — you **MUST** include a concise, visible note (e.g. a `> [!NOTE]` alert) indicating the content was AI/Copilot-generated. Skip this if the user explicitly asks you to omit it.
 
 ## Audit mode
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -66,7 +66,7 @@ Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_old
 
 ### helix-queues-setup.yml files
 
-These files reference OS versions directly (not via variables) in conditional blocks per platform. Each inline reference follows the same `(<QueueName>)<HostQueue>@<image>` format.
+These files reference OS versions directly (not via variables) in conditional blocks per platform. Most Linux container-backed inline references follow the `(<QueueName>)<HostQueue>@<image>` format, while a few entries are plain queue values (for example, some AzureLinux-only queues). Preserve the existing format for the specific entry you are updating.
 
 ## Inputs
 
@@ -215,7 +215,7 @@ gh pr comment <pr-number> --body "/azp run runtime-extra-platforms"
 
 Tell the user you've triggered the pipeline and which distros required it.
 
-> **Note:** The `outerloop` pipeline (`libraries/outerloop.yml`) does not add Linux distro coverage beyond the default pipeline — the extra-platforms distros (Fedora, Debian, openSUSE) are explicitly excluded from outerloop runs. Do **not** trigger outerloop for Linux distro version changes unless the user explicitly requests it.
+> **Note:** The `outerloop` pipeline (`libraries/outerloop.yml`) does not add Linux distro coverage beyond the default pipeline for normal PR validation. The extra-platforms distros (Fedora, Debian, openSUSE) are only brought in for specific non-PR / rolling-build-style cases there, so **do not** trigger outerloop for Linux distro version changes unless the user explicitly requests it.
 
 ### 7. Check other branches
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -18,8 +18,8 @@ Update OS version references in Helix queue definition files. These files contro
 - An OS version is approaching or has reached EOL and should be replaced
 - A new OS version is released and should be added to Helix testing for coverage
 - We take a more proactive approach on `main`. If a distro version will be EOL before our annual November release, we should update it to a newer version. If a distro version is expected to ship within one quarter (3 months) and a `prereqs` container image already exists, we should add it to Helix testing.
-- The availablility of an image in the `prereqs` container repo is a strong signal that the OS version is approved for Helix testing, at least on `main`.
-- Helix coverage does not match the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json).
+- The availability of an image in the `prereqs` container repo is a strong signal that the OS version is approved for Helix testing, at least on `main`.
+- Helix coverage does not match the supported-os matrix (for example, the relevant `release-notes/<dotnet-version>/supported-os.json` file in [dotnet/core](https://github.com/dotnet/core/tree/main/release-notes)).
 - Upgrading "oldest" or "latest" version slots for a distro
 
 For servicing / `release/*` branches, be more conservative: only update to GA and already-supported distro versions unless the user explicitly asks for a forward-looking change.
@@ -53,7 +53,7 @@ Many Linux container-backed entries in this file use a pattern like:
 
 ```yaml
 # <Distro> <arch>
-# Latest: <version>
+# Latest: <distro-version>
 - name: helix_linux_x64_<distro>_latest
   value: (<QueueName>)<HostQueue>@mcr.microsoft.com/dotnet-buildtools/prereqs:<image-tag>
 ```
@@ -89,13 +89,13 @@ Before making any changes, confirm the target container image exists. One conven
 
 ```bash
 curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
-  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("<distro>-<version>"))) | sort | .[]'
+  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("<distro>-<distro-version>"))) | sort | .[]'
 ```
 
 If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an open issue or PR already exists, for example:
 
 ```bash
-gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
+gh search issues "<distro> <distro-version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
 ```
 
 ### 2. Check support policy first, then EOL dates if needed
@@ -103,16 +103,16 @@ gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-do
 First, inspect the relevant `supported-os.json` entry in `dotnet/core` to see whether the distro/version is already supported for the target release and to find its official lifecycle link:
 
 ```bash
-curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<version>/supported-os.json \
+curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<dotnet-version>/supported-os.json \
   | jq '.families[] | select(.name == "Linux") | .distributions[] | select(.id == "<distro-id>") | {name, lifecycle, supportedVersions: ."supported-versions", unsupportedVersions: ."unsupported-versions"}'
 ```
 
-If the target version is already listed in `supportedVersions`, that is the primary signal that the change is appropriate for the corresponding release line. On servicing branches, prefer versions that are already GA and present there.
+If the target distro version is already listed in `supportedVersions`, that is the primary signal that the change is appropriate for the corresponding release line. On servicing branches, prefer versions that are already GA and present there.
 
 If you need an independent lifecycle check, or if `supported-os.json` does not yet reflect the situation clearly, use [endoflife.date](https://endoflife.date) as a fallback:
 
 ```bash
-curl -s https://endoflife.date/api/<distro-id>.json | jq '.[] | select(.cycle == "<version>") | {cycle, eol, releaseDate}'
+curl -s https://endoflife.date/api/<distro-id>.json | jq '.[] | select(.cycle == "<distro-version>") | {cycle, eol, releaseDate}'
 ```
 
 The `<distro-id>` values typically match across both sources (e.g. `fedora`, `alpine`, `debian`, `opensuse`, `ubuntu`, `centos-stream`).
@@ -240,7 +240,7 @@ Note: Release branch updates should be done in separate PRs.
 
 ### 8. Cross-reference with supported-os
 
-Check if the relevant `supported-os.json` in dotnet/core needs corresponding updates. The file lives under the pattern `release-notes/<version>/supported-os.json` (for example, `release-notes/8.0/supported-os.json`) in the [release-notes directory](https://github.com/dotnet/core/tree/main/release-notes). If a new version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
+Check if the relevant `supported-os.json` in dotnet/core needs corresponding updates. The file lives under the pattern `release-notes/<dotnet-version>/supported-os.json` (for example, `release-notes/8.0/supported-os.json`) in the [release-notes directory](https://github.com/dotnet/core/tree/main/release-notes). If a new distro version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
 
 ### 9. Create PR
 
@@ -260,7 +260,7 @@ When asked to audit all OS coverage:
 
 1. Fetch the current supported-os.json for the target .NET version:
    ```bash
-   curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<version>/supported-os.json
+   curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<dotnet-version>/supported-os.json
    ```
 
 2. For each Linux distro in supported-os, check:

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -171,12 +171,14 @@ For each reference found in step 3:
    | Distro | Queue name pattern | Image tag pattern |
    |--------|--------------------|-------------------|
    | Alpine | `Alpine.<ver-no-dots>.Amd64.Open` | `alpine-<ver>-helix-amd64` |
-   | Alpine (edge) | `Alpine.edge.Amd64.Open` | `alpine-edge-helix-amd64` |
+   | Alpine (edge) | `Alpine.edge.Amd64.Open` (casing varies by file; see note below) | `alpine-edge-helix-amd64` |
    | CentOS Stream | `Centos.<ver>.Amd64.Open` | `centos-stream-<ver>-helix-amd64` |
    | Debian | `Debian.<ver>.Amd64.Open` | `debian-<ver>-helix-amd64` |
    | Fedora | `Fedora.<ver>.Amd64.Open` | `fedora-<ver>-helix-amd64` |
    | openSUSE | `openSUSE.<ver>.Amd64.Open` | `opensuse-<ver>-helix-amd64` |
    | Ubuntu | `Ubuntu.<ver-no-dots>.Amd64.Open` | `ubuntu-<ver>-helix-amd64` |
+
+   For Alpine edge queues, the casing of `edge` is not consistent across the repo (`Alpine.edge.Amd64.Open` in `helix-platforms.yml` vs `Alpine.Edge.Amd64.Open` in `libraries/helix-queues-setup.yml`). When updating queue strings, **preserve the existing casing used in each file** rather than normalizing to a single pattern.
 
    AzureLinux (e.g. `AzureLinux.3.Amd64.Open`) appears as both a standalone VM queue and the primary host queue for container-based distros. It does not follow the container image pattern above.
 
@@ -190,7 +192,7 @@ After editing, verify:
 
 1. **No stale references remain:**
    ```bash
-   grep -rn "<old-version-pattern>" \
+   grep -rn -i "<old-version-pattern>" \
      eng/pipelines/helix-platforms.yml \
      eng/pipelines/libraries/helix-queues-setup.yml \
      eng/pipelines/coreclr/templates/helix-queues-setup.yml \

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -41,7 +41,7 @@ OS version references appear in these pipeline files:
 | `eng/pipelines/coreclr/templates/helix-queues-setup.yml` | CoreCLR Helix queue assignments — inline OS version references |
 | `eng/pipelines/installer/helix-queues-setup.yml` | Installer Helix queue assignments |
 | `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
-| `docs/workflow/using-docker.md` | Documents the official build/test Docker images — should stay in sync with `pipeline-with-resources.yml` |
+| `docs/workflow/using-docker.md` | Documents the official build/test Docker images — update only when build image versions change (cross-compilation images, not Helix test images) |
 
 ### helix-platforms.yml structure
 
@@ -68,7 +68,7 @@ Where:
 - `<HostQueue>` — physical host queue, e.g. `AzureLinux.3.Amd64.Open`
 - `<image-tag>` — container image tag, e.g. `fedora-44-helix-amd64`
 
-Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_<distro>_oldest_internal`) that use the same queue/image but drop the `.Open` suffix. When an `_internal` counterpart exists, update both the `.Open` and `_internal` entries.
+Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_oldest_internal`, `helix_linux_musl_arm32_latest_internal`) that use the same queue/image but drop the `.Open` suffix. When an `_internal` counterpart exists, update both the `.Open` and `_internal` entries.
 
 ### helix-queues-setup.yml files
 
@@ -89,6 +89,8 @@ If the user provides only a distro name without specifying slots, determine the 
 - If the distro currently has `latest == oldest`: only update `latest` to the new version
 
 ## Process
+
+Requires `curl` and `jq` for the verification and audit steps below.
 
 ### 1. Verify container image availability
 
@@ -114,6 +116,13 @@ If the image is **not found**, stop and inform the user. The image must be creat
 
 ```bash
 gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
+```
+
+If `gh` is not authenticated, use the GitHub API directly:
+
+```bash
+curl -s "https://api.github.com/search/issues?q=repo:dotnet/dotnet-buildtools-prereqs-docker+state:open+<distro>+<version>" \
+  | jq '.items[] | {title, html_url}'
 ```
 
 ### 2. Check EOL dates
@@ -168,6 +177,8 @@ For each reference found in step 3:
    | openSUSE | `openSUSE.<ver>.Amd64.Open` | `opensuse-<ver>-helix-amd64` |
    | Ubuntu | `Ubuntu.<ver-no-dots>.Amd64.Open` | `ubuntu-<ver>-helix-amd64` |
 
+   AzureLinux (e.g. `AzureLinux.3.Amd64.Open`) appears as both a standalone VM queue and the primary host queue for container-based distros. It does not follow the container image pattern above.
+
    Architecture suffixes vary: `Amd64`, `Arm64`, `ArmArch`, `Arm32` for queue names; `amd64`, `arm64v8`, `arm32v7` for image tags.
 
    For ARM-based queues, host queues are often `Ubuntu.2204.ArmArch.Open`, but some queues (for example `helix_linux_arm64_oldest`) use AzureLinux-based host queues such as `AzureLinux.3.Arm64.Open`. Follow the existing pattern for the specific queue in `eng/pipelines/helix-platforms.yml` when updating versions.
@@ -202,6 +213,8 @@ for branch in $(git branch -r | grep -E 'origin/release/'); do
   git show "$branch:eng/pipelines/helix-platforms.yml" 2>/dev/null | grep -n -i "<distro>" || echo "(no matches or file not found)"
 done
 ```
+
+> **Note**: In shallow clones, remote release branches may not be visible. Run `git fetch origin 'refs/heads/release/*:refs/remotes/origin/release/*'` first, or check release branches via GitHub.
 
 Release branches should be updated when:
 - The old version is EOL or approaching EOL

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,10 +15,12 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## When to use
 
-- A new OS version is released (or expected to ship within one quarter and a prereqs container image already exists) and should be added to Helix testing
+- On `main`, a new OS version is released (or is expected to ship within one quarter and a prereqs container image already exists) and should be added to Helix testing
 - An OS version is approaching or has reached EOL and should be replaced
 - Periodic audit to ensure Helix coverage matches the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json); update the version segment to match your target)
 - Upgrading "oldest" or "latest" version slots for a distro
+
+For servicing / `release/*` branches, be more conservative: only update to GA and already-supported distro versions unless the user explicitly asks for a forward-looking change.
 
 ## When NOT to use
 
@@ -221,6 +223,8 @@ done
 Release branches should be updated when:
 - The old version is EOL or approaching EOL
 - The release branch will be serviced for longer than the old version's remaining support
+
+On servicing branches, prefer GA and already-supported distro versions. Do not pre-stage not-yet-GA or merely upcoming versions there unless the user explicitly requests it.
 
 Note: Release branch updates should be done in separate PRs.
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -16,6 +16,7 @@ Update OS version references in Helix queue definition files. These files contro
 ## When to use
 
 - A new OS version is released and should be added to Helix testing
+- A new OS version is expected to ship within 3 months (one quarter) and a prereqs container image already exists — this is a good candidate for early onboarding to `main`
 - An OS version is approaching or has reached EOL and should be replaced
 - Periodic audit to ensure Helix coverage matches the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json); update the version segment to match your target)
 - Upgrading "oldest" or "latest" version slots for a distro

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,9 +15,11 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## When to use
 
-- On `main`, a new OS version is released (or is expected to ship within one quarter and a prereqs container image already exists) and should be added to Helix testing
 - An OS version is approaching or has reached EOL and should be replaced
-- Periodic audit to ensure Helix coverage matches the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json); update the version segment to match your target)
+- A new OS version is released and should be added to Helix testing for coverage
+- We take a more proactive approach on `main`. If a distro version will be EOL before our annual November release, we should update it to a newer version. If a distro version is expected to ship within one quarter (3 months) and a `prereqs` container image already exists, we should add it to Helix testing.
+- The availablility of an image in the `prereqs` container repo is a strong signal that the OS version is approved for Helix testing, at least on `main`.
+- Helix coverage does not match the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json).
 - Upgrading "oldest" or "latest" version slots for a distro
 
 For servicing / `release/*` branches, be more conservative: only update to GA and already-supported distro versions unless the user explicitly asks for a forward-looking change.
@@ -25,14 +27,12 @@ For servicing / `release/*` branches, be more conservative: only update to GA an
 ## When NOT to use
 
 - Creating new container images → file an issue or PR at [dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker)
-- Updating `supported-os.json` / `supported-os.md` → use the `update-supported-os` skill in [dotnet/core](https://github.com/dotnet/core)
+- Updating `supported-os.json` / `supported-os.md` → file an issue in [dotnet/core](https://github.com/dotnet/core)
 - Adding entirely new distros or architectures to Helix (requires pipeline template changes beyond version bumps)
 - Requesting new Helix VM queues → file an issue at [dotnet/dnceng](https://github.com/dotnet/dnceng)
 - Updating Windows or macOS Helix queues — these use VM-based queues with a simpler format (e.g. `Windows.11.Amd64.Client.Open`) and version updates typically require dnceng coordination
 
 ## Key files
-
-The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it first for context on policies and processes.
 
 OS version references appear in these pipeline files:
 
@@ -44,6 +44,8 @@ OS version references appear in these pipeline files:
 | `eng/pipelines/installer/helix-queues-setup.yml` | Installer Helix queue assignments |
 | `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
 | `docs/workflow/using-docker.md` | Documents the official build/test Docker images — update only when build image versions change (cross-compilation images, not Helix test images) |
+
+The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
 
 ### helix-platforms.yml structure
 
@@ -75,10 +77,7 @@ The user provides one or more of:
 - **Branch** — defaults to current branch; may also need release branch updates
 - **Audit mode** — "check all OS versions against supported-os.json"
 
-If the user provides only a distro name without specifying slots, determine the correct updates based on:
-- If adding a brand-new version: it typically becomes the new `latest`, and the previous `latest` becomes `oldest`
-- If replacing an EOL version: update `oldest` to the next supported version
-- If the distro currently has `latest == oldest`: only update `latest` to the new version
+If the user provides only a distro name without specifying slots, either ask or determine with basic logic which slots to update (for example, if the current `latest` is EOL, update `latest`; if the current `oldest` is EOL, update `oldest`).
 
 ## Process
 
@@ -99,15 +98,24 @@ If the image is **not found**, stop and inform the user. The image must be creat
 gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
 ```
 
-### 2. Check EOL dates
+### 2. Check support policy first, then EOL dates if needed
 
-Look up the distro's lifecycle to confirm the version change makes sense:
+First, inspect the relevant `supported-os.json` entry in `dotnet/core` to see whether the distro/version is already supported for the target release and to find its official lifecycle link:
+
+```bash
+curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<version>/supported-os.json \
+  | jq '.families[] | select(.name == "Linux") | .distributions[] | select(.id == "<distro-id>") | {name, lifecycle, supportedVersions: ."supported-versions", unsupportedVersions: ."unsupported-versions"}'
+```
+
+If the target version is already listed in `supportedVersions`, that is the primary signal that the change is appropriate for the corresponding release line. On servicing branches, prefer versions that are already GA and present there.
+
+If you need an independent lifecycle check, or if `supported-os.json` does not yet reflect the situation clearly, use [endoflife.date](https://endoflife.date) as a fallback:
 
 ```bash
 curl -s https://endoflife.date/api/<distro-id>.json | jq '.[] | select(.cycle == "<version>") | {cycle, eol, releaseDate}'
 ```
 
-The `<distro-id>` matches [endoflife.date](https://endoflife.date) product IDs (e.g. `fedora`, `alpine`, `debian`, `opensuse`, `ubuntu`, `centos-stream`).
+The `<distro-id>` values typically match across both sources (e.g. `fedora`, `alpine`, `debian`, `opensuse`, `ubuntu`, `centos-stream`).
 
 ### 3. Scan current references
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -226,7 +226,13 @@ Not all Helix queues run in the default PR pipeline (`runtime`). Some distros ar
 | CentOS Stream | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine (versioned) | linux_musl_x64, linux_musl_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
 
-After creating a PR, tell the user whether the changed queues require an extra-platforms run to get CI coverage. If so, include a `/azp run runtime-extra-platforms` comment on the PR (or instruct the user to post one).
+After creating a PR, check whether the changed queues require an extra-platforms run to get CI coverage. If so, post the trigger comment on the PR directly:
+
+```bash
+gh pr comment <pr-number> --body "/azp run runtime-extra-platforms"
+```
+
+Tell the user you've triggered the pipeline and why it was needed.
 
 ### 7. Check other branches
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -218,15 +218,19 @@ Not all Helix queues run in the default PR pipeline (`runtime`). Some distros ar
 | Fedora | linux_x64 | `libraries/helix-queues-setup.yml` |
 | openSUSE | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine edge | linux_musl_x64 | `libraries/helix-queues-setup.yml` |
+| Ubuntu | linux_arm64 | `libraries/helix-queues-setup.yml` |
+| Alpine (versioned) | linux_musl_arm64 | `libraries/helix-queues-setup.yml` |
 
 **Distros in the default PR pipeline** — no extra pipeline needed:
 
 | Distro | Platform | File |
 |--------|----------|------|
-| Ubuntu | linux_x64, linux_arm64 | `libraries/helix-queues-setup.yml` |
+| Ubuntu | linux_x64 | `libraries/helix-queues-setup.yml` |
 | AzureLinux | linux_x64, linux_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
 | CentOS Stream | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine (versioned) | linux_musl_x64, linux_musl_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
+
+> **Note:** Alpine versioned linux_musl_arm64 is behind `isExtraPlatformsBuild` in `libraries/helix-queues-setup.yml`, but runs unconditionally in `coreclr/templates/helix-queues-setup.yml`. It is listed here because coreclr provides default pipeline coverage.
 
 **Decision:** After creating a PR, cross-reference the distros you changed against the tables above. Only trigger `runtime-extra-platforms` if **at least one** changed distro is in the first table. If every changed distro is in the second table, the default `runtime` pipeline provides full coverage and no extra pipeline run is needed.
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -208,7 +208,7 @@ After editing, verify:
 
 Not all Helix queues run in the default PR pipeline (`runtime`). Some distros are only exercised by the **extra-platforms** pipeline (`runtime-extra-platforms`), which runs on a daily schedule and can be triggered on PRs with `/azp run runtime-extra-platforms`.
 
-**Distros behind the `isExtraPlatformsBuild` guard** (extra-platforms pipeline required):
+**Distros behind the `isExtraPlatformsBuild` guard** — need `runtime-extra-platforms`:
 
 | Distro | Platform | File |
 |--------|----------|------|
@@ -217,7 +217,7 @@ Not all Helix queues run in the default PR pipeline (`runtime`). Some distros ar
 | openSUSE | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine edge | linux_musl_x64 | `libraries/helix-queues-setup.yml` |
 
-**Distros in the default PR pipeline** (always exercised):
+**Distros in the default PR pipeline** — no extra pipeline needed:
 
 | Distro | Platform | File |
 |--------|----------|------|
@@ -226,13 +226,15 @@ Not all Helix queues run in the default PR pipeline (`runtime`). Some distros ar
 | CentOS Stream | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine (versioned) | linux_musl_x64, linux_musl_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
 
-After creating a PR, check whether the changed queues require an extra-platforms run to get CI coverage. If so, post the trigger comment on the PR directly:
+**Decision:** After creating a PR, cross-reference the distros you changed against the tables above. Only trigger `runtime-extra-platforms` if **at least one** changed distro is in the first table. If every changed distro is in the second table, the default `runtime` pipeline provides full coverage and no extra pipeline run is needed.
+
+When extra-platforms is needed, post the trigger comment on the PR:
 
 ```bash
 gh pr comment <pr-number> --body "/azp run runtime-extra-platforms"
 ```
 
-Tell the user you've triggered the pipeline and why it was needed.
+Tell the user you've triggered the pipeline and which distros required it.
 
 ### 7. Check other branches
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -173,16 +173,18 @@ After editing, verify:
 
 Not all Helix queues run in the default PR pipeline (`runtime`). Some distros are only exercised by the **extra-platforms** pipeline (`runtime-extra-platforms`), which runs on a daily schedule and can be triggered on PRs with `/azp run runtime-extra-platforms`.
 
-**Distros behind the `isExtraPlatformsBuild` guard** — need `runtime-extra-platforms`:
+**Distros behind the `isExtraPlatformsBuild` guard** — generally need `runtime-extra-platforms` for coverage that is not already exercised by the default `runtime` pipeline:
 
 | Distro | Platform | File |
 |--------|----------|------|
-| Debian | linux_x64, linux_arm | `libraries/helix-queues-setup.yml` |
+| Debian* | linux_x64, linux_arm | `libraries/helix-queues-setup.yml` |
 | Fedora | linux_x64 | `libraries/helix-queues-setup.yml` |
 | openSUSE | linux_x64 | `libraries/helix-queues-setup.yml` |
 | Alpine edge | linux_musl_x64 | `libraries/helix-queues-setup.yml` |
 | Ubuntu | linux_arm64 | `libraries/helix-queues-setup.yml` |
 | Alpine (versioned) | linux_musl_arm64 | `libraries/helix-queues-setup.yml` |
+
+> **Note:** Debian `linux_x64` is also exercised in the default `runtime` pipeline for some libraries scenarios (for example, when `interpreter: true` or `isSingleFile: true`). Use `runtime-extra-platforms` when you need Debian coverage outside those default-pipeline cases; Debian `linux_arm` remains extra-platforms-only here.
 
 **Distros in the default PR pipeline** — no extra pipeline needed:
 
@@ -195,7 +197,7 @@ Not all Helix queues run in the default PR pipeline (`runtime`). Some distros ar
 
 > **Note:** Alpine versioned linux_musl_arm64 is behind `isExtraPlatformsBuild` in `libraries/helix-queues-setup.yml`, but runs unconditionally in `coreclr/templates/helix-queues-setup.yml`. It is listed here because coreclr provides default pipeline coverage.
 
-**Decision:** After creating a PR, cross-reference the distros you changed against the tables above. Only trigger `runtime-extra-platforms` if **at least one** changed distro is in the first table. If every changed distro is in the second table, the default `runtime` pipeline provides full coverage and no extra pipeline run is needed.
+**Decision:** After creating a PR, cross-reference the distro/platform combinations you changed against the tables above. Trigger `runtime-extra-platforms` when you changed coverage that is only, or primarily, exercised by the first table. If every changed distro/platform is already covered by the default `runtime` pipeline, no extra pipeline run is needed.
 
 When extra-platforms is needed, post the trigger comment on the PR:
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,8 +15,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## When to use
 
-- A new OS version is released and should be added to Helix testing
-- A new OS version is expected to ship within 3 months (one quarter) and a prereqs container image already exists — this is a good candidate for early onboarding to `main`
+- A new OS version is released (or expected to ship within one quarter and a prereqs container image already exists) and should be added to Helix testing
 - An OS version is approaching or has reached EOL and should be replaced
 - Periodic audit to ensure Helix coverage matches the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json); update the version segment to match your target)
 - Upgrading "oldest" or "latest" version slots for a distro
@@ -52,22 +51,10 @@ This file defines named variables following a consistent pattern:
 # <Distro> <arch>
 # Latest: <version>
 - name: helix_linux_x64_<distro>_latest
-  value: (<QueueName>)<HostQueue>@<container-image>
-
-# Oldest: <version>
-- name: helix_linux_x64_<distro>_oldest
-  value: (<QueueName>)<HostQueue>@<container-image>
+  value: (<QueueName>)<HostQueue>@mcr.microsoft.com/dotnet-buildtools/prereqs:<image-tag>
 ```
 
-The value format for container-based queues is:
-```
-(<QueueName>)<HostQueue>@mcr.microsoft.com/dotnet-buildtools/prereqs:<image-tag>
-```
-
-Where:
-- `<QueueName>` — Helix queue identifier, e.g. `Fedora.44.Amd64.Open`
-- `<HostQueue>` — physical host queue, e.g. `AzureLinux.3.Amd64.Open`
-- `<image-tag>` — container image tag, e.g. `fedora-44-helix-amd64`
+Where `<QueueName>` is the Helix queue identifier (e.g. `Fedora.44.Amd64.Open`), `<HostQueue>` is the physical host queue (e.g. `AzureLinux.3.Amd64.Open`), and `<image-tag>` is the container image tag (e.g. `fedora-44-helix-amd64`).
 
 Some platform variables have `_internal` counterparts (e.g. `helix_linux_x64_oldest_internal`, `helix_linux_musl_arm32_latest_internal`) that use the same queue/image but drop the `.Open` suffix. When an `_internal` counterpart exists, update both the `.Open` and `_internal` entries.
 
@@ -102,28 +89,10 @@ curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docke
   | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("<distro>-<version>"))) | sort | .[]'
 ```
 
-Examples:
-```bash
-# Check for Fedora 44 images
-curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
-  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("fedora-44"))) | sort | .[]'
-
-# Check for Ubuntu 26.04 images
-curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
-  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("ubuntu-26.04"))) | sort | .[]'
-```
-
-If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an issue or PR already exists:
+If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an open issue or PR already exists:
 
 ```bash
 gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
-```
-
-If `gh` is not authenticated, use the GitHub API directly:
-
-```bash
-curl -s "https://api.github.com/search/issues?q=repo:dotnet/dotnet-buildtools-prereqs-docker+state:open+<distro>+<version>" \
-  | jq '.items[] | {title, html_url}'
 ```
 
 ### 2. Check EOL dates
@@ -164,7 +133,6 @@ For each reference found in step 3:
 2. **Update `helix-queues-setup.yml` files** — libraries, coreclr, and installer templates
    - Search for inline references to the old version and update them
    - These are direct queue strings, not variable references
-   - Not all distros appear in all files — only update references that exist
 
 3. **Version naming conventions** — follow existing patterns exactly:
 
@@ -190,17 +158,7 @@ For each reference found in step 3:
 
 After editing, verify:
 
-1. **No stale references remain:**
-   ```bash
-   grep -rn -i "<old-version-pattern>" \
-     eng/pipelines/helix-platforms.yml \
-     eng/pipelines/libraries/helix-queues-setup.yml \
-     eng/pipelines/coreclr/templates/helix-queues-setup.yml \
-     eng/pipelines/installer/helix-queues-setup.yml \
-     eng/pipelines/common/templates/pipeline-with-resources.yml \
-     docs/workflow/using-docker.md
-   ```
-   Stale references to the old version are acceptable only if intentionally kept (e.g. the version is still used for `oldest`).
+1. **No stale references remain** — re-run the grep from step 3, replacing the distro name with the old version pattern. Stale references are acceptable only if intentionally kept (e.g. the version is still used for `oldest`).
 
 2. **All new references are syntactically consistent** — compare with adjacent entries in the same file to verify formatting.
 
@@ -269,18 +227,7 @@ Check if the relevant `supported-os.json` in dotnet/core needs corresponding upd
 
 ### 9. Create PR
 
-1. Create a branch:
-   ```bash
-   git checkout -b update-helix-<distro>-<version>
-   ```
-
-2. Commit changes:
-   ```bash
-   git add eng/pipelines/
-   git commit -m "Update <distro> Helix queues to <version>"
-   ```
-
-3. The PR description should include:
+The PR description should include:
    - Table of changes (old version → new version, which slots)
    - EOL dates for old and new versions
    - Confirmation that container images are available

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -17,7 +17,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 - A new OS version is released and should be added to Helix testing
 - An OS version is approaching or has reached EOL and should be replaced
-- Periodic audit to ensure Helix coverage matches the supported-os matrix (e.g. [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json) — adjust the version to match your target)
+- Periodic audit to ensure Helix coverage matches the supported-os matrix (for example, [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json); update the version segment to match your target)
 - Upgrading "oldest" or "latest" version slots for a distro
 
 ## When NOT to use

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: update-os-coverage
+description: >
+  Update OS version references in Helix queue definitions to add new versions,
+  replace EOL versions, or audit coverage against the supported-os matrix.
+  USE FOR: adding new OS versions to Helix queues, replacing EOL OS versions,
+  upgrading "oldest" or "latest" version references, auditing Helix coverage.
+  DO NOT USE FOR: creating new container images (that's dotnet-buildtools-prereqs-docker),
+  updating supported-os.json (that's the update-supported-os skill in dotnet/core).
+---
+
+# Update OS Coverage
+
+Update OS version references in Helix queue definition files. These files control which operating system versions are used for CI/CD testing via Helix.
+
+## When to use
+
+- A new OS version is released and should be added to Helix testing
+- An OS version is approaching or has reached EOL and should be replaced
+- Periodic audit to ensure Helix coverage matches the [supported-os matrix](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json)
+- Upgrading "oldest" or "latest" version slots for a distro
+
+## When NOT to use
+
+- Creating new container images → file an issue or PR at [dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker)
+- Updating `supported-os.json` / `supported-os.md` → use the `update-supported-os` skill in [dotnet/core](https://github.com/dotnet/core)
+- Adding entirely new distros or architectures to Helix (requires pipeline template changes beyond version bumps)
+- Requesting new Helix VM queues → file an issue at [dotnet/dnceng](https://github.com/dotnet/dnceng)
+
+## Key files
+
+The [OS onboarding guide](docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it first for context on policies and processes.
+
+OS version references appear in these pipeline files:
+
+| File | Purpose |
+|------|---------|
+| `eng/pipelines/helix-platforms.yml` | **Primary target.** Central platform definitions — defines `latest` and `oldest` version variables for all OS/arch combinations |
+| `eng/pipelines/libraries/helix-queues-setup.yml` | Libraries Helix queue assignments — inline OS version references per platform |
+| `eng/pipelines/coreclr/templates/helix-queues-setup.yml` | CoreCLR Helix queue assignments — inline OS version references |
+| `eng/pipelines/installer/helix-queues-setup.yml` | Installer Helix queue assignments |
+| `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
+| `docs/workflow/using-docker.md` | Documents the official build/test Docker images — should stay in sync with `pipeline-with-resources.yml` |
+
+### helix-platforms.yml structure
+
+This file defines named variables following a consistent pattern:
+
+```yaml
+# <Distro> <arch>
+# Latest: <version>
+- name: helix_linux_x64_<distro>_latest
+  value: (<QueueName>)<HostQueue>@<container-image>
+
+# Oldest: <version>
+- name: helix_linux_x64_<distro>_oldest
+  value: (<QueueName>)<HostQueue>@<container-image>
+```
+
+The value format for container-based queues is:
+```
+(<QueueName>)<HostQueue>@mcr.microsoft.com/dotnet-buildtools/prereqs:<image-tag>
+```
+
+Where:
+- `<QueueName>` — Helix queue identifier, e.g. `Fedora.44.Amd64.Open`
+- `<HostQueue>` — physical host queue, e.g. `AzureLinux.3.Amd64.Open`
+- `<image-tag>` — container image tag, e.g. `fedora-44-helix-amd64`
+
+### helix-queues-setup.yml files
+
+These files reference OS versions directly (not via variables) in conditional blocks per platform. Each inline reference follows the same `(<QueueName>)<HostQueue>@<image>` format.
+
+## Inputs
+
+The user provides one or more of:
+
+- **Distro and version** — e.g. "Update Fedora to 44", "Replace Alpine 3.20 with 3.22"
+- **Slot** — whether to update `latest`, `oldest`, or both
+- **Branch** — defaults to current branch; may also need release branch updates
+- **Audit mode** — "check all OS versions against supported-os.json"
+
+If the user provides only a distro name without specifying slots, determine the correct updates based on:
+- If adding a brand-new version: it typically becomes the new `latest`, and the previous `latest` becomes `oldest`
+- If replacing an EOL version: update `oldest` to the next supported version
+- If the distro currently has `latest == oldest`: only update `latest` to the new version
+
+## Process
+
+### 1. Verify container image availability
+
+Before making any changes, confirm the target container image exists. Check the [image-info JSON](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json) for published images:
+
+```bash
+curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
+  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("<distro>-<version>"))) | sort | .[]'
+```
+
+Examples:
+```bash
+# Check for Fedora 44 images
+curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
+  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("fedora-44"))) | sort | .[]'
+
+# Check for Ubuntu 26.04 images
+curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
+  | jq '[.repos[].images[].platforms[].simpleTags[]] | map(select(startswith("ubuntu-26.04"))) | sort | .[]'
+```
+
+If the image is **not found**, stop and inform the user. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an issue or PR already exists:
+
+```bash
+gh search issues "<distro> <version>" --repo dotnet/dotnet-buildtools-prereqs-docker --state open
+```
+
+### 2. Check EOL dates
+
+Look up the distro's lifecycle to confirm the version change makes sense:
+
+```bash
+curl -s https://endoflife.date/api/<distro-id>.json | jq '.[] | select(.cycle == "<version>") | {cycle, eol, releaseDate}'
+```
+
+The `<distro-id>` matches [endoflife.date](https://endoflife.date) product IDs (e.g. `fedora`, `alpine`, `debian`, `opensuse`, `ubuntu`, `centos-stream`).
+
+### 3. Scan current references
+
+Search for all current references to the distro being updated:
+
+```bash
+grep -rn -i "<distro>" \
+  eng/pipelines/helix-platforms.yml \
+  eng/pipelines/libraries/helix-queues-setup.yml \
+  eng/pipelines/coreclr/templates/helix-queues-setup.yml \
+  eng/pipelines/installer/helix-queues-setup.yml \
+  eng/pipelines/common/templates/pipeline-with-resources.yml
+```
+
+Note every occurrence — the same distro may appear in multiple sections (x64, arm32, arm64) and in multiple files.
+
+### 4. Apply changes
+
+For each reference found in step 3:
+
+1. **Update `helix-platforms.yml`** — this is the primary file
+   - Update the version comment (e.g. `# Latest: 43` → `# Latest: 44`)
+   - Update the variable value — all three parts: queue name, and image tag
+   - Preserve the existing host queue (e.g. `AzureLinux.3.Amd64.Open`) — this does not change with distro version updates
+
+2. **Update `helix-queues-setup.yml` files** — libraries, coreclr, and installer templates
+   - Search for inline references to the old version and update them
+   - These are direct queue strings, not variable references
+   - Not all distros appear in all files — only update references that exist
+
+3. **Version naming conventions** — follow existing patterns exactly:
+
+   | Distro | Queue name pattern | Image tag pattern |
+   |--------|--------------------|-------------------|
+   | Alpine | `Alpine.<ver-no-dots>.Amd64.Open` | `alpine-<ver>-helix-amd64` |
+   | CentOS Stream | `Centos.<ver>.Amd64.Open` | `centos-stream-<ver>-helix-amd64` |
+   | Debian | `Debian.<ver>.Amd64.Open` | `debian-<ver>-helix-amd64` |
+   | Fedora | `Fedora.<ver>.Amd64.Open` | `fedora-<ver>-helix-amd64` |
+   | openSUSE | `openSUSE.<ver>.Amd64.Open` | `opensuse-<ver>-helix-amd64` |
+   | Ubuntu | `Ubuntu.<ver-no-dots>.Amd64.Open` | `ubuntu-<ver>-helix-amd64` |
+
+   Architecture suffixes vary: `Amd64`, `Arm64`, `Arm32` for queue names; `amd64`, `arm64v8`, `arm32v7` for image tags.
+
+   For ARM-based queues, the host queue is typically `Ubuntu.2204.ArmArch.Open` (not AzureLinux).
+
+### 5. Validate changes
+
+After editing, verify:
+
+1. **No stale references remain:**
+   ```bash
+   grep -rn "<old-version-pattern>" \
+     eng/pipelines/helix-platforms.yml \
+     eng/pipelines/libraries/helix-queues-setup.yml \
+     eng/pipelines/coreclr/templates/helix-queues-setup.yml \
+     eng/pipelines/installer/helix-queues-setup.yml \
+     eng/pipelines/common/templates/pipeline-with-resources.yml
+   ```
+   Stale references to the old version are acceptable only if intentionally kept (e.g. the version is still used for `oldest`).
+
+2. **All new references are syntactically consistent** — compare with adjacent entries in the same file to verify formatting.
+
+3. **Variable names are unchanged** — only the `value` fields change, never the `name` fields.
+
+### 6. Check other branches
+
+After updating `main`, check whether release branches also need updates:
+
+```bash
+for branch in $(git branch -r | grep -E 'origin/release/' | head -10); do
+  echo "=== $branch ==="
+  git show "$branch:eng/pipelines/helix-platforms.yml" 2>/dev/null | grep -n -i "<distro>" || echo "(no matches or file not found)"
+done
+```
+
+Release branches should be updated when:
+- The old version is EOL or approaching EOL
+- The release branch will be serviced for longer than the old version's remaining support
+
+Note: Release branch updates should be done in separate PRs.
+
+### 7. Cross-reference with supported-os
+
+Check if the [supported-os.json](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json) in dotnet/core needs corresponding updates. If a new version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
+
+### 8. Create PR
+
+1. Create a branch:
+   ```bash
+   git checkout -b update-helix-<distro>-<version>
+   ```
+
+2. Commit changes:
+   ```bash
+   git add eng/pipelines/
+   git commit -m "Update <distro> Helix queues to <version>"
+   ```
+
+3. The PR description should include:
+   - Table of changes (old version → new version, which slots)
+   - EOL dates for old and new versions
+   - Confirmation that container images are available
+   - Link to the [os-onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
+   - Link to tracking issue if applicable (e.g. [dotnet/core#9638](https://github.com/dotnet/core/issues/9638))
+
+## Audit mode
+
+When asked to audit all OS coverage:
+
+1. Fetch the current supported-os.json for the target .NET version:
+   ```bash
+   curl -sL https://github.com/dotnet/core/raw/refs/heads/main/release-notes/<version>/supported-os.json
+   ```
+
+2. For each Linux distro in supported-os, check:
+   - The `latest` version in `helix-platforms.yml` should be the newest supported version
+   - The `oldest` version should be the oldest still-supported version
+   - No EOL versions should remain
+
+3. Check EOL dates for all referenced versions:
+   ```bash
+   curl -s https://endoflife.date/api/<distro-id>.json | jq '[.[] | select(.eol != false) | select(.eol < "YYYY-MM-DD")] | .[].cycle'
+   ```
+
+4. Report findings as a table:
+
+   | Distro | Slot | Current | Recommended | Reason |
+   |--------|------|---------|-------------|--------|
+   | Fedora | latest | 43 | 44 | 44 now GA |
+   | Fedora | oldest | 42 | 43 | 42 EOL 2026-05-13 |
+
+## Reference
+
+- [OS onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
+- [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
+- [Prereq container image lifecycle](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/lifecycle.md)
+- [Container image registry (image-info)](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)
+- [endoflife.date](https://endoflife.date/) for OS lifecycle data
+- [PR #125991](https://github.com/dotnet/runtime/pull/125991) — example EOL OS version replacement
+- [PR #111768](https://github.com/dotnet/runtime/pull/111768) — example new OS version onboarding

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -26,6 +26,7 @@ Update OS version references in Helix queue definition files. These files contro
 - Updating `supported-os.json` / `supported-os.md` → use the `update-supported-os` skill in [dotnet/core](https://github.com/dotnet/core)
 - Adding entirely new distros or architectures to Helix (requires pipeline template changes beyond version bumps)
 - Requesting new Helix VM queues → file an issue at [dotnet/dnceng](https://github.com/dotnet/dnceng)
+- Updating Windows or macOS Helix queues — these use VM-based queues with a simpler format (e.g. `Windows.11.Amd64.Client.Open`) and version updates typically require dnceng coordination
 
 ## Key files
 
@@ -262,7 +263,7 @@ When asked to audit all OS coverage:
 
 ## Reference
 
-- [OS onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
+- [OS onboarding guide](/docs/project/os-onboarding.md)
 - [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
 - [Prereq container image lifecycle](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/lifecycle.md)
 - [Container image registry (image-info)](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -17,7 +17,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 - A new OS version is released and should be added to Helix testing
 - An OS version is approaching or has reached EOL and should be replaced
-- Periodic audit to ensure Helix coverage matches the [supported-os matrix](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json)
+- Periodic audit to ensure Helix coverage matches the supported-os matrix (e.g. [`release-notes/11.0/supported-os.json`](https://github.com/dotnet/core/blob/main/release-notes/11.0/supported-os.json) — adjust the version to match your target)
 - Upgrading "oldest" or "latest" version slots for a distro
 
 ## When NOT to use
@@ -29,7 +29,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## Key files
 
-The [OS onboarding guide](docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it first for context on policies and processes.
+The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it first for context on policies and processes.
 
 OS version references appear in these pipeline files:
 
@@ -133,7 +133,8 @@ grep -rn -i "<distro>" \
   eng/pipelines/libraries/helix-queues-setup.yml \
   eng/pipelines/coreclr/templates/helix-queues-setup.yml \
   eng/pipelines/installer/helix-queues-setup.yml \
-  eng/pipelines/common/templates/pipeline-with-resources.yml
+  eng/pipelines/common/templates/pipeline-with-resources.yml \
+  docs/workflow/using-docker.md
 ```
 
 Note every occurrence — the same distro may appear in multiple sections (x64, arm32, arm64) and in multiple files.
@@ -144,7 +145,7 @@ For each reference found in step 3:
 
 1. **Update `helix-platforms.yml`** — this is the primary file
    - Update the version comment (e.g. `# Latest: 43` → `# Latest: 44`)
-   - Update the variable value — all three parts: queue name, and image tag
+   - Update the variable value — adjust the queue name and image tag to use the new version
    - Preserve the existing host queue (e.g. `AzureLinux.3.Amd64.Open`) — this does not change with distro version updates
 
 2. **Update `helix-queues-setup.yml` files** — libraries, coreclr, and installer templates
@@ -178,7 +179,8 @@ After editing, verify:
      eng/pipelines/libraries/helix-queues-setup.yml \
      eng/pipelines/coreclr/templates/helix-queues-setup.yml \
      eng/pipelines/installer/helix-queues-setup.yml \
-     eng/pipelines/common/templates/pipeline-with-resources.yml
+     eng/pipelines/common/templates/pipeline-with-resources.yml \
+     docs/workflow/using-docker.md
    ```
    Stale references to the old version are acceptable only if intentionally kept (e.g. the version is still used for `oldest`).
 

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -204,7 +204,31 @@ After editing, verify:
 
 3. **Variable names are unchanged** — only the `value` fields change, never the `name` fields.
 
-### 6. Check other branches
+### 6. CI pipeline coverage
+
+Not all Helix queues run in the default PR pipeline (`runtime`). Some distros are only exercised by the **extra-platforms** pipeline (`runtime-extra-platforms`), which runs on a daily schedule and can be triggered on PRs with `/azp run runtime-extra-platforms`.
+
+**Distros behind the `isExtraPlatformsBuild` guard** (extra-platforms pipeline required):
+
+| Distro | Platform | File |
+|--------|----------|------|
+| Debian | linux_x64, linux_arm | `libraries/helix-queues-setup.yml` |
+| Fedora | linux_x64 | `libraries/helix-queues-setup.yml` |
+| openSUSE | linux_x64 | `libraries/helix-queues-setup.yml` |
+| Alpine edge | linux_musl_x64 | `libraries/helix-queues-setup.yml` |
+
+**Distros in the default PR pipeline** (always exercised):
+
+| Distro | Platform | File |
+|--------|----------|------|
+| Ubuntu | linux_x64, linux_arm64 | `libraries/helix-queues-setup.yml` |
+| AzureLinux | linux_x64, linux_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
+| CentOS Stream | linux_x64 | `libraries/helix-queues-setup.yml` |
+| Alpine (versioned) | linux_musl_x64, linux_musl_arm64 | `libraries/helix-queues-setup.yml`, `coreclr/templates/helix-queues-setup.yml` |
+
+After creating a PR, tell the user whether the changed queues require an extra-platforms run to get CI coverage. If so, include a `/azp run runtime-extra-platforms` comment on the PR (or instruct the user to post one).
+
+### 7. Check other branches
 
 After updating `main`, check whether release branches also need updates:
 
@@ -223,11 +247,11 @@ Release branches should be updated when:
 
 Note: Release branch updates should be done in separate PRs.
 
-### 7. Cross-reference with supported-os
+### 8. Cross-reference with supported-os
 
 Check if the relevant `supported-os.json` in dotnet/core needs corresponding updates. The file lives under the pattern `release-notes/<version>/supported-os.json` (for example, `release-notes/8.0/supported-os.json`) in the [release-notes directory](https://github.com/dotnet/core/tree/main/release-notes). If a new version is being added to Helix but isn't yet in supported-os, inform the user to run the `update-supported-os` skill in dotnet/core.
 
-### 8. Create PR
+### 9. Create PR
 
 1. Create a branch:
    ```bash
@@ -244,6 +268,7 @@ Check if the relevant `supported-os.json` in dotnet/core needs corresponding upd
    - Table of changes (old version → new version, which slots)
    - EOL dates for old and new versions
    - Confirmation that container images are available
+   - Which CI pipeline(s) need to run (see [step 6](#6-ci-pipeline-coverage))
    - Link to the [os-onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
    - Link to tracking issue if applicable (e.g. [dotnet/core#9638](https://github.com/dotnet/core/issues/9638))
 


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with assistance from GitHub Copilot CLI.

Add a new Copilot skill (`update-os-coverage`) that automates updating OS version references in Helix queue definition files.

## What it does

The skill guides through the full process of updating OS versions in Helix pipelines:

1. Verify container image availability at dotnet-buildtools-prereqs-docker
2. Check EOL dates via endoflife.date
3. Scan all pipeline files for current references
4. Apply version updates (queue names, image tags, comments)
5. Validate no stale references remain
6. Check release branches for needed updates
7. Cross-reference with supported-os.json in dotnet/core

## Key files it operates on

- `eng/pipelines/helix-platforms.yml` (primary)
- `eng/pipelines/libraries/helix-queues-setup.yml`
- `eng/pipelines/coreclr/templates/helix-queues-setup.yml`
- `eng/pipelines/installer/helix-queues-setup.yml`
- `eng/pipelines/common/templates/pipeline-with-resources.yml`
- `docs/workflow/using-docker.md`

References the [OS onboarding guide](docs/project/os-onboarding.md) as the authoritative source for policies and processes.

Tested by running the skill against a Fedora 43→44 update — it correctly updated the 2 files with Fedora references, verified image availability, and validated results.