### PR TITLE
Fix wrong gc join in BGC mark phase

### DIFF
--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -2102,8 +2102,6 @@ void gc_heap::background_mark_phase ()
 
 #ifdef FEATURE_JAVAMARSHAL
 
-    // FIXME Any reason this code should be different for BGC ? Otherwise extract it to some common method ?
-
 #ifdef MULTIPLE_HEAPS
     dprintf(3, ("Joining for short weak handle scan"));
     bgc_t_join.join(this, gc_join_bridge_processing);

--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -2106,15 +2106,15 @@ void gc_heap::background_mark_phase ()
 
 #ifdef MULTIPLE_HEAPS
     dprintf(3, ("Joining for short weak handle scan"));
-    gc_t_join.join(this, gc_join_bridge_processing);
-    if (gc_t_join.joined())
+    bgc_t_join.join(this, gc_join_bridge_processing);
+    if (bgc_t_join.joined())
     {
 #endif //MULTIPLE_HEAPS
         global_bridge_list = GCScan::GcProcessBridgeObjects (max_generation, max_generation, &sc, &num_global_bridge_objs);
 
 #ifdef MULTIPLE_HEAPS
         dprintf (3, ("Starting all gc thread after bridge processing"));
-        gc_t_join.restart();
+        bgc_t_join.restart();
     }
 #endif //MULTIPLE_HEAPS
 


### PR DESCRIPTION
There was a wrong join struct instance being used in the `background_mark_phase`. Instead of `bgc_t_join`, it was using `gc_t_join` that is meant for regular mark phase usage. It caused hangs during GC in some edge cases, for example for GCPerfSim invocation with the following command line:
GCPerfSim.dll -tc 4 -tagb 540 -tlgb 0 -lohar 1000 -pohar 0 -sohsr 100-4000 -lohsr 102400-204800 -pohsr 100-204800 -sohsi 0 -lohsi 0 -pohsi 0 -sohpi 0 -lohpi 0 -sohfi 0 -lohfi 0 -pohfi 0 -allocType reference -testKind time

The issue was introduced by the change that added the JAVA GC bridge.

Close #122996