### PR TITLE
[Wasm RyuJIT] Fix for assert in obscure block store scenario

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2918,7 +2918,14 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
     {
         nullCheckSrc = (src->gtFlags & GTF_IND_NONFAULTING) == 0;
         src          = src->gtGetOp1();
-        srcReg       = GetMultiUseOperandReg(src);
+        if (isNativeOp && !nullCheckSrc)
+        {
+            ;
+        }
+        else
+        {
+            srcReg = GetMultiUseOperandReg(src);
+        }
         assert(!src->isContained());
     }
     else if (src->OperIs(GT_CNS_INT, GT_INIT_VAL))
@@ -2948,6 +2955,10 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
         destReg    = GetFramePointerReg();
         destOffset = m_compiler->lvaFrameAddress(lclVar->GetLclNum(), &fpBased) + lclVar->GetLclOffs();
         assert(fpBased);
+    }
+    else if (isNativeOp && !nullCheckDest)
+    {
+        ;
     }
     else if (isCopyBlk || nullCheckDest)
     {
@@ -2979,6 +2990,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
         if (src->isContained())
         {
             assert(isCopyBlk);
+            assert(srcReg != REG_NA);
             emit->emitIns_I(INS_local_get, EA_PTRSIZE, WasmRegToIndex(srcReg));
             if (srcOffset != 0)
             {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2918,11 +2918,8 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
     {
         nullCheckSrc = (src->gtFlags & GTF_IND_NONFAULTING) == 0;
         src          = src->gtGetOp1();
-        if (isNativeOp && !nullCheckSrc)
-        {
-            ;
-        }
-        else
+        // We need to match lowering and only fetch a register for src when we're expected to.
+        if (!isNativeOp || nullCheckSrc)
         {
             srcReg = GetMultiUseOperandReg(src);
         }
@@ -2958,7 +2955,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
     }
     else if (isNativeOp && !nullCheckDest)
     {
-        ;
+        // We need to match lowering in this specific case by not fetching a register for dest.
     }
     else if (isCopyBlk || nullCheckDest)
     {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2901,7 +2901,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
     assert(isNativeOp || blkOp->GetLayout()->HasGCPtr());
 #endif // DEBUG
 
-    bool      nullCheckDest = ((blkOp->gtFlags & GTF_IND_NONFAULTING) == 0) && !dstOnStack;
+    bool      nullCheckDest = (blkOp->gtFlags & GTF_IND_NONFAULTING) == 0;
     bool      nullCheckSrc  = false;
     GenTree*  dest          = blkOp->Addr();
     GenTree*  src           = blkOp->Data();

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -225,18 +225,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
     GenTree* dstAddr = blkNode->Addr();
     GenTree* src     = blkNode->Data();
 
-    // TODO-WASM-CQ: Identify the specific cases where we can skip doing this and still generate valid code
-    // in codegen, i.e. non-faulting destination combined with native opcode. Right now this adds some code
-    // bloat due to creating a temporary for a destination that may only get used once.
-    // We know trivially that we won't nullcheck a destination that is a local variable's address, so we can
-    // skip generating the temporary for that case. If we don't do this, we get an error during regalloc caused
-    // by RewriteLocalStackStore creating and lowering a block store too 'late' to mark the dstAddr as multiply
-    // used successfully.
-    if (!dstAddr->OperIs(GT_LCL_ADDR))
-    {
-        SetMultiplyUsed(dstAddr DEBUGARG("LowerBlockStore destination address"));
-    }
-
     if (blkNode->OperIsInitBlkOp())
     {
         if (src->OperIs(GT_INIT_VAL))
@@ -299,9 +287,32 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         if (src->OperIs(GT_IND))
         {
             GenTree* srcAddr = src->gtGetOp1();
-            // TODO-WASM-CQ: Skip doing this if the indirection is nonfaulting and the src is only used once.
-            SetMultiplyUsed(srcAddr DEBUGARG("LowerBlockStore source address (indirection)"));
+            if (
+                (blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
+                ((src->gtFlags & GTF_IND_NONFAULTING) == 0)
+            )
+            {
+                SetMultiplyUsed(srcAddr DEBUGARG("LowerBlockStore source address (indirection)"));
+            }
         }
+    }
+
+    // TODO-WASM-CQ: Identify the specific cases where we can skip doing this and still generate valid code
+    // in codegen, i.e. non-faulting destination combined with native opcode. Right now this adds some code
+    // bloat due to creating a temporary for a destination that may only get used once.
+    // We know trivially that we won't nullcheck a destination that is a local variable's address, so we can
+    // skip generating the temporary for that case. If we don't do this, we get an error during regalloc caused
+    // by RewriteLocalStackStore creating and lowering a block store too 'late' to mark the dstAddr as multiply
+    // used successfully.
+    if (
+        !dstAddr->OperIs(GT_LCL_ADDR) &&
+        (
+            (blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
+            ((blkNode->gtFlags & GTF_IND_NONFAULTING) == 0)
+        )
+    )
+    {
+        SetMultiplyUsed(dstAddr DEBUGARG("LowerBlockStore destination address"));
     }
 }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -287,30 +287,26 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         if (src->OperIs(GT_IND))
         {
             GenTree* srcAddr = src->gtGetOp1();
-            if (
-                (blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
-                ((src->gtFlags & GTF_IND_NONFAULTING) == 0)
-            )
+            // Only set the source as multiply-used if it's faulting or we're not using a native opcode for the
+            // copy/fill operation. This avoids failures later in compilation in obscure cases.
+            if ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
+                ((src->gtFlags & GTF_IND_NONFAULTING) == 0))
             {
                 SetMultiplyUsed(srcAddr DEBUGARG("LowerBlockStore source address (indirection)"));
             }
         }
     }
 
-    // TODO-WASM-CQ: Identify the specific cases where we can skip doing this and still generate valid code
-    // in codegen, i.e. non-faulting destination combined with native opcode. Right now this adds some code
-    // bloat due to creating a temporary for a destination that may only get used once.
-    // We know trivially that we won't nullcheck a destination that is a local variable's address, so we can
-    // skip generating the temporary for that case. If we don't do this, we get an error during regalloc caused
-    // by RewriteLocalStackStore creating and lowering a block store too 'late' to mark the dstAddr as multiply
-    // used successfully.
     if (
+        // We know trivially that we won't nullcheck a destination that is a local variable's address, so we can
+        // skip generating the temporary for that case. If we don't do this, we get an error during regalloc caused
+        // by RewriteLocalStackStore creating and lowering a block store too 'late' to mark the dstAddr as multiply
+        // used successfully.
         !dstAddr->OperIs(GT_LCL_ADDR) &&
-        (
-            (blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
-            ((blkNode->gtFlags & GTF_IND_NONFAULTING) == 0)
-        )
-    )
+        // For native opcode copies/fills with a non-faulting destination, we can't reliably mark the address as
+        // multiply-used - it will cause failures later in compilation. So avoid those cases too.
+        ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
+         ((blkNode->gtFlags & GTF_IND_NONFAULTING) == 0)))
     {
         SetMultiplyUsed(dstAddr DEBUGARG("LowerBlockStore destination address"));
     }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -298,11 +298,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
     }
 
     if (
-        // We know trivially that we won't nullcheck a destination that is a local variable's address, so we can
-        // skip generating the temporary for that case. If we don't do this, we get an error during regalloc caused
-        // by RewriteLocalStackStore creating and lowering a block store too 'late' to mark the dstAddr as multiply
-        // used successfully.
-        !dstAddr->OperIs(GT_LCL_ADDR) &&
         // For native opcode copies/fills with a non-faulting destination, we can't reliably mark the address as
         // multiply-used - it will cause failures later in compilation. So avoid those cases too.
         ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -295,8 +295,7 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         }
     }
 
-    if (
-        ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
+    if (((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
          ((blkNode->gtFlags & GTF_IND_NONFAULTING) == 0)))
     {
         SetMultiplyUsed(dstAddr DEBUGARG("LowerBlockStore destination address"));

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -287,8 +287,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         if (src->OperIs(GT_IND))
         {
             GenTree* srcAddr = src->gtGetOp1();
-            // Only set the source as multiply-used if it's faulting or we're not using a native opcode for the
-            // copy/fill operation. This avoids failures later in compilation in obscure cases.
             if ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
                 ((src->gtFlags & GTF_IND_NONFAULTING) == 0))
             {
@@ -298,8 +296,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
     }
 
     if (
-        // For native opcode copies/fills with a non-faulting destination, we can't reliably mark the address as
-        // multiply-used - it will cause failures later in compilation. So avoid those cases too.
         ((blkNode->gtBlkOpKind != GenTreeBlk::BlkOpKindNativeOpcode) ||
          ((blkNode->gtFlags & GTF_IND_NONFAULTING) == 0)))
     {


### PR DESCRIPTION
This fixes the assert about temporary regs from ```System.ValueTuple`4[System.__Canon,System.__Canon,System.__Canon,System.__Canon]:System.IComparable.CompareTo(System.Object):int:this``` in #125756