### PR TITLE
Restore src/tests packages in one-shot

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -5,6 +5,7 @@
 
   <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.props" />
   <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.InTree.targets" />
+  <Import Project="restore.projects.props" />
 
   <PropertyGroup>
     <XunitTestBinBase Condition="'$(XunitTestBinBase)'==''" >$(BaseOutputPathWithConfig)</XunitTestBinBase>
@@ -21,27 +22,6 @@
     <DisabledTestDir Include="Common" />
     <DisabledTestDir Include="Tests" />
     <DisabledTestDir Include="TestWrappers" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RestoreProjects Include="Common\test_dependencies_fs\test_dependencies.fsproj" />
-    <RestoreProjects Include="Common\test_dependencies\test_dependencies.csproj" />
-    <RestoreProjects Include="Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
-    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_Arm.csproj" />
-    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_General.csproj" />
-    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_X86.csproj" />
-    <RestoreProjects Include="Common\XUnitLogChecker\XUnitLogChecker.csproj"
-                     Condition="$(IsXUnitLogCheckerSupported)">
-      <!-- XUnitLogChecker is published as AOT, so it needs the current RID. The RID may change during the build.
-           This flag will force restore to use the latest RuntimeIdentifier property. -->
-      <ForceRestore>true</ForceRestore>
-    </RestoreProjects>
-    <RestoreProjects Include="Common\XUnitWrapperGenerator\XUnitWrapperGenerator.csproj" />
-    <RestoreProjects Include="Common\XUnitWrapperLibrary\XUnitWrapperLibrary.csproj" />
-    <RestoreProjects Include="Common\XHarnessRunnerLibrary\XHarnessRunnerLibrary.csproj" />
-    <RestoreProjects Include="Common\external\external.csproj" />
-    <RestoreProjects Include="Common\ilasm\ilasm.ilproj" />
-    <RestoreProjects Include="tracing\userevents\common\userevents_common.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -191,22 +171,17 @@
   <Target Name="BatchRestorePackages">
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
 
-    <!-- restore all csproj's with PackageReferences in one pass -->
-    <MSBuild Projects="build.proj"
-             Properties="RestoreProj=%(RestoreProjects.Identity);_ForceRestore=%(RestoreProjects.ForceRestore)"
-             Targets="RestorePackage" />
+    <PropertyGroup>
+      <_RestoreProperties>MSBuildRestoreSessionId=$([System.Guid]::NewGuid());TargetOS=$(TargetOS);TargetArchitecture=$(TargetArchitecture);Configuration=$(Configuration);CrossBuild=$(CrossBuild);SetTFMForRestore=true;RuntimeIdentifier=$(RuntimeIdentifier)</_RestoreProperties>
+      <_RestoreProperties Condition="'$(UseLocalAppHostPack)' == 'true' or '$(TargetOS)' == 'browser'">$(_RestoreProperties);EnableAppHostPackDownload=false;EnableTargetingPackDownload=false;EnableRuntimePackDownload=false</_RestoreProperties>
+    </PropertyGroup>
+
+    <!-- Use a dedicated traversal project to restore all test dependencies in one graph invocation. -->
+    <MSBuild Projects="restore.proj"
+             Targets="Restore"
+             Properties="$(_RestoreProperties)" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages...Done." />
-  </Target>
-
-  <Target Name="RestorePackage">
-    <PropertyGroup>
-      <_ConfigurationProperties>/p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:Configuration=$(Configuration) /p:CrossBuild=$(CrossBuild)</_ConfigurationProperties>
-      <_ConfigurationProperties Condition="'$(UseLocalAppHostPack)' == 'true' or '$(TargetOS)' == 'browser'">$(_ConfigurationProperties) -p:EnableAppHostPackDownload=false -p:EnableTargetingPackDownload=false -p:EnableRuntimePackDownload=false</_ConfigurationProperties>
-      <_ForceRestore Condition="'$(_ForceRestore)' == 'true'">-f</_ForceRestore>
-      <DotnetRestoreCommand>"$(DotNetTool)" restore $(_ForceRestore) -r $(RuntimeIdentifier) $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true /p:RuntimeIdentifier=$(RuntimeIdentifier) $(_ConfigurationProperties)</DotnetRestoreCommand>
-    </PropertyGroup>
-    <Exec Command="$(DotnetRestoreCommand)"/>
   </Target>
 
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->

--- a/src/tests/restore.proj
+++ b/src/tests/restore.proj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal">
+  <Import Project="restore.projects.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="@(RestoreProjects)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/restore.projects.props
+++ b/src/tests/restore.projects.props
@@ -1,0 +1,17 @@
+<Project>
+  <ItemGroup>
+    <RestoreProjects Include="Common\test_dependencies_fs\test_dependencies.fsproj" />
+    <RestoreProjects Include="Common\test_dependencies\test_dependencies.csproj" />
+    <RestoreProjects Include="Common\CoreCLRTestLibrary\CoreCLRTestLibrary.csproj" />
+    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_Arm.csproj" />
+    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_General.csproj" />
+    <RestoreProjects Include="Common\GenerateHWIntrinsicTests\GenerateHWIntrinsicTests_X86.csproj" />
+    <RestoreProjects Include="Common\XUnitLogChecker\XUnitLogChecker.csproj" Condition="$(IsXUnitLogCheckerSupported)" />
+    <RestoreProjects Include="Common\XUnitWrapperGenerator\XUnitWrapperGenerator.csproj" />
+    <RestoreProjects Include="Common\XUnitWrapperLibrary\XUnitWrapperLibrary.csproj" />
+    <RestoreProjects Include="Common\XHarnessRunnerLibrary\XHarnessRunnerLibrary.csproj" />
+    <RestoreProjects Include="Common\external\external.csproj" />
+    <RestoreProjects Include="Common\ilasm\ilasm.ilproj" />
+    <RestoreProjects Include="tracing\userevents\common\userevents_common.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
On rebuild of `src/tests/build.cmd`, before:

```
    [10:26:11.23] Restoring all packages...

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    Restored C:\temp\runtime\src\tests\Common\XUnitLogChecker\XUnitLogChecker.csproj (in 171 ms).

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.

    Determining projects to restore...
    All projects are up-to-date for restore.
  [10:29:49.75] Restoring all packages...Done.
```

and after:

```
  [14:38:42.29] Restoring all packages...
  Determining projects to restore...
  All projects are up-to-date for restore.
  [14:38:43.48] Restoring all packages...Done.
```

Fixes #123633