### PR TITLE
Use simulator queue instead of device queue for Apple mobile in runtime.yml

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1151,8 +1151,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/125522
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1197,8 +1197,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/125522
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1243,8 +1243,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/125522
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -785,7 +785,7 @@
                       BuildInParallel="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(ArchiveTests)' == 'true' and ('$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos') and '$(UseNativeAOTRuntime)' == 'true'">
+  <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(TargetsAppleMobile)' == 'true' and '$(UseNativeAOTRuntime)' == 'true'">
     <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj"
                     Exclude="@(ProjectExclusions)"
                     BuildInParallel="false" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -786,7 +786,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ArchiveTests)' == 'true' and '$(TargetsAppleMobile)' == 'true' and '$(UseNativeAOTRuntime)' == 'true'">
-    <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\$(TargetOS)\Device\**\*.Test.csproj"
+    <ProjectReference Include="$(RepoRoot)\src\tests\FunctionalTests\iOS\Device\**\*.Test.csproj"
                     Exclude="@(ProjectExclusions)"
                     BuildInParallel="false" />
   </ItemGroup>


### PR DESCRIPTION
## Description

The Apple mobile device queue isn't reliable, replacing it with simulators until it get's resolved.