### PR TITLE
Make sure m_synchronizedOrAsyncRetValVarIndex is always initialized

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4693,23 +4693,26 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
         if (!m_isSynchronized && !m_isAsyncMethodWithContextSaveRestore)
             NO_WAY("INTERP_LOAD_RETURN_VALUE_FOR_SYNCHRONIZED_OR_ASYNC used in a non-synchronized or async method");
 
-        INTERP_DUMP("INTERP_LOAD_RETURN_VALUE_FOR_SYNCHRONIZED_OR_ASYNC with synchronized ret val var V%d\n", (int)m_synchronizedOrAsyncRetValVarIndex);
-
-        if (m_synchronizedOrAsyncRetValVarIndex != -1)
+        if (m_synchronizedOrAsyncRetValVarIndex == -1)
         {
-            // If the function returns a value, and we've processed a ret instruction, we'll have a var to load
-            EmitLoadVar(m_synchronizedOrAsyncRetValVarIndex);
-        }
-        else
-        {
+            // Code inside for-loops, for example, is not emitted in the first pass, so we can reach the async
+            // epilog with m_synchronizedOrAsyncRetValVarIndex uninitialized.
             CORINFO_SIG_INFO sig = m_methodInfo->args;
             InterpType retType = GetInterpType(sig.retType);
             if (retType != InterpTypeVoid)
             {
-                // Push... something so the codegen of the ret doesn't fail. It doesn't matter, as this code will never be reached.
-                // This should only be possible in valid IL when the method always will throw
-                PushInterpType(InterpTypeI, NULL);
+                CORINFO_CLASS_HANDLE retClsHnd = (retType == InterpTypeVT) ? sig.retTypeClass : NULL;
+                PushInterpType(retType, retClsHnd);
+                m_synchronizedOrAsyncRetValVarIndex = m_pStackPointer[-1].var;
+                m_pStackPointer--;
+                INTERP_DUMP("Created ret val var V%d (pre-created in epilog)\n", m_synchronizedOrAsyncRetValVarIndex);
             }
+        }
+
+        INTERP_DUMP("INTERP_LOAD_RETURN_VALUE_FOR_SYNCHRONIZED_OR_ASYNC with ret val var V%d\n", (int)m_synchronizedOrAsyncRetValVarIndex);
+        if (m_synchronizedOrAsyncRetValVarIndex != -1)
+        {
+            EmitLoadVar(m_synchronizedOrAsyncRetValVarIndex);
         }
         m_ip += 5;
         return;


### PR DESCRIPTION
For runtime async methods, CEE_RET doesn't really return, rather it writes to this `m_synchronizedOrAsyncRetValVarIndex` variable and then branches to the runtime async epilog. This epilog will end up returning the value from this variable as the method return. When emitting this epilog, we were making the assumption that the entire IL body of the method was traversed, so we expected to have the return var index initialized. This is not true, since the interpreter defers emit for bblocks that don't have the stack height yet initialized.

In the example below, previous code was just creating a dummy variable that doesn't end up being used by CEE_RET opcodes. The fix is to properly create this variable and persist it in `m_synchronizedOrAsyncRetValVarIndex`.

```
public static async Task<string> WeirdAsync()
{
    for (int i = 0; i < 2; i++)
        return "test";
    throw new Exception();
}

// IL_0000:  ldc.i4.0
// IL_0001:  stloc.0
// IL_0002:  br.s       IL_000a
//
// IL_0004:  ldstr      "test"  // We don't have stack state here so this return is not reached in the first emit pass
// IL_0009:  ret
//
// IL_000a:  ldloc.0
// IL_000b:  ldc.i4.2
// IL_000c:  blt.s      IL_0004
//
// IL_000e:  newobj     instance void [System.Runtime]System.Exception::.ctor()
// IL_0013:  throw

```