### PR TITLE
Use CompressionLevel=Fastest for all test archive ZipDirectory calls

### DIFF
--- a/eng/testing/tests.ioslike.targets
+++ b/eng/testing/tests.ioslike.targets
@@ -227,7 +227,8 @@
     <ZipDirectory Condition="'$(GenerateXcodeProject)' == 'true'"
                   SourceDirectory="$(_AppBundleDir)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
-                  Overwrite="true" />
+                  Overwrite="true"
+                  CompressionLevel="Fastest" />
 
     <RemoveDir Condition="'$(NeedsToBuildAppsOnHelixLocal)' != 'true'" Directories="$(OutDir)" />
   </Target>

--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -107,7 +107,8 @@
     <MakeDir Directories="$(TestArchiveTestsDir)" />
     <ZipDirectory SourceDirectory="$(_ZipSourceDirectory)"
                   DestinationFile="$([MSBuild]::NormalizePath('$(TestArchiveTestsDir)', '$(TestProjectName).zip'))"
-                  Overwrite="true" />
+                  Overwrite="true"
+                  CompressionLevel="Fastest" />
     <!-- delete the BundleDir and PublishDir in CI builds to save disk space on build agents since they're no longer needed -->
     <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true'" Directories="$(BundleDir)" ContinueOnError="WarnAndContinue" />
     <RemoveDir Condition="'$(ContinuousIntegrationBuild)' == 'true' and '$(OS)' != 'Windows_NT'" Directories="$(PublishDir)" ContinueOnError="WarnAndContinue" />

--- a/src/libraries/sendtohelix.proj
+++ b/src/libraries/sendtohelix.proj
@@ -246,7 +246,8 @@
 
     <ZipDirectory SourceDirectory="$(TestArchiveRoot)coreclr"
                   DestinationFile="$(TestArchiveRoot)coreclr.zip"
-                  Overwrite="true" />
+                  Overwrite="true"
+                  CompressionLevel="Fastest" />
   </Target>
 
   <Target Name="CompressRuntimeDirectory"
@@ -264,7 +265,8 @@
 
     <ZipDirectory SourceDirectory="$(NetCoreAppCurrentTestHostPath)"
                   DestinationFile="$(TestArchiveRuntimeFile)"
-                  Overwrite="true" />
+                  Overwrite="true"
+                  CompressionLevel="Fastest" />
   </Target>
 
   <!--

--- a/src/mono/browser/build/WasmApp.InTree.targets
+++ b/src/mono/browser/build/WasmApp.InTree.targets
@@ -26,7 +26,7 @@
       <HelixArchiveRunOnlyAppsDir>$([MSBuild]::NormalizeDirectory($(HelixArchiveRunOnlyRoot), $(OSPlatformConfig), $(WasmHelixTestAppRelativeDir)))</HelixArchiveRunOnlyAppsDir>
       <ZippedApp>$(OutputPath)$(AssemblyName).zip</ZippedApp>
     </PropertyGroup>
-    <ZipDirectory SourceDirectory="$(WasmAppDir)" DestinationFile="$(ZippedApp)" />
+    <ZipDirectory SourceDirectory="$(WasmAppDir)" DestinationFile="$(ZippedApp)" CompressionLevel="Fastest" />
     <Copy SourceFiles="$(ZippedApp)" DestinationFolder="$(HelixArchiveRunOnlyAppsDir)" />
   </Target>
 </Project>

--- a/src/mono/wasi/build/WasiApp.InTree.targets
+++ b/src/mono/wasi/build/WasiApp.InTree.targets
@@ -63,7 +63,7 @@
       <HelixArchiveRunOnlyAppsDir>$([MSBuild]::NormalizeDirectory($(HelixArchiveRunOnlyRoot), $(OSPlatformConfig), $(WasmHelixTestAppRelativeDir)))</HelixArchiveRunOnlyAppsDir>
       <ZippedApp>$(OutputPath)$(AssemblyName).zip</ZippedApp>
     </PropertyGroup>
-    <ZipDirectory SourceDirectory="$(WasiAppDir)" DestinationFile="$(ZippedApp)" />
+    <ZipDirectory SourceDirectory="$(WasiAppDir)" DestinationFile="$(ZippedApp)" CompressionLevel="Fastest" />
     <Copy SourceFiles="$(ZippedApp)" DestinationFolder="$(HelixArchiveRunOnlyAppsDir)" />
   </Target>
 </Project>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -547,7 +547,8 @@
     <ZipDirectory
       Condition="'@(MergedPayloads)' != ''"
       SourceDirectory="@(MergedPayloads->Metadata('PayloadDirectory'))"
-      DestinationFile="$(MergedPayloadsRootDirectory)\%(MergedPayloads.PayloadGroup).zip" />
+      DestinationFile="$(MergedPayloadsRootDirectory)\%(MergedPayloads.PayloadGroup).zip"
+      CompressionLevel="Fastest" />
   </Target>
 
 


### PR DESCRIPTION
Binlog analysis of the osx-arm64 Libraries_CheckedCoreCLR leg (build 1360967) showed ZipTestArchive consuming 8.2 minutes of aggregate CPU time across 255 invocations using the default Optimal compression.

Switch all 7 ZipDirectory call sites to CompressionLevel=Fastest. These are test payloads destined for Helix where transfer speed on Azure networks makes the marginal size increase negligible, while the compression speedup is substantial.