### PR TITLE
Vectorize Atanh for Vector64/128/256/512 and TensorPrimitives

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
+++ b/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
@@ -250,6 +250,58 @@ namespace System.Tests
             }
         }
 
+        public static IEnumerable<object[]> AtanhDouble
+        {
+            get
+            {
+                yield return new object[] {  double.NegativeInfinity,  double.NaN,                0.0 };
+                yield return new object[] { -1.0,                      double.NegativeInfinity,   0.0 };
+                yield return new object[] { -0.78539816339744831,     -1.0593061708232432,        DoubleCrossPlatformMachineEpsilon * 10 }; // value: -(pi / 4)
+                yield return new object[] { -0.70710678118654752,     -0.88137358701954316,       DoubleCrossPlatformMachineEpsilon };      // value: -(1 / sqrt(2))
+                yield return new object[] { -0.69314718055994531,     -0.85398804799752392,       DoubleCrossPlatformMachineEpsilon };      // value: -(ln(2))
+                yield return new object[] { -0.63661977236758134,     -0.75246926714192719,       DoubleCrossPlatformMachineEpsilon };      // value: -(2 / pi)
+                yield return new object[] { -0.43429448190325183,     -0.46517735014659639,       DoubleCrossPlatformMachineEpsilon };      // value: -(log10(e))
+                yield return new object[] { -0.31830988618379067,     -0.32976531495669914,       DoubleCrossPlatformMachineEpsilon };      // value: -(1 / pi)
+                yield return new object[] { -0.0,                     -0.0,                       0.0 };
+                yield return new object[] {  double.NaN,               double.NaN,                0.0 };
+                yield return new object[] {  0.0,                      0.0,                       0.0 };
+                yield return new object[] {  0.31830988618379067,      0.32976531495669914,       DoubleCrossPlatformMachineEpsilon };      // value:  (1 / pi)
+                yield return new object[] {  0.43429448190325183,      0.46517735014659639,       DoubleCrossPlatformMachineEpsilon };      // value:  (log10(e))
+                yield return new object[] {  0.63661977236758134,      0.75246926714192719,       DoubleCrossPlatformMachineEpsilon };      // value:  (2 / pi)
+                yield return new object[] {  0.69314718055994531,      0.85398804799752392,       DoubleCrossPlatformMachineEpsilon };      // value:  (ln(2))
+                yield return new object[] {  0.70710678118654752,      0.88137358701954316,       DoubleCrossPlatformMachineEpsilon };      // value:  (1 / sqrt(2))
+                yield return new object[] {  0.78539816339744831,      1.0593061708232432,        DoubleCrossPlatformMachineEpsilon * 10 }; // value:  (pi / 4)
+                yield return new object[] {  1.0,                      double.PositiveInfinity,   0.0 };
+                yield return new object[] {  double.PositiveInfinity,  double.NaN,                0.0 };
+            }
+        }
+
+        public static IEnumerable<object[]> AtanhSingle
+        {
+            get
+            {
+                yield return new object[] {  float.NegativeInfinity,  float.NaN,           0.0f };
+                yield return new object[] { -1.0f,                    float.NegativeInfinity, 0.0f };
+                yield return new object[] { -0.785398163f,           -1.05930626f,         SingleCrossPlatformMachineEpsilon * 10 };  // value: -(pi / 4)
+                yield return new object[] { -0.707106781f,           -0.881373584f,        SingleCrossPlatformMachineEpsilon };       // value: -(1 / sqrt(2))
+                yield return new object[] { -0.693147181f,           -0.853988051f,        SingleCrossPlatformMachineEpsilon };       // value: -(ln(2))
+                yield return new object[] { -0.636619772f,           -0.752469242f,        SingleCrossPlatformMachineEpsilon };       // value: -(2 / pi)
+                yield return new object[] { -0.434294482f,           -0.465177357f,        SingleCrossPlatformMachineEpsilon };       // value: -(log10(e))
+                yield return new object[] { -0.318309886f,           -0.329765290f,        SingleCrossPlatformMachineEpsilon };       // value: -(1 / pi)
+                yield return new object[] { -0.0f,                   -0.0f,                0.0f };
+                yield return new object[] {  float.NaN,               float.NaN,           0.0f };
+                yield return new object[] {  0.0f,                    0.0f,                0.0f };
+                yield return new object[] {  0.318309886f,            0.329765290f,        SingleCrossPlatformMachineEpsilon };       // value:  (1 / pi)
+                yield return new object[] {  0.434294482f,            0.465177357f,        SingleCrossPlatformMachineEpsilon };       // value:  (log10(e))
+                yield return new object[] {  0.636619772f,            0.752469242f,        SingleCrossPlatformMachineEpsilon };       // value:  (2 / pi)
+                yield return new object[] {  0.693147181f,            0.853988051f,        SingleCrossPlatformMachineEpsilon };       // value:  (ln(2))
+                yield return new object[] {  0.707106781f,            0.881373584f,        SingleCrossPlatformMachineEpsilon };       // value:  (1 / sqrt(2))
+                yield return new object[] {  0.785398163f,            1.05930626f,         SingleCrossPlatformMachineEpsilon * 10 };  // value:  (pi / 4)
+                yield return new object[] {  1.0f,                    float.PositiveInfinity, 0.0f };
+                yield return new object[] {  float.PositiveInfinity,  float.NaN,           0.0f };
+            }
+        }
+
         public static IEnumerable<object[]> CosDouble
         {
             get

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atanh.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atanh.cs
@@ -1,6 +1,7 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.Intrinsics;
 
 namespace System.Numerics.Tensors
@@ -29,11 +30,65 @@ namespace System.Numerics.Tensors
         internal readonly struct AtanhOperator<T> : IUnaryOperator<T, T>
             where T : IHyperbolicFunctions<T>
         {
-            public static bool Vectorizable => false; // TODO: Vectorize
+            public static bool Vectorizable =>
+#if NET11_0_OR_GREATER
+                typeof(T) == typeof(float) || typeof(T) == typeof(double);
+#else
+                false;
+#endif
+
             public static T Invoke(T x) => T.Atanh(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+
+            public static Vector128<T> Invoke(Vector128<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector128.Atanh(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector128.Atanh(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
+
+            public static Vector256<T> Invoke(Vector256<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector256.Atanh(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector256.Atanh(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
+
+            public static Vector512<T> Invoke(Vector512<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector512.Atanh(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector512.Atanh(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -463,7 +463,7 @@ namespace System.Numerics.Tensors.Tests
             yield return Create(TensorPrimitives.Asinh, T.Asinh);
             yield return Create(TensorPrimitives.AsinPi, T.AsinPi);
             yield return Create(TensorPrimitives.Asin, T.Asin, trigTolerance);
-            yield return Create(TensorPrimitives.Atanh, T.Atanh);
+            yield return Create(TensorPrimitives.Atanh, T.Atanh, Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14, floatTolerance: 1e-6f));
             yield return Create(TensorPrimitives.AtanPi, T.AtanPi);
             yield return Create(TensorPrimitives.Atan, T.Atan);
             yield return Create(TensorPrimitives.BitDecrement, T.BitDecrement);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -854,6 +854,47 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector64.Atanh(Vector64{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<double> Atanh(Vector128<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhDouble<Vector128<double>, Vector128<long>, Vector128<ulong>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector64.Atanh(vector._lower),
+                    Vector64.Atanh(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector64.Atanh(Vector64{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<float> Atanh(Vector128<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                if (Vector256.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanhSingle<Vector128<float>, Vector128<int>, Vector128<uint>, Vector256<double>, Vector256<long>, Vector256<ulong>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanhSingle<Vector128<float>, Vector128<int>, Vector128<uint>, Vector128<double>, Vector128<long>, Vector128<ulong>>(vector);
+                }
+            }
+            else
+            {
+                return Create(
+                    Vector64.Atanh(vector._lower),
+                    Vector64.Atanh(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector64.Cos(Vector64{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector128<double> Cos(Vector128<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -878,7 +878,14 @@ namespace System.Runtime.Intrinsics
         {
             if (IsHardwareAccelerated)
             {
-                return VectorMath.AtanhSingle<Vector256<float>, Vector256<int>, Vector256<uint>, Vector512<double>, Vector512<long>, Vector512<ulong>>(vector);
+                if (Vector512.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanhSingle<Vector256<float>, Vector256<int>, Vector256<uint>, Vector512<double>, Vector512<long>, Vector512<ulong>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanhSingle<Vector256<float>, Vector256<int>, Vector256<uint>, Vector256<double>, Vector256<long>, Vector256<ulong>>(vector);
+                }
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -855,6 +855,40 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector128.Atanh(Vector128{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<double> Atanh(Vector256<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhDouble<Vector256<double>, Vector256<long>, Vector256<ulong>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.Atanh(vector._lower),
+                    Vector128.Atanh(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector128.Atanh(Vector128{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<float> Atanh(Vector256<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhSingle<Vector256<float>, Vector256<int>, Vector256<uint>, Vector512<double>, Vector512<long>, Vector512<ulong>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.Atanh(vector._lower),
+                    Vector128.Atanh(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector128.Cos(Vector128{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<double> Cos(Vector256<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -758,6 +758,40 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector256.Atanh(Vector256{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<double> Atanh(Vector512<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhDouble<Vector512<double>, Vector512<long>, Vector512<ulong>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.Atanh(vector._lower),
+                    Vector256.Atanh(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector256.Atanh(Vector256{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<float> Atanh(Vector512<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhSingle<Vector512<float>, Vector512<int>, Vector512<uint>, Vector512<double>, Vector512<long>, Vector512<ulong>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.Atanh(vector._lower),
+                    Vector256.Atanh(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector256.Cos(Vector256{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<double> Cos(Vector512<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -819,6 +819,47 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <summary>Computes the inverse hyperbolic tangent of each element in a vector.</summary>
+        /// <param name="vector">The vector whose inverse hyperbolic tangent is to be computed.</param>
+        /// <returns>A vector whose elements are the inverse hyperbolic tangent of the corresponding elements in <paramref name="vector" />.</returns>
+        /// <remarks>The input should be in the range (-1, 1).</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector64<double> Atanh(Vector64<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanhDouble<Vector64<double>, Vector64<long>, Vector64<ulong>>(vector);
+            }
+            else
+            {
+                return Atanh<double>(vector);
+            }
+        }
+
+        /// <summary>Computes the inverse hyperbolic tangent of each element in a vector.</summary>
+        /// <param name="vector">The vector whose inverse hyperbolic tangent is to be computed.</param>
+        /// <returns>A vector whose elements are the inverse hyperbolic tangent of the corresponding elements in <paramref name="vector" />.</returns>
+        /// <remarks>The input should be in the range (-1, 1).</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector64<float> Atanh(Vector64<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                if (Vector128.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanhSingle<Vector64<float>, Vector64<int>, Vector64<uint>, Vector128<double>, Vector128<long>, Vector128<ulong>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanhSingle<Vector64<float>, Vector64<int>, Vector64<uint>, Vector64<double>, Vector64<long>, Vector64<ulong>>(vector);
+                }
+            }
+            else
+            {
+                return Atanh<float>(vector);
+            }
+        }
+
         /// <summary>Computes the cos of each element in a vector.</summary>
         /// <param name="vector">The vector that will have its Cos computed.</param>
         /// <returns>A vector whose elements are the cos of the elements in <paramref name="vector" />.</returns>
@@ -3707,6 +3748,20 @@ namespace System.Runtime.Intrinsics
             for (int index = 0; index < Vector64<T>.Count; index++)
             {
                 T value = T.Asin(vector.GetElementUnsafe(index));
+                result.SetElementUnsafe(index, value);
+            }
+
+            return result;
+        }
+
+        internal static Vector64<T> Atanh<T>(Vector64<T> vector)
+            where T : IHyperbolicFunctions<T>
+        {
+            Unsafe.SkipInit(out Vector64<T> result);
+
+            for (int index = 0; index < Vector64<T>.Count; index++)
+            {
+                T value = T.Atanh(vector.GetElementUnsafe(index));
                 result.SetElementUnsafe(index, value);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
@@ -3221,5 +3221,175 @@ namespace System.Runtime.Intrinsics
 
             return ax + ax * g * poly + (TVectorDouble.Create(PIBY2) & gtHalf);
         }
+
+        public static TVectorDouble AtanhDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(TVectorDouble x)
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+            where TVectorInt64 : unmanaged, ISimdVector<TVectorInt64, long>
+            where TVectorUInt64 : unmanaged, ISimdVector<TVectorUInt64, ulong>
+        {
+            // This code is based on `atanh` from amd/aocl-libm-ose
+            // Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+            //
+            // Licensed under the BSD 3-Clause "New" or "Revised" License
+            // See THIRD-PARTY-NOTICES.TXT for the full license text
+
+            // Implementation Notes (from atanh.c)
+            // ------------------------------------
+            // For |x| < 3.72e-9: atanh(x) = x (tiny approximation)
+            // For |x| < 0.5: atanh(x) = x + x^3 * P(x^2)/Q(x^2) using [5,5] minimax rational polynomial
+            // For |x| >= 0.5: atanh(x) = sign(x) * 0.5 * log1p(2|x|/(1-|x|))
+            // Special cases: atanh(±1) = ±∞, atanh(x) = NaN for |x| > 1
+
+            // [5,5] minimax rational polynomial coefficients from Sollya (atanh.c)
+            // Numerator: evaluated as A0 + A1*r + A2*r^2 + A3*r^3 + A4*r^4 + A5*r^5 where r = x^2
+            const double A0 = 4.74825735897473566460e-01;  // 0x1.e638b7bbea45ep-2
+            const double A1 = -1.10283567978463414860e+00; // -0x1.1a53706989746p0
+            const double A2 = 8.84681425365016482765e-01;  // 0x1.c4f4f6baa48ffp-1
+            const double A3 = -2.81802109617808160813e-01; // -0x1.2090bb7302592p-2
+            const double A4 = 2.87286386005485144812e-02;  // 0x1.d6b0a4cfde8fcp-6
+            const double A5 = -1.04681588927531371807e-04; // -0x1.b711000f5a53bp-14
+
+            // Denominator
+            const double B0 = 1.42447720769242058836e+00;  // 0x1.6caa89ccefb46p0
+            const double B1 = -4.16319336396935479883e+00; // -0x1.0a71c2944b0bfp2
+            const double B2 = 4.54147006260845120806e+00;  // 0x1.22a7720caaa5dp2
+            const double B3 = -2.26088837489884886267e+00; // -0x1.2164ca4f0c6f3p1
+            const double B4 = 4.95611965555031008801e-01;  // 0x1.fb81b3fe42b33p-2
+            const double B5 = -3.58615543701695377310e-02; // -0x1.25c7216683ecap-5
+
+            const double HALF = 0.5;
+            const double TINY_THRESHOLD = 3.72529029846191406250e-09; // 0x3e30000000000000 as double
+
+            TVectorDouble sign = x & TVectorDouble.Create(-0.0);
+            TVectorDouble ax = TVectorDouble.Abs(x);
+
+            // Special cases
+            TVectorDouble nanMask = TVectorDouble.GreaterThan(ax, TVectorDouble.One);
+            TVectorDouble infMask = TVectorDouble.Equals(ax, TVectorDouble.One);
+            TVectorDouble tinyMask = TVectorDouble.LessThan(ax, TVectorDouble.Create(TINY_THRESHOLD));
+            TVectorDouble smallMask = TVectorDouble.LessThan(ax, TVectorDouble.Create(HALF));
+
+            // For |x| < 0.5: use [5,5] minimax rational polynomial
+            // atanh(x) = x + x^3 * P(x^2)/Q(x^2)
+            TVectorDouble r = x * x; // r = x^2
+
+            // Evaluate numerator: A0 + A1*r + A2*r^2 + A3*r^3 + A4*r^4 + A5*r^5
+            TVectorDouble num = TVectorDouble.Create(A5);
+            num = TVectorDouble.MultiplyAddEstimate(num, r, TVectorDouble.Create(A4));
+            num = TVectorDouble.MultiplyAddEstimate(num, r, TVectorDouble.Create(A3));
+            num = TVectorDouble.MultiplyAddEstimate(num, r, TVectorDouble.Create(A2));
+            num = TVectorDouble.MultiplyAddEstimate(num, r, TVectorDouble.Create(A1));
+            num = TVectorDouble.MultiplyAddEstimate(num, r, TVectorDouble.Create(A0));
+
+            // Evaluate denominator: B0 + B1*r + B2*r^2 + B3*r^3 + B4*r^4 + B5*r^5
+            TVectorDouble den = TVectorDouble.Create(B5);
+            den = TVectorDouble.MultiplyAddEstimate(den, r, TVectorDouble.Create(B4));
+            den = TVectorDouble.MultiplyAddEstimate(den, r, TVectorDouble.Create(B3));
+            den = TVectorDouble.MultiplyAddEstimate(den, r, TVectorDouble.Create(B2));
+            den = TVectorDouble.MultiplyAddEstimate(den, r, TVectorDouble.Create(B1));
+            den = TVectorDouble.MultiplyAddEstimate(den, r, TVectorDouble.Create(B0));
+
+            TVectorDouble poly = num / den;
+            TVectorDouble smallResult = x + (x * r) * poly;
+
+            // For |x| >= 0.5: atanh(x) = sign(x) * 0.5 * log1p(2|x|/(1-|x|))
+            // AMD uses log1p directly; we use log(1+x) since no vectorized log1p is available.
+            // For |x| >= 0.5, ratio >= 2, so 1+ratio >= 3 — log and log1p are equivalent at this magnitude.
+            TVectorDouble oneMinusAx = TVectorDouble.One - ax;
+            TVectorDouble ratio = (TVectorDouble.Create(2.0) * ax) / oneMinusAx;
+            TVectorDouble largeResult = TVectorDouble.Create(HALF) * LogDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(TVectorDouble.One + ratio);
+            largeResult |= sign; // restore sign
+
+            // Select based on magnitude
+            TVectorDouble result = TVectorDouble.ConditionalSelect(smallMask, smallResult, largeResult);
+            result = TVectorDouble.ConditionalSelect(tinyMask, x, result);
+            result = TVectorDouble.ConditionalSelect(infMask, TVectorDouble.Create(double.PositiveInfinity) ^ sign, result);
+            result = TVectorDouble.ConditionalSelect(nanMask, TVectorDouble.Create(double.NaN), result);
+
+            return result;
+        }
+
+        public static TVectorSingle AtanhSingle<TVectorSingle, TVectorInt32, TVectorUInt32, TVectorDouble, TVectorInt64, TVectorUInt64>(TVectorSingle x)
+            where TVectorSingle : unmanaged, ISimdVector<TVectorSingle, float>
+            where TVectorInt32 : unmanaged, ISimdVector<TVectorInt32, int>
+            where TVectorUInt32 : unmanaged, ISimdVector<TVectorUInt32, uint>
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+            where TVectorInt64 : unmanaged, ISimdVector<TVectorInt64, long>
+            where TVectorUInt64 : unmanaged, ISimdVector<TVectorUInt64, ulong>
+        {
+            // This code is based on `atanhf` from amd/aocl-libm-ose
+            // Copyright (C) 2021-2022 Advanced Micro Devices, Inc. All rights reserved.
+            //
+            // Licensed under the BSD 3-Clause "New" or "Revised" License
+            // See THIRD-PARTY-NOTICES.TXT for the full license text
+
+            TVectorSingle sign = x & TVectorSingle.Create(-0.0f);
+            TVectorSingle ax = TVectorSingle.Abs(x);
+            TVectorSingle nanMask = TVectorSingle.GreaterThan(ax, TVectorSingle.One);
+            TVectorSingle infMask = TVectorSingle.Equals(ax, TVectorSingle.One);
+            TVectorSingle tinyMask = TVectorSingle.LessThan(ax, TVectorSingle.Create(1.220703125e-4f)); // 0x39000000
+
+            TVectorSingle result;
+
+            if (TVectorSingle.ElementCount == TVectorDouble.ElementCount)
+            {
+                TVectorDouble dax = Widen<TVectorSingle, TVectorDouble>(ax);
+                result = Narrow<TVectorDouble, TVectorSingle>(
+                    AtanhSingleCoreDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(dax));
+            }
+            else
+            {
+                TVectorDouble daxLo = WidenLower<TVectorSingle, TVectorDouble>(ax);
+                TVectorDouble daxHi = WidenUpper<TVectorSingle, TVectorDouble>(ax);
+                result = Narrow<TVectorDouble, TVectorSingle>(
+                    AtanhSingleCoreDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(daxLo),
+                    AtanhSingleCoreDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(daxHi));
+            }
+
+            result ^= sign;
+            result = TVectorSingle.ConditionalSelect(tinyMask, x, result);
+            result = TVectorSingle.ConditionalSelect(infMask, TVectorSingle.Create(float.PositiveInfinity) ^ sign, result);
+            result = TVectorSingle.ConditionalSelect(nanMask, TVectorSingle.Create(float.NaN), result);
+
+            return result;
+        }
+
+        private static TVectorDouble AtanhSingleCoreDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(
+            TVectorDouble ax)
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+            where TVectorInt64 : unmanaged, ISimdVector<TVectorInt64, long>
+            where TVectorUInt64 : unmanaged, ISimdVector<TVectorUInt64, ulong>
+        {
+            // [2,2] minimax rational polynomial coefficients (AMD atanhf.c)
+            const double A0 = 0.39453629046e0;          // 0x1.9401524271847p-2
+            const double A1 = -0.28120347286e0;         // -0x1.1ff3cd9dd2406p-2
+            const double A2 = 0.92834212715e-2;         // 0x1.3032fb60c755ep-7
+            const double A3 = 0.11836088638e1;          // 0x1.2f00fd9146d70p+0
+            const double A4 = -0.15537744551e1;         // -0x1.8dc429a603c4bp+0
+            const double A5 = 0.45281890445e0;          // 0x1.cfafc2467e421p-2
+
+            TVectorDouble smallMask = TVectorDouble.LessThan(ax, TVectorDouble.Create(0.5));
+
+            // For |x| < 0.5: POLY_EVAL_EVEN_4(x, A0, A1, A2) / POLY_EVAL_EVEN_4(x, A3, A4, A5)
+            TVectorDouble x2 = ax * ax;
+            TVectorDouble x4 = x2 * x2;
+
+            TVectorDouble num = TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(A2), x4,
+                TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(A1), x2, TVectorDouble.Create(A0)));
+            TVectorDouble den = TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(A5), x4,
+                TVectorDouble.MultiplyAddEstimate(TVectorDouble.Create(A4), x2, TVectorDouble.Create(A3)));
+
+            TVectorDouble poly = num / den;
+            TVectorDouble t = ax * x2;
+            TVectorDouble smallResult = ax + t * poly;
+
+            // For |x| >= 0.5: atanh(x) = 0.5 * log1p(2|x|/(1-|x|))
+            // AMD uses log1p directly; we use log(1+x) since no vectorized log1p is available.
+            // For |x| >= 0.5, ratio >= 2, so 1+ratio >= 3 — log and log1p are equivalent at this magnitude.
+            TVectorDouble r_pos = (TVectorDouble.Create(2.0) * ax) / (TVectorDouble.One - ax);
+            TVectorDouble largeResult = TVectorDouble.Create(0.5) * LogDouble<TVectorDouble, TVectorInt64, TVectorUInt64>(TVectorDouble.One + r_pos);
+
+            return TVectorDouble.ConditionalSelect(smallMask, smallResult, largeResult);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -21,6 +21,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Asin(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Asin(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Atanh(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Atanh(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
@@ -484,6 +486,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Asin(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Asin(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Atanh(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Atanh(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
@@ -936,6 +940,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Asin(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> Asin(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector512<double> Atanh(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector512<float> Atanh(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
@@ -1387,6 +1393,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> Asin(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> Asin(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<double> Atanh(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Atanh(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -5322,6 +5322,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector128<double> actualResult = Vector128.Atanh(Vector128.Create(value));
+            AssertEqual(Vector128.Create(expectedResult), actualResult, Vector128.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector128<float> actualResult = Vector128.Atanh(Vector128.Create(value));
+            AssertEqual(Vector128.Create(expectedResult), actualResult, Vector128.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
@@ -6498,6 +6498,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector256<double> actualResult = Vector256.Atanh(Vector256.Create(value));
+            AssertEqual(Vector256.Create(expectedResult), actualResult, Vector256.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector256<float> actualResult = Vector256.Atanh(Vector256.Create(value));
+            AssertEqual(Vector256.Create(expectedResult), actualResult, Vector256.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector512Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector512Tests.cs
@@ -6281,6 +6281,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector512<double> actualResult = Vector512.Atanh(Vector512.Create(value));
+            AssertEqual(Vector512.Create(expectedResult), actualResult, Vector512.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector512<float> actualResult = Vector512.Atanh(Vector512.Create(value));
+            AssertEqual(Vector512.Create(expectedResult), actualResult, Vector512.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -4596,6 +4596,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector64<double> actualResult = Vector64.Atanh(Vector64.Create(value));
+            AssertEqual(Vector64.Create(expectedResult), actualResult, Vector64.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanhSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanhSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector64<float> actualResult = Vector64.Atanh(Vector64.Create(value));
+            AssertEqual(Vector64.Create(expectedResult), actualResult, Vector64.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {


### PR DESCRIPTION
Add vectorized Atanh implementations for float and double across all SIMD vector types.

## Description

- Exposes new `Vector64/128/256/512.Atanh` APIs and updates the `System.Runtime.Intrinsics` ref surface.
- Implements the shared vectorized math kernels in `VectorMath` for `atanh` (double core + float via widen/narrow).
- Enables `TensorPrimitives.Atanh` vectorization for `float`/`double` and adjusts test tolerances accordingly.
- Fixed `Vector256.Atanh(float)` to branch on `Vector512.IsHardwareAccelerated` and fall back to `Vector256<double>` when Vector512 isn't available, matching the pattern used by `Asin`, `Cos`, `Exp`, and other float implementations.
- Added unit tests for Vector64/128/256/512.Atanh APIs covering accuracy (with tolerances) and special cases (NaN, ±0, |x|>1 → NaN, x=±1 → ±Infinity) following the existing Asin/Cos test patterns. Test data added to `GenericMathTestMemberData` with `AtanhDouble` and `AtanhSingle` data sources covering standard mathematical constants.