### PR TITLE
Vectorize Atan for Vector64/128/256/512 and TensorPrimitives

### DIFF
--- a/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
+++ b/src/libraries/Common/tests/System/GenericMathTestMemberData.cs
@@ -250,6 +250,78 @@ namespace System.Tests
             }
         }
 
+        public static IEnumerable<object[]> AtanDouble
+        {
+            get
+            {
+                yield return new object[] {  double.NegativeInfinity, -1.5707963267948966,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected: -(pi / 2)
+                yield return new object[] { -7.7635756709721848,      -1.4426950408889634,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected: -(log2(e))
+                yield return new object[] { -6.3341191670421916,      -1.4142135623730950,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected: -(sqrt(2))
+                yield return new object[] { -2.1108768356626451,      -1.1283791670955126,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected: -(2 / sqrt(pi))
+                yield return new object[] { -1.5574077246549022,      -1.0,                 DoubleCrossPlatformMachineEpsilon * 10 };
+                yield return new object[] { -1.1134071468135374,      -0.83900756059574755, DoubleCrossPlatformMachineEpsilon };      // expected: -(pi - ln(10))
+                yield return new object[] { -1.0,                     -0.78539816339744831, DoubleCrossPlatformMachineEpsilon };      // expected: -(pi / 4)
+                yield return new object[] { -0.85451043200960189,     -0.70710678118654752, DoubleCrossPlatformMachineEpsilon };      // expected: -(1 / sqrt(2))
+                yield return new object[] { -0.83064087786078395,     -0.69314718055994531, DoubleCrossPlatformMachineEpsilon };      // expected: -(ln(2))
+                yield return new object[] { -0.73930295048660405,     -0.63661977236758134, DoubleCrossPlatformMachineEpsilon };      // expected: -(2 / pi)
+                yield return new object[] { -0.46382906716062964,     -0.43429448190325183, DoubleCrossPlatformMachineEpsilon };      // expected: -(log10(e))
+                yield return new object[] { -0.45054953406980750,     -0.42331082513074800, DoubleCrossPlatformMachineEpsilon };      // expected: -(pi - e)
+                yield return new object[] { -0.32951473309607836,     -0.31830988618379067, DoubleCrossPlatformMachineEpsilon };      // expected: -(1 / pi)
+                yield return new object[] { -0.0,                     -0.0,                 0.0 };
+                yield return new object[] {  double.NaN,               double.NaN,          0.0 };
+                yield return new object[] {  0.0,                      0.0,                 0.0 };
+                yield return new object[] {  0.32951473309607836,      0.31830988618379067, DoubleCrossPlatformMachineEpsilon };      // expected:  (1 / pi)
+                yield return new object[] {  0.45054953406980750,      0.42331082513074800, DoubleCrossPlatformMachineEpsilon };      // expected:  (pi - e)
+                yield return new object[] {  0.46382906716062964,      0.43429448190325183, DoubleCrossPlatformMachineEpsilon };      // expected:  (log10(e))
+                yield return new object[] {  0.73930295048660405,      0.63661977236758134, DoubleCrossPlatformMachineEpsilon };      // expected:  (2 / pi)
+                yield return new object[] {  0.83064087786078395,      0.69314718055994531, DoubleCrossPlatformMachineEpsilon };      // expected:  (ln(2))
+                yield return new object[] {  0.85451043200960189,      0.70710678118654752, DoubleCrossPlatformMachineEpsilon };      // expected:  (1 / sqrt(2))
+                yield return new object[] {  1.0,                      0.78539816339744831, DoubleCrossPlatformMachineEpsilon };      // expected:  (pi / 4)
+                yield return new object[] {  1.1134071468135374,       0.83900756059574755, DoubleCrossPlatformMachineEpsilon };      // expected:  (pi - ln(10))
+                yield return new object[] {  1.5574077246549022,       1.0,                 DoubleCrossPlatformMachineEpsilon * 10 };
+                yield return new object[] {  2.1108768356626451,       1.1283791670955126,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected:  (2 / sqrt(pi))
+                yield return new object[] {  6.3341191670421916,       1.4142135623730950,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected:  (sqrt(2))
+                yield return new object[] {  7.7635756709721848,       1.4426950408889634,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected:  (log2(e))
+                yield return new object[] {  double.PositiveInfinity,  1.5707963267948966,  DoubleCrossPlatformMachineEpsilon * 10 }; // expected:  (pi / 2)
+            }
+        }
+
+        public static IEnumerable<object[]> AtanSingle
+        {
+            get
+            {
+                yield return new object[] {  float.NegativeInfinity, -1.57079633f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected: -(pi / 2)
+                yield return new object[] { -7.76357567f,           -1.44269504f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected: -(log2(e))
+                yield return new object[] { -6.33411917f,           -1.41421356f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected: -(sqrt(2))
+                yield return new object[] { -2.11087684f,           -1.12837917f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected: -(2 / sqrt(pi))
+                yield return new object[] { -1.55740772f,           -1.0f,         SingleCrossPlatformMachineEpsilon * 10 };
+                yield return new object[] { -1.11340715f,           -0.839007561f, SingleCrossPlatformMachineEpsilon };      // expected: -(pi - ln(10))
+                yield return new object[] { -1.0f,                  -0.785398163f, SingleCrossPlatformMachineEpsilon };      // expected: -(pi / 4)
+                yield return new object[] { -0.854510432f,          -0.707106781f, SingleCrossPlatformMachineEpsilon };      // expected: -(1 / sqrt(2))
+                yield return new object[] { -0.830640878f,          -0.693147181f, SingleCrossPlatformMachineEpsilon };      // expected: -(ln(2))
+                yield return new object[] { -0.739302950f,          -0.636619772f, SingleCrossPlatformMachineEpsilon };      // expected: -(2 / pi)
+                yield return new object[] { -0.463829067f,          -0.434294482f, SingleCrossPlatformMachineEpsilon };      // expected: -(log10(e))
+                yield return new object[] { -0.450549534f,          -0.423310825f, SingleCrossPlatformMachineEpsilon };      // expected: -(pi - e)
+                yield return new object[] { -0.329514733f,          -0.318309886f, SingleCrossPlatformMachineEpsilon };      // expected: -(1 / pi)
+                yield return new object[] { -0.0f,                  -0.0f,         0.0f };
+                yield return new object[] {  float.NaN,              float.NaN,    0.0f };
+                yield return new object[] {  0.0f,                   0.0f,         0.0f };
+                yield return new object[] {  0.329514733f,           0.318309886f, SingleCrossPlatformMachineEpsilon };      // expected:  (1 / pi)
+                yield return new object[] {  0.450549534f,           0.423310825f, SingleCrossPlatformMachineEpsilon };      // expected:  (pi - e)
+                yield return new object[] {  0.463829067f,           0.434294482f, SingleCrossPlatformMachineEpsilon };      // expected:  (log10(e))
+                yield return new object[] {  0.739302950f,           0.636619772f, SingleCrossPlatformMachineEpsilon };      // expected:  (2 / pi)
+                yield return new object[] {  0.830640878f,           0.693147181f, SingleCrossPlatformMachineEpsilon };      // expected:  (ln(2))
+                yield return new object[] {  0.854510432f,           0.707106781f, SingleCrossPlatformMachineEpsilon };      // expected:  (1 / sqrt(2))
+                yield return new object[] {  1.0f,                   0.785398163f, SingleCrossPlatformMachineEpsilon };      // expected:  (pi / 4)
+                yield return new object[] {  1.11340715f,            0.839007561f, SingleCrossPlatformMachineEpsilon };      // expected:  (pi - ln(10))
+                yield return new object[] {  1.55740772f,            1.0f,         SingleCrossPlatformMachineEpsilon * 10 };
+                yield return new object[] {  2.11087684f,            1.12837917f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected:  (2 / sqrt(pi))
+                yield return new object[] {  6.33411917f,            1.41421356f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected:  (sqrt(2))
+                yield return new object[] {  7.76357567f,            1.44269504f,  SingleCrossPlatformMachineEpsilon * 10 }; // expected:  (log2(e))
+                yield return new object[] {  float.PositiveInfinity,  1.57079633f, SingleCrossPlatformMachineEpsilon * 10 }; // expected:  (pi / 2)
+            }
+        }
+
         public static IEnumerable<object[]> CosDouble
         {
             get

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.Atan.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.Intrinsics;
 
 namespace System.Numerics.Tensors
@@ -29,11 +30,65 @@ namespace System.Numerics.Tensors
         internal readonly struct AtanOperator<T> : IUnaryOperator<T, T>
             where T : ITrigonometricFunctions<T>
         {
-            public static bool Vectorizable => false; // TODO: Vectorize
+            public static bool Vectorizable =>
+#if NET11_0_OR_GREATER
+                typeof(T) == typeof(float) || typeof(T) == typeof(double);
+#else
+                false;
+#endif
+
             public static T Invoke(T x) => T.Atan(x);
-            public static Vector128<T> Invoke(Vector128<T> x) => throw new NotSupportedException();
-            public static Vector256<T> Invoke(Vector256<T> x) => throw new NotSupportedException();
-            public static Vector512<T> Invoke(Vector512<T> x) => throw new NotSupportedException();
+
+            public static Vector128<T> Invoke(Vector128<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector128.Atan(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector128.Atan(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
+
+            public static Vector256<T> Invoke(Vector256<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector256.Atan(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector256.Atan(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
+
+            public static Vector512<T> Invoke(Vector512<T> x)
+            {
+#if NET11_0_OR_GREATER
+                if (typeof(T) == typeof(double))
+                {
+                    return Vector512.Atan(x.AsDouble()).As<double, T>();
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(float));
+                    return Vector512.Atan(x.AsSingle()).As<float, T>();
+                }
+#else
+                throw new NotSupportedException();
+#endif
+            }
         }
     }
 }

--- a/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
+++ b/src/libraries/System.Numerics.Tensors/tests/TensorPrimitives.Generic.cs
@@ -464,8 +464,8 @@ namespace System.Numerics.Tensors.Tests
             yield return Create(TensorPrimitives.AsinPi, T.AsinPi);
             yield return Create(TensorPrimitives.Asin, T.Asin, trigTolerance);
             yield return Create(TensorPrimitives.Atanh, T.Atanh);
-            yield return Create(TensorPrimitives.AtanPi, T.AtanPi);
-            yield return Create(TensorPrimitives.Atan, T.Atan);
+            yield return Create(TensorPrimitives.AtanPi, T.AtanPi, Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14, floatTolerance: 1e-6f));
+            yield return Create(TensorPrimitives.Atan, T.Atan, Helpers.DetermineTolerance<T>(doubleTolerance: 1e-14, floatTolerance: 1e-6f));
             yield return Create(TensorPrimitives.BitDecrement, T.BitDecrement);
             yield return Create(TensorPrimitives.BitIncrement, T.BitIncrement);
             yield return Create(TensorPrimitives.Cbrt, T.Cbrt, Helpers.DetermineTolerance<T>(doubleTolerance: 1e-13));

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -854,6 +854,47 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector64.Atan(Vector64{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<double> Atan(Vector128<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanDouble<Vector128<double>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector64.Atan(vector._lower),
+                    Vector64.Atan(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector64.Atan(Vector64{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector128<float> Atan(Vector128<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                if (Vector256.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanSingle<Vector128<float>, Vector128<int>, Vector256<double>, Vector256<long>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanSingle<Vector128<float>, Vector128<int>, Vector128<double>, Vector128<long>>(vector);
+                }
+            }
+            else
+            {
+                return Create(
+                    Vector64.Atan(vector._lower),
+                    Vector64.Atan(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector64.Cos(Vector64{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector128<double> Cos(Vector128<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -855,6 +855,47 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector128.Atan(Vector128{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<double> Atan(Vector256<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanDouble<Vector256<double>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector128.Atan(vector._lower),
+                    Vector128.Atan(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector128.Atan(Vector128{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector256<float> Atan(Vector256<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                if (Vector512.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanSingle<Vector256<float>, Vector256<int>, Vector512<double>, Vector512<long>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanSingle<Vector256<float>, Vector256<int>, Vector256<double>, Vector256<long>>(vector);
+                }
+            }
+            else
+            {
+                return Create(
+                    Vector128.Atan(vector._lower),
+                    Vector128.Atan(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector128.Cos(Vector128{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector256<double> Cos(Vector256<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -758,6 +758,40 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <inheritdoc cref="Vector256.Atan(Vector256{double})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<double> Atan(Vector512<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanDouble<Vector512<double>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.Atan(vector._lower),
+                    Vector256.Atan(vector._upper)
+                );
+            }
+        }
+
+        /// <inheritdoc cref="Vector256.Atan(Vector256{float})" />
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector512<float> Atan(Vector512<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanSingle<Vector512<float>, Vector512<int>, Vector512<double>, Vector512<long>>(vector);
+            }
+            else
+            {
+                return Create(
+                    Vector256.Atan(vector._lower),
+                    Vector256.Atan(vector._upper)
+                );
+            }
+        }
+
         /// <inheritdoc cref="Vector256.Cos(Vector256{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector512<double> Cos(Vector512<double> vector)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -819,6 +819,47 @@ namespace System.Runtime.Intrinsics
             }
         }
 
+        /// <summary>Computes the arc tangent of each element in a vector.</summary>
+        /// <param name="vector">The vector whose arc tangent is to be computed.</param>
+        /// <returns>A vector whose elements are the arc tangent of the corresponding elements in <paramref name="vector" />.</returns>
+        /// <remarks>The angles are returned in radians.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector64<double> Atan(Vector64<double> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                return VectorMath.AtanDouble<Vector64<double>>(vector);
+            }
+            else
+            {
+                return Atan<double>(vector);
+            }
+        }
+
+        /// <summary>Computes the arc tangent of each element in a vector.</summary>
+        /// <param name="vector">The vector whose arc tangent is to be computed.</param>
+        /// <returns>A vector whose elements are the arc tangent of the corresponding elements in <paramref name="vector" />.</returns>
+        /// <remarks>The angles are returned in radians.</remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Vector64<float> Atan(Vector64<float> vector)
+        {
+            if (IsHardwareAccelerated)
+            {
+                if (Vector128.IsHardwareAccelerated)
+                {
+                    return VectorMath.AtanSingle<Vector64<float>, Vector64<int>, Vector128<double>, Vector128<long>>(vector);
+                }
+                else
+                {
+                    return VectorMath.AtanSingle<Vector64<float>, Vector64<int>, Vector64<double>, Vector64<long>>(vector);
+                }
+            }
+            else
+            {
+                return Atan<float>(vector);
+            }
+        }
+
         /// <summary>Computes the cos of each element in a vector.</summary>
         /// <param name="vector">The vector that will have its Cos computed.</param>
         /// <returns>A vector whose elements are the cos of the elements in <paramref name="vector" />.</returns>
@@ -3707,6 +3748,20 @@ namespace System.Runtime.Intrinsics
             for (int index = 0; index < Vector64<T>.Count; index++)
             {
                 T value = T.Asin(vector.GetElementUnsafe(index));
+                result.SetElementUnsafe(index, value);
+            }
+
+            return result;
+        }
+
+        internal static Vector64<T> Atan<T>(Vector64<T> vector)
+            where T : ITrigonometricFunctions<T>
+        {
+            Unsafe.SkipInit(out Vector64<T> result);
+
+            for (int index = 0; index < Vector64<T>.Count; index++)
+            {
+                T value = T.Atan(vector.GetElementUnsafe(index));
                 result.SetElementUnsafe(index, value);
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/VectorMath.cs
@@ -3221,5 +3221,235 @@ namespace System.Runtime.Intrinsics
 
             return ax + ax * g * poly + (TVectorDouble.Create(PIBY2) & gtHalf);
         }
+
+        public static TVectorDouble AtanDouble<TVectorDouble>(TVectorDouble x)
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+        {
+            // This code is based on `atan` from amd/aocl-libm-ose
+            // Copyright (C) 2008-2023 Advanced Micro Devices, Inc. All rights reserved.
+            //
+            // Licensed under the BSD 3-Clause "New" or "Revised" License
+            // See THIRD-PARTY-NOTICES.TXT for the full license text
+
+            // Implementation Notes
+            // --------------------
+            // Argument reduction to range [-7/16,7/16]
+            // Use the following identities:
+            // atan(x) = pi/2 - atan(1/x)                when x > 39/16
+            //         = arctan(1.5) + atan((x-1.5)/(1+1.5*x))  when 19/16 < x <= 39/16
+            //         = pi/4 + atan((x-1)/(1+x))        when 11/16 < x <= 19/16
+            //         = arctan(0.5) + atan((2x-1)/(2+x))       when 7/16 < x <= 11/16
+            //         = atan(x)                         when x <= 7/16
+            //
+            // Core approximation: Remez(4,4) on [-7/16,7/16]
+
+            // Range boundaries
+            const double R7_16 = 0.4375;    // 7/16
+            const double R11_16 = 0.6875;   // 11/16
+            const double R19_16 = 1.1875;   // 19/16
+            const double R39_16 = 2.4375;   // 39/16
+
+            // (chi, clo) pairs for high-precision addition
+            const double CHI_0 = 0.0;
+            const double CLO_0 = 0.0;
+            const double CHI_HALF = 4.63647609000806093515e-01;  // arctan(0.5)
+            const double CLO_HALF = 2.26987774529616809294e-17;
+            const double CHI_1 = 7.85398163397448278999e-01;     // arctan(1.0) = pi/4
+            const double CLO_1 = 3.06161699786838240164e-17;
+            const double CHI_1_5 = 9.82793723247329054082e-01;   // arctan(1.5)
+            const double CLO_1_5 = 1.39033110312309953701e-17;
+            const double CHI_INF = 1.57079632679489655800e+00;   // arctan(inf) = pi/2
+            const double CLO_INF = 6.12323399573676480327e-17;
+
+            // Remez(4,4) polynomial coefficients for numerator
+            const double P0 = 0.268297920532545909e0;
+            const double P1 = 0.447677206805497472e0;
+            const double P2 = 0.220638780716667420e0;
+            const double P3 = 0.304455919504853031e-1;
+            const double P4 = 0.142316903342317766e-3;
+
+            // Remez(4,4) polynomial coefficients for denominator
+            const double Q0 = 0.804893761597637733e0;
+            const double Q1 = 0.182596787737507063e1;
+            const double Q2 = 0.141254259931958921e1;
+            const double Q3 = 0.424602594203847109e0;
+            const double Q4 = 0.389525873944742195e-1;
+
+            TVectorDouble sign = x & TVectorDouble.Create(-0.0);
+            TVectorDouble v = TVectorDouble.Abs(x);
+
+            // Determine which region each element falls into
+            TVectorDouble gtR39_16 = TVectorDouble.GreaterThan(v, TVectorDouble.Create(R39_16));
+            TVectorDouble gtR19_16 = TVectorDouble.GreaterThan(v, TVectorDouble.Create(R19_16));
+            TVectorDouble gtR11_16 = TVectorDouble.GreaterThan(v, TVectorDouble.Create(R11_16));
+            TVectorDouble gtR7_16 = TVectorDouble.GreaterThan(v, TVectorDouble.Create(R7_16));
+
+            // Compute reduced argument for each region
+
+            // Region 5: x > 39/16: reduced = -1/v
+            TVectorDouble reduced5 = -TVectorDouble.One / v;
+
+            // Region 4: 19/16 < x <= 39/16: reduced = (v-1.5)/(1+1.5*v)
+            TVectorDouble reduced4 = (v - TVectorDouble.Create(1.5)) / (TVectorDouble.One + TVectorDouble.Create(1.5) * v);
+
+            // Region 3: 11/16 < x <= 19/16: reduced = (v-1)/(1+v)
+            TVectorDouble reduced3 = (v - TVectorDouble.One) / (TVectorDouble.One + v);
+
+            // Region 2: 7/16 < x <= 11/16: reduced = (2*v-1)/(2+v)
+            TVectorDouble reduced2 = (TVectorDouble.Create(2.0) * v - TVectorDouble.One) / (TVectorDouble.Create(2.0) + v);
+
+            // Region 1: x <= 7/16: reduced = v
+            TVectorDouble reduced1 = v;
+
+            // Select reduced argument
+            TVectorDouble reduced = TVectorDouble.ConditionalSelect(gtR39_16, reduced5,
+                                    TVectorDouble.ConditionalSelect(gtR19_16, reduced4,
+                                    TVectorDouble.ConditionalSelect(gtR11_16, reduced3,
+                                    TVectorDouble.ConditionalSelect(gtR7_16, reduced2, reduced1))));
+
+            // Select chi (high part of constant)
+            TVectorDouble chi = TVectorDouble.ConditionalSelect(gtR39_16, TVectorDouble.Create(CHI_INF),
+                               TVectorDouble.ConditionalSelect(gtR19_16, TVectorDouble.Create(CHI_1_5),
+                               TVectorDouble.ConditionalSelect(gtR11_16, TVectorDouble.Create(CHI_1),
+                               TVectorDouble.ConditionalSelect(gtR7_16, TVectorDouble.Create(CHI_HALF), TVectorDouble.Create(CHI_0)))));
+
+            // Select clo (low part of constant)
+            TVectorDouble clo = TVectorDouble.ConditionalSelect(gtR39_16, TVectorDouble.Create(CLO_INF),
+                               TVectorDouble.ConditionalSelect(gtR19_16, TVectorDouble.Create(CLO_1_5),
+                               TVectorDouble.ConditionalSelect(gtR11_16, TVectorDouble.Create(CLO_1),
+                               TVectorDouble.ConditionalSelect(gtR7_16, TVectorDouble.Create(CLO_HALF), TVectorDouble.Create(CLO_0)))));
+
+            // Compute s = reduced^2
+            TVectorDouble s = reduced * reduced;
+
+            // Evaluate numerator polynomial: P0 + s*(P1 + s*(P2 + s*(P3 + s*P4)))
+            TVectorDouble num = TVectorDouble.Create(P4);
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(P3));
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(P2));
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(P1));
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(P0));
+
+            // Evaluate denominator polynomial: Q0 + s*(Q1 + s*(Q2 + s*(Q3 + s*Q4)))
+            TVectorDouble denom = TVectorDouble.Create(Q4);
+            denom = TVectorDouble.MultiplyAddEstimate(denom, s, TVectorDouble.Create(Q3));
+            denom = TVectorDouble.MultiplyAddEstimate(denom, s, TVectorDouble.Create(Q2));
+            denom = TVectorDouble.MultiplyAddEstimate(denom, s, TVectorDouble.Create(Q1));
+            denom = TVectorDouble.MultiplyAddEstimate(denom, s, TVectorDouble.Create(Q0));
+
+            // q = reduced * s * num / denom
+            TVectorDouble q = reduced * s * num / denom;
+
+            // result = chi - ((q - clo) - reduced)
+            TVectorDouble result = chi - ((q - clo) - reduced);
+
+            // Restore sign
+            result ^= sign;
+
+            return result;
+        }
+
+        public static TVectorSingle AtanSingle<TVectorSingle, TVectorInt32, TVectorDouble, TVectorInt64>(TVectorSingle x)
+            where TVectorSingle : unmanaged, ISimdVector<TVectorSingle, float>
+            where TVectorInt32 : unmanaged, ISimdVector<TVectorInt32, int>
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+            where TVectorInt64 : unmanaged, ISimdVector<TVectorInt64, long>
+        {
+            // This code is based on `atanf` from amd/aocl-libm-ose
+            // Copyright (C) 2008-2022 Advanced Micro Devices, Inc. All rights reserved.
+            //
+            // Licensed under the BSD 3-Clause "New" or "Revised" License
+            // See THIRD-PARTY-NOTICES.TXT for the full license text
+
+            TVectorSingle nanMask = ~TVectorSingle.Equals(x, x);
+            TVectorSingle sign = x & TVectorSingle.Create(-0.0f);
+            TVectorSingle ax = TVectorSingle.Abs(x);
+            TVectorSingle tinyMask = TVectorSingle.LessThan(ax, TVectorSingle.Create(1.9073486328125e-06f));  // 2^-19
+            TVectorSingle overflowMask = TVectorSingle.GreaterThanOrEqual(ax, TVectorSingle.Create(67108864.0f)); // 2^26
+
+            TVectorSingle result;
+
+            if (TVectorSingle.ElementCount == TVectorDouble.ElementCount)
+            {
+                TVectorDouble dax = Widen<TVectorSingle, TVectorDouble>(ax);
+                result = Narrow<TVectorDouble, TVectorSingle>(AtanSingleCoreDouble<TVectorDouble>(dax));
+            }
+            else
+            {
+                TVectorDouble daxLo = WidenLower<TVectorSingle, TVectorDouble>(ax);
+                TVectorDouble daxHi = WidenUpper<TVectorSingle, TVectorDouble>(ax);
+                result = Narrow<TVectorDouble, TVectorSingle>(
+                    AtanSingleCoreDouble<TVectorDouble>(daxLo),
+                    AtanSingleCoreDouble<TVectorDouble>(daxHi));
+            }
+
+            result ^= sign;
+            result = TVectorSingle.ConditionalSelect(tinyMask, x, result);
+            result = TVectorSingle.ConditionalSelect(overflowMask & ~nanMask, TVectorSingle.Create(1.5707964f) ^ sign, result);
+            result = TVectorSingle.ConditionalSelect(nanMask, TVectorSingle.Create(float.NaN), result);
+
+            return result;
+        }
+
+        private static TVectorDouble AtanSingleCoreDouble<TVectorDouble>(TVectorDouble ax)
+            where TVectorDouble : unmanaged, ISimdVector<TVectorDouble, double>
+        {
+            // Rational polynomial coefficients for Remez(2,2) (AMD atanf.c)
+            const double C0 = 0.296528598819239217902158651186e0;
+            const double C1 = 0.192324546402108583211697690500e0;
+            const double C2 = 0.470677934286149214138357545549e-2;
+            const double C3 = 0.889585796862432286486651434570e0;
+            const double C4 = 0.111072499995399550138837673349e1;
+            const double C5 = 0.299309699959659728404442796915e0;
+
+            // Argument reduction boundary constants
+            const double R7_16 = 0.4375;               // 7/16
+            const double R11_16 = 0.6875;               // 11/16
+            const double R19_16 = 1.1875;               // 19/16
+            const double R39_16 = 2.4375;               // 39/16
+
+            // Precomputed arctan values for reduction points
+            const double VALUE0 = 0.0;                                     // atan(0)
+            const double VALUE1 = 4.63647609000806093515e-01;              // atan(0.5)
+            const double VALUE2 = 7.85398163397448278999e-01;              // atan(1)
+            const double VALUE3 = 9.82793723247329054082e-01;              // atan(1.5)
+
+            TVectorDouble r1 = TVectorDouble.LessThan(ax, TVectorDouble.Create(R7_16));
+            TVectorDouble r2 = TVectorDouble.LessThan(ax, TVectorDouble.Create(R11_16));
+            TVectorDouble r3 = TVectorDouble.LessThan(ax, TVectorDouble.Create(R19_16));
+            TVectorDouble r4 = TVectorDouble.LessThan(ax, TVectorDouble.Create(R39_16));
+
+            // Start with region 5 (largest range) and work backwards
+            TVectorDouble reduced = -TVectorDouble.One / ax;
+            TVectorDouble c = TVectorDouble.Create(1.57079632679489655800e+00); // pi/2
+
+            TVectorDouble x4 = (ax - TVectorDouble.Create(1.5)) / (TVectorDouble.One + TVectorDouble.Create(1.5) * ax);
+            reduced = TVectorDouble.ConditionalSelect(r4, x4, reduced);
+            c = TVectorDouble.ConditionalSelect(r4, TVectorDouble.Create(VALUE3), c);
+
+            TVectorDouble x3 = (ax - TVectorDouble.One) / (TVectorDouble.One + ax);
+            reduced = TVectorDouble.ConditionalSelect(r3, x3, reduced);
+            c = TVectorDouble.ConditionalSelect(r3, TVectorDouble.Create(VALUE2), c);
+
+            TVectorDouble x2 = (TVectorDouble.Create(2.0) * ax - TVectorDouble.One) / (TVectorDouble.Create(2.0) + ax);
+            reduced = TVectorDouble.ConditionalSelect(r2, x2, reduced);
+            c = TVectorDouble.ConditionalSelect(r2, TVectorDouble.Create(VALUE1), c);
+
+            reduced = TVectorDouble.ConditionalSelect(r1, ax, reduced);
+            c = TVectorDouble.ConditionalSelect(r1, TVectorDouble.Create(VALUE0), c);
+
+            TVectorDouble s = reduced * reduced;
+
+            TVectorDouble num = TVectorDouble.Create(C2);
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(C1));
+            num = TVectorDouble.MultiplyAddEstimate(num, s, TVectorDouble.Create(C0));
+
+            TVectorDouble den = TVectorDouble.Create(C5);
+            den = TVectorDouble.MultiplyAddEstimate(den, s, TVectorDouble.Create(C4));
+            den = TVectorDouble.MultiplyAddEstimate(den, s, TVectorDouble.Create(C3));
+
+            TVectorDouble p = reduced * s * num / den;
+
+            return c - (p - reduced);
+        }
     }
 }

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -21,6 +21,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Asin(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Asin(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<double> Atan(System.Runtime.Intrinsics.Vector128<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector128<float> Atan(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
@@ -484,6 +486,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Asin(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Asin(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<double> Atan(System.Runtime.Intrinsics.Vector256<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector256<float> Atan(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
@@ -936,6 +940,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Asin(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> Asin(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector512<double> Atan(System.Runtime.Intrinsics.Vector512<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector512<float> Atan(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
@@ -1387,6 +1393,8 @@ namespace System.Runtime.Intrinsics
         public static bool AnyWhereAllBitsSet<T>(System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> Asin(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> Asin(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<double> Atan(System.Runtime.Intrinsics.Vector64<double> vector) { throw null; }
+        public static System.Runtime.Intrinsics.Vector64<float> Atan(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Byte> AsByte<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Double> AsDouble<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<System.Int16> AsInt16<T>(this System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector128Tests.cs
@@ -5322,6 +5322,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector128<double> actualResult = Vector128.Atan(Vector128.Create(value));
+            AssertEqual(Vector128.Create(expectedResult), actualResult, Vector128.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector128<float> actualResult = Vector128.Atan(Vector128.Create(value));
+            AssertEqual(Vector128.Create(expectedResult), actualResult, Vector128.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector256Tests.cs
@@ -6498,6 +6498,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector256<double> actualResult = Vector256.Atan(Vector256.Create(value));
+            AssertEqual(Vector256.Create(expectedResult), actualResult, Vector256.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector256<float> actualResult = Vector256.Atan(Vector256.Create(value));
+            AssertEqual(Vector256.Create(expectedResult), actualResult, Vector256.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector512Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector512Tests.cs
@@ -6281,6 +6281,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector512<double> actualResult = Vector512.Atan(Vector512.Create(value));
+            AssertEqual(Vector512.Create(expectedResult), actualResult, Vector512.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector512<float> actualResult = Vector512.Atan(Vector512.Create(value));
+            AssertEqual(Vector512.Create(expectedResult), actualResult, Vector512.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {

--- a/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
+++ b/src/libraries/System.Runtime.Intrinsics/tests/Vectors/Vector64Tests.cs
@@ -4596,6 +4596,22 @@ namespace System.Runtime.Intrinsics.Tests.Vectors
         }
 
         [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanDouble), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanDoubleTest(double value, double expectedResult, double variance)
+        {
+            Vector64<double> actualResult = Vector64.Atan(Vector64.Create(value));
+            AssertEqual(Vector64.Create(expectedResult), actualResult, Vector64.Create(variance));
+        }
+
+        [Theory]
+        [MemberData(nameof(GenericMathTestMemberData.AtanSingle), MemberType = typeof(GenericMathTestMemberData))]
+        public void AtanSingleTest(float value, float expectedResult, float variance)
+        {
+            Vector64<float> actualResult = Vector64.Atan(Vector64.Create(value));
+            AssertEqual(Vector64.Create(expectedResult), actualResult, Vector64.Create(variance));
+        }
+
+        [Theory]
         [MemberData(nameof(GenericMathTestMemberData.CosDouble), MemberType = typeof(GenericMathTestMemberData))]
         public void CosDoubleTest(double value, double expectedResult, double variance)
         {


### PR DESCRIPTION
Add vectorized Atan implementations for float and double across all SIMD vector types, with corresponding unit tests.

## Description

- Adds `Vector64/128/256/512.Atan` APIs (float/double) and updates the System.Runtime.Intrinsics reference assembly surface area.
- Implements vectorized `atan` kernels in `VectorMath` (double core and single via widening to double core).
- Enables TensorPrimitives `Atan` vectorization for `float`/`double` (NET11+) and updates tolerances in generic tests.
- Adds `AtanDouble` and `AtanSingle` test data to `GenericMathTestMemberData` with 29 test cases each, covering edge cases (±0, NaN, ±Infinity) and representative magnitudes using well-known mathematical constants.
- Adds `AtanDoubleTest` and `AtanSingleTest` unit tests to `Vector64Tests.cs`, `Vector128Tests.cs`, `Vector256Tests.cs`, and `Vector512Tests.cs`, following the same `[Theory]`/`[MemberData]` pattern as the existing `Asin`, `Cos`, and `Sin` tests.