### PR TITLE
Add DirectoryPath property to DirectoryNotFoundException

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -130,7 +130,11 @@ internal static partial class Interop
 
             case Error.ENOTDIR:
                 return !string.IsNullOrEmpty(path) ?
+#if NET
                     new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path), path) :
+#else
+                    new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path)) :
+#endif
                     new DirectoryNotFoundException(SR.IO_PathNotFound_NoPathName);
 
             case Error.EACCES:

--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -130,7 +130,7 @@ internal static partial class Interop
 
             case Error.ENOTDIR:
                 return !string.IsNullOrEmpty(path) ?
-#if NET
+#if NET11_0_OR_GREATER
                     new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path), path) :
 #else
                     new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path)) :

--- a/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/libraries/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -130,7 +130,7 @@ internal static partial class Interop
 
             case Error.ENOTDIR:
                 return !string.IsNullOrEmpty(path) ?
-                    new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path)) :
+                    new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, path), path) :
                     new DirectoryNotFoundException(SR.IO_PathNotFound_NoPathName);
 
             case Error.EACCES:

--- a/src/libraries/Common/src/System/IO/Win32Marshal.cs
+++ b/src/libraries/Common/src/System/IO/Win32Marshal.cs
@@ -34,7 +34,7 @@ namespace System.IO
                     return new FileNotFoundException(
                         string.IsNullOrEmpty(path) ? SR.IO_FileNotFound : SR.Format(SR.IO_FileNotFound_FileName, path), path);
                 case Interop.Errors.ERROR_PATH_NOT_FOUND:
-#if NET
+#if NET11_0_OR_GREATER
                     return new DirectoryNotFoundException(
                         string.IsNullOrEmpty(path) ? SR.IO_PathNotFound_NoPathName : SR.Format(SR.IO_PathNotFound_Path, path), path);
 #else

--- a/src/libraries/Common/src/System/IO/Win32Marshal.cs
+++ b/src/libraries/Common/src/System/IO/Win32Marshal.cs
@@ -34,8 +34,13 @@ namespace System.IO
                     return new FileNotFoundException(
                         string.IsNullOrEmpty(path) ? SR.IO_FileNotFound : SR.Format(SR.IO_FileNotFound_FileName, path), path);
                 case Interop.Errors.ERROR_PATH_NOT_FOUND:
+#if NET
                     return new DirectoryNotFoundException(
                         string.IsNullOrEmpty(path) ? SR.IO_PathNotFound_NoPathName : SR.Format(SR.IO_PathNotFound_Path, path), path);
+#else
+                    return new DirectoryNotFoundException(
+                        string.IsNullOrEmpty(path) ? SR.IO_PathNotFound_NoPathName : SR.Format(SR.IO_PathNotFound_Path, path));
+#endif
                 case Interop.Errors.ERROR_ACCESS_DENIED:
                     return new UnauthorizedAccessException(
                         string.IsNullOrEmpty(path) ? SR.UnauthorizedAccess_IODenied_NoPathName : SR.Format(SR.UnauthorizedAccess_IODenied_Path, path));

--- a/src/libraries/Common/src/System/IO/Win32Marshal.cs
+++ b/src/libraries/Common/src/System/IO/Win32Marshal.cs
@@ -35,7 +35,7 @@ namespace System.IO
                         string.IsNullOrEmpty(path) ? SR.IO_FileNotFound : SR.Format(SR.IO_FileNotFound_FileName, path), path);
                 case Interop.Errors.ERROR_PATH_NOT_FOUND:
                     return new DirectoryNotFoundException(
-                        string.IsNullOrEmpty(path) ? SR.IO_PathNotFound_NoPathName : SR.Format(SR.IO_PathNotFound_Path, path));
+                        string.IsNullOrEmpty(path) ? SR.IO_PathNotFound_NoPathName : SR.Format(SR.IO_PathNotFound_Path, path), path);
                 case Interop.Errors.ERROR_ACCESS_DENIED:
                     return new UnauthorizedAccessException(
                         string.IsNullOrEmpty(path) ? SR.UnauthorizedAccess_IODenied_NoPathName : SR.Format(SR.UnauthorizedAccess_IODenied_Path, path));

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -63,7 +63,11 @@ namespace Microsoft.Extensions.FileProviders
             Root = PathUtils.EnsureTrailingSlash(fullRoot);
             if (!Directory.Exists(Root))
             {
+#if NET
                 throw new DirectoryNotFoundException(null, Root);
+#else
+                throw new DirectoryNotFoundException(Root);
+#endif
             }
 
             _filters = filters;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.FileProviders
             Root = PathUtils.EnsureTrailingSlash(fullRoot);
             if (!Directory.Exists(Root))
             {
-                throw new DirectoryNotFoundException(Root);
+                throw new DirectoryNotFoundException(Root, Root);
             }
 
             _filters = filters;

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.FileProviders
             Root = PathUtils.EnsureTrailingSlash(fullRoot);
             if (!Directory.Exists(Root))
             {
-#if NET
+#if NET11_0_OR_GREATER
                 throw new DirectoryNotFoundException(null, Root);
 #else
                 throw new DirectoryNotFoundException(Root);

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/src/PhysicalFileProvider.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Extensions.FileProviders
             Root = PathUtils.EnsureTrailingSlash(fullRoot);
             if (!Directory.Exists(Root))
             {
-                throw new DirectoryNotFoundException(Root, Root);
+                throw new DirectoryNotFoundException(null, Root);
             }
 
             _filters = filters;

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -34,7 +34,11 @@ namespace System.DirectoryServices.Protocols
             {
                 if (!Directory.Exists(value))
                 {
+#if NET
                     throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value), value);
+#else
+                    throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value));
+#endif
                 }
 
                 SetStringOptionHelper(LdapOption.LDAP_OPT_X_TLS_CACERTDIR, value);

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -34,7 +34,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (!Directory.Exists(value))
                 {
-#if NET
+#if NET11_0_OR_GREATER
                     throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value), value);
 #else
                     throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value));

--- a/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/src/System/DirectoryServices/Protocols/ldap/LdapSessionOptions.Linux.cs
@@ -34,7 +34,7 @@ namespace System.DirectoryServices.Protocols
             {
                 if (!Directory.Exists(value))
                 {
-                    throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value));
+                    throw new DirectoryNotFoundException(SR.Format(SR.DirectoryNotFound, value), value);
                 }
 
                 SetStringOptionHelper(LdapOption.LDAP_OPT_X_TLS_CACERTDIR, value);

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -67,7 +67,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName));
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName);
             }
 
             // Rely on Path.GetFullPath for validation of paths
@@ -135,7 +135,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName)));
+                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName));
             }
 
             // Rely on Path.GetFullPath for validation of paths
@@ -190,7 +190,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName));
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName);
             }
 
             // Throws if the destination file exists
@@ -253,7 +253,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName)));
+                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName));
             }
 
             return CreateFromDirectoryInternalAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, options, cancellationToken);
@@ -309,7 +309,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName));
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName);
             }
 
             // Rely on Path.GetFullPath for validation of paths
@@ -377,7 +377,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName)));
+                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName));
             }
 
             // Rely on Path.GetFullPath for validation of paths
@@ -440,7 +440,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName));
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName);
             }
 
             using FileStream archive = File.OpenRead(sourceFileName);
@@ -509,7 +509,7 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName)));
+                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName));
             }
 
             return ExtractToDirectoryInternalAsync(sourceFileName, destinationDirectoryName, options, cancellationToken);

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
@@ -46,7 +46,7 @@ namespace System.Security.AccessControl
                     {
                         // DirectorySecurity
                         if ((name != null) && (name.Length != 0))
-                            exception = new DirectoryNotFoundException(name, name);
+                            exception = new DirectoryNotFoundException(null, name);
                         else
                             exception = new DirectoryNotFoundException();
                     }

--- a/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
+++ b/src/libraries/System.IO.FileSystem.AccessControl/src/System/Security/AccessControl/FileSystemSecurity.cs
@@ -46,7 +46,7 @@ namespace System.Security.AccessControl
                     {
                         // DirectorySecurity
                         if ((name != null) && (name.Length != 0))
-                            exception = new DirectoryNotFoundException(name);
+                            exception = new DirectoryNotFoundException(name, name);
                         else
                             exception = new DirectoryNotFoundException();
                     }

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFile.cs
@@ -360,7 +360,7 @@ namespace System.IO.IsolatedStorage
             }
             catch (DirectoryNotFoundException)
             {
-                throw new DirectoryNotFoundException(SR.Format(SR.PathNotFound_Path, sourceDirectoryName));
+                throw new DirectoryNotFoundException(SR.Format(SR.PathNotFound_Path, sourceDirectoryName), sourceDirectoryName);
             }
             catch (PathTooLongException)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Unix.cs
@@ -277,7 +277,7 @@ namespace System.Net.Sockets
                     string? dirname = Path.GetDirectoryName(fnfe.FileName);
                     if (!string.IsNullOrEmpty(dirname) && !Directory.Exists(dirname))
                     {
-                        throw new DirectoryNotFoundException(fnfe.Message);
+                        throw new DirectoryNotFoundException(fnfe.Message, dirname);
                     }
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -296,7 +296,7 @@
     <value>Decimal constructor requires an array or span of four valid decimal bytes.</value>
   </data>
   <data name="Arg_DirectoryNotFoundException" xml:space="preserve">
-    <value>Attempted to access a path that is not on the disk.</value>
+    <value>Could not find directory.</value>
   </data>
   <data name="Arg_DivideByZero" xml:space="preserve">
     <value>Attempted to divide by zero.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -296,7 +296,7 @@
     <value>Decimal constructor requires an array or span of four valid decimal bytes.</value>
   </data>
   <data name="Arg_DirectoryNotFoundException" xml:space="preserve">
-    <value>Could not find directory.</value>
+    <value>Unable to find the specified directory.</value>
   </data>
   <data name="Arg_DivideByZero" xml:space="preserve">
     <value>Attempted to divide by zero.</value>

--- a/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
+++ b/src/libraries/System.Private.CoreLib/src/Resources/Strings.resx
@@ -2840,6 +2840,12 @@
   <data name="IO_FileLoad_FileName" xml:space="preserve">
     <value>Could not load the file '{0}'.</value>
   </data>
+  <data name="IO_DirectoryName_Name" xml:space="preserve">
+    <value>Directory path: '{0}'</value>
+  </data>
+  <data name="IO_DirectoryNotFound_Path" xml:space="preserve">
+    <value>Could not find directory '{0}'.</value>
+  </data>
   <data name="IO_FileName_Name" xml:space="preserve">
     <value>File name: '{0}'</value>
   </data>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -37,38 +36,21 @@ namespace System.IO
         }
 
         public DirectoryNotFoundException(string? message, string? directoryPath)
-            : base(message)
+            : base(message ?? (directoryPath is not null
+                ? SR.Format(SR.IO_DirectoryNotFound_Path, directoryPath)
+                : SR.Arg_DirectoryNotFoundException))
         {
             HResult = HResults.COR_E_DIRECTORYNOTFOUND;
             DirectoryPath = directoryPath;
         }
 
         public DirectoryNotFoundException(string? message, string? directoryPath, Exception? innerException)
-            : base(message, innerException)
+            : base(message ?? (directoryPath is not null
+                ? SR.Format(SR.IO_DirectoryNotFound_Path, directoryPath)
+                : SR.Arg_DirectoryNotFoundException), innerException)
         {
             HResult = HResults.COR_E_DIRECTORYNOTFOUND;
             DirectoryPath = directoryPath;
-        }
-
-        public override string Message
-        {
-            get
-            {
-                SetMessageField();
-                Debug.Assert(_message != null, "_message was null after calling SetMessageField");
-                return _message;
-            }
-        }
-
-        private void SetMessageField()
-        {
-            if (_message is null)
-            {
-                if (DirectoryPath is null)
-                    _message = SR.Arg_DirectoryNotFoundException;
-                else
-                    _message = SR.Format(SR.IO_DirectoryNotFound_Path, DirectoryPath);
-            }
         }
 
         public string? DirectoryPath { get; }
@@ -94,7 +76,14 @@ namespace System.IO
         protected DirectoryNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
-            DirectoryPath = info.GetString("DirectoryNotFound_DirectoryPath");
+            foreach (SerializationEntry entry in info)
+            {
+                if (entry.Name == "DirectoryNotFound_DirectoryPath")
+                {
+                    DirectoryPath = (string?)entry.Value;
+                    break;
+                }
+            }
         }
 
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 
@@ -35,11 +36,73 @@ namespace System.IO
             HResult = HResults.COR_E_DIRECTORYNOTFOUND;
         }
 
+        public DirectoryNotFoundException(string? message, string? directoryPath)
+            : base(message)
+        {
+            HResult = HResults.COR_E_DIRECTORYNOTFOUND;
+            DirectoryPath = directoryPath;
+        }
+
+        public DirectoryNotFoundException(string? message, string? directoryPath, Exception? innerException)
+            : base(message, innerException)
+        {
+            HResult = HResults.COR_E_DIRECTORYNOTFOUND;
+            DirectoryPath = directoryPath;
+        }
+
+        public override string Message
+        {
+            get
+            {
+                SetMessageField();
+                Debug.Assert(_message != null, "_message was null after calling SetMessageField");
+                return _message;
+            }
+        }
+
+        private void SetMessageField()
+        {
+            if (_message is null)
+            {
+                if (DirectoryPath is null)
+                    _message = SR.Arg_DirectoryNotFoundException;
+                else
+                    _message = SR.Format(SR.IO_DirectoryNotFound_Path, DirectoryPath);
+            }
+        }
+
+        public string? DirectoryPath { get; }
+
+        public override string ToString()
+        {
+            string s = GetType().ToString() + ": " + Message;
+
+            if (!string.IsNullOrEmpty(DirectoryPath))
+                s += Environment.NewLineConst + SR.Format(SR.IO_DirectoryName_Name, DirectoryPath);
+
+            if (InnerException is not null)
+                s += Environment.NewLineConst + InnerExceptionPrefix + InnerException.ToString();
+
+            if (StackTrace is not null)
+                s += Environment.NewLineConst + StackTrace;
+
+            return s;
+        }
+
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected DirectoryNotFoundException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
+            DirectoryPath = info.GetString("DirectoryNotFound_DirectoryPath");
+        }
+
+        [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            base.GetObjectData(info, context);
+            info.AddValue("DirectoryNotFound_DirectoryPath", DirectoryPath, typeof(string));
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/DirectoryNotFoundException.cs
@@ -36,12 +36,8 @@ namespace System.IO
         }
 
         public DirectoryNotFoundException(string? message, string? directoryPath)
-            : base(message ?? (directoryPath is not null
-                ? SR.Format(SR.IO_DirectoryNotFound_Path, directoryPath)
-                : SR.Arg_DirectoryNotFoundException))
+            : this(message, directoryPath, innerException: null)
         {
-            HResult = HResults.COR_E_DIRECTORYNOTFOUND;
-            DirectoryPath = directoryPath;
         }
 
         public DirectoryNotFoundException(string? message, string? directoryPath, Exception? innerException)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -182,7 +182,7 @@ namespace System.IO
             // https://github.com/dotnet/runtime/issues/14885 is found that doesn't require
             // validity checks before making an API call.
             if (!System.IO.Directory.Exists(Path.GetDirectoryName(FullName)))
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullName));
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullName), Path.GetDirectoryName(FullName));
 
             if (!Exists)
                 throw new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, FullName), FullName);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -182,7 +182,10 @@ namespace System.IO
             // https://github.com/dotnet/runtime/issues/14885 is found that doesn't require
             // validity checks before making an API call.
             if (!System.IO.Directory.Exists(Path.GetDirectoryName(FullName)))
-                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, FullName), Path.GetDirectoryName(FullName));
+            {
+                string? directoryPath = Path.GetDirectoryName(FullName);
+                throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, directoryPath), directoryPath);
+            }
 
             if (!Exists)
                 throw new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, FullName), FullName);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileInfo.cs
@@ -181,11 +181,9 @@ namespace System.IO
             // as it does on Windows.These checks can be removed if a solution to
             // https://github.com/dotnet/runtime/issues/14885 is found that doesn't require
             // validity checks before making an API call.
-            if (!System.IO.Directory.Exists(Path.GetDirectoryName(FullName)))
-            {
-                string? directoryPath = Path.GetDirectoryName(FullName);
+            string? directoryPath = Path.GetDirectoryName(FullName);
+            if (!System.IO.Directory.Exists(directoryPath))
                 throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, directoryPath), directoryPath);
-            }
 
             if (!Exists)
                 throw new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, FullName), FullName);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/FileSystem.Unix.cs
@@ -418,7 +418,7 @@ namespace System.IO
                 // Throw if the source doesn't exist.
                 if (Interop.Sys.LStat(srcNoDirectorySeparator, out Interop.Sys.FileStatus sourceFileStatus) < 0)
                 {
-                    throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+                    throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath), sourceFullPath);
                 }
                 // Source and destination must not be the same file unless it is a case-sensitive rename.
                 else if (sourceFileStatus.Dev == destFileStatus.Dev &&
@@ -454,7 +454,7 @@ namespace System.IO
                     case Interop.Error.EACCES: // match Win32 exception
                         throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, sourceFullPath), errorInfo.RawErrno);
                     case Interop.Error.ENOENT:
-                        throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
+                        throw new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath), sourceFullPath);
                     case Interop.Error.ENOTDIR: // sourceFullPath exists and it's not a directory
                         throw new IOException(SR.Format(SR.IO_PathNotFound_Path, sourceFullPath));
                     default:

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10303,10 +10303,10 @@ namespace System.IO
         public DirectoryNotFoundException(string? message, string? directoryPath) { }
         public DirectoryNotFoundException(string? message, string? directoryPath, System.Exception? innerException) { }
         public string? DirectoryPath { get { throw null; } }
+        public override string Message { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-        public override string Message { get { throw null; } }
         public override string ToString() { throw null; }
     }
     public partial class EndOfStreamException : System.IO.IOException

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10303,7 +10303,6 @@ namespace System.IO
         public DirectoryNotFoundException(string? message, string? directoryPath) { }
         public DirectoryNotFoundException(string? message, string? directoryPath, System.Exception? innerException) { }
         public string? DirectoryPath { get { throw null; } }
-        public override string Message { get { throw null; } }
         [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
         [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
         public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -10300,6 +10300,14 @@ namespace System.IO
         protected DirectoryNotFoundException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
         public DirectoryNotFoundException(string? message) { }
         public DirectoryNotFoundException(string? message, System.Exception? innerException) { }
+        public DirectoryNotFoundException(string? message, string? directoryPath) { }
+        public DirectoryNotFoundException(string? message, string? directoryPath, System.Exception? innerException) { }
+        public string? DirectoryPath { get { throw null; } }
+        [System.ComponentModel.EditorBrowsableAttribute(System.ComponentModel.EditorBrowsableState.Never)]
+        [System.ObsoleteAttribute("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId="SYSLIB0051", UrlFormat="https://aka.ms/dotnet-warnings/{0}")]
+        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public override string Message { get { throw null; } }
+        public override string ToString() { throw null; }
     }
     public partial class EndOfStreamException : System.IO.IOException
     {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IO/DirectoryNotFoundExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IO/DirectoryNotFoundExceptionTests.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
 using Xunit;
 using System.Tests;
 
@@ -37,25 +39,51 @@ namespace System.IO.Tests
             Assert.Null(exception.DirectoryPath);
         }
 
-        [Fact]
-        public static void Ctor_String_String()
+        [Theory]
+        [InlineData("That directory is gone.", @"C:\missing\dir")]
+        [InlineData("", @"/data/reports")]
+        [InlineData("Custom message", "")]
+        public static void Ctor_String_String(string message, string directoryPath)
         {
-            string message = "That directory is gone.";
-            string directoryPath = @"C:\missing\dir";
             var exception = new DirectoryNotFoundException(message, directoryPath);
             ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, message: message);
             Assert.Equal(directoryPath, exception.DirectoryPath);
         }
 
-        [Fact]
-        public static void Ctor_String_String_Exception()
+        [Theory]
+        [InlineData("That directory is gone.", @"C:\missing\dir")]
+        [InlineData("", @"/data/reports")]
+        [InlineData("Custom message", "")]
+        public static void Ctor_String_String_Exception(string message, string directoryPath)
         {
-            string message = "That directory is gone.";
-            string directoryPath = @"C:\missing\dir";
             var innerException = new Exception("Inner exception");
             var exception = new DirectoryNotFoundException(message, directoryPath, innerException);
             ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, innerException: innerException, message: message);
             Assert.Equal(directoryPath, exception.DirectoryPath);
+        }
+
+        [Fact]
+        public static void Ctor_NullDirectoryPath()
+        {
+            string message = "msg";
+            var exception = new DirectoryNotFoundException(message, (string?)null);
+            ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, message: message);
+            Assert.Null(exception.DirectoryPath);
+
+            var innerException = new Exception();
+            var exception2 = new DirectoryNotFoundException(message, (string?)null, innerException);
+            ExceptionHelpers.ValidateExceptionProperties(exception2, hResult: HResults.COR_E_DIRECTORYNOTFOUND, innerException: innerException, message: message);
+            Assert.Null(exception2.DirectoryPath);
+        }
+
+        [Fact]
+        public static void Ctor_NullMessageAndNullDirectoryPath()
+        {
+            var exception = new DirectoryNotFoundException(null, (string?)null);
+            ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, validateMessage: false);
+            Assert.Null(exception.DirectoryPath);
+            Assert.NotNull(exception.Message);
+            Assert.NotEmpty(exception.Message);
         }
 
         [Fact]
@@ -68,7 +96,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public static void ToStringTest()
+        public static void ToString_WithDirectoryPath()
         {
             string message = "That directory is gone.";
             string directoryPath = @"C:\missing\dir";
@@ -86,6 +114,36 @@ namespace System.IO.Tests
                 Assert.False(string.IsNullOrEmpty(exception.StackTrace));
                 Assert.Contains(exception.StackTrace, exception.ToString());
             }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public static void ToString_WithoutDirectoryPath_OmitsDirectoryLine(string? directoryPath)
+        {
+            var exception = new DirectoryNotFoundException("message", directoryPath);
+            string toString = exception.ToString();
+            Assert.DoesNotContain("Directory path:", toString);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
+        public static void GetObjectData_Roundtrip()
+        {
+            string message = "dir not found";
+            string directoryPath = @"C:\missing\dir";
+            var original = new DirectoryNotFoundException(message, directoryPath);
+
+#pragma warning disable SYSLIB0011
+            var formatter = new BinaryFormatter();
+            using var stream = new MemoryStream();
+            formatter.Serialize(stream, original);
+            stream.Position = 0;
+            var deserialized = (DirectoryNotFoundException)formatter.Deserialize(stream);
+#pragma warning restore SYSLIB0011
+
+            Assert.Equal(message, deserialized.Message);
+            Assert.Equal(directoryPath, deserialized.DirectoryPath);
+            Assert.Equal(original.HResult, deserialized.HResult);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IO/DirectoryNotFoundExceptionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/IO/DirectoryNotFoundExceptionTests.cs
@@ -15,6 +15,7 @@ namespace System.IO.Tests
         {
             var exception = new DirectoryNotFoundException();
             ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, validateMessage: false);
+            Assert.Null(exception.DirectoryPath);
         }
 
         [Fact]
@@ -23,6 +24,7 @@ namespace System.IO.Tests
             string message = "That page was missing from the directory.";
             var exception = new DirectoryNotFoundException(message);
             ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, message: message);
+            Assert.Null(exception.DirectoryPath);
         }
 
         [Fact]
@@ -32,6 +34,58 @@ namespace System.IO.Tests
             var innerException = new Exception("Inner exception");
             var exception = new DirectoryNotFoundException(message, innerException);
             ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, innerException: innerException, message: message);
+            Assert.Null(exception.DirectoryPath);
+        }
+
+        [Fact]
+        public static void Ctor_String_String()
+        {
+            string message = "That directory is gone.";
+            string directoryPath = @"C:\missing\dir";
+            var exception = new DirectoryNotFoundException(message, directoryPath);
+            ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, message: message);
+            Assert.Equal(directoryPath, exception.DirectoryPath);
+        }
+
+        [Fact]
+        public static void Ctor_String_String_Exception()
+        {
+            string message = "That directory is gone.";
+            string directoryPath = @"C:\missing\dir";
+            var innerException = new Exception("Inner exception");
+            var exception = new DirectoryNotFoundException(message, directoryPath, innerException);
+            ExceptionHelpers.ValidateExceptionProperties(exception, hResult: HResults.COR_E_DIRECTORYNOTFOUND, innerException: innerException, message: message);
+            Assert.Equal(directoryPath, exception.DirectoryPath);
+        }
+
+        [Fact]
+        public static void Message_AutoConstructed_WhenNullMessage_WithDirectoryPath()
+        {
+            string directoryPath = @"/data/reports";
+            var exception = new DirectoryNotFoundException(null, directoryPath);
+            Assert.NotNull(exception.Message);
+            Assert.Contains(directoryPath, exception.Message);
+        }
+
+        [Fact]
+        public static void ToStringTest()
+        {
+            string message = "That directory is gone.";
+            string directoryPath = @"C:\missing\dir";
+            var innerException = new Exception("Inner exception");
+            var exception = new DirectoryNotFoundException(message, directoryPath, innerException);
+
+            string toString = exception.ToString();
+            Assert.Contains(": " + message, toString);
+            Assert.Contains(": '" + directoryPath + "'", toString);
+            Assert.Contains("---> " + innerException.ToString(), toString);
+
+            try { throw exception; }
+            catch
+            {
+                Assert.False(string.IsNullOrEmpty(exception.StackTrace));
+                Assert.Contains(exception.StackTrace, exception.ToString());
+            }
         }
     }
 }

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -150,7 +150,7 @@ namespace System.Security.AccessControl
                         exception = isContainer switch
                         {
                             false => new FileNotFoundException(name),
-                            true  => new DirectoryNotFoundException(name)
+                            true  => new DirectoryNotFoundException(name, name)
                         };
                     }
                     else if (error == Interop.Errors.ERROR_NO_SECURITY_ON_OBJECT)

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/NativeObjectSecurity.cs
@@ -150,7 +150,7 @@ namespace System.Security.AccessControl
                         exception = isContainer switch
                         {
                             false => new FileNotFoundException(name),
-                            true  => new DirectoryNotFoundException(name, name)
+                            true  => new DirectoryNotFoundException(null, name)
                         };
                     }
                     else if (error == Interop.Errors.ERROR_NO_SECURITY_ON_OBJECT)


### PR DESCRIPTION
Closes #103468

Adds a `DirectoryPath` property to `DirectoryNotFoundException` as approved in [API review](https://github.com/dotnet/runtime/issues/103468#issuecomment-2286841778).

### What's included

- `DirectoryPath` nullable property on `DirectoryNotFoundException`, matching the pattern of `FileNotFoundException.FileName`
- Two new constructors accepting `directoryPath` (`message + directoryPath`, `message + directoryPath + innerException`)
- Auto-constructed message when `message` is null but `directoryPath` is provided, via null-coalescing in the constructors
- `ToString()` override that includes `DirectoryPath` on a separate line
- Serialization support via `GetObjectData` / version-tolerant deserialization constructor
- Ref assembly updates for `System.Runtime`
- Updated `Arg_DirectoryNotFoundException` default message from `"Attempted to access a path that is not on the disk."` to `"Unable to find the specified directory."` to match `FileNotFoundException`'s `"Unable to find the specified file."` pattern and align better with the new `IO_DirectoryNotFound_Path` string.
- Tests for all new constructors, property, message auto-construction, `ToString()` output, null edge cases, and serialization round-trip

### Implementation notes

- Follows the `FileNotFoundException` implementation pattern:
    - The property is `string?` (nullable) because not all throw sites have a path available
    - The new constructors null-coalesce `message` (consistent with existing DNFE constructors), auto-constructing a descriptive message from `directoryPath` when `message` is null
- Uses managed `SR.Format(...)` for message construction rather than native interop, as recommended during API review
- Version-tolerant deserialization: iterates `SerializationInfo` entries to handle old payloads that lack the `DirectoryPath` field
- `#if NET11_0_OR_GREATER` guards on throw sites in multi-TFM files (`Win32Marshal.cs`, `Interop.IOErrors.cs`, `PhysicalFileProvider.cs`, `LdapSessionOptions.Linux.cs`) since the new constructor isn't available on older TFM targets


### Internal throw-site updates

Updated 18 internal throw sites across 12 files to pass directory paths to the new constructors, so that `DirectoryPath` is populated for runtime-generated exceptions:

| Area | File(s) | Path variable |
|------|---------|---------------|
| CoreLib / Common | `Win32Marshal.cs` | `path` |
| CoreLib / Common | `Interop.IOErrors.cs` (Unix ENOTDIR) | `path` |
| CoreLib | `FileInfo.cs` (MoveTo) | directory of `FullName` |
| CoreLib | `FileSystem.Unix.cs` (×2, directory rename) | `sourceFullPath` |
| System.Formats.Tar | `TarFile.cs` (×8) | `sourceDirectoryName` / `destinationDirectoryName` |
| System.IO.IsolatedStorage | `IsolatedStorageFile.cs` | `sourceDirectoryName` |
| System.IO.FileSystem.AccessControl | `FileSystemSecurity.cs` | `name` |
| System.Net.Sockets | `SocketAsyncEventArgs.Unix.cs` | `dirname` |
| System.Security.AccessControl | `NativeObjectSecurity.cs` | `name` |
| System.DirectoryServices.Protocols | `LdapSessionOptions.Linux.cs` | `value` |
| Microsoft.Extensions.FileProviders.Physical | `PhysicalFileProvider.cs` | `Root` |

**Not updated** (by design):
- 3 sites with no path available (`SharedMemoryManager.Unix.cs` default ctor, `Interop.IOErrors.cs` empty-path branch, `FileSystemSecurity.cs` null-name branch)
- 4 threading sites (`EventWaitHandle`, `Mutex`, `EventWaitHandleAcl`, `MutexAcl`) where the `name` is a named sync object, not a filesystem directory
