### PR TITLE
Update Fedora Helix queues: latest 43 → 44

### DIFF
--- a/eng/pipelines/helix-platforms.yml
+++ b/eng/pipelines/helix-platforms.yml
@@ -121,9 +121,9 @@ variables:
     value: (Debian.13.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-13-helix-amd64
 
   # Fedora x64
-  # Latest: 43
+  # Latest: 44
   - name: helix_linux_x64_fedora_latest
-    value: (Fedora.43.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-43-helix-amd64
+    value: (Fedora.44.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-44-helix-amd64
 
   # Oldest: 43
   - name: helix_linux_x64_fedora_oldest

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -62,7 +62,7 @@ jobs:
           - ${{ if and(eq(parameters.jobParameters.isExtraPlatformsBuild, true), ne(parameters.jobParameters.testScope, 'outerloop'))}}:
             # extra-platforms CoreCLR (inner loop only)
             - (Debian.13.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-13-helix-amd64
-            - (Fedora.43.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-43-helix-amd64
+            - (Fedora.44.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-44-helix-amd64
             - (openSUSE.16.0.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-16.0-helix-amd64
 
           - ${{ if eq(parameters.jobParameters.testScope, 'outerloop') }}:


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated using the [`update-os-coverage` skill](https://github.com/dotnet/runtime/pull/126384).

## Summary

Update Fedora Helix test queues to use Fedora 44 as the `latest` slot, with Fedora 43 remaining as the `oldest` slot.

## Changes

| File | Change |
|------|--------|
| `eng/pipelines/helix-platforms.yml` | Fedora latest: 43 → 44 |
| `eng/pipelines/libraries/helix-queues-setup.yml` | extra-platforms Fedora: 43 → 44 |

## Version Details

| Version | Slot | EOL |
|---------|------|-----|
| Fedora 44 | latest (new) | ~2027-06 (estimated) |
| Fedora 43 | oldest | 2026-12-09 |
| Fedora 42 | removed | 2026-05-13 |

## Verification

- ✅ Container image `fedora-44-helix-amd64` confirmed available in [image-info](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)
- ✅ No stale Fedora 43 references remain outside the `oldest` slot
- ✅ Variable names unchanged; only values updated

## Full Audit

All other Linux distros are current:
- **Alpine**: edge / 3.23 ✅
- **Azure Linux**: 3.0 ✅
- **CentOS Stream**: 10 / 9 ✅
- **Debian**: 13 / 13 ✅
- **openSUSE**: 16.0 / 16.0 ✅
- **Ubuntu**: 26.04 / 22.04 ✅

Ref: [OS onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md) · [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)