### PR TITLE
Escape LDAP filter values in System.DirectoryServices.AccountManagement

### DIFF
--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADAMStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADAMStoreCtx.cs
@@ -279,7 +279,7 @@ namespace System.DirectoryServices.AccountManagement
                 {
                     using (DirectorySearcher dirSearcher = new DirectorySearcher(deSCN))
                     {
-                        dirSearcher.Filter = "(&(objectClass=classSchema)(systemAuxiliaryClass=" + auxClassName + "))";
+                        dirSearcher.Filter = "(&(objectClass=classSchema)(systemAuxiliaryClass=" + ADUtils.EscapeRFC2254SpecialChars(auxClassName) + "))";
                         dirSearcher.PropertiesToLoad.Add("ldapDisplayName");
 
                         List<string> objectClasses = new List<string>();
@@ -331,7 +331,7 @@ namespace System.DirectoryServices.AccountManagement
                         foreach (string objectClass in _cachedBindableObjectList)
                         {
                             filter.Append("(objectClass=");
-                            filter.Append(objectClass);
+                            filter.Append(ADUtils.EscapeRFC2254SpecialChars(objectClass));
                             filter.Append(')');
                         }
 

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADStoreCtx.cs
@@ -1510,7 +1510,7 @@ namespace System.DirectoryServices.AccountManagement
                     Debug.Assert(foreignPrincipal.ContextType != ContextType.ApplicationDirectory);
 
                     DirectorySearcher[] memberSearcher = { SDSUtils.ConstructSearcher(this.ctxBase) };
-                    memberSearcher[0].Filter = "(&(objectClass=Group)(member=" + foreignPrincipal.DistinguishedName + "))";
+                    memberSearcher[0].Filter = "(&(objectClass=Group)(member=" + ADUtils.EscapeRFC2254SpecialChars(foreignPrincipal.DistinguishedName) + "))";
                     memberSearcher[0].CacheResults = false;
 
                     resultSet = new ADDNLinkedAttrSet(foreignPrincipal.DistinguishedName, memberSearcher, null, null, false, this);

--- a/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADUtils.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/src/System/DirectoryServices/AccountManagement/AD/ADUtils.cs
@@ -153,6 +153,10 @@ namespace System.DirectoryServices.AccountManagement
             {
                 switch (c)
                 {
+                    case '\0':
+                        sb.Append(@"\00");
+                        break;
+
                     case '(':
                         sb.Append(@"\28");
                         break;

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/ADUtilsTests.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/ADUtilsTests.cs
@@ -25,11 +25,20 @@ namespace System.DirectoryServices.AccountManagement.Tests
         [InlineData("", "")]
         [InlineData("nothingspecial123", "nothingspecial123")]
         [InlineData("CN=user,OU=test (lab),DC=contoso,DC=com", @"CN=user,OU=test \28lab\29,DC=contoso,DC=com")]
+        [InlineData("membername))", @"membername\29\29")]
         public void EscapeRFC2254SpecialChars_EscapesCorrectly(string input, string expected)
         {
             string result = EscapeRFC2254SpecialChars(input);
 
             Assert.Equal(expected, result);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework))]
+        public void EscapeRFC2254SpecialChars_EscapesNulCharacter()
+        {
+            string result = EscapeRFC2254SpecialChars("\0");
+
+            Assert.Equal(@"\00", result);
         }
     }
 }

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/ADUtilsTests.cs
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/ADUtilsTests.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Reflection;
+using Xunit;
+
+namespace System.DirectoryServices.AccountManagement.Tests
+{
+    public class ADUtilsTests
+    {
+        private static string EscapeRFC2254SpecialChars(string input)
+        {
+            Type adUtilsType = typeof(PrincipalContext).Assembly.GetType("System.DirectoryServices.AccountManagement.ADUtils", throwOnError: true);
+            MethodInfo method = adUtilsType.GetMethod("EscapeRFC2254SpecialChars", BindingFlags.Static | BindingFlags.NonPublic);
+            return (string)method.Invoke(null, new object[] { input });
+        }
+
+        [Theory]
+        [InlineData("simple", "simple")]
+        [InlineData("has(paren", @"has\28paren")]
+        [InlineData("has)paren", @"has\29paren")]
+        [InlineData("has*star", @"has\2astar")]
+        [InlineData(@"has\backslash", @"has\5cbackslash")]
+        [InlineData("(all*special)\\chars", @"\28all\2aspecial\29\5cchars")]
+        [InlineData("", "")]
+        [InlineData("nothingspecial123", "nothingspecial123")]
+        [InlineData("CN=user,OU=test (lab),DC=contoso,DC=com", @"CN=user,OU=test \28lab\29,DC=contoso,DC=com")]
+        public void EscapeRFC2254SpecialChars_EscapesCorrectly(string input, string expected)
+        {
+            string result = EscapeRFC2254SpecialChars(input);
+
+            Assert.Equal(expected, result);
+        }
+    }
+}

--- a/src/libraries/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
+++ b/src/libraries/System.DirectoryServices.AccountManagement/tests/System.DirectoryServices.AccountManagement.Tests.csproj
@@ -5,6 +5,7 @@
   <ItemGroup>
     <Compile Include="PrincipalContextTests.cs" />
     <Compile Include="AccountManagementTests.cs" />
+    <Compile Include="ADUtilsTests.cs" />
     <Compile Include="$(CommonTestPath)System\DirectoryServices\LdapConfiguration.cs" Link="Common\DirectoryServices\LdapConfiguration.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Use `ADUtils.EscapeRFC2254SpecialChars` to escape values interpolated into LDAP filter strings in `ADAMStoreCtx` and `ADStoreCtx`. This ensures filters remain well-formed when values contain RFC 2254 special characters such as `(`, `)`, `*`, or `\`.

Includes unit tests for `EscapeRFC2254SpecialChars`.