### PR TITLE
Fix for arm64 outerloop jitstress failures in FMA

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -441,6 +441,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 {
                     case 2:
                     {
+                        assert(!isRMW);
+
                         HWIntrinsicImmOpHelper helper(this, intrin.op2, node);
 
                         for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
@@ -454,6 +456,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     case 3:
                     {
+                        assert(!isRMW);
+
                         HWIntrinsicImmOpHelper helper(this, intrin.op3, node);
 
                         for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
@@ -469,7 +473,10 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     {
                         assert(isRMW);
 
-                        HWIntrinsicImmOpHelper helper(this, intrin.op4, node);
+                        // emitIns_R_R_R_R_I may emit a mov (when not redundant) for RMW instructions;
+                        // the ImmOpHelper must account for that mov
+                        int numInstrs = (targetReg != op1Reg) ? 2 : 1;
+                        HWIntrinsicImmOpHelper helper(this, intrin.op4, node, numInstrs);
 
                         for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
                         {
@@ -499,8 +506,9 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(hasImmediateOperand);
 
-            GenTree*               shiftOp = isRMW ? intrin.op3 : intrin.op2;
-            HWIntrinsicImmOpHelper helper(this, shiftOp, node);
+            GenTree* shiftOp   = isRMW ? intrin.op3 : intrin.op2;
+            int      numInstrs = (isRMW && (targetReg != op1Reg)) ? 2 : 1;
+            HWIntrinsicImmOpHelper helper(this, shiftOp, node, numInstrs);
 
             for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
             {

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -475,7 +475,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                         // emitIns_R_R_R_R_I may emit a mov (when not redundant) for RMW instructions;
                         // the ImmOpHelper must account for that mov
-                        int numInstrs = (targetReg != op1Reg) ? 2 : 1;
+                        int                    numInstrs = (targetReg != op1Reg) ? 2 : 1;
                         HWIntrinsicImmOpHelper helper(this, intrin.op4, node, numInstrs);
 
                         for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
@@ -506,8 +506,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
         {
             assert(hasImmediateOperand);
 
-            GenTree* shiftOp   = isRMW ? intrin.op3 : intrin.op2;
-            int      numInstrs = (isRMW && (targetReg != op1Reg)) ? 2 : 1;
+            GenTree*               shiftOp   = isRMW ? intrin.op3 : intrin.op2;
+            int                    numInstrs = (isRMW && (targetReg != op1Reg)) ? 2 : 1;
             HWIntrinsicImmOpHelper helper(this, shiftOp, node, numInstrs);
 
             for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())


### PR DESCRIPTION
Previous codegen for FMLA, when supplied with a non-constant operand, looked something like:
```
mov     v0.8b, v8.8b // fill in RMW operand
br      x20
fmla    v0.2s, v9.2s, v10.s[0]
b       G_M19624_IG23
fmla    v0.2s, v9.2s, v10.s[1]
b       G_M19624_IG23
// and so on for each of the immediates
```
With the recent refactor to move the mov-emit-for-RMW down into the emit routines, the mov is emitted instead when codegen happens for each arm of the jump table:
```
br      x20
mov     v0.8b, v8.8b                    // fill in RMW operand
fmla    v0.2s, v9.2s, v10.s[0]
b       G_M19624_IG24
mov     v0.8b, v8.8b                   // fill in RMW operand
fmla    v0.2s, v9.2s, v10.s[1]
b       G_M19624_IG24
// etc...
```
Bug happens because the jump table builder thought each case would contain only 1 instruction, not two.

@a74nh Another option to fix this is to undo the refactor just for this case, and not duplicate the mov in each branch.  This would yield slightly smaller codesize.  I think it shouldn't matter much overall because the size difference is small, and the non-constant-operand case is rare.  Let me know if we should go this route instead

fixes #126379 