### PR TITLE
Fix MarshalArrayAsParam/AsLPArray/AsLPArrayTest test

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/Marshaller.cs
@@ -1114,9 +1114,30 @@ namespace Internal.TypeSystem.Interop
 
             codeStream.Emit(ILOpcode.mul_ovf);
 
-            codeStream.Emit(ILOpcode.call, emitter.NewToken(
-                InteropTypes.GetMarshal(Context).GetKnownMethod("AllocCoTaskMem"u8, null)));
-            StoreNativeValue(codeStream);
+            if (!In)
+            {
+                // For out only parameters, zero initialize the native buffer.
+                // The native callee may attempt to free the pointers in each slot
+                // before writing new values. Uninitialized garbage pointers would cause heap corruption.
+                var vAllocSize = emitter.NewLocal(Context.GetWellKnownType(WellKnownType.Int32));
+                codeStream.Emit(ILOpcode.dup);
+                codeStream.EmitStLoc(vAllocSize);
+
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    InteropTypes.GetMarshal(Context).GetKnownMethod("AllocCoTaskMem"u8, null)));
+                codeStream.Emit(ILOpcode.dup);
+                StoreNativeValue(codeStream);
+                // Zero initialize: initblk(nativeBuffer, 0, allocSize)
+                codeStream.EmitLdc(0);
+                codeStream.EmitLdLoc(vAllocSize);
+                codeStream.Emit(ILOpcode.initblk);
+            }
+            else
+            {
+                codeStream.Emit(ILOpcode.call, emitter.NewToken(
+                    InteropTypes.GetMarshal(Context).GetKnownMethod("AllocCoTaskMem"u8, null)));
+                StoreNativeValue(codeStream);
+            }
 
             codeStream.EmitLabel(lNullArray);
         }

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -649,6 +649,7 @@ public class ArrayMarshal
     #endregion
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/126467", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     public static void TestMultidimensional()
     {
         Console.WriteLine("================== [Get_Multidimensional_Array_Sum] ============");

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -8,6 +8,8 @@ using TestLibrary;
 
 namespace MarshalArrayAsParam.Default;
 
+[ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
+[SkipOnMono("needs triage")]
 public class ArrayMarshal
 {
     public struct TestStruct
@@ -313,7 +315,8 @@ public class ArrayMarshal
         return array;
     }
 
-    private static void TestMarshalByVal_NoAttributes()
+    [Fact]
+    public static void TestMarshalByVal_NoAttributes()
     {
         Console.WriteLine("ByVal marshaling CLR array as c-style-array no attributes");
 
@@ -346,7 +349,8 @@ public class ArrayMarshal
         }
     }
 
-    private static void TestMarshalByVal_In()
+    [Fact]
+    public static void TestMarshalByVal_In()
     {
         Console.WriteLine("ByVal marshaling  CLR array as c-style-array with InAttribute applied");
 
@@ -382,7 +386,8 @@ public class ArrayMarshal
 
     #region Marshal InOut ByVal
 
-    private static void TestMarshalInOut_ByVal()
+    [Fact]
+    public static void TestMarshalInOut_ByVal()
     {
         Console.WriteLine("By value marshaling CLR array as c-style-array with InAttribute and OutAttribute applied");
         Console.WriteLine("CStyle_Array_Int_InOut");
@@ -546,7 +551,8 @@ public class ArrayMarshal
 
     #region Marshal Out ByVal
 
-    private static void TestMarshalOut_ByVal()
+    [Fact]
+    public static void TestMarshalOut_ByVal()
     {
         Console.WriteLine("By value marshaling CLR array as c-style-array with OutAttribute applied");
 
@@ -642,7 +648,8 @@ public class ArrayMarshal
 
     #endregion
 
-    private static void TestMultidimensional()
+    [Fact]
+    public static void TestMultidimensional()
     {
         Console.WriteLine("================== [Get_Multidimensional_Array_Sum] ============");
         int[,] array = InitMultidimensionalBlittableArray(ROWS, COLUMNS);
@@ -653,28 +660,5 @@ public class ArrayMarshal
         }
 
         Assert.Equal(sum, Get_Multidimensional_Array_Sum(array, ROWS, COLUMNS));
-    }
-
-    [Fact]
-    [SkipOnMono("needs triage")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
-    public static int TestEntryPoint()
-    {
-        try
-        {
-            TestMarshalByVal_NoAttributes();
-            TestMarshalByVal_In();
-            TestMarshalInOut_ByVal();
-            TestMarshalOut_ByVal();
-            TestMultidimensional();
-
-            Console.WriteLine("\nTest PASS.");
-            return 100;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"\nTEST FAIL: {e}");
-            return 101;
-        }
     }
 }

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsDefault/AsDefaultTest.cs
@@ -655,10 +655,8 @@ public class ArrayMarshal
         Assert.Equal(sum, Get_Multidimensional_Array_Sum(array, ROWS, COLUMNS));
     }
 
-    [ActiveIssue("https://github.com/dotnet/runtimelab/issues/176: VARIANT marshalling", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [Fact]
     [SkipOnMono("needs triage")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/81674", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     public static int TestEntryPoint()
     {

--- a/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
+++ b/src/tests/Interop/PInvoke/Array/MarshalArrayAsParam/AsLPArray/AsLPArrayTest.cs
@@ -632,10 +632,8 @@ public class ArrayMarshal
     }
     #endregion
 
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/81674", typeof(Utilities), nameof(Utilities.IsNativeAot))]
     [Fact]
     [SkipOnMono("needs triage")]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/81674", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/91388", typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     public static int TestEntryPoint()
     {


### PR DESCRIPTION
When marshalling an `[Out, MarshalAs(UnmanagedType.LPArray)] string[]` parameter, the marshaller allocates a native buffer but skips initialization (`TransformManagedToNative` is skipped for out-only parameters). Native callees can attempt to free those uninitialized pointers and cause heap corruption.

Fixes #81674.