### PR TITLE
Fix ZipArchive Update removing data descriptors

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -366,7 +366,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
 
             entriesToWrite = new(_entries.Count);
 
-            long[] entryEndOffsets = ComputeEntryEndOffsets();
+            ComputeEntryEndOffsets();
 
             for (int i = 0; i < _entries.Count; i++)
             {
@@ -378,7 +378,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 }
                 else
                 {
-                    WriteFileCalculateOffsets(entry, entryEndOffsets[i], ref startingOffset, ref nextFileOffset);
+                    WriteFileCalculateOffsets(entry, ref startingOffset, ref nextFileOffset);
 
                     // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                     // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -366,8 +366,6 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
 
             entriesToWrite = new(_entries.Count);
 
-            ComputeEntryEndOffsets();
-
             for (int i = 0; i < _entries.Count; i++)
             {
                 ZipArchiveEntry entry = _entries[i];

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -366,10 +366,8 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
 
             entriesToWrite = new(_entries.Count);
 
-            for (int i = 0; i < _entries.Count; i++)
+            foreach(ZipArchiveEntry entry in _entries)
             {
-                ZipArchiveEntry entry = _entries[i];
-
                 if (!entry.OriginallyInArchive)
                 {
                     entriesToWrite.Add(entry);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -365,6 +365,9 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
             completeRewriteStartingOffset = startingOffset;
 
             entriesToWrite = new(_entries.Count);
+
+            long[] entryEndOffsets = ComputeEntryEndOffsets();
+
             for (int i = 0; i < _entries.Count; i++)
             {
                 ZipArchiveEntry entry = _entries[i];
@@ -375,19 +378,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 }
                 else
                 {
-                    // Compute the end offset of this entry: the start of the next original entry, or the central directory,
-                    // including any trailing data descriptor bytes.
-                    long entryEndOffset = _centralDirectoryStart;
-                    for (int j = i + 1; j < _entries.Count; j++)
-                    {
-                        if (_entries[j].OriginallyInArchive)
-                        {
-                            entryEndOffset = _entries[j].OffsetOfLocalHeader;
-                            break;
-                        }
-                    }
-
-                    WriteFileCalculateOffsets(entry, entryEndOffset, ref startingOffset, ref nextFileOffset);
+                    WriteFileCalculateOffsets(entry, entryEndOffsets[i], ref startingOffset, ref nextFileOffset);
 
                     // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                     // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -375,8 +375,8 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 }
                 else
                 {
-                    // Compute the end offset of this entry: the start of the next original entry, or the central directory.
-                    // This correctly includes any trailing data descriptor bytes.
+                    // Compute the end offset of this entry: the start of the next original entry, or the central directory,
+                    // including any trailing data descriptor bytes.
                     long entryEndOffset = _centralDirectoryStart;
                     for (int j = i + 1; j < _entries.Count; j++)
                     {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -366,7 +366,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
 
             entriesToWrite = new(_entries.Count);
 
-            foreach(ZipArchiveEntry entry in _entries)
+            foreach (ZipArchiveEntry entry in _entries)
             {
                 if (!entry.OriginallyInArchive)
                 {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -365,16 +365,29 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
             completeRewriteStartingOffset = startingOffset;
 
             entriesToWrite = new(_entries.Count);
-            foreach (ZipArchiveEntry entry in _entries)
+            for (int i = 0; i < _entries.Count; i++)
             {
+                ZipArchiveEntry entry = _entries[i];
+
                 if (!entry.OriginallyInArchive)
                 {
                     entriesToWrite.Add(entry);
                 }
                 else
                 {
+                    // Compute the end offset of this entry: the start of the next original entry, or the central directory.
+                    // This correctly includes any trailing data descriptor bytes.
+                    long entryEndOffset = _centralDirectoryStart;
+                    for (int j = i + 1; j < _entries.Count; j++)
+                    {
+                        if (_entries[j].OriginallyInArchive)
+                        {
+                            entryEndOffset = _entries[j].OffsetOfLocalHeader;
+                            break;
+                        }
+                    }
 
-                    WriteFileCalculateOffsets(entry, ref startingOffset, ref nextFileOffset);
+                    WriteFileCalculateOffsets(entry, entryEndOffset, ref startingOffset, ref nextFileOffset);
 
                     // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                     // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -806,6 +806,8 @@ namespace System.IO.Compression
             {
                 if (_entries[i].OriginallyInArchive)
                 {
+                    Debug.Assert(nextOriginalOffset >= _entries[i].OffsetOfLocalHeader,
+                        "Original entries are expected in ascending offset order");
                     _entries[i].EndOfLocalEntryData = nextOriginalOffset;
                     nextOriginalOffset = _entries[i].OffsetOfLocalHeader;
                 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -765,13 +765,15 @@ namespace System.IO.Compression
             }
         }
 
-        private static void WriteFileCalculateOffsets(ZipArchiveEntry entry, ref long startingOffset, ref long nextFileOffset)
+        private static void WriteFileCalculateOffsets(ZipArchiveEntry entry, long entryEndOffset, ref long startingOffset, ref long nextFileOffset)
         {
             if (entry.Changes == ChangeState.Unchanged)
             {
                 // Keep track of the expected position of the file entry after the final untouched file entry so that when the loop completes,
                 // we'll know which position to start writing new entries from.
-                nextFileOffset = Math.Max(nextFileOffset, entry.GetOffsetOfCompressedData() + entry.CompressedLength);
+                // Use the end offset derived from the next entry's local header (or central directory start for the last entry)
+                // rather than compressed data offset + length, because the latter does not account for data descriptors.
+                nextFileOffset = Math.Max(nextFileOffset, entryEndOffset);
             }
             // When calculating the starting offset to load the files from, only look at changed entries which are already in the archive.
             else
@@ -832,15 +834,29 @@ namespace System.IO.Compression
                 completeRewriteStartingOffset = startingOffset;
                 entriesToWrite = new(_entries.Count);
 
-                foreach (ZipArchiveEntry entry in _entries)
+                for (int i = 0; i < _entries.Count; i++)
                 {
+                    ZipArchiveEntry entry = _entries[i];
+
                     if (!entry.OriginallyInArchive)
                     {
                         entriesToWrite.Add(entry);
                     }
                     else
                     {
-                        WriteFileCalculateOffsets(entry, ref startingOffset, ref nextFileOffset);
+                        // Compute the end offset of this entry: the start of the next original entry, or the central directory.
+                        // This correctly includes any trailing data descriptor bytes.
+                        long entryEndOffset = _centralDirectoryStart;
+                        for (int j = i + 1; j < _entries.Count; j++)
+                        {
+                            if (_entries[j].OriginallyInArchive)
+                            {
+                                entryEndOffset = _entries[j].OffsetOfLocalHeader;
+                                break;
+                            }
+                        }
+
+                        WriteFileCalculateOffsets(entry, entryEndOffset, ref startingOffset, ref nextFileOffset);
 
                         // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                         // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.
@@ -858,7 +874,6 @@ namespace System.IO.Compression
                         }
                     }
                 }
-
                 WriteFileUpdateModeFinalWork(startingOffset, nextFileOffset);
             }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -870,7 +870,6 @@ namespace System.IO.Compression
                         }
                     }
                 }
-                
                 WriteFileUpdateModeFinalWork(startingOffset, nextFileOffset);
             }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -590,6 +590,16 @@ namespace System.IO.Compression
             if (Mode == ZipArchiveMode.Update)
             {
                 _entries.Sort(ZipArchiveEntry.LocalHeaderOffsetComparer.Instance);
+
+                // Precompute EndOfLocalEntryData for each entry. At read time every entry is original
+                // and sorted by offset, so entry[i]'s end is entry[i+1]'s start (or the central directory
+                // for the last entry). This correctly includes any trailing data descriptor bytes.
+                for (int i = 0; i < _entries.Count; i++)
+                {
+                    _entries[i].EndOfLocalEntryData = i < _entries.Count - 1
+                        ? _entries[i + 1].OffsetOfLocalHeader
+                        : _centralDirectoryStart;
+                }
             }
         }
 
@@ -793,27 +803,6 @@ namespace System.IO.Compression
             }
         }
 
-        /// <summary>
-        /// Precompute <see cref="ZipArchiveEntry.EndOfLocalEntryData"/> for each originally-in-archive entry
-        /// in a single reverse pass. The end of each original entry is the start of the next original
-        /// entry (or the central directory for the last one). This correctly includes any trailing
-        /// data descriptor bytes, without needing to seek or read the archive stream.
-        /// </summary>
-        private void ComputeEntryEndOffsets()
-        {
-            long nextOriginalOffset = _centralDirectoryStart;
-            for (int i = _entries.Count - 1; i >= 0; i--)
-            {
-                if (_entries[i].OriginallyInArchive)
-                {
-                    Debug.Assert(nextOriginalOffset >= _entries[i].OffsetOfLocalHeader,
-                        "Original entries are expected in ascending offset order");
-                    _entries[i].EndOfLocalEntryData = nextOriginalOffset;
-                    nextOriginalOffset = _entries[i].OffsetOfLocalHeader;
-                }
-            }
-        }
-
         private void WriteFileUpdateModeFinalWork(long startingOffset, long nextFileOffset)
         {
             // If the offset of entries to write from is still at long.MaxValue, then we know that nothing has been deleted,
@@ -854,8 +843,6 @@ namespace System.IO.Compression
                 long nextFileOffset = 0;
                 completeRewriteStartingOffset = startingOffset;
                 entriesToWrite = new(_entries.Count);
-
-                ComputeEntryEndOffsets();
 
                 for (int i = 0; i < _entries.Count; i++)
                 {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -844,10 +844,8 @@ namespace System.IO.Compression
                 completeRewriteStartingOffset = startingOffset;
                 entriesToWrite = new(_entries.Count);
 
-                for (int i = 0; i < _entries.Count; i++)
+                foreach (ZipArchiveEntry entry in _entries)
                 {
-                    ZipArchiveEntry entry = _entries[i];
-
                     if (!entry.OriginallyInArchive)
                     {
                         entriesToWrite.Add(entry);
@@ -872,6 +870,7 @@ namespace System.IO.Compression
                         }
                     }
                 }
+                
                 WriteFileUpdateModeFinalWork(startingOffset, nextFileOffset);
             }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -765,15 +765,15 @@ namespace System.IO.Compression
             }
         }
 
-        private static void WriteFileCalculateOffsets(ZipArchiveEntry entry, long entryEndOffset, ref long startingOffset, ref long nextFileOffset)
+        private static void WriteFileCalculateOffsets(ZipArchiveEntry entry, ref long startingOffset, ref long nextFileOffset)
         {
             if (entry.Changes == ChangeState.Unchanged)
             {
                 // Keep track of the expected position of the file entry after the final untouched file entry so that when the loop completes,
                 // we'll know which position to start writing new entries from.
-                // Use the end offset derived from the next entry's local header (or central directory start for the last entry)
-                // rather than compressed data offset + length, because the latter does not account for data descriptors.
-                nextFileOffset = Math.Max(nextFileOffset, entryEndOffset);
+                // EndOfLocalEntryData includes any trailing data descriptor because it was pre-computed from the
+                // next entry's offset or the central directory start.
+                nextFileOffset = Math.Max(nextFileOffset, entry.EndOfLocalEntryData);
             }
             // When calculating the starting offset to load the files from, only look at changed entries which are already in the archive.
             else
@@ -794,25 +794,22 @@ namespace System.IO.Compression
         }
 
         /// <summary>
-        /// Precompute end offsets for original entries in a single reverse pass.
-        /// The end of each original entry is the start of the next original entry (or
-        /// the central directory for the last one). This correctly includes any trailing
-        /// data descriptor bytes.
+        /// Precompute <see cref="ZipArchiveEntry.EndOfLocalEntryData"/> for each originally-in-archive entry
+        /// in a single reverse pass. The end of each original entry is the start of the next original
+        /// entry (or the central directory for the last one). This correctly includes any trailing
+        /// data descriptor bytes, without needing to seek or read the archive stream.
         /// </summary>
-        private long[] ComputeEntryEndOffsets()
+        private void ComputeEntryEndOffsets()
         {
-            long[] entryEndOffsets = new long[_entries.Count];
             long nextOriginalOffset = _centralDirectoryStart;
             for (int i = _entries.Count - 1; i >= 0; i--)
             {
                 if (_entries[i].OriginallyInArchive)
                 {
-                    entryEndOffsets[i] = nextOriginalOffset;
+                    _entries[i].EndOfLocalEntryData = nextOriginalOffset;
                     nextOriginalOffset = _entries[i].OffsetOfLocalHeader;
                 }
             }
-
-            return entryEndOffsets;
         }
 
         private void WriteFileUpdateModeFinalWork(long startingOffset, long nextFileOffset)
@@ -856,7 +853,7 @@ namespace System.IO.Compression
                 completeRewriteStartingOffset = startingOffset;
                 entriesToWrite = new(_entries.Count);
 
-                long[] entryEndOffsets = ComputeEntryEndOffsets();
+                ComputeEntryEndOffsets();
 
                 for (int i = 0; i < _entries.Count; i++)
                 {
@@ -868,7 +865,7 @@ namespace System.IO.Compression
                     }
                     else
                     {
-                        WriteFileCalculateOffsets(entry, entryEndOffsets[i], ref startingOffset, ref nextFileOffset);
+                        WriteFileCalculateOffsets(entry, ref startingOffset, ref nextFileOffset);
 
                         // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                         // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -844,8 +844,8 @@ namespace System.IO.Compression
                     }
                     else
                     {
-                        // Compute the end offset of this entry: the start of the next original entry, or the central directory.
-                        // This correctly includes any trailing data descriptor bytes.
+                        // Compute the end offset of this entry: the start of the next original entry, or the central directory,
+                        // including any trailing data descriptor bytes.
                         long entryEndOffset = _centralDirectoryStart;
                         for (int j = i + 1; j < _entries.Count; j++)
                         {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -793,6 +793,28 @@ namespace System.IO.Compression
             }
         }
 
+        /// <summary>
+        /// Precompute end offsets for original entries in a single reverse pass.
+        /// The end of each original entry is the start of the next original entry (or
+        /// the central directory for the last one). This correctly includes any trailing
+        /// data descriptor bytes.
+        /// </summary>
+        private long[] ComputeEntryEndOffsets()
+        {
+            long[] entryEndOffsets = new long[_entries.Count];
+            long nextOriginalOffset = _centralDirectoryStart;
+            for (int i = _entries.Count - 1; i >= 0; i--)
+            {
+                if (_entries[i].OriginallyInArchive)
+                {
+                    entryEndOffsets[i] = nextOriginalOffset;
+                    nextOriginalOffset = _entries[i].OffsetOfLocalHeader;
+                }
+            }
+
+            return entryEndOffsets;
+        }
+
         private void WriteFileUpdateModeFinalWork(long startingOffset, long nextFileOffset)
         {
             // If the offset of entries to write from is still at long.MaxValue, then we know that nothing has been deleted,
@@ -834,6 +856,8 @@ namespace System.IO.Compression
                 completeRewriteStartingOffset = startingOffset;
                 entriesToWrite = new(_entries.Count);
 
+                long[] entryEndOffsets = ComputeEntryEndOffsets();
+
                 for (int i = 0; i < _entries.Count; i++)
                 {
                     ZipArchiveEntry entry = _entries[i];
@@ -844,19 +868,7 @@ namespace System.IO.Compression
                     }
                     else
                     {
-                        // Compute the end offset of this entry: the start of the next original entry, or the central directory,
-                        // including any trailing data descriptor bytes.
-                        long entryEndOffset = _centralDirectoryStart;
-                        for (int j = i + 1; j < _entries.Count; j++)
-                        {
-                            if (_entries[j].OriginallyInArchive)
-                            {
-                                entryEndOffset = _entries[j].OffsetOfLocalHeader;
-                                break;
-                            }
-                        }
-
-                        WriteFileCalculateOffsets(entry, entryEndOffset, ref startingOffset, ref nextFileOffset);
+                        WriteFileCalculateOffsets(entry, entryEndOffsets[i], ref startingOffset, ref nextFileOffset);
 
                         // We want to re-write entries which are after the starting offset of the first entry which has pending data to write.
                         // NB: the existing ZipArchiveEntries are sorted in _entries by their position ascending.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -425,18 +425,7 @@ public partial class ZipArchiveEntry
     {
         byte[] signatureBuffer = new byte[sizeof(uint)];
         await _archive.ArchiveStream.ReadExactlyAsync(signatureBuffer, cancellationToken).ConfigureAwait(false);
-
-        bool hasSignature = signatureBuffer.AsSpan().SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
-
-        int bytesToSkip = AreSizesTooLarge
-            ? (hasSignature
-                ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
-                : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)
-            : (hasSignature
-                ? ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize
-                : ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize);
-
-        _archive.ArchiveStream.Seek(bytesToSkip, SeekOrigin.Current);
+        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -406,12 +406,17 @@ public partial class ZipArchiveEntry
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 
                 // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
-                // path the data descriptor bytes remain in the file. Restore bit 3 so the local header and
-                // central directory accurately indicate that a data descriptor follows the compressed data.
+                // path the data descriptor bytes remain in the file. Restore bit 3 in memory so the central
+                // directory stays consistent, and patch the on-disk header only if it was actually rewritten.
                 if (hadDataDescriptor)
                 {
                     _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
-                    PatchLocalFileHeaderBitFlags();
+
+                    bool headerWritten = !(_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite);
+                    if (headerWritten)
+                    {
+                        PatchLocalFileHeaderBitFlags();
+                    }
                 }
 
                 // If we know that we need to update the file header (but don't need to load and update the data itself)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -403,10 +403,6 @@ public partial class ZipArchiveEntry
                 _everOpenedForWrite = true;
                 // Capture data descriptor state before WriteLocalFileHeaderAsync clears bit 3 for seekable streams.
                 bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                // Capture whether the original entry used ZIP64 before WriteLocalFileHeaderAsync
-                // potentially modifies offset/size state. This determines whether the data
-                // descriptor uses 32-bit or 64-bit field sizes.
-                bool wasZip64 = ShouldUseZIP64;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 
                 // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
@@ -429,17 +425,17 @@ public partial class ZipArchiveEntry
                 // so that subsequent entries are written at the correct position.
                 if (hadDataDescriptor)
                 {
-                    await SkipDataDescriptorAsync(wasZip64, cancellationToken).ConfigureAwait(false);
+                    await SkipDataDescriptorAsync(cancellationToken).ConfigureAwait(false);
                 }
             }
         }
     }
 
-    private async ValueTask SkipDataDescriptorAsync(bool zip64, CancellationToken cancellationToken)
+    private async ValueTask SkipDataDescriptorAsync(CancellationToken cancellationToken)
     {
         byte[] signatureBuffer = new byte[sizeof(uint)];
         await _archive.ArchiveStream.ReadExactlyAsync(signatureBuffer, cancellationToken).ConfigureAwait(false);
-        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer, zip64), SeekOrigin.Current);
+        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -316,14 +316,14 @@ public partial class ZipArchiveEntry
     }
 
     // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken, bool preserveDataDescriptor = false)
+    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
+        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
         {
             byte[] lfStaticHeader = new byte[ZipLocalFileHeader.SizeOfLocalHeader];
-            WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength, crc32ToWrite);
+            WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
 
             // write header
             await _archive.ArchiveStream.WriteAsync(lfStaticHeader, cancellationToken).ConfigureAwait(false);
@@ -401,11 +401,7 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
-                // If the entry originally used a data descriptor and we are not rewriting the data,
-                // the descriptor record remains on disk after the compressed bytes. Preserve bit 3
-                // and write zeros for CRC/sizes so that sequential readers see a consistent entry.
-                bool preserveDataDescriptor = _originallyInArchive && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken, preserveDataDescriptor).ConfigureAwait(false);
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -401,23 +401,7 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
-                // Capture data descriptor state before WriteLocalFileHeaderAsync clears bit 3 for seekable streams.
-                bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
-
-                // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
-                // path the data descriptor bytes remain in the file. Restore bit 3 in memory so the central
-                // directory stays consistent, and patch the on-disk header only if it was actually rewritten.
-                if (hadDataDescriptor)
-                {
-                    _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
-
-                    bool headerWritten = !(_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite);
-                    if (headerWritten)
-                    {
-                        await PatchLocalFileHeaderBitFlagsAsync(cancellationToken).ConfigureAwait(false);
-                    }
-                }
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.
@@ -427,16 +411,6 @@ public partial class ZipArchiveEntry
                 }
             }
         }
-    }
-
-    private async ValueTask PatchLocalFileHeaderBitFlagsAsync(CancellationToken cancellationToken)
-    {
-        long savedPosition = _archive.ArchiveStream.Position;
-        _archive.ArchiveStream.Position = _offsetOfLocalHeader + ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags;
-        byte[] flagBytes = new byte[sizeof(ushort)];
-        BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
-        await _archive.ArchiveStream.WriteAsync(flagBytes, cancellationToken).ConfigureAwait(false);
-        _archive.ArchiveStream.Position = savedPosition;
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -316,7 +316,7 @@ public partial class ZipArchiveEntry
     }
 
     // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken, bool preserveDataDescriptor = false)
+    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -383,7 +383,7 @@ public partial class ZipArchiveEntry
                     _compressedSize = 0;
                 }
 
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: true, cancellationToken).ConfigureAwait(false);
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: true, preserveDataDescriptor: false, cancellationToken).ConfigureAwait(false);
 
                 // according to ZIP specs, zero-byte files MUST NOT include file data
                 if (_uncompressedSize != 0)
@@ -405,7 +405,7 @@ public partial class ZipArchiveEntry
                 // since the descriptor bytes remain on disk after the compressed data.
                 bool preserveDataDescriptor = _originallyInArchive
                     && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken, preserveDataDescriptor).ConfigureAwait(false);
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor, cancellationToken).ConfigureAwait(false);
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -415,7 +415,7 @@ public partial class ZipArchiveEntry
                     bool headerWritten = !(_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite);
                     if (headerWritten)
                     {
-                        PatchLocalFileHeaderBitFlags();
+                        await PatchLocalFileHeaderBitFlagsAsync(cancellationToken).ConfigureAwait(false);
                     }
                 }
 
@@ -434,6 +434,16 @@ public partial class ZipArchiveEntry
                 }
             }
         }
+    }
+
+    private async ValueTask PatchLocalFileHeaderBitFlagsAsync(CancellationToken cancellationToken)
+    {
+        long savedPosition = _archive.ArchiveStream.Position;
+        _archive.ArchiveStream.Position = _offsetOfLocalHeader + ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags;
+        byte[] flagBytes = new byte[sizeof(ushort)];
+        BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
+        await _archive.ArchiveStream.WriteAsync(flagBytes, cancellationToken).ConfigureAwait(false);
+        _archive.ArchiveStream.Position = savedPosition;
     }
 
     private async ValueTask SkipDataDescriptorAsync(CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -316,14 +316,14 @@ public partial class ZipArchiveEntry
     }
 
     // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken)
+    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken, bool preserveDataDescriptor = false)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
+        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
         {
             byte[] lfStaticHeader = new byte[ZipLocalFileHeader.SizeOfLocalHeader];
-            WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
+            WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength, crc32ToWrite);
 
             // write header
             await _archive.ArchiveStream.WriteAsync(lfStaticHeader, cancellationToken).ConfigureAwait(false);
@@ -401,7 +401,11 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
+                // If the entry originally used a data descriptor and we are not rewriting the data,
+                // the descriptor record remains on disk after the compressed bytes. Preserve bit 3
+                // and write zeros for CRC/sizes so that sequential readers see a consistent entry.
+                bool preserveDataDescriptor = _originallyInArchive && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken, preserveDataDescriptor).ConfigureAwait(false);
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -419,18 +419,11 @@ public partial class ZipArchiveEntry
                     }
                 }
 
-                // If we know that we need to update the file header (but don't need to load and update the data itself)
-                // then advance the position past it.
-                if (_compressedSize != 0)
+                // Advance the stream past the compressed data and any trailing data descriptor
+                // by seeking to the pre-computed end-of-entry boundary.
+                if (_endOfLocalEntryData > _archive.ArchiveStream.Position)
                 {
-                    _archive.ArchiveStream.Seek(_compressedSize, SeekOrigin.Current);
-                }
-
-                // If the original entry had a data descriptor after the compressed data, skip past it
-                // so that subsequent entries are written at the correct position.
-                if (hadDataDescriptor)
-                {
-                    await SkipDataDescriptorAsync(cancellationToken).ConfigureAwait(false);
+                    _archive.ArchiveStream.Seek(_endOfLocalEntryData, SeekOrigin.Begin);
                 }
             }
         }
@@ -444,13 +437,6 @@ public partial class ZipArchiveEntry
         BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
         await _archive.ArchiveStream.WriteAsync(flagBytes, cancellationToken).ConfigureAwait(false);
         _archive.ArchiveStream.Position = savedPosition;
-    }
-
-    private async ValueTask SkipDataDescriptorAsync(CancellationToken cancellationToken)
-    {
-        byte[] signatureBuffer = new byte[sizeof(uint)];
-        await _archive.ArchiveStream.ReadExactlyAsync(signatureBuffer, cancellationToken).ConfigureAwait(false);
-        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -405,7 +405,7 @@ public partial class ZipArchiveEntry
                 // since the descriptor bytes remain on disk after the compressed data.
                 bool preserveDataDescriptor = _originallyInArchive
                     && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor, cancellationToken).ConfigureAwait(false);
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor: preserveDataDescriptor, cancellationToken).ConfigureAwait(false);
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -401,7 +401,6 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
-                // Save whether the original entry had a data descriptor before WriteLocalFileHeader clears the bit.
                 bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -403,6 +403,10 @@ public partial class ZipArchiveEntry
                 _everOpenedForWrite = true;
                 // Capture data descriptor state before WriteLocalFileHeaderAsync clears bit 3 for seekable streams.
                 bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                // Capture whether the original entry used ZIP64 before WriteLocalFileHeaderAsync
+                // potentially modifies offset/size state. This determines whether the data
+                // descriptor uses 32-bit or 64-bit field sizes.
+                bool wasZip64 = ShouldUseZIP64;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 
                 // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
@@ -425,17 +429,17 @@ public partial class ZipArchiveEntry
                 // so that subsequent entries are written at the correct position.
                 if (hadDataDescriptor)
                 {
-                    await SkipDataDescriptorAsync(cancellationToken).ConfigureAwait(false);
+                    await SkipDataDescriptorAsync(wasZip64, cancellationToken).ConfigureAwait(false);
                 }
             }
         }
     }
 
-    private async ValueTask SkipDataDescriptorAsync(CancellationToken cancellationToken)
+    private async ValueTask SkipDataDescriptorAsync(bool zip64, CancellationToken cancellationToken)
     {
         byte[] signatureBuffer = new byte[sizeof(uint)];
         await _archive.ArchiveStream.ReadExactlyAsync(signatureBuffer, cancellationToken).ConfigureAwait(false);
-        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
+        _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer, zip64), SeekOrigin.Current);
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -316,14 +316,14 @@ public partial class ZipArchiveEntry
     }
 
     // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken)
+    private async Task<bool> WriteLocalFileHeaderAsync(bool isEmptyFile, bool forceWrite, CancellationToken cancellationToken, bool preserveDataDescriptor = false)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
+        if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
         {
             byte[] lfStaticHeader = new byte[ZipLocalFileHeader.SizeOfLocalHeader];
-            WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
+            WriteLocalFileHeaderPrepare(lfStaticHeader, crc32ToWrite, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
 
             // write header
             await _archive.ArchiveStream.WriteAsync(lfStaticHeader, cancellationToken).ConfigureAwait(false);
@@ -401,7 +401,11 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
-                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
+                // Preserve the data descriptor flag for entries that originally had one,
+                // since the descriptor bytes remain on disk after the compressed data.
+                bool preserveDataDescriptor = _originallyInArchive
+                    && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken, preserveDataDescriptor).ConfigureAwait(false);
 
                 // Advance the stream past the compressed data and any trailing data descriptor
                 // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -401,8 +401,18 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
+                // Capture data descriptor state before WriteLocalFileHeaderAsync clears bit 3 for seekable streams.
                 bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
+
+                // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
+                // path the data descriptor bytes remain in the file. Restore bit 3 so the local header and
+                // central directory accurately indicate that a data descriptor follows the compressed data.
+                if (hadDataDescriptor)
+                {
+                    _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
+                    PatchLocalFileHeaderBitFlags();
+                }
 
                 // If we know that we need to update the file header (but don't need to load and update the data itself)
                 // then advance the position past it.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -401,6 +401,8 @@ public partial class ZipArchiveEntry
             if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
             {
                 _everOpenedForWrite = true;
+                // Save whether the original entry had a data descriptor before WriteLocalFileHeader clears the bit.
+                bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                 await WriteLocalFileHeaderAsync(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, cancellationToken).ConfigureAwait(false);
 
                 // If we know that we need to update the file header (but don't need to load and update the data itself)
@@ -409,8 +411,33 @@ public partial class ZipArchiveEntry
                 {
                     _archive.ArchiveStream.Seek(_compressedSize, SeekOrigin.Current);
                 }
+
+                // If the original entry had a data descriptor after the compressed data, skip past it
+                // so that subsequent entries are written at the correct position.
+                if (hadDataDescriptor)
+                {
+                    await SkipDataDescriptorAsync(cancellationToken).ConfigureAwait(false);
+                }
             }
         }
+    }
+
+    private async ValueTask SkipDataDescriptorAsync(CancellationToken cancellationToken)
+    {
+        byte[] signatureBuffer = new byte[sizeof(uint)];
+        await _archive.ArchiveStream.ReadExactlyAsync(signatureBuffer, cancellationToken).ConfigureAwait(false);
+
+        bool hasSignature = signatureBuffer.AsSpan().SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
+
+        int bytesToSkip = AreSizesTooLarge
+            ? (hasSignature
+                ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
+                : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)
+            : (hasSignature
+                ? ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize
+                : ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize);
+
+        _archive.ArchiveStream.Seek(bytesToSkip, SeekOrigin.Current);
     }
 
     // Using _offsetOfLocalHeader, seeks back to where CRC and sizes should be in the header,

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1245,7 +1245,6 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
-                    // Save whether the original entry had a data descriptor before WriteLocalFileHeader clears the bit.
                     bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1066,6 +1066,7 @@ namespace System.IO.Compression
             if (isEmptyFile)
             {
                 CompressionMethod = ZipCompressionMethod.Stored;
+                _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
                 Debug.Assert(_uncompressedSize == 0);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1078,7 +1078,6 @@ namespace System.IO.Compression
             if (isEmptyFile)
             {
                 CompressionMethod = ZipCompressionMethod.Stored;
-                _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
                 Debug.Assert(_uncompressedSize == 0);
@@ -1098,8 +1097,6 @@ namespace System.IO.Compression
                 }
                 else // if we are not in streaming mode, we have to decide if we want to write zip64 headers
                 {
-                    // We are in seekable mode so we will not need to write a data descriptor
-                    _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
                     if (ShouldUseZIP64
 #if DEBUG_FORCE_ZIP64
                         || (_archive._forceZip64 && _archive.Mode == ZipArchiveMode.Update)
@@ -1158,6 +1155,13 @@ namespace System.IO.Compression
                 _archive.ArchiveStream.Seek(currExtraFieldDataLength, SeekOrigin.Current);
 
                 return false;
+            }
+
+            // We are writing the header. For seekable/empty-file paths the sizes are written
+            // directly into the header, so a data descriptor is not needed.
+            if (isEmptyFile || _archive.ArchiveStream.CanSeek)
+            {
+                _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
             }
 
             return true;
@@ -1257,23 +1261,7 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
-                    // Capture data descriptor state before WriteLocalFileHeader clears bit 3 for seekable streams.
-                    bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
-
-                    // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
-                    // path the data descriptor bytes remain in the file. Restore bit 3 in memory so the central
-                    // directory stays consistent, and patch the on-disk header only if it was actually rewritten.
-                    if (hadDataDescriptor)
-                    {
-                        _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
-
-                        bool headerWritten = !(_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite);
-                        if (headerWritten)
-                        {
-                            PatchLocalFileHeaderBitFlags();
-                        }
-                    }
 
                     // Advance the stream past the compressed data and any trailing data descriptor
                     // by seeking to the pre-computed end-of-entry boundary.
@@ -1283,20 +1271,6 @@ namespace System.IO.Compression
                     }
                 }
             }
-        }
-
-        /// <summary>
-        /// Seeks back to the general purpose bit flags field in the just-written local file header
-        /// and overwrites it with the current value of <see cref="_generalPurposeBitFlag"/>.
-        /// </summary>
-        private void PatchLocalFileHeaderBitFlags()
-        {
-            long savedPosition = _archive.ArchiveStream.Position;
-            _archive.ArchiveStream.Position = _offsetOfLocalHeader + ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags;
-            Span<byte> flagBytes = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
-            _archive.ArchiveStream.Write(flagBytes);
-            _archive.ArchiveStream.Position = savedPosition;
         }
 
         private const int MetadataBufferLength = ZipLocalFileHeader.FieldLengths.VersionNeededToExtract + ZipLocalFileHeader.FieldLengths.GeneralPurposeBitFlags;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1274,18 +1274,25 @@ namespace System.IO.Compression
         {
             Span<byte> signatureBuffer = stackalloc byte[sizeof(uint)];
             _archive.ArchiveStream.ReadExactly(signatureBuffer);
+            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
+        }
 
-            bool hasSignature = signatureBuffer.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
+        /// <summary>
+        /// Given the first 4 bytes read after the compressed data, returns the number of
+        /// remaining bytes to seek past the data descriptor. Detects the optional signature
+        /// and uses 32-bit or 64-bit field sizes as appropriate.
+        /// </summary>
+        private int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes)
+        {
+            bool hasSignature = leadingBytes.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
 
-            int bytesToSkip = AreSizesTooLarge
+            return AreSizesTooLarge
                 ? (hasSignature
                     ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
                     : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)
                 : (hasSignature
                     ? ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize
                     : ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize);
-
-            _archive.ArchiveStream.Seek(bytesToSkip, SeekOrigin.Current);
         }
 
         private const int MetadataBufferLength = ZipLocalFileHeader.FieldLengths.VersionNeededToExtract + ZipLocalFileHeader.FieldLengths.GeneralPurposeBitFlags;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1245,8 +1245,18 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
+                    // Capture data descriptor state before WriteLocalFileHeader clears bit 3 for seekable streams.
                     bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
+
+                    // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
+                    // path the data descriptor bytes remain in the file. Restore bit 3 so the local header and
+                    // central directory accurately indicate that a data descriptor follows the compressed data.
+                    if (hadDataDescriptor)
+                    {
+                        _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
+                        PatchLocalFileHeaderBitFlags();
+                    }
 
                     // If we know that we need to update the file header (but don't need to load and update the data itself)
                     // then advance the position past it.
@@ -1263,6 +1273,20 @@ namespace System.IO.Compression
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Seeks back to the general purpose bit flags field in the just-written local file header
+        /// and overwrites it with the current value of <see cref="_generalPurposeBitFlag"/>.
+        /// </summary>
+        private void PatchLocalFileHeaderBitFlags()
+        {
+            long savedPosition = _archive.ArchiveStream.Position;
+            _archive.ArchiveStream.Position = _offsetOfLocalHeader + ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags;
+            Span<byte> flagBytes = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
+            _archive.ArchiveStream.Write(flagBytes);
+            _archive.ArchiveStream.Position = savedPosition;
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1141,11 +1141,12 @@ namespace System.IO.Compression
                 extraFieldLength = (ushort)bigExtraFieldLength;
             }
 
+            crc32ToWrite = _crc32;
+
             // If this is an existing, unchanged entry then silently skip forwards.
             // If it's new or changed, write the header.
             if (_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite)
             {
-                crc32ToWrite = _crc32;
                 _archive.ArchiveStream.Seek(ZipLocalFileHeader.SizeOfLocalHeader + _storedEntryNameBytes.Length, SeekOrigin.Current);
 
                 if (zip64ExtraField != null)
@@ -1160,15 +1161,14 @@ namespace System.IO.Compression
 
             // We are writing the header. For seekable/empty-file paths the sizes are written
             // directly into the header, so a data descriptor is not needed.
-            // However, when preserving a data descriptor (metadata-only rewrite of an existing entry
-            // that originally had bit 3 set), keep it set and zero the CRC/sizes since the real
-            // values live in the trailing descriptor that remains on disk.
             if (isEmptyFile || _archive.ArchiveStream.CanSeek)
             {
                 if (preserveDataDescriptor && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0)
                 {
                     compressedSizeTruncated = 0;
                     uncompressedSizeTruncated = 0;
+
+                    // zero the CRC/sizes since the real values live in the trailing descriptor that remains on disk.
                     crc32ToWrite = 0;
 
                     if (zip64ExtraField is not null)
@@ -1179,12 +1179,7 @@ namespace System.IO.Compression
                 else
                 {
                     _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
-                    crc32ToWrite = _crc32;
                 }
-            }
-            else
-            {
-                crc32ToWrite = _crc32;
             }
 
             return true;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1244,6 +1244,8 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
+                    // Save whether the original entry had a data descriptor before WriteLocalFileHeader clears the bit.
+                    bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 
                     // If we know that we need to update the file header (but don't need to load and update the data itself)
@@ -1252,8 +1254,38 @@ namespace System.IO.Compression
                     {
                         _archive.ArchiveStream.Seek(_compressedSize, SeekOrigin.Current);
                     }
+
+                    // If the original entry had a data descriptor after the compressed data, skip past it
+                    // so that subsequent entries are written at the correct position.
+                    if (hadDataDescriptor)
+                    {
+                        SkipDataDescriptor();
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        /// Reads past a data descriptor that follows the compressed data in the archive stream.
+        /// The data descriptor signature (0x08074B50) is optional per the ZIP spec, so we read the
+        /// first 4 bytes to detect it and seek past the remaining fields accordingly.
+        /// </summary>
+        private void SkipDataDescriptor()
+        {
+            Span<byte> signatureBuffer = stackalloc byte[sizeof(uint)];
+            _archive.ArchiveStream.ReadExactly(signatureBuffer);
+
+            bool hasSignature = signatureBuffer.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
+
+            int bytesToSkip = AreSizesTooLarge
+                ? (hasSignature
+                    ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
+                    : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)
+                : (hasSignature
+                    ? ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize
+                    : ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize);
+
+            _archive.ArchiveStream.Seek(bytesToSkip, SeekOrigin.Current);
         }
 
         private const int MetadataBufferLength = ZipLocalFileHeader.FieldLengths.VersionNeededToExtract + ZipLocalFileHeader.FieldLengths.GeneralPurposeBitFlags;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1062,7 +1062,7 @@ namespace System.IO.Compression
 
         private bool ShouldUseZIP64 => AreSizesTooLarge || IsOffsetTooLarge;
 
-        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength)
+        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite)
         {
             // _entryname only gets set when we read in or call moveTo. MoveTo does a check, and
             // reading in should not be able to produce an entryname longer than ushort.MaxValue
@@ -1080,6 +1080,7 @@ namespace System.IO.Compression
                 CompressionMethod = ZipCompressionMethod.Stored;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
+                crc32ToWrite = 0;
                 Debug.Assert(_uncompressedSize == 0);
                 Debug.Assert(_crc32 == 0);
             }
@@ -1092,11 +1093,22 @@ namespace System.IO.Compression
                     _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
                     compressedSizeTruncated = 0;
                     uncompressedSizeTruncated = 0;
+                    crc32ToWrite = 0;
                     // the crc should not have been set if we are in create mode, but clear it just to be sure
                     Debug.Assert(_crc32 == 0);
                 }
+                else if (preserveDataDescriptor)
+                {
+                    // The existing data descriptor bytes will remain on disk. Preserve bit 3 and
+                    // write zeros for CRC and sizes, matching the original streaming format, so that
+                    // sequential readers are not confused by the on-disk descriptor record.
+                    compressedSizeTruncated = 0;
+                    uncompressedSizeTruncated = 0;
+                    crc32ToWrite = 0;
+                }
                 else // if we are not in streaming mode, we have to decide if we want to write zip64 headers
                 {
+                    crc32ToWrite = _crc32;
                     if (ShouldUseZIP64
 #if DEBUG_FORCE_ZIP64
                         || (_archive._forceZip64 && _archive.Mode == ZipArchiveMode.Update)
@@ -1157,9 +1169,10 @@ namespace System.IO.Compression
                 return false;
             }
 
-            // We are writing the header. For seekable/empty-file paths the sizes are written
-            // directly into the header, so a data descriptor is not needed.
-            if (isEmptyFile || _archive.ArchiveStream.CanSeek)
+            // We are writing the header. Clear the data descriptor bit unless the existing
+            // on-disk data descriptor is being preserved, in which case bit 3 must remain set
+            // so sequential readers know to expect the descriptor record after the compressed data.
+            if (!preserveDataDescriptor && (isEmptyFile || _archive.ArchiveStream.CanSeek))
             {
                 _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
             }
@@ -1167,14 +1180,14 @@ namespace System.IO.Compression
             return true;
         }
 
-        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength)
+        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength, uint crc32ToWrite)
         {
             ZipLocalFileHeader.SignatureConstantBytes.CopyTo(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Signature..]);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.VersionNeededToExtract..], (ushort)_versionToExtract);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags..], (ushort)_generalPurposeBitFlag);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressionMethod..], (ushort)CompressionMethod);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.LastModified..], ZipHelper.DateTimeToDosTime(_lastModified.DateTime));
-            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], _crc32);
+            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], crc32ToWrite);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressedSize..], compressedSizeTruncated);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.UncompressedSize..], uncompressedSizeTruncated);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.FilenameLength..], (ushort)_storedEntryNameBytes.Length);
@@ -1182,12 +1195,12 @@ namespace System.IO.Compression
         }
 
         // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite)
+        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor = false)
         {
-            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
+            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
             {
                 Span<byte> lfStaticHeader = stackalloc byte[ZipLocalFileHeader.SizeOfLocalHeader];
-                WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
+                WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength, crc32ToWrite);
 
                 // write header
                 _archive.ArchiveStream.Write(lfStaticHeader);
@@ -1261,7 +1274,11 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
-                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
+                    // If the entry originally used a data descriptor and we are not rewriting the data,
+                    // the descriptor record remains on disk after the compressed bytes. Preserve bit 3
+                    // and write zeros for CRC/sizes so that sequential readers see a consistent entry.
+                    bool preserveDataDescriptor = _originallyInArchive && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor: preserveDataDescriptor);
 
                     // Advance the stream past the compressed data and any trailing data descriptor
                     // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1247,6 +1247,10 @@ namespace System.IO.Compression
                     _everOpenedForWrite = true;
                     // Capture data descriptor state before WriteLocalFileHeader clears bit 3 for seekable streams.
                     bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                    // Capture whether the original entry used ZIP64 before WriteLocalFileHeader
+                    // potentially modifies offset/size state. This determines whether the data
+                    // descriptor uses 32-bit or 64-bit field sizes.
+                    bool wasZip64 = ShouldUseZIP64;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 
                     // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
@@ -1269,7 +1273,7 @@ namespace System.IO.Compression
                     // so that subsequent entries are written at the correct position.
                     if (hadDataDescriptor)
                     {
-                        SkipDataDescriptor();
+                        SkipDataDescriptor(wasZip64);
                     }
                 }
             }
@@ -1294,11 +1298,11 @@ namespace System.IO.Compression
         /// The data descriptor signature (0x08074B50) is optional per the ZIP spec, so we read the
         /// first 4 bytes to detect it and seek past the remaining fields accordingly.
         /// </summary>
-        private void SkipDataDescriptor()
+        private void SkipDataDescriptor(bool zip64)
         {
             Span<byte> signatureBuffer = stackalloc byte[sizeof(uint)];
             _archive.ArchiveStream.ReadExactly(signatureBuffer);
-            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
+            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer, zip64), SeekOrigin.Current);
         }
 
         /// <summary>
@@ -1306,11 +1310,11 @@ namespace System.IO.Compression
         /// remaining bytes to seek past the data descriptor. Detects the optional signature
         /// and uses 32-bit or 64-bit field sizes as appropriate.
         /// </summary>
-        private int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes)
+        private static int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes, bool zip64)
         {
             bool hasSignature = leadingBytes.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
 
-            return AreSizesTooLarge
+            return zip64
                 ? (hasSignature
                     ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
                     : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -30,6 +30,7 @@ namespace System.IO.Compression
         private long _uncompressedSize;
         private long _offsetOfLocalHeader;
         private long? _storedOffsetOfCompressedData;
+        private long _endOfLocalEntryData;
         private uint _crc32;
         // An array of buffers, each a maximum of MaxSingleBufferSize in size
         private byte[][]? _compressedBytes;
@@ -1006,6 +1007,17 @@ namespace System.IO.Compression
 
         private bool AreSizesTooLarge => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
 
+        /// <summary>
+        /// The position immediately after all entry data (including any trailing data descriptor).
+        /// Pre-computed during the Update-mode write phase from the next entry's local header offset
+        /// or the central directory start offset.
+        /// </summary>
+        internal long EndOfLocalEntryData
+        {
+            get => _endOfLocalEntryData;
+            set => _endOfLocalEntryData = value;
+        }
+
         private static CompressionLevel MapCompressionLevel(BitFlagValues generalPurposeBitFlag, ZipCompressionMethod compressionMethod)
         {
             // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
@@ -1263,18 +1275,11 @@ namespace System.IO.Compression
                         }
                     }
 
-                    // If we know that we need to update the file header (but don't need to load and update the data itself)
-                    // then advance the position past it.
-                    if (_compressedSize != 0)
+                    // Advance the stream past the compressed data and any trailing data descriptor
+                    // by seeking to the pre-computed end-of-entry boundary.
+                    if (_endOfLocalEntryData > _archive.ArchiveStream.Position)
                     {
-                        _archive.ArchiveStream.Seek(_compressedSize, SeekOrigin.Current);
-                    }
-
-                    // If the original entry had a data descriptor after the compressed data, skip past it
-                    // so that subsequent entries are written at the correct position.
-                    if (hadDataDescriptor)
-                    {
-                        SkipDataDescriptor();
+                        _archive.ArchiveStream.Seek(_endOfLocalEntryData, SeekOrigin.Begin);
                     }
                 }
             }
@@ -1292,36 +1297,6 @@ namespace System.IO.Compression
             BinaryPrimitives.WriteUInt16LittleEndian(flagBytes, (ushort)_generalPurposeBitFlag);
             _archive.ArchiveStream.Write(flagBytes);
             _archive.ArchiveStream.Position = savedPosition;
-        }
-
-        /// <summary>
-        /// Reads past a data descriptor that follows the compressed data in the archive stream.
-        /// The data descriptor signature (0x08074B50) is optional per the ZIP spec, so we read the
-        /// first 4 bytes to detect it and seek past the remaining fields accordingly.
-        /// </summary>
-        private void SkipDataDescriptor()
-        {
-            Span<byte> signatureBuffer = stackalloc byte[sizeof(uint)];
-            _archive.ArchiveStream.ReadExactly(signatureBuffer);
-            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
-        }
-
-        /// <summary>
-        /// Given the first 4 bytes read after the compressed data, returns the number of
-        /// remaining bytes to seek past the data descriptor. Detects the optional signature
-        /// and uses 32-bit or 64-bit field sizes as appropriate.
-        /// </summary>
-        private int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes)
-        {
-            bool hasSignature = leadingBytes.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
-
-            return AreSizesTooLarge
-                ? (hasSignature
-                    ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
-                    : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)
-                : (hasSignature
-                    ? ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize
-                    : ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.ZipDataDescriptor.FieldLengths.UncompressedSize);
         }
 
         private const int MetadataBufferLength = ZipLocalFileHeader.FieldLengths.VersionNeededToExtract + ZipLocalFileHeader.FieldLengths.GeneralPurposeBitFlags;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1247,10 +1247,6 @@ namespace System.IO.Compression
                     _everOpenedForWrite = true;
                     // Capture data descriptor state before WriteLocalFileHeader clears bit 3 for seekable streams.
                     bool hadDataDescriptor = (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                    // Capture whether the original entry used ZIP64 before WriteLocalFileHeader
-                    // potentially modifies offset/size state. This determines whether the data
-                    // descriptor uses 32-bit or 64-bit field sizes.
-                    bool wasZip64 = ShouldUseZIP64;
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 
                     // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
@@ -1273,7 +1269,7 @@ namespace System.IO.Compression
                     // so that subsequent entries are written at the correct position.
                     if (hadDataDescriptor)
                     {
-                        SkipDataDescriptor(wasZip64);
+                        SkipDataDescriptor();
                     }
                 }
             }
@@ -1298,11 +1294,11 @@ namespace System.IO.Compression
         /// The data descriptor signature (0x08074B50) is optional per the ZIP spec, so we read the
         /// first 4 bytes to detect it and seek past the remaining fields accordingly.
         /// </summary>
-        private void SkipDataDescriptor(bool zip64)
+        private void SkipDataDescriptor()
         {
             Span<byte> signatureBuffer = stackalloc byte[sizeof(uint)];
             _archive.ArchiveStream.ReadExactly(signatureBuffer);
-            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer, zip64), SeekOrigin.Current);
+            _archive.ArchiveStream.Seek(GetDataDescriptorSkipBytes(signatureBuffer), SeekOrigin.Current);
         }
 
         /// <summary>
@@ -1310,11 +1306,11 @@ namespace System.IO.Compression
         /// remaining bytes to seek past the data descriptor. Detects the optional signature
         /// and uses 32-bit or 64-bit field sizes as appropriate.
         /// </summary>
-        private static int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes, bool zip64)
+        private int GetDataDescriptorSkipBytes(ReadOnlySpan<byte> leadingBytes)
         {
             bool hasSignature = leadingBytes.SequenceEqual(ZipLocalFileHeader.DataDescriptorSignatureConstantBytes);
 
-            return zip64
+            return AreSizesTooLarge
                 ? (hasSignature
                     ? ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.Crc32 + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize
                     : ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.CompressedSize + ZipLocalFileHeader.Zip64DataDescriptor.FieldLengths.UncompressedSize)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1672,7 +1672,7 @@ namespace System.IO.Compression
                     {
                         _everWritten = true;
                         // write local header, we are good to go
-                        _usedZip64inLH = await _entry.WriteLocalFileHeaderAsync(isEmptyFile: false, forceWrite: true, cancellationToken).ConfigureAwait(false);
+                        _usedZip64inLH = await _entry.WriteLocalFileHeaderAsync(isEmptyFile: false, forceWrite: true, preserveDataDescriptor: false, cancellationToken).ConfigureAwait(false);
                     }
 
                     await _crcSizeStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
@@ -1733,7 +1733,7 @@ namespace System.IO.Compression
                     if (!_everWritten)
                     {
                         // write local header, no data, so we use stored
-                        await _entry.WriteLocalFileHeaderAsync(isEmptyFile: true, forceWrite: true, cancellationToken: default).ConfigureAwait(false);
+                        await _entry.WriteLocalFileHeaderAsync(isEmptyFile: true, forceWrite: true, preserveDataDescriptor: false, cancellationToken: default).ConfigureAwait(false);
                     }
                     else
                     {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1250,12 +1250,17 @@ namespace System.IO.Compression
                     WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 
                     // WriteLocalFileHeaderInitialize clears bit 3 for seekable streams, but in the metadata-only
-                    // path the data descriptor bytes remain in the file. Restore bit 3 so the local header and
-                    // central directory accurately indicate that a data descriptor follows the compressed data.
+                    // path the data descriptor bytes remain in the file. Restore bit 3 in memory so the central
+                    // directory stays consistent, and patch the on-disk header only if it was actually rewritten.
                     if (hadDataDescriptor)
                     {
                         _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
-                        PatchLocalFileHeaderBitFlags();
+
+                        bool headerWritten = !(_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite);
+                        if (headerWritten)
+                        {
+                            PatchLocalFileHeaderBitFlags();
+                        }
                     }
 
                     // If we know that we need to update the file header (but don't need to load and update the data itself)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1009,8 +1009,8 @@ namespace System.IO.Compression
 
         /// <summary>
         /// The position immediately after all entry data (including any trailing data descriptor).
-        /// Pre-computed during the Update-mode write phase from the next entry's local header offset
-        /// or the central directory start offset.
+        /// Computed while reading the central directory from the next entry's local header offset
+        /// or, for the last entry, the central directory start offset.
         /// </summary>
         internal long EndOfLocalEntryData
         {
@@ -1283,7 +1283,7 @@ namespace System.IO.Compression
                     // since the descriptor bytes remain on disk after the compressed data.
                     bool preserveDataDescriptor = _originallyInArchive
                         && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor);
+                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor: preserveDataDescriptor);
 
                     // Advance the stream past the compressed data and any trailing data descriptor
                     // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1062,7 +1062,7 @@ namespace System.IO.Compression
 
         private bool ShouldUseZIP64 => AreSizesTooLarge || IsOffsetTooLarge;
 
-        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite)
+        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength)
         {
             // _entryname only gets set when we read in or call moveTo. MoveTo does a check, and
             // reading in should not be able to produce an entryname longer than ushort.MaxValue
@@ -1080,7 +1080,6 @@ namespace System.IO.Compression
                 CompressionMethod = ZipCompressionMethod.Stored;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
-                crc32ToWrite = 0;
                 Debug.Assert(_uncompressedSize == 0);
                 Debug.Assert(_crc32 == 0);
             }
@@ -1093,22 +1092,11 @@ namespace System.IO.Compression
                     _generalPurposeBitFlag |= BitFlagValues.DataDescriptor;
                     compressedSizeTruncated = 0;
                     uncompressedSizeTruncated = 0;
-                    crc32ToWrite = 0;
                     // the crc should not have been set if we are in create mode, but clear it just to be sure
                     Debug.Assert(_crc32 == 0);
                 }
-                else if (preserveDataDescriptor)
-                {
-                    // The existing data descriptor bytes will remain on disk. Preserve bit 3 and
-                    // write zeros for CRC and sizes, matching the original streaming format, so that
-                    // sequential readers are not confused by the on-disk descriptor record.
-                    compressedSizeTruncated = 0;
-                    uncompressedSizeTruncated = 0;
-                    crc32ToWrite = 0;
-                }
                 else // if we are not in streaming mode, we have to decide if we want to write zip64 headers
                 {
-                    crc32ToWrite = _crc32;
                     if (ShouldUseZIP64
 #if DEBUG_FORCE_ZIP64
                         || (_archive._forceZip64 && _archive.Mode == ZipArchiveMode.Update)
@@ -1169,10 +1157,9 @@ namespace System.IO.Compression
                 return false;
             }
 
-            // We are writing the header. Clear the data descriptor bit unless the existing
-            // on-disk data descriptor is being preserved, in which case bit 3 must remain set
-            // so sequential readers know to expect the descriptor record after the compressed data.
-            if (!preserveDataDescriptor && (isEmptyFile || _archive.ArchiveStream.CanSeek))
+            // We are writing the header. For seekable/empty-file paths the sizes are written
+            // directly into the header, so a data descriptor is not needed.
+            if (isEmptyFile || _archive.ArchiveStream.CanSeek)
             {
                 _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
             }
@@ -1180,14 +1167,14 @@ namespace System.IO.Compression
             return true;
         }
 
-        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength, uint crc32ToWrite)
+        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength)
         {
             ZipLocalFileHeader.SignatureConstantBytes.CopyTo(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Signature..]);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.VersionNeededToExtract..], (ushort)_versionToExtract);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags..], (ushort)_generalPurposeBitFlag);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressionMethod..], (ushort)CompressionMethod);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.LastModified..], ZipHelper.DateTimeToDosTime(_lastModified.DateTime));
-            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], crc32ToWrite);
+            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], _crc32);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressedSize..], compressedSizeTruncated);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.UncompressedSize..], uncompressedSizeTruncated);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.FilenameLength..], (ushort)_storedEntryNameBytes.Length);
@@ -1195,12 +1182,12 @@ namespace System.IO.Compression
         }
 
         // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor = false)
+        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite)
         {
-            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
+            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
             {
                 Span<byte> lfStaticHeader = stackalloc byte[ZipLocalFileHeader.SizeOfLocalHeader];
-                WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength, crc32ToWrite);
+                WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
 
                 // write header
                 _archive.ArchiveStream.Write(lfStaticHeader);
@@ -1274,11 +1261,7 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
-                    // If the entry originally used a data descriptor and we are not rewriting the data,
-                    // the descriptor record remains on disk after the compressed bytes. Preserve bit 3
-                    // and write zeros for CRC/sizes so that sequential readers see a consistent entry.
-                    bool preserveDataDescriptor = _originallyInArchive && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
-                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor: preserveDataDescriptor);
+                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
 
                     // Advance the stream past the compressed data and any trailing data descriptor
                     // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1163,7 +1163,7 @@ namespace System.IO.Compression
             // directly into the header, so a data descriptor is not needed.
             if (isEmptyFile || _archive.ArchiveStream.CanSeek)
             {
-                if (preserveDataDescriptor && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0)
+                if (preserveDataDescriptor)
                 {
                     compressedSizeTruncated = 0;
                     uncompressedSizeTruncated = 0;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1062,7 +1062,7 @@ namespace System.IO.Compression
 
         private bool ShouldUseZIP64 => AreSizesTooLarge || IsOffsetTooLarge;
 
-        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength)
+        private bool WriteLocalFileHeaderInitialize(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite)
         {
             // _entryname only gets set when we read in or call moveTo. MoveTo does a check, and
             // reading in should not be able to produce an entryname longer than ushort.MaxValue
@@ -1145,6 +1145,7 @@ namespace System.IO.Compression
             // If it's new or changed, write the header.
             if (_originallyInArchive && Changes == ZipArchive.ChangeState.Unchanged && !forceWrite)
             {
+                crc32ToWrite = _crc32;
                 _archive.ArchiveStream.Seek(ZipLocalFileHeader.SizeOfLocalHeader + _storedEntryNameBytes.Length, SeekOrigin.Current);
 
                 if (zip64ExtraField != null)
@@ -1159,22 +1160,44 @@ namespace System.IO.Compression
 
             // We are writing the header. For seekable/empty-file paths the sizes are written
             // directly into the header, so a data descriptor is not needed.
+            // However, when preserving a data descriptor (metadata-only rewrite of an existing entry
+            // that originally had bit 3 set), keep it set and zero the CRC/sizes since the real
+            // values live in the trailing descriptor that remains on disk.
             if (isEmptyFile || _archive.ArchiveStream.CanSeek)
             {
-                _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
+                if (preserveDataDescriptor && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0)
+                {
+                    compressedSizeTruncated = 0;
+                    uncompressedSizeTruncated = 0;
+                    crc32ToWrite = 0;
+
+                    if (zip64ExtraField is not null)
+                    {
+                        zip64ExtraField = new() { CompressedSize = 0, UncompressedSize = 0 };
+                    }
+                }
+                else
+                {
+                    _generalPurposeBitFlag &= ~BitFlagValues.DataDescriptor;
+                    crc32ToWrite = _crc32;
+                }
+            }
+            else
+            {
+                crc32ToWrite = _crc32;
             }
 
             return true;
         }
 
-        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength)
+        private void WriteLocalFileHeaderPrepare(Span<byte> lfStaticHeader, uint crc32, uint compressedSizeTruncated, uint uncompressedSizeTruncated, ushort extraFieldLength)
         {
             ZipLocalFileHeader.SignatureConstantBytes.CopyTo(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Signature..]);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.VersionNeededToExtract..], (ushort)_versionToExtract);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags..], (ushort)_generalPurposeBitFlag);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressionMethod..], (ushort)CompressionMethod);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.LastModified..], ZipHelper.DateTimeToDosTime(_lastModified.DateTime));
-            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], _crc32);
+            BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.Crc32..], crc32);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.CompressedSize..], compressedSizeTruncated);
             BinaryPrimitives.WriteUInt32LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.UncompressedSize..], uncompressedSizeTruncated);
             BinaryPrimitives.WriteUInt16LittleEndian(lfStaticHeader[ZipLocalFileHeader.FieldLocations.FilenameLength..], (ushort)_storedEntryNameBytes.Length);
@@ -1182,12 +1205,12 @@ namespace System.IO.Compression
         }
 
         // return value is true if we allocated an extra field for 64 bit headers, un/compressed size
-        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite)
+        private bool WriteLocalFileHeader(bool isEmptyFile, bool forceWrite, bool preserveDataDescriptor = false)
         {
-            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength))
+            if (WriteLocalFileHeaderInitialize(isEmptyFile, forceWrite, preserveDataDescriptor, out Zip64ExtraField? zip64ExtraField, out uint compressedSizeTruncated, out uint uncompressedSizeTruncated, out ushort extraFieldLength, out uint crc32ToWrite))
             {
                 Span<byte> lfStaticHeader = stackalloc byte[ZipLocalFileHeader.SizeOfLocalHeader];
-                WriteLocalFileHeaderPrepare(lfStaticHeader, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
+                WriteLocalFileHeaderPrepare(lfStaticHeader, crc32ToWrite, compressedSizeTruncated, uncompressedSizeTruncated, extraFieldLength);
 
                 // write header
                 _archive.ArchiveStream.Write(lfStaticHeader);
@@ -1261,7 +1284,11 @@ namespace System.IO.Compression
                 if (_archive.Mode == ZipArchiveMode.Update || !_everOpenedForWrite)
                 {
                     _everOpenedForWrite = true;
-                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite);
+                    // Preserve the data descriptor flag for entries that originally had one,
+                    // since the descriptor bytes remain on disk after the compressed data.
+                    bool preserveDataDescriptor = _originallyInArchive
+                        && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0;
+                    WriteLocalFileHeader(isEmptyFile: _uncompressedSize == 0, forceWrite: forceWrite, preserveDataDescriptor);
 
                     // Advance the stream past the compressed data and any trailing data descriptor
                     // by seeking to the pre-computed end-of-entry boundary.

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -1343,5 +1344,177 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        /// <summary>
+        /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
+        /// validates that data descriptor signatures are present and bit 3 is set in the raw bytes,
+        /// then reopens in Update mode, adds a new entry, and verifies the archive structure remains valid.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Update_DataDescriptorSignature_IsCorrectlyWrittenAndPreserved(bool async)
+        {
+            const uint LocalFileHeaderSignature = 0x04034b50;
+            const uint DataDescriptorSignature = 0x08074b50;
+            const ushort DataDescriptorBitFlag = 0x0008;
+
+            byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            int originalEntryCount = 3;
+
+            // Step 1: Create a zip using a non-seekable stream, which forces bit 3 (data descriptor)
+            byte[] zipBytes;
+            using (MemoryStream backing = new MemoryStream())
+            {
+                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
+                {
+                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+
+                    for (int i = 0; i < originalEntryCount; i++)
+                    {
+                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin");
+                        Stream s = await OpenEntryStream(async, entry);
+                        if (async)
+                            await s.WriteAsync(entryData);
+                        else
+                            s.Write(entryData);
+                        s.WriteByte((byte)i);
+                        await DisposeStream(async, s);
+                    }
+
+                    await DisposeZipArchive(async, createArchive);
+                }
+
+                zipBytes = backing.ToArray();
+            }
+
+            // Step 2: Validate the raw bytes - verify bit 3 is set and data descriptor signatures exist
+            int dataDescriptorCount = 0;
+            int localHeaderCount = 0;
+            int offset = 0;
+
+            while (offset < zipBytes.Length - 4)
+            {
+                uint signature = BinaryPrimitives.ReadUInt32LittleEndian(zipBytes.AsSpan(offset));
+
+                if (signature == LocalFileHeaderSignature)
+                {
+                    localHeaderCount++;
+                    // General purpose bit flag is at offset 6 from the local file header signature
+                    ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(offset + 6));
+                    Assert.True((flags & DataDescriptorBitFlag) != 0,
+                        $"Bit 3 (data descriptor flag) should be set for entry created via non-seekable stream. Flags: 0x{flags:X4}");
+                    offset += 4;
+                }
+                else if (signature == DataDescriptorSignature)
+                {
+                    dataDescriptorCount++;
+                    offset += 4;
+                }
+                else
+                {
+                    offset++;
+                }
+            }
+
+            Assert.Equal(originalEntryCount, localHeaderCount);
+            Assert.Equal(originalEntryCount, dataDescriptorCount);
+
+            // Step 3: Reopen in Update mode and add a new entry
+            byte[] updatedZipBytes;
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(zipBytes);
+                ms.Position = 0;
+
+                ZipArchive updateArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+                Assert.Equal(originalEntryCount, updateArchive.Entries.Count);
+
+                ZipArchiveEntry added = updateArchive.CreateEntry("added.bin");
+                Stream addedStream = await OpenEntryStream(async, added);
+                if (async)
+                    await addedStream.WriteAsync(entryData);
+                else
+                    addedStream.Write(entryData);
+                addedStream.WriteByte(0xFF);
+                await DisposeStream(async, addedStream);
+
+                await DisposeZipArchive(async, updateArchive);
+
+                updatedZipBytes = ms.ToArray();
+            }
+
+            // Step 4: Validate the updated archive - original entries should still have data descriptors
+            dataDescriptorCount = 0;
+            localHeaderCount = 0;
+            int entriesWithDataDescriptorBit = 0;
+            offset = 0;
+
+            while (offset < updatedZipBytes.Length - 4)
+            {
+                uint signature = BinaryPrimitives.ReadUInt32LittleEndian(updatedZipBytes.AsSpan(offset));
+
+                if (signature == LocalFileHeaderSignature)
+                {
+                    localHeaderCount++;
+                    ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(updatedZipBytes.AsSpan(offset + 6));
+                    if ((flags & DataDescriptorBitFlag) != 0)
+                    {
+                        entriesWithDataDescriptorBit++;
+                    }
+                    offset += 4;
+                }
+                else if (signature == DataDescriptorSignature)
+                {
+                    dataDescriptorCount++;
+                    offset += 4;
+                }
+                else
+                {
+                    offset++;
+                }
+            }
+
+            // After update, we should have 4 local headers (3 original + 1 added)
+            Assert.Equal(originalEntryCount + 1, localHeaderCount);
+            // The original 3 entries should still have data descriptors
+            // (the bit flag and signature count should match for entries with data descriptors)
+            Assert.Equal(dataDescriptorCount, entriesWithDataDescriptorBit);
+
+            // Step 5: Reopen in Read mode and verify all entries are readable
+            using (MemoryStream ms = new MemoryStream(updatedZipBytes))
+            {
+                ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read, leaveOpen: true);
+                Assert.Equal(originalEntryCount + 1, readArchive.Entries.Count);
+
+                for (int i = 0; i < originalEntryCount; i++)
+                {
+                    ZipArchiveEntry entry = readArchive.Entries[i];
+                    byte[] expected = [.. entryData, (byte)i];
+                    byte[] actual = new byte[expected.Length];
+                    Stream rs = await OpenEntryStream(async, entry);
+                    int bytesRead = async
+                        ? await rs.ReadAsync(actual)
+                        : rs.Read(actual);
+                    Assert.Equal(expected.Length, bytesRead);
+                    Assert.Equal(expected, actual);
+                    await DisposeStream(async, rs);
+                }
+
+                // Verify the newly added entry
+                {
+                    ZipArchiveEntry entry = readArchive.Entries[originalEntryCount];
+                    byte[] expected = [.. entryData, 0xFF];
+                    byte[] actual = new byte[expected.Length];
+                    Stream rs = await OpenEntryStream(async, entry);
+                    int bytesRead = async
+                        ? await rs.ReadAsync(actual)
+                        : rs.Read(actual);
+                    Assert.Equal(expected.Length, bytesRead);
+                    Assert.Equal(expected, actual);
+                    await DisposeStream(async, rs);
+                }
+
+                await DisposeZipArchive(async, readArchive);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1669,6 +1669,75 @@ namespace System.IO.Compression.Tests
 
                 await DisposeZipArchive(async, readArchive);
             }
+
+            // Step 4: Validate structural integrity — original entries must retain bit 3 and
+            // have CRC/sizes zeroed in the local header (values live in the data descriptor).
+            const uint LocalFileHeaderSignature = 0x04034b50;
+            const uint DataDescriptorSignature = 0x08074b50;
+            const ushort DataDescriptorBitFlag = 0x0008;
+            const uint EndOfCentralDirectorySignature = 0x06054B50;
+            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
+
+            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
+
+            int eocdOffset = -1;
+            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(i)) == EndOfCentralDirectorySignature)
+                {
+                    eocdOffset = i;
+                    break;
+                }
+            }
+            Assert.True(eocdOffset >= 0, "EOCD not found.");
+
+            int centralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(eocdOffset + 16)));
+            int totalEntries = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(eocdOffset + 10));
+            Assert.Equal(originalEntryCount + 1, totalEntries);
+
+            List<(int LocalHeaderOffset, uint CompressedSize)> entries = new();
+            int cdOffset = centralDirOffset;
+            for (int i = 0; i < totalEntries; i++)
+            {
+                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset)));
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 20));
+                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 28));
+                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 30));
+                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 32));
+                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 42));
+                entries.Add((checked((int)localHeaderOffset), compressedSize));
+                cdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
+            }
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                (int localHeaderOffset, uint compressedSize) = entries[i];
+                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(localHeaderOffset)));
+                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(localHeaderOffset + 6));
+                uint localCrc = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(localHeaderOffset + 14));
+                uint localCompSize = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(localHeaderOffset + 18));
+                uint localUncompSize = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(localHeaderOffset + 22));
+
+                if (i < originalEntryCount)
+                {
+                    // Original entries must preserve bit 3 and have zeroed CRC/sizes in the local header.
+                    Assert.True((flags & DataDescriptorBitFlag) != 0, $"Entry {i}: bit 3 should be preserved.");
+                    Assert.True(localCrc == 0, $"Entry {i}: local header CRC should be 0 when bit 3 is set.");
+                    Assert.True(localCompSize == 0, $"Entry {i}: local header compressed size should be 0 when bit 3 is set.");
+                    Assert.True(localUncompSize == 0, $"Entry {i}: local header uncompressed size should be 0 when bit 3 is set.");
+
+                    // Verify the data descriptor is present with the correct signature.
+                    ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(localHeaderOffset + 26));
+                    ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(localHeaderOffset + 28));
+                    int descriptorOffset = localHeaderOffset + 30 + fileNameLength + extraFieldLength + (int)compressedSize;
+                    Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(descriptorOffset)));
+                }
+                else
+                {
+                    // Newly added entry should NOT have bit 3 (written on seekable stream).
+                    Assert.True((flags & DataDescriptorBitFlag) == 0, $"Entry {i}: added entry should not have bit 3.");
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1480,8 +1480,9 @@ namespace System.IO.Compression.Tests
         /// <summary>
         /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
         /// reopens in Update mode, deletes an entry from the middle, and verifies the remaining
-        /// entries are intact. This exercises offset recalculation in ComputeEntryEndOffsets when
-        /// entries with data descriptors are removed and subsequent entries must shift.
+        /// entries are intact. This exercises the EndOfLocalEntryData values computed while reading
+        /// the central directory, which are then used to correctly shift subsequent entries after
+        /// an entry with a data descriptor is removed.
         /// </summary>
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1344,6 +1344,69 @@ namespace System.IO.Compression.Tests
             }
         }
 
+        private static async Task<byte[]> CreateNonSeekableZip(bool async, byte[] entryData, int entryCount)
+        {
+            using MemoryStream backing = new MemoryStream();
+            using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
+            {
+                ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+
+                for (int i = 0; i < entryCount; i++)
+                {
+                    ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
+                    Stream s = await OpenEntryStream(async, entry);
+                    if (async)
+                        await s.WriteAsync(entryData);
+                    else
+                        s.Write(entryData);
+                    s.WriteByte((byte)i);
+                    await DisposeStream(async, s);
+                }
+
+                await DisposeZipArchive(async, createArchive);
+            }
+
+            return backing.ToArray();
+        }
+
+        private static List<(int LocalHeaderOffset, uint CompressedSize)> ParseZipEntryHeaders(byte[] zipBytes, out int totalEntries)
+        {
+            const uint EndOfCentralDirectorySignature = 0x06054B50;
+            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
+
+            ReadOnlySpan<byte> span = zipBytes.AsSpan();
+
+            int eocdOffset = -1;
+            for (int i = zipBytes.Length - 22; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(i)) == EndOfCentralDirectorySignature)
+                {
+                    eocdOffset = i;
+                    break;
+                }
+            }
+            Assert.True(eocdOffset >= 0, "EOCD not found.");
+
+            totalEntries = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(eocdOffset + 10));
+            int centralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(eocdOffset + 16)));
+
+            List<(int LocalHeaderOffset, uint CompressedSize)> entries = new();
+            int cdOffset = centralDirOffset;
+            for (int i = 0; i < totalEntries; i++)
+            {
+                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset)));
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 20));
+                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 28));
+                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 30));
+                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 32));
+                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 42));
+                entries.Add((checked((int)localHeaderOffset), compressedSize));
+                cdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
+            }
+
+            return entries;
+        }
+
         /// <summary>
         /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
         /// then reopens in Update mode, adds a new entry, and verifies the archive structure remains valid.
@@ -1355,41 +1418,13 @@ namespace System.IO.Compression.Tests
             const uint LocalFileHeaderSignature = 0x04034b50;
             const uint DataDescriptorSignature = 0x08074b50;
             const ushort DataDescriptorBitFlag = 0x0008;
-            const uint EndOfCentralDirectorySignature = 0x06054B50;
-            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
 
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 3;
 
-            // Step 1: Create a zip using a non-seekable stream, which forces bit 3 (data descriptor)
-            byte[] zipBytes;
-            using (MemoryStream backing = new MemoryStream())
-            {
-                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
-                {
-                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+            byte[] zipBytes = await CreateNonSeekableZip(async, entryData, originalEntryCount);
 
-                    for (int i = 0; i < originalEntryCount; i++)
-                    {
-                        // Use NoCompression so the stored bytes are deterministic and cannot
-                        // accidentally contain local-header or data-descriptor signature sequences.
-                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
-                        Stream s = await OpenEntryStream(async, entry);
-                        if (async)
-                            await s.WriteAsync(entryData);
-                        else
-                            s.Write(entryData);
-                        s.WriteByte((byte)i);
-                        await DisposeStream(async, s);
-                    }
-
-                    await DisposeZipArchive(async, createArchive);
-                }
-
-                zipBytes = backing.ToArray();
-            }
-
-            // Step 2: Reopen in Update mode and add a new entry
+            // Reopen in Update mode and add a new entry
             byte[] updatedZipBytes;
             using (MemoryStream ms = new MemoryStream())
             {
@@ -1413,46 +1448,16 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Step 3:Validate the updated archive structurally - original entries should still have
-            // data descriptors at the expected positions.
+            // Validate the updated archive structurally
+            List<(int LocalHeaderOffset, uint CompressedSize)> updatedEntries = ParseZipEntryHeaders(updatedZipBytes, out int updatedTotalEntries);
             ReadOnlySpan<byte> updatedSpan = updatedZipBytes.AsSpan();
 
-            int updatedEocdOffset = -1;
-            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
-            {
-                if (BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(i)) == EndOfCentralDirectorySignature)
-                {
-                    updatedEocdOffset = i;
-                    break;
-                }
-            }
-            Assert.True(updatedEocdOffset >= 0, "End of Central Directory record not found in updated archive.");
-
-            int updatedCentralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedEocdOffset + 16)));
-            int updatedTotalEntries = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedEocdOffset + 10));
-
-            List<(int LocalHeaderOffset, uint CompressedSize)> updatedEntries = new();
-            int updatedCdOffset = updatedCentralDirOffset;
-            for (int i = 0; i < updatedTotalEntries; i++)
-            {
-                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset)));
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset + 20));
-                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 28));
-                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 30));
-                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 32));
-                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset + 42));
-                updatedEntries.Add((checked((int)localHeaderOffset), compressedSize));
-                updatedCdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
-            }
-
             int dataDescriptorCount = 0;
-            int localHeaderCount = 0;
             int entriesWithDataDescriptorBit = 0;
             foreach ((int localHeaderOffset, uint compressedSize) in updatedEntries)
             {
                 Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(localHeaderOffset)));
                 ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(localHeaderOffset + 6));
-                localHeaderCount++;
 
                 if ((flags & DataDescriptorBitFlag) != 0)
                 {
@@ -1467,9 +1472,7 @@ namespace System.IO.Compression.Tests
                 }
             }
 
-            // After update, we should have 4 local headers (3 original + 1 added)
-            Assert.Equal(originalEntryCount + 1, localHeaderCount);
-            // The original 3 entries should still have data descriptors
+            Assert.Equal(originalEntryCount + 1, updatedTotalEntries);
             Assert.Equal(originalEntryCount, entriesWithDataDescriptorBit);
             Assert.Equal(originalEntryCount, dataDescriptorCount);
         }
@@ -1487,30 +1490,7 @@ namespace System.IO.Compression.Tests
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 5;
 
-            byte[] zipBytes;
-            using (MemoryStream backing = new MemoryStream())
-            {
-                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
-                {
-                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
-
-                    for (int i = 0; i < originalEntryCount; i++)
-                    {
-                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
-                        Stream s = await OpenEntryStream(async, entry);
-                        if (async)
-                            await s.WriteAsync(entryData);
-                        else
-                            s.Write(entryData);
-                        s.WriteByte((byte)i);
-                        await DisposeStream(async, s);
-                    }
-
-                    await DisposeZipArchive(async, createArchive);
-                }
-
-                zipBytes = backing.ToArray();
-            }
+            byte[] zipBytes = await CreateNonSeekableZip(async, entryData, originalEntryCount);
 
             byte[] updatedZipBytes;
             using (MemoryStream ms = new MemoryStream())
@@ -1571,33 +1551,9 @@ namespace System.IO.Compression.Tests
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 3;
 
-            // Step 1: Create a zip using a non-seekable stream, which forces bit 3 (data descriptor)
-            byte[] zipBytes;
-            using (MemoryStream backing = new MemoryStream())
-            {
-                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
-                {
-                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+            byte[] zipBytes = await CreateNonSeekableZip(async, entryData, originalEntryCount);
 
-                    for (int i = 0; i < originalEntryCount; i++)
-                    {
-                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
-                        Stream s = await OpenEntryStream(async, entry);
-                        if (async)
-                            await s.WriteAsync(entryData);
-                        else
-                            s.Write(entryData);
-                        s.WriteByte((byte)i);
-                        await DisposeStream(async, s);
-                    }
-
-                    await DisposeZipArchive(async, createArchive);
-                }
-
-                zipBytes = backing.ToArray();
-            }
-
-            // Step 2: Reopen in Update mode, change metadata on the middle entry, and add a new entry
+            // Reopen in Update mode, change metadata on the middle entry, and add a new entry
             byte[] updatedZipBytes;
             DateTimeOffset newTimestamp = new DateTimeOffset(2020, 6, 15, 12, 0, 0, TimeSpan.Zero);
             using (MemoryStream ms = new MemoryStream())
@@ -1627,88 +1583,27 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Step 3: Reopen in Read mode and verify all entries are readable with correct data
+            // Verify the metadata change was preserved (compare DateTime only — DOS time format
+            // does not preserve timezone offset)
             using (MemoryStream ms = new MemoryStream(updatedZipBytes))
             {
                 ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read, leaveOpen: true);
-                Assert.Equal(originalEntryCount + 1, readArchive.Entries.Count);
-
-                for (int i = 0; i < originalEntryCount; i++)
-                {
-                    ZipArchiveEntry entry = readArchive.GetEntry($"entry{i}.bin");
-                    Assert.NotNull(entry);
-                    byte[] expected = [.. entryData, (byte)i];
-                    byte[] actual = new byte[expected.Length];
-                    Stream rs = await OpenEntryStream(async, entry);
-                    if (async)
-                        await rs.ReadExactlyAsync(actual);
-                    else
-                        rs.ReadExactly(actual);
-                    Assert.Equal(expected, actual);
-                    await DisposeStream(async, rs);
-                }
-
-                // Verify the metadata change was preserved (compare DateTime only — DOS time format
-                // does not preserve timezone offset)
                 ZipArchiveEntry verifyMiddle = readArchive.GetEntry("entry1.bin");
                 Assert.NotNull(verifyMiddle);
                 Assert.Equal(newTimestamp.DateTime, verifyMiddle.LastWriteTime.DateTime);
-
-                // Verify the newly added entry
-                ZipArchiveEntry verifyAdded = readArchive.GetEntry("added.bin");
-                Assert.NotNull(verifyAdded);
-                byte[] expectedAdded = [.. entryData, 0xFF];
-                byte[] actualAdded = new byte[expectedAdded.Length];
-                Stream addedRs = await OpenEntryStream(async, verifyAdded);
-                if (async)
-                    await addedRs.ReadExactlyAsync(actualAdded);
-                else
-                    addedRs.ReadExactly(actualAdded);
-                Assert.Equal(expectedAdded, actualAdded);
-                await DisposeStream(async, addedRs);
-
                 await DisposeZipArchive(async, readArchive);
             }
 
-            // Step 4: Validate structural integrity — original entries must retain bit 3 and
+            // Validate structural integrity — original entries must retain bit 3 and
             // have CRC/sizes zeroed in the local header (values live in the data descriptor).
             const uint LocalFileHeaderSignature = 0x04034b50;
             const uint DataDescriptorSignature = 0x08074b50;
             const ushort DataDescriptorBitFlag = 0x0008;
-            const uint EndOfCentralDirectorySignature = 0x06054B50;
-            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
 
-            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
-
-            int eocdOffset = -1;
-            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
-            {
-                if (BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(i)) == EndOfCentralDirectorySignature)
-                {
-                    eocdOffset = i;
-                    break;
-                }
-            }
-            Assert.True(eocdOffset >= 0, "EOCD not found.");
-
-            int centralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(eocdOffset + 16)));
-            int totalEntries = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(eocdOffset + 10));
+            List<(int LocalHeaderOffset, uint CompressedSize)> entries = ParseZipEntryHeaders(updatedZipBytes, out int totalEntries);
             Assert.Equal(originalEntryCount + 1, totalEntries);
 
-            List<(int LocalHeaderOffset, uint CompressedSize)> entries = new();
-            int cdOffset = centralDirOffset;
-            for (int i = 0; i < totalEntries; i++)
-            {
-                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset)));
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 20));
-                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 28));
-                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 30));
-                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(span.Slice(cdOffset + 32));
-                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(span.Slice(cdOffset + 42));
-                entries.Add((checked((int)localHeaderOffset), compressedSize));
-                cdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
-            }
-
+            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
             for (int i = 0; i < entries.Count; i++)
             {
                 (int localHeaderOffset, uint compressedSize) = entries[i];

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1389,7 +1389,7 @@ namespace System.IO.Compression.Tests
                 zipBytes = backing.ToArray();
             }
 
-            // Reopen in Update mode and add a new entry
+            // Step 2: Reopen in Update mode and add a new entry
             byte[] updatedZipBytes;
             using (MemoryStream ms = new MemoryStream())
             {
@@ -1413,7 +1413,7 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Validate the updated archive structurally - original entries should still have
+            // Step 3:Validate the updated archive structurally - original entries should still have
             // data descriptors at the expected positions.
             ReadOnlySpan<byte> updatedSpan = updatedZipBytes.AsSpan();
 
@@ -1472,6 +1472,90 @@ namespace System.IO.Compression.Tests
             // The original 3 entries should still have data descriptors
             Assert.Equal(originalEntryCount, entriesWithDataDescriptorBit);
             Assert.Equal(originalEntryCount, dataDescriptorCount);
+        }
+
+        /// <summary>
+        /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
+        /// reopens in Update mode, deletes an entry from the middle, and verifies the remaining
+        /// entries are intact. This exercises offset recalculation in ComputeEntryEndOffsets when
+        /// entries with data descriptors are removed and subsequent entries must shift.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Update_DataDescriptorWithDeletedEntry_PreservesArchive(bool async)
+        {
+            byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            int originalEntryCount = 5;
+
+            byte[] zipBytes;
+            using (MemoryStream backing = new MemoryStream())
+            {
+                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
+                {
+                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+
+                    for (int i = 0; i < originalEntryCount; i++)
+                    {
+                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
+                        Stream s = await OpenEntryStream(async, entry);
+                        if (async)
+                            await s.WriteAsync(entryData);
+                        else
+                            s.Write(entryData);
+                        s.WriteByte((byte)i);
+                        await DisposeStream(async, s);
+                    }
+
+                    await DisposeZipArchive(async, createArchive);
+                }
+
+                zipBytes = backing.ToArray();
+            }
+
+            byte[] updatedZipBytes;
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(zipBytes);
+                ms.Position = 0;
+
+                ZipArchive updateArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+                Assert.Equal(originalEntryCount, updateArchive.Entries.Count);
+
+                ZipArchiveEntry toDelete = updateArchive.GetEntry("entry1.bin");
+                Assert.NotNull(toDelete);
+                toDelete.Delete();
+
+                await DisposeZipArchive(async, updateArchive);
+
+                updatedZipBytes = ms.ToArray();
+            }
+
+            using (MemoryStream ms = new MemoryStream(updatedZipBytes))
+            {
+                ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read, leaveOpen: true);
+                Assert.Equal(originalEntryCount - 1, readArchive.Entries.Count);
+                Assert.Null(readArchive.GetEntry("entry1.bin"));
+
+                for (int i = 0; i < originalEntryCount; i++)
+                {
+                    if (i == 1)
+                        continue;
+
+                    ZipArchiveEntry entry = readArchive.GetEntry($"entry{i}.bin");
+                    Assert.NotNull(entry);
+                    byte[] expected = [.. entryData, (byte)i];
+                    byte[] actual = new byte[expected.Length];
+                    Stream rs = await OpenEntryStream(async, entry);
+                    if (async)
+                        await rs.ReadExactlyAsync(actual);
+                    else
+                        rs.ReadExactly(actual);
+                    Assert.Equal(expected, actual);
+                    await DisposeStream(async, rs);
+                }
+
+                await DisposeZipArchive(async, readArchive);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1559,15 +1559,98 @@ namespace System.IO.Compression.Tests
         }
 
         /// <summary>
+        /// After a metadata-only update (e.g. LastWriteTime change) to an entry that originally used a
+        /// data descriptor, the rewritten local file header must still have bit 3 set and must keep CRC
+        /// and sizes as zero, because the original data descriptor bytes remain on disk after the
+        /// compressed data. Verifies the raw local header bytes of the modified entry.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Update_DataDescriptorWithMetadataOnlyChange_PreservesLocalHeaderFormat(bool async)
+        {
+            const ushort DataDescriptorBitFlag = 0x0008;
+            const uint DataDescriptorSignature = 0x08074b50;
+
+            byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+            // Create a zip on a non-seekable stream to force bit 3 / data descriptor on all entries.
+            byte[] zipBytes;
+            using (MemoryStream backing = new MemoryStream())
+            {
+                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
+                {
+                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+                    ZipArchiveEntry entry = createArchive.CreateEntry("entry.bin", CompressionLevel.NoCompression);
+                    Stream s = await OpenEntryStream(async, entry);
+                    if (async)
+                        await s.WriteAsync(entryData);
+                    else
+                        s.Write(entryData);
+                    await DisposeStream(async, s);
+                    await DisposeZipArchive(async, createArchive);
+                }
+                zipBytes = backing.ToArray();
+            }
+
+            // Reopen in Update mode and change only metadata — do NOT open the entry stream.
+            byte[] updatedZipBytes;
+            DateTimeOffset newTimestamp = new DateTimeOffset(2020, 6, 15, 12, 0, 0, TimeSpan.Zero);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(zipBytes);
+                ms.Position = 0;
+                ZipArchive updateArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+                ZipArchiveEntry entry = updateArchive.GetEntry("entry.bin");
+                Assert.NotNull(entry);
+                entry.LastWriteTime = newTimestamp;
+                await DisposeZipArchive(async, updateArchive);
+                updatedZipBytes = ms.ToArray();
+            }
+
+            // Inspect the raw bytes of the rewritten local file header.
+            // Because the data descriptor bytes remain on disk after the compressed data, the local
+            // header must preserve bit 3 and write zeros for CRC/sizes so that sequential readers
+            // (not using the central directory) see a consistent streaming-format entry.
+            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
+
+            // Local file header starts at offset 0 for the first (and only) entry.
+            ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(span[6..]);
+            Assert.True((flags & DataDescriptorBitFlag) != 0, "Bit 3 (data descriptor) must remain set in the rewritten local header.");
+
+            uint lhCrc32 = BinaryPrimitives.ReadUInt32LittleEndian(span[14..]);
+            uint lhCompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[18..]);
+            uint lhUncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[22..]);
+            Assert.Equal(0u, lhCrc32, "CRC-32 must be zero in local header when bit 3 is set.");
+            Assert.Equal(0u, lhCompressedSize, "Compressed size must be zero in local header when bit 3 is set.");
+            Assert.Equal(0u, lhUncompressedSize, "Uncompressed size must be zero in local header when bit 3 is set.");
+
+            // The data descriptor must still be present immediately after the compressed data.
+            ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span[26..]);
+            ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span[28..]);
+            int dataOffset = 30 + fileNameLength + extraFieldLength;
+            int descriptorOffset = dataOffset + entryData.Length;
+            Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[descriptorOffset..]),
+                "Data descriptor signature must be present after the compressed data.");
+        }
+
+        /// <summary>
         /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
         /// reopens in Update mode, modifies only metadata (LastWriteTime) on a middle entry without
         /// reading its data, adds a new entry, and verifies all entries are intact.
         /// This exercises the metadata-only rewrite path which must seek past data descriptors.
+        /// Also validates the on-disk structure: original entries must still have bit 3 set and their
+        /// data descriptors present at the correct offsets; the new entry must not have bit 3.
         /// </summary>
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
         public async Task Update_DataDescriptorWithMetadataOnlyChange_PreservesArchive(bool async)
         {
+            const uint LocalFileHeaderSignature = 0x04034b50;
+            const uint DataDescriptorSignature = 0x08074b50;
+            const ushort DataDescriptorBitFlag = 0x0008;
+            const uint EndOfCentralDirectorySignature = 0x06054B50;
+            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
+
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 3;
 
@@ -1668,6 +1751,81 @@ namespace System.IO.Compression.Tests
                 await DisposeStream(async, addedRs);
 
                 await DisposeZipArchive(async, readArchive);
+            }
+
+            // Step 4: Validate the on-disk structure by walking raw bytes.
+            // Parse the central directory to obtain each entry's local header offset and compressed
+            // size, then inspect each local header directly.
+            // - The 3 original entries had data descriptors; the metadata-only rewrite must preserve
+            //   bit 3 and keep CRC/sizes as zero in the local header so sequential readers see a
+            //   consistent streaming-format entry.  The data descriptor must still follow the data.
+            // - The newly added entry was written to a seekable stream and must NOT have bit 3.
+            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
+
+            int eocdOffset = -1;
+            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(span[i..]) == EndOfCentralDirectorySignature)
+                {
+                    eocdOffset = i;
+                    break;
+                }
+            }
+            Assert.True(eocdOffset >= 0, "End of Central Directory record not found.");
+
+            int totalEntries = BinaryPrimitives.ReadUInt16LittleEndian(span[(eocdOffset + 10)..]);
+            int cdOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(span[(eocdOffset + 16)..]));
+            Assert.Equal(originalEntryCount + 1, totalEntries);
+
+            // Collect (localHeaderOffset, compressedSize) from the central directory.
+            var entries = new List<(int LocalHeaderOffset, uint CompressedSize)>(totalEntries);
+            int pos = cdOffset;
+            for (int i = 0; i < totalEntries; i++)
+            {
+                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[pos..]));
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[(pos + 20)..]);
+                ushort fnLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 28)..]);
+                ushort exLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 30)..]);
+                ushort cmLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 32)..]);
+                uint lhOffset = BinaryPrimitives.ReadUInt32LittleEndian(span[(pos + 42)..]);
+                entries.Add((checked((int)lhOffset), compressedSize));
+                pos += 46 + fnLen + exLen + cmLen;
+            }
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                (int lhOff, uint compressedSize) = entries[i];
+                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[lhOff..]));
+                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 6)..]);
+                bool isOriginalEntry = i < originalEntryCount;
+
+                if (isOriginalEntry)
+                {
+                    // Original entries must preserve bit 3: the data descriptor bytes remain on disk
+                    // and the local header CRC/sizes must be zero to stay consistent with them.
+                    Assert.True((flags & DataDescriptorBitFlag) != 0,
+                        $"Entry {i}: bit 3 must remain set after a metadata-only rewrite.");
+                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 14)..]),
+                        $"Entry {i}: CRC-32 must be zero in local header when bit 3 is set.");
+                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 18)..]),
+                        $"Entry {i}: compressed size must be zero in local header when bit 3 is set.");
+                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 22)..]),
+                        $"Entry {i}: uncompressed size must be zero in local header when bit 3 is set.");
+
+                    // Data descriptor must be present immediately after the compressed data.
+                    ushort fnLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 26)..]);
+                    ushort exLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 28)..]);
+                    int descriptorOffset = lhOff + 30 + fnLen + exLen + (int)compressedSize;
+                    Assert.Equal(DataDescriptorSignature,
+                        BinaryPrimitives.ReadUInt32LittleEndian(span[descriptorOffset..]),
+                        $"Entry {i}: data descriptor signature must follow the compressed data.");
+                }
+                else
+                {
+                    // The newly added entry was written to a seekable stream; it must not have bit 3.
+                    Assert.True((flags & DataDescriptorBitFlag) == 0,
+                        $"Entry {i}: newly added entry must not have bit 3 set.");
+                }
             }
         }
     }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1388,35 +1388,60 @@ namespace System.IO.Compression.Tests
                 zipBytes = backing.ToArray();
             }
 
-            // Step 2: Validate the raw bytes - verify bit 3 is set and data descriptor signatures exist.
-            // This byte scan is safe because NoCompression stores raw bytes, and our payload [0..15, i]
-            // cannot contain the 'PK' (0x50,0x4B) prefix used in ZIP signatures.
+            // Step 2: Validate the raw bytes structurally - verify bit 3 is set and that each entry
+            // has a data descriptor immediately following its data.
+            const uint EndOfCentralDirectorySignature = 0x06054B50;
+            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
+
+            ReadOnlySpan<byte> zipSpan = zipBytes.AsSpan();
+
+            // Locate End of Central Directory (EOCD) by scanning backwards from the end.
+            int eocdOffset = -1;
+            for (int i = zipBytes.Length - 22; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(i)) == EndOfCentralDirectorySignature)
+                {
+                    eocdOffset = i;
+                    break;
+                }
+            }
+            Assert.True(eocdOffset >= 0, "End of Central Directory record not found.");
+
+            // EOCD+16 = offset of central directory
+            int centralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(eocdOffset + 16)));
+
+            // Walk the central directory to collect each entry's local header offset and compressed size.
+            List<(int LocalHeaderOffset, uint CompressedSize)> entries = new();
+            int cdOffset = centralDirOffset;
+            for (int i = 0; i < originalEntryCount; i++)
+            {
+                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset)));
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset + 20));
+                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 28));
+                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 30));
+                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 32));
+                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset + 42));
+                entries.Add((checked((int)localHeaderOffset), compressedSize));
+                cdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
+            }
+
+            // Walk local file headers and verify data descriptors at expected positions.
             int dataDescriptorCount = 0;
             int localHeaderCount = 0;
-            int offset = 0;
-
-            while (offset < zipBytes.Length - 4)
+            foreach ((int localHeaderOffset, uint compressedSize) in entries)
             {
-                uint signature = BinaryPrimitives.ReadUInt32LittleEndian(zipBytes.AsSpan(offset));
+                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(localHeaderOffset)));
+                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 6));
+                Assert.True((flags & DataDescriptorBitFlag) != 0,
+                    $"Bit 3 (data descriptor flag) should be set for entry created via non-seekable stream. Flags: 0x{flags:X4}");
 
-                if (signature == LocalFileHeaderSignature)
-                {
-                    localHeaderCount++;
-                    // General purpose bit flag is at offset 6 from the local file header signature
-                    ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(offset + 6));
-                    Assert.True((flags & DataDescriptorBitFlag) != 0,
-                        $"Bit 3 (data descriptor flag) should be set for entry created via non-seekable stream. Flags: 0x{flags:X4}");
-                    offset += 4;
-                }
-                else if (signature == DataDescriptorSignature)
-                {
-                    dataDescriptorCount++;
-                    offset += 4;
-                }
-                else
-                {
-                    offset++;
-                }
+                ushort localFileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 26));
+                ushort localExtraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 28));
+                int descriptorOffset = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength + (int)compressedSize;
+                Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(descriptorOffset)));
+
+                localHeaderCount++;
+                dataDescriptorCount++;
             }
 
             Assert.Equal(originalEntryCount, localHeaderCount);
@@ -1446,36 +1471,57 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Step 4: Validate the updated archive - original entries should still have data descriptors.
-            // This byte scan is safe because NoCompression stores raw bytes, and our payload cannot
-            // contain the 'PK' (0x50,0x4B) prefix used in ZIP signatures.
+            // Step 4: Validate the updated archive structurally - original entries should still have
+            // data descriptors at the expected positions.
+            ReadOnlySpan<byte> updatedSpan = updatedZipBytes.AsSpan();
+
+            int updatedEocdOffset = -1;
+            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
+            {
+                if (BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(i)) == EndOfCentralDirectorySignature)
+                {
+                    updatedEocdOffset = i;
+                    break;
+                }
+            }
+            Assert.True(updatedEocdOffset >= 0, "End of Central Directory record not found in updated archive.");
+
+            int updatedCentralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedEocdOffset + 16)));
+            int updatedTotalEntries = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedEocdOffset + 10));
+
+            List<(int LocalHeaderOffset, uint CompressedSize)> updatedEntries = new();
+            int updatedCdOffset = updatedCentralDirOffset;
+            for (int i = 0; i < updatedTotalEntries; i++)
+            {
+                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset)));
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset + 20));
+                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 28));
+                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 30));
+                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(updatedCdOffset + 32));
+                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(updatedCdOffset + 42));
+                updatedEntries.Add((checked((int)localHeaderOffset), compressedSize));
+                updatedCdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
+            }
+
             dataDescriptorCount = 0;
             localHeaderCount = 0;
             int entriesWithDataDescriptorBit = 0;
-            offset = 0;
-
-            while (offset < updatedZipBytes.Length - 4)
+            foreach ((int localHeaderOffset, uint compressedSize) in updatedEntries)
             {
-                uint signature = BinaryPrimitives.ReadUInt32LittleEndian(updatedZipBytes.AsSpan(offset));
+                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(localHeaderOffset)));
+                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(localHeaderOffset + 6));
+                localHeaderCount++;
 
-                if (signature == LocalFileHeaderSignature)
+                if ((flags & DataDescriptorBitFlag) != 0)
                 {
-                    localHeaderCount++;
-                    ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(updatedZipBytes.AsSpan(offset + 6));
-                    if ((flags & DataDescriptorBitFlag) != 0)
-                    {
-                        entriesWithDataDescriptorBit++;
-                    }
-                    offset += 4;
-                }
-                else if (signature == DataDescriptorSignature)
-                {
+                    entriesWithDataDescriptorBit++;
+
+                    ushort localFileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(localHeaderOffset + 26));
+                    ushort localExtraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(updatedSpan.Slice(localHeaderOffset + 28));
+                    int descriptorOffset = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength + (int)compressedSize;
+                    Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(updatedSpan.Slice(descriptorOffset)));
+
                     dataDescriptorCount++;
-                    offset += 4;
-                }
-                else
-                {
-                    offset++;
                 }
             }
 

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1559,98 +1559,15 @@ namespace System.IO.Compression.Tests
         }
 
         /// <summary>
-        /// After a metadata-only update (e.g. LastWriteTime change) to an entry that originally used a
-        /// data descriptor, the rewritten local file header must still have bit 3 set and must keep CRC
-        /// and sizes as zero, because the original data descriptor bytes remain on disk after the
-        /// compressed data. Verifies the raw local header bytes of the modified entry.
-        /// </summary>
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Update_DataDescriptorWithMetadataOnlyChange_PreservesLocalHeaderFormat(bool async)
-        {
-            const ushort DataDescriptorBitFlag = 0x0008;
-            const uint DataDescriptorSignature = 0x08074b50;
-
-            byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
-
-            // Create a zip on a non-seekable stream to force bit 3 / data descriptor on all entries.
-            byte[] zipBytes;
-            using (MemoryStream backing = new MemoryStream())
-            {
-                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
-                {
-                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
-                    ZipArchiveEntry entry = createArchive.CreateEntry("entry.bin", CompressionLevel.NoCompression);
-                    Stream s = await OpenEntryStream(async, entry);
-                    if (async)
-                        await s.WriteAsync(entryData);
-                    else
-                        s.Write(entryData);
-                    await DisposeStream(async, s);
-                    await DisposeZipArchive(async, createArchive);
-                }
-                zipBytes = backing.ToArray();
-            }
-
-            // Reopen in Update mode and change only metadata — do NOT open the entry stream.
-            byte[] updatedZipBytes;
-            DateTimeOffset newTimestamp = new DateTimeOffset(2020, 6, 15, 12, 0, 0, TimeSpan.Zero);
-            using (MemoryStream ms = new MemoryStream())
-            {
-                ms.Write(zipBytes);
-                ms.Position = 0;
-                ZipArchive updateArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
-                ZipArchiveEntry entry = updateArchive.GetEntry("entry.bin");
-                Assert.NotNull(entry);
-                entry.LastWriteTime = newTimestamp;
-                await DisposeZipArchive(async, updateArchive);
-                updatedZipBytes = ms.ToArray();
-            }
-
-            // Inspect the raw bytes of the rewritten local file header.
-            // Because the data descriptor bytes remain on disk after the compressed data, the local
-            // header must preserve bit 3 and write zeros for CRC/sizes so that sequential readers
-            // (not using the central directory) see a consistent streaming-format entry.
-            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
-
-            // Local file header starts at offset 0 for the first (and only) entry.
-            ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(span[6..]);
-            Assert.True((flags & DataDescriptorBitFlag) != 0, "Bit 3 (data descriptor) must remain set in the rewritten local header.");
-
-            uint lhCrc32 = BinaryPrimitives.ReadUInt32LittleEndian(span[14..]);
-            uint lhCompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[18..]);
-            uint lhUncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[22..]);
-            Assert.Equal(0u, lhCrc32, "CRC-32 must be zero in local header when bit 3 is set.");
-            Assert.Equal(0u, lhCompressedSize, "Compressed size must be zero in local header when bit 3 is set.");
-            Assert.Equal(0u, lhUncompressedSize, "Uncompressed size must be zero in local header when bit 3 is set.");
-
-            // The data descriptor must still be present immediately after the compressed data.
-            ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(span[26..]);
-            ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(span[28..]);
-            int dataOffset = 30 + fileNameLength + extraFieldLength;
-            int descriptorOffset = dataOffset + entryData.Length;
-            Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[descriptorOffset..]),
-                "Data descriptor signature must be present after the compressed data.");
-        }
-
-        /// <summary>
         /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
         /// reopens in Update mode, modifies only metadata (LastWriteTime) on a middle entry without
         /// reading its data, adds a new entry, and verifies all entries are intact.
         /// This exercises the metadata-only rewrite path which must seek past data descriptors.
-        /// Also validates the on-disk structure: original entries must still have bit 3 set and their
-        /// data descriptors present at the correct offsets; the new entry must not have bit 3.
         /// </summary>
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
         public async Task Update_DataDescriptorWithMetadataOnlyChange_PreservesArchive(bool async)
         {
-            const uint LocalFileHeaderSignature = 0x04034b50;
-            const uint DataDescriptorSignature = 0x08074b50;
-            const ushort DataDescriptorBitFlag = 0x0008;
-            const uint EndOfCentralDirectorySignature = 0x06054B50;
-            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
-
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 3;
 
@@ -1751,81 +1668,6 @@ namespace System.IO.Compression.Tests
                 await DisposeStream(async, addedRs);
 
                 await DisposeZipArchive(async, readArchive);
-            }
-
-            // Step 4: Validate the on-disk structure by walking raw bytes.
-            // Parse the central directory to obtain each entry's local header offset and compressed
-            // size, then inspect each local header directly.
-            // - The 3 original entries had data descriptors; the metadata-only rewrite must preserve
-            //   bit 3 and keep CRC/sizes as zero in the local header so sequential readers see a
-            //   consistent streaming-format entry.  The data descriptor must still follow the data.
-            // - The newly added entry was written to a seekable stream and must NOT have bit 3.
-            ReadOnlySpan<byte> span = updatedZipBytes.AsSpan();
-
-            int eocdOffset = -1;
-            for (int i = updatedZipBytes.Length - 22; i >= 0; i--)
-            {
-                if (BinaryPrimitives.ReadUInt32LittleEndian(span[i..]) == EndOfCentralDirectorySignature)
-                {
-                    eocdOffset = i;
-                    break;
-                }
-            }
-            Assert.True(eocdOffset >= 0, "End of Central Directory record not found.");
-
-            int totalEntries = BinaryPrimitives.ReadUInt16LittleEndian(span[(eocdOffset + 10)..]);
-            int cdOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(span[(eocdOffset + 16)..]));
-            Assert.Equal(originalEntryCount + 1, totalEntries);
-
-            // Collect (localHeaderOffset, compressedSize) from the central directory.
-            var entries = new List<(int LocalHeaderOffset, uint CompressedSize)>(totalEntries);
-            int pos = cdOffset;
-            for (int i = 0; i < totalEntries; i++)
-            {
-                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[pos..]));
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(span[(pos + 20)..]);
-                ushort fnLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 28)..]);
-                ushort exLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 30)..]);
-                ushort cmLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(pos + 32)..]);
-                uint lhOffset = BinaryPrimitives.ReadUInt32LittleEndian(span[(pos + 42)..]);
-                entries.Add((checked((int)lhOffset), compressedSize));
-                pos += 46 + fnLen + exLen + cmLen;
-            }
-
-            for (int i = 0; i < entries.Count; i++)
-            {
-                (int lhOff, uint compressedSize) = entries[i];
-                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(span[lhOff..]));
-                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 6)..]);
-                bool isOriginalEntry = i < originalEntryCount;
-
-                if (isOriginalEntry)
-                {
-                    // Original entries must preserve bit 3: the data descriptor bytes remain on disk
-                    // and the local header CRC/sizes must be zero to stay consistent with them.
-                    Assert.True((flags & DataDescriptorBitFlag) != 0,
-                        $"Entry {i}: bit 3 must remain set after a metadata-only rewrite.");
-                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 14)..]),
-                        $"Entry {i}: CRC-32 must be zero in local header when bit 3 is set.");
-                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 18)..]),
-                        $"Entry {i}: compressed size must be zero in local header when bit 3 is set.");
-                    Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(span[(lhOff + 22)..]),
-                        $"Entry {i}: uncompressed size must be zero in local header when bit 3 is set.");
-
-                    // Data descriptor must be present immediately after the compressed data.
-                    ushort fnLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 26)..]);
-                    ushort exLen = BinaryPrimitives.ReadUInt16LittleEndian(span[(lhOff + 28)..]);
-                    int descriptorOffset = lhOff + 30 + fnLen + exLen + (int)compressedSize;
-                    Assert.Equal(DataDescriptorSignature,
-                        BinaryPrimitives.ReadUInt32LittleEndian(span[descriptorOffset..]),
-                        $"Entry {i}: data descriptor signature must follow the compressed data.");
-                }
-                else
-                {
-                    // The newly added entry was written to a seekable stream; it must not have bit 3.
-                    Assert.True((flags & DataDescriptorBitFlag) == 0,
-                        $"Entry {i}: newly added entry must not have bit 3 set.");
-                }
             }
         }
     }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1609,10 +1609,11 @@ namespace System.IO.Compression.Tests
                     await DisposeStream(async, rs);
                 }
 
-                // Verify the metadata change was preserved
+                // Verify the metadata change was preserved (compare DateTime only — DOS time format
+                // does not preserve timezone offset)
                 ZipArchiveEntry verifyMiddle = readArchive.GetEntry("entry1.bin");
                 Assert.NotNull(verifyMiddle);
-                Assert.Equal(newTimestamp, verifyMiddle.LastWriteTime);
+                Assert.Equal(newTimestamp.DateTime, verifyMiddle.LastWriteTime.DateTime);
 
                 // Verify the newly added entry
                 ZipArchiveEntry verifyAdded = readArchive.GetEntry("added.bin");

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1346,7 +1346,6 @@ namespace System.IO.Compression.Tests
 
         /// <summary>
         /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
-        /// validates that data descriptor signatures are present and bit 3 is set in the raw bytes,
         /// then reopens in Update mode, adds a new entry, and verifies the archive structure remains valid.
         /// </summary>
         [Theory]
@@ -1356,6 +1355,8 @@ namespace System.IO.Compression.Tests
             const uint LocalFileHeaderSignature = 0x04034b50;
             const uint DataDescriptorSignature = 0x08074b50;
             const ushort DataDescriptorBitFlag = 0x0008;
+            const uint EndOfCentralDirectorySignature = 0x06054B50;
+            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
 
             byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
             int originalEntryCount = 3;
@@ -1388,66 +1389,7 @@ namespace System.IO.Compression.Tests
                 zipBytes = backing.ToArray();
             }
 
-            // Step 2: Validate the raw bytes structurally - verify bit 3 is set and that each entry
-            // has a data descriptor immediately following its data.
-            const uint EndOfCentralDirectorySignature = 0x06054B50;
-            const uint CentralDirectoryFileHeaderSignature = 0x02014B50;
-
-            ReadOnlySpan<byte> zipSpan = zipBytes.AsSpan();
-
-            // Locate End of Central Directory (EOCD) by scanning backwards from the end.
-            int eocdOffset = -1;
-            for (int i = zipBytes.Length - 22; i >= 0; i--)
-            {
-                if (BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(i)) == EndOfCentralDirectorySignature)
-                {
-                    eocdOffset = i;
-                    break;
-                }
-            }
-            Assert.True(eocdOffset >= 0, "End of Central Directory record not found.");
-
-            // EOCD+16 = offset of central directory
-            int centralDirOffset = checked((int)BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(eocdOffset + 16)));
-
-            // Walk the central directory to collect each entry's local header offset and compressed size.
-            List<(int LocalHeaderOffset, uint CompressedSize)> entries = new();
-            int cdOffset = centralDirOffset;
-            for (int i = 0; i < originalEntryCount; i++)
-            {
-                Assert.Equal(CentralDirectoryFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset)));
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset + 20));
-                ushort fileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 28));
-                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 30));
-                ushort fileCommentLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(cdOffset + 32));
-                uint localHeaderOffset = BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(cdOffset + 42));
-                entries.Add((checked((int)localHeaderOffset), compressedSize));
-                cdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
-            }
-
-            // Walk local file headers and verify data descriptors at expected positions.
-            int dataDescriptorCount = 0;
-            int localHeaderCount = 0;
-            foreach ((int localHeaderOffset, uint compressedSize) in entries)
-            {
-                Assert.Equal(LocalFileHeaderSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(localHeaderOffset)));
-                ushort flags = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 6));
-                Assert.True((flags & DataDescriptorBitFlag) != 0,
-                    $"Bit 3 (data descriptor flag) should be set for entry created via non-seekable stream. Flags: 0x{flags:X4}");
-
-                ushort localFileNameLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 26));
-                ushort localExtraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(zipSpan.Slice(localHeaderOffset + 28));
-                int descriptorOffset = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength + (int)compressedSize;
-                Assert.Equal(DataDescriptorSignature, BinaryPrimitives.ReadUInt32LittleEndian(zipSpan.Slice(descriptorOffset)));
-
-                localHeaderCount++;
-                dataDescriptorCount++;
-            }
-
-            Assert.Equal(originalEntryCount, localHeaderCount);
-            Assert.Equal(originalEntryCount, dataDescriptorCount);
-
-            // Step 3: Reopen in Update mode and add a new entry
+            // Reopen in Update mode and add a new entry
             byte[] updatedZipBytes;
             using (MemoryStream ms = new MemoryStream())
             {
@@ -1471,7 +1413,7 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Step 4: Validate the updated archive structurally - original entries should still have
+            // Validate the updated archive structurally - original entries should still have
             // data descriptors at the expected positions.
             ReadOnlySpan<byte> updatedSpan = updatedZipBytes.AsSpan();
 
@@ -1503,8 +1445,8 @@ namespace System.IO.Compression.Tests
                 updatedCdOffset += 46 + fileNameLength + extraFieldLength + fileCommentLength;
             }
 
-            dataDescriptorCount = 0;
-            localHeaderCount = 0;
+            int dataDescriptorCount = 0;
+            int localHeaderCount = 0;
             int entriesWithDataDescriptorBit = 0;
             foreach ((int localHeaderOffset, uint compressedSize) in updatedEntries)
             {
@@ -1530,45 +1472,6 @@ namespace System.IO.Compression.Tests
             // The original 3 entries should still have data descriptors
             Assert.Equal(originalEntryCount, entriesWithDataDescriptorBit);
             Assert.Equal(originalEntryCount, dataDescriptorCount);
-
-            // Step 5: Reopen in Read mode and verify all entries are readable
-            using (MemoryStream ms = new MemoryStream(updatedZipBytes))
-            {
-                ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read, leaveOpen: true);
-                Assert.Equal(originalEntryCount + 1, readArchive.Entries.Count);
-
-                for (int i = 0; i < originalEntryCount; i++)
-                {
-                    ZipArchiveEntry entry = readArchive.GetEntry($"entry{i}.bin");
-                    Assert.NotNull(entry);
-                    byte[] expected = [.. entryData, (byte)i];
-                    byte[] actual = new byte[expected.Length];
-                    Stream rs = await OpenEntryStream(async, entry);
-                    if (async)
-                        await rs.ReadExactlyAsync(actual);
-                    else
-                        rs.ReadExactly(actual);
-                    Assert.Equal(expected, actual);
-                    await DisposeStream(async, rs);
-                }
-
-                // Verify the newly added entry
-                {
-                    ZipArchiveEntry entry = readArchive.GetEntry("added.bin");
-                    Assert.NotNull(entry);
-                    byte[] expected = [.. entryData, 0xFF];
-                    byte[] actual = new byte[expected.Length];
-                    Stream rs = await OpenEntryStream(async, entry);
-                    if (async)
-                        await rs.ReadExactlyAsync(actual);
-                    else
-                        rs.ReadExactly(actual);
-                    Assert.Equal(expected, actual);
-                    await DisposeStream(async, rs);
-                }
-
-                await DisposeZipArchive(async, readArchive);
-            }
         }
 
         /// <summary>

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1518,5 +1518,117 @@ namespace System.IO.Compression.Tests
                 await DisposeZipArchive(async, readArchive);
             }
         }
+
+        /// <summary>
+        /// Creates a zip archive via a non-seekable stream (which forces data descriptor / bit 3),
+        /// reopens in Update mode, modifies only metadata (LastWriteTime) on a middle entry without
+        /// reading its data, adds a new entry, and verifies all entries are intact.
+        /// This exercises the metadata-only rewrite path which must seek past data descriptors.
+        /// </summary>
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Update_DataDescriptorWithMetadataOnlyChange_PreservesArchive(bool async)
+        {
+            byte[] entryData = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+            int originalEntryCount = 3;
+
+            // Step 1: Create a zip using a non-seekable stream, which forces bit 3 (data descriptor)
+            byte[] zipBytes;
+            using (MemoryStream backing = new MemoryStream())
+            {
+                using (var nonSeekable = new WrappedStream(backing, canRead: false, canWrite: true, canSeek: false))
+                {
+                    ZipArchive createArchive = await CreateZipArchive(async, nonSeekable, ZipArchiveMode.Create);
+
+                    for (int i = 0; i < originalEntryCount; i++)
+                    {
+                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin");
+                        Stream s = await OpenEntryStream(async, entry);
+                        if (async)
+                            await s.WriteAsync(entryData);
+                        else
+                            s.Write(entryData);
+                        s.WriteByte((byte)i);
+                        await DisposeStream(async, s);
+                    }
+
+                    await DisposeZipArchive(async, createArchive);
+                }
+
+                zipBytes = backing.ToArray();
+            }
+
+            // Step 2: Reopen in Update mode, change metadata on the middle entry, and add a new entry
+            byte[] updatedZipBytes;
+            DateTimeOffset newTimestamp = new DateTimeOffset(2020, 6, 15, 12, 0, 0, TimeSpan.Zero);
+            using (MemoryStream ms = new MemoryStream())
+            {
+                ms.Write(zipBytes);
+                ms.Position = 0;
+
+                ZipArchive updateArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Update, leaveOpen: true);
+                Assert.Equal(originalEntryCount, updateArchive.Entries.Count);
+
+                // Only change metadata — do NOT open the entry stream (exercises the metadata-only rewrite path)
+                ZipArchiveEntry middleEntry = updateArchive.GetEntry("entry1.bin");
+                Assert.NotNull(middleEntry);
+                middleEntry.LastWriteTime = newTimestamp;
+
+                ZipArchiveEntry added = updateArchive.CreateEntry("added.bin");
+                Stream addedStream = await OpenEntryStream(async, added);
+                if (async)
+                    await addedStream.WriteAsync(entryData);
+                else
+                    addedStream.Write(entryData);
+                addedStream.WriteByte(0xFF);
+                await DisposeStream(async, addedStream);
+
+                await DisposeZipArchive(async, updateArchive);
+
+                updatedZipBytes = ms.ToArray();
+            }
+
+            // Step 3: Reopen in Read mode and verify all entries are readable with correct data
+            using (MemoryStream ms = new MemoryStream(updatedZipBytes))
+            {
+                ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read, leaveOpen: true);
+                Assert.Equal(originalEntryCount + 1, readArchive.Entries.Count);
+
+                for (int i = 0; i < originalEntryCount; i++)
+                {
+                    ZipArchiveEntry entry = readArchive.GetEntry($"entry{i}.bin");
+                    Assert.NotNull(entry);
+                    byte[] expected = [.. entryData, (byte)i];
+                    byte[] actual = new byte[expected.Length];
+                    Stream rs = await OpenEntryStream(async, entry);
+                    if (async)
+                        await rs.ReadExactlyAsync(actual);
+                    else
+                        rs.ReadExactly(actual);
+                    Assert.Equal(expected, actual);
+                    await DisposeStream(async, rs);
+                }
+
+                // Verify the metadata change was preserved
+                ZipArchiveEntry verifyMiddle = readArchive.GetEntry("entry1.bin");
+                Assert.NotNull(verifyMiddle);
+                Assert.Equal(newTimestamp, verifyMiddle.LastWriteTime);
+
+                // Verify the newly added entry
+                ZipArchiveEntry verifyAdded = readArchive.GetEntry("added.bin");
+                Assert.NotNull(verifyAdded);
+                byte[] expectedAdded = [.. entryData, 0xFF];
+                byte[] actualAdded = new byte[expectedAdded.Length];
+                Stream addedRs = await OpenEntryStream(async, verifyAdded);
+                if (async)
+                    await addedRs.ReadExactlyAsync(actualAdded);
+                else
+                    addedRs.ReadExactly(actualAdded);
+                Assert.Equal(expectedAdded, actualAdded);
+                await DisposeStream(async, addedRs);
+
+                await DisposeZipArchive(async, readArchive);
+            }
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1476,8 +1476,8 @@ namespace System.IO.Compression.Tests
             // After update, we should have 4 local headers (3 original + 1 added)
             Assert.Equal(originalEntryCount + 1, localHeaderCount);
             // The original 3 entries should still have data descriptors
-            // (the bit flag and signature count should match for entries with data descriptors)
-            Assert.Equal(dataDescriptorCount, entriesWithDataDescriptorBit);
+            Assert.Equal(originalEntryCount, entriesWithDataDescriptorBit);
+            Assert.Equal(originalEntryCount, dataDescriptorCount);
 
             // Step 5: Reopen in Read mode and verify all entries are readable
             using (MemoryStream ms = new MemoryStream(updatedZipBytes))
@@ -1487,28 +1487,30 @@ namespace System.IO.Compression.Tests
 
                 for (int i = 0; i < originalEntryCount; i++)
                 {
-                    ZipArchiveEntry entry = readArchive.Entries[i];
+                    ZipArchiveEntry entry = readArchive.GetEntry($"entry{i}.bin");
+                    Assert.NotNull(entry);
                     byte[] expected = [.. entryData, (byte)i];
                     byte[] actual = new byte[expected.Length];
                     Stream rs = await OpenEntryStream(async, entry);
-                    int bytesRead = async
-                        ? await rs.ReadAsync(actual)
-                        : rs.Read(actual);
-                    Assert.Equal(expected.Length, bytesRead);
+                    if (async)
+                        await rs.ReadExactlyAsync(actual);
+                    else
+                        rs.ReadExactly(actual);
                     Assert.Equal(expected, actual);
                     await DisposeStream(async, rs);
                 }
 
                 // Verify the newly added entry
                 {
-                    ZipArchiveEntry entry = readArchive.Entries[originalEntryCount];
+                    ZipArchiveEntry entry = readArchive.GetEntry("added.bin");
+                    Assert.NotNull(entry);
                     byte[] expected = [.. entryData, 0xFF];
                     byte[] actual = new byte[expected.Length];
                     Stream rs = await OpenEntryStream(async, entry);
-                    int bytesRead = async
-                        ? await rs.ReadAsync(actual)
-                        : rs.Read(actual);
-                    Assert.Equal(expected.Length, bytesRead);
+                    if (async)
+                        await rs.ReadExactlyAsync(actual);
+                    else
+                        rs.ReadExactly(actual);
                     Assert.Equal(expected, actual);
                     await DisposeStream(async, rs);
                 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_UpdateTests.cs
@@ -1370,7 +1370,9 @@ namespace System.IO.Compression.Tests
 
                     for (int i = 0; i < originalEntryCount; i++)
                     {
-                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin");
+                        // Use NoCompression so the stored bytes are deterministic and cannot
+                        // accidentally contain local-header or data-descriptor signature sequences.
+                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
                         Stream s = await OpenEntryStream(async, entry);
                         if (async)
                             await s.WriteAsync(entryData);
@@ -1386,7 +1388,9 @@ namespace System.IO.Compression.Tests
                 zipBytes = backing.ToArray();
             }
 
-            // Step 2: Validate the raw bytes - verify bit 3 is set and data descriptor signatures exist
+            // Step 2: Validate the raw bytes - verify bit 3 is set and data descriptor signatures exist.
+            // This byte scan is safe because NoCompression stores raw bytes, and our payload [0..15, i]
+            // cannot contain the 'PK' (0x50,0x4B) prefix used in ZIP signatures.
             int dataDescriptorCount = 0;
             int localHeaderCount = 0;
             int offset = 0;
@@ -1442,7 +1446,9 @@ namespace System.IO.Compression.Tests
                 updatedZipBytes = ms.ToArray();
             }
 
-            // Step 4: Validate the updated archive - original entries should still have data descriptors
+            // Step 4: Validate the updated archive - original entries should still have data descriptors.
+            // This byte scan is safe because NoCompression stores raw bytes, and our payload cannot
+            // contain the 'PK' (0x50,0x4B) prefix used in ZIP signatures.
             dataDescriptorCount = 0;
             localHeaderCount = 0;
             int entriesWithDataDescriptorBit = 0;
@@ -1542,7 +1548,7 @@ namespace System.IO.Compression.Tests
 
                     for (int i = 0; i < originalEntryCount; i++)
                     {
-                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin");
+                        ZipArchiveEntry entry = createArchive.CreateEntry($"entry{i}.bin", CompressionLevel.NoCompression);
                         Stream s = await OpenEntryStream(async, entry);
                         if (async)
                             await s.WriteAsync(entryData);


### PR DESCRIPTION
# Fix ZipArchive Update mode corruption when entries have data descriptors (bit 3)

Fixes #126344

## Description

When opening an existing ZIP in `ZipArchiveMode.Update` and disposing (which triggers the write-back), the offset calculations in `WriteFileCalculateOffsets` and the stream seeking in `WriteLocalFileHeaderAndDataIfNeeded`/`WriteLocalFileHeaderAndDataIfNeededAsync` did not account for the data descriptor bytes (12–24 bytes depending on format) that follow compressed data when general purpose bit flag bit 3 is set. This caused new or shifted entries to overwrite data descriptors, corrupting the archive.

This commonly affects archives created on non-seekable streams (which always set bit 3) or by external tools such as Java's `ZipOutputStream`, Azure blob storage SDKs, and similar.

This is a .NET 10 regression introduced by PR #102704's selective-rewrite optimization.

## Changes

### Offset calculation fix (`ZipArchive.cs`)

- **Central directory read** — During `ReadCentralDirectory()`, `EndOfLocalEntryData` is precomputed for each originally-in-archive entry. Since `_entries` is sorted by local header offset, each entry's end boundary is the next original entry's `OffsetOfLocalHeader`, or `_centralDirectoryStart` for the last entry. This naturally accounts for any trailing data (data descriptors, padding, etc.) without any stream I/O.
- **`WriteFileCalculateOffsets`** — Now uses `entry.EndOfLocalEntryData` instead of `GetOffsetOfCompressedData() + CompressedLength`, which did not include data descriptor bytes.

### Metadata-only seek fix (`ZipArchiveEntry.cs`, `ZipArchiveEntry.Async.cs`)

- After writing the local file header for an unchanged/metadata-only entry, the stream now seeks to the absolute `EndOfLocalEntryData` position instead of using a relative seek by `_compressedSize`. This single seek correctly advances past both compressed data and any trailing data descriptor, with zero stream reads.

### Data descriptor (bit 3) preservation during metadata-only rewrites (`ZipArchiveEntry.cs`, `ZipArchiveEntry.Async.cs`)

- `WriteLocalFileHeader` / `WriteLocalFileHeaderAsync` accept a new `preserveDataDescriptor` parameter. When true (metadata-only rewrite of an entry that originally had bit 3 set), the method keeps bit 3 in the general purpose bit flag and zeros CRC32/compressed size/uncompressed size in the local header — matching the on-disk data descriptor convention.
- `WriteLocalFileHeaderPrepare` now takes an explicit `crc32` parameter instead of reading `_crc32` directly, allowing the caller to pass zero when preserving the data descriptor.
- `WriteLocalFileHeaderAndDataIfNeeded` / `WriteLocalFileHeaderAndDataIfNeededAsync` compute `preserveDataDescriptor` in the metadata-only else branch: `_originallyInArchive && (_generalPurposeBitFlag & BitFlagValues.DataDescriptor) != 0`.
- For entries whose headers *are* fully rewritten (force-written after a rewrite point), bit 3 is correctly cleared since the sizes are written directly into the header. Any orphaned data descriptor bytes become harmless dead space — compliant readers ignore them when bit 3 is not set.

## Testing

Three new regression tests in `zip_UpdateTests.cs`, all parameterized on `bool async` via `[Theory]`/`[MemberData]` to exercise sync `Dispose` and async `DisposeAsync` code paths:

### `Update_DataDescriptorSignature_IsCorrectlyWrittenAndPreserved`

Creates a 3-entry archive via a non-seekable stream (forces bit 3 / data descriptors) with `NoCompression`, reopens in Update mode, adds a new entry. Performs a structural binary walk of the updated archive: EOCD → central directory → local file headers, verifying bit 3 flags on original entries and data descriptor signatures at the correct computed byte offsets.

### `Update_DataDescriptorWithDeletedEntry_PreservesArchive`

Creates a 5-entry archive via a non-seekable stream, reopens in Update mode, deletes a middle entry. Verifies the remaining 4 entries are readable with correct data. Exercises offset recalculation in `ComputeEntryEndOffsets` when entries with data descriptors are removed and subsequent entries must shift.

### `Update_DataDescriptorWithMetadataOnlyChange_PreservesArchive`

Creates a 3-entry archive via a non-seekable stream, reopens in Update mode, changes `LastWriteTime` on the middle entry **without opening its stream** (exercises the metadata-only rewrite path), adds a new entry. Verifies the metadata change was preserved via ZipArchive read-back. Then performs a structural binary walk validating that all original entries retain bit 3, have zeroed CRC32/sizes in the local header, and have valid data descriptor signatures at the expected byte offsets. The newly added entry must NOT have bit 3.

## Test results

All 1739 tests pass with 0 errors, 0 failures (1733 existing + 6 new test runs).
