### PR TITLE
Skip unsupported tests and increase timeouts for Apple mobile CI legs

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -164,7 +164,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR_RuntimeTests
       buildArgs: -s clr+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 360
       # extra steps, run tests
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -78,7 +78,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_Mono_RuntimeTests
       buildArgs: -s mono+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 360
       # extra steps, run tests
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
@@ -234,7 +234,7 @@ jobs:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR_RuntimeTests
       buildArgs: -s clr+libs -c $(_BuildConfig)
-      timeoutInMinutes: 240
+      timeoutInMinutes: 360
       # extra steps, run tests
       extraVariablesTemplates:
         - template: /eng/pipelines/common/templates/runtimes/test-variables.yml

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessHandlesTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessHandlesTests.cs
@@ -9,6 +9,7 @@ using Xunit;
 namespace System.Diagnostics.Tests
 {
     [SkipOnPlatform(TestPlatforms.Android, "sh is not available on Android")]
+    [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Not supported on Apple mobile platforms.")]
     public class ProcessHandlesTests : ProcessTestBase
     {
         [Theory]

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -519,7 +519,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS or tvOS.")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Not supported on iOS, tvOS, or MacCatalyst.")]
         public void TestStartOnUnixWithBadPermissions()
         {
             string path = GetTestFilePath();

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -402,14 +402,14 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Not supported on iOS, tvOS, and MacCatalyst.")]
         public void ProcessStart_TryOpenFolder_UseShellExecuteIsFalse_ThrowsWin32Exception()
         {
             Assert.Throws<Win32Exception>(() => Process.Start(new ProcessStartInfo { UseShellExecute = false, FileName = Path.GetTempPath() }));
         }
 
         [Fact]
-        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "Not supported on iOS and tvOS.")]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Not supported on iOS, tvOS, and MacCatalyst.")]
         public void TestStartWithBadWorkingDirectory()
         {
             string program;

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -284,6 +284,7 @@ namespace System.Net.NameResolution.Tests
         // 3. Different systems configure localhost differently
         // The key requirement is that localhost subdomains return loopback addresses.
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/126456", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst | TestPlatforms.Android)]
         public async Task DnsGetHostAddresses_LocalhostAndSubdomain_BothReturnLoopback()
         {
             IPAddress[] localhostAddresses = Dns.GetHostAddresses("localhost");

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -449,6 +449,7 @@ namespace System.Net.NameResolution.Tests
         // 3. Different systems configure localhost differently
         // The key requirement is that localhost subdomains return loopback addresses.
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/126456", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst | TestPlatforms.Android)]
         public async Task DnsGetHostEntry_LocalhostAndSubdomain_BothReturnLoopback()
         {
             IPHostEntry localhostEntry = Dns.GetHostEntry("localhost");

--- a/src/tests/Regressions/coreclr/15241/genericcontext.ilproj
+++ b/src/tests/Regressions/coreclr/15241/genericcontext.ilproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
+  <PropertyGroup>
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="genericcontext.il" />
   </ItemGroup>


### PR DESCRIPTION
## Description

Skip tests that throw `PlatformNotSupportedException` or fail due to platform-specific behavior on Apple mobile (iOS, tvOS, MacCatalyst) and Android devices. 

Fixes #126455
Fixes #126456
Fixes #126462
Fixes #126463