### PR TITLE
[wasm][coreclr] Enable passing tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -194,7 +194,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Reflection.Tests\System.Reflection.Tests.csproj" />
     <!-- crashes -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Http\tests\Microsoft.Extensions.Http.Tests\Microsoft.Extensions.Http.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core\tests\Microsoft.VisualBasic.Core.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.IO.Compression.ZipFile\tests\System.IO.Compression.ZipFile.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
@@ -213,7 +212,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Intrinsics\tests\System.Runtime.Intrinsics.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Dynamic.Runtime.Tests\System.Dynamic.Runtime.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Runtime.Extensions.Tests\System.Runtime.Extensions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Overlapped\tests\System.Threading.Overlapped.Tests.csproj" />
     <!-- long running suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq\tests\System.Linq.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary

2. **Enable 2 test suites** that now pass on browser-wasm/CoreCLR

## Tests re-enabled

| Suite | Passed | Failed | Skipped |
|-------|--------|--------|---------|
| Microsoft.Extensions.Http.Tests | 84 | 0 | 76 |
| System.Threading.Overlapped.Tests | 12 | 0 | 0 |


Tests verified locally with:
```
./dotnet.sh build -c Debug /t:Test <csproj> \
  /p:TargetOS=browser /p:TargetArchitecture=wasm \
  /p:RuntimeFlavor=CoreCLR /p:Scenario=WasmTestOnChrome
```