### PR TITLE
Fix race condition in cached interface dispatch stubs

### DIFF
--- a/src/coreclr/runtime/amd64/StubDispatch.S
+++ b/src/coreclr/runtime/amd64/StubDispatch.S
@@ -28,6 +28,16 @@ LEAF_ENTRY RhpInterfaceDispatch\entries, _TEXT
         // load r10 to point to the cache block.
         mov     r10, [r11 + OFFSETOF__InterfaceDispatchCell__m_pCache]
 
+        // Validate r10 is a cache pointer matching the expected cache size.
+        // This compensates for a race where the stub was updated to expect a larger cache
+        // but we loaded a stale (smaller or non-cache) m_pCache value.
+        // On detection, re-dispatch through the indirection cell to retry with the current
+        // stub and cache pair.
+        test    r10, IDC_CACHE_POINTER_MASK
+        jnz     LOCAL_LABEL(RaceRetry_\entries)
+        cmp     dword ptr [r10 + OFFSETOF__InterfaceDispatchCache__m_cEntries], \entries
+        jne     LOCAL_LABEL(RaceRetry_\entries)
+
         // Load the MethodTable from the object instance in rdi.
 #ifdef TARGET_APPLE
 // Apple's linker has issues which break unwind info if
@@ -55,6 +65,10 @@ LEAF_ENTRY RhpInterfaceDispatch\entries, _TEXT
         // r11 still contains the indirection cell address.
 
         jmp     C_FUNC(RhpInterfaceDispatchSlow)
+
+LOCAL_LABEL(RaceRetry_\entries):
+        jmp     [r11]
+
 LEAF_END RhpInterfaceDispatch\entries, _TEXT
 
 .endm // DEFINE_INTERFACE_DISPATCH_STUB

--- a/src/coreclr/runtime/amd64/StubDispatch.asm
+++ b/src/coreclr/runtime/amd64/StubDispatch.asm
@@ -23,6 +23,7 @@ DEFINE_INTERFACE_DISPATCH_STUB macro entries
 
 StubName textequ @CatStr( RhpInterfaceDispatch, entries )
 StubAVLocation textequ @CatStr( RhpInterfaceDispatchAVLocation, entries )
+RaceRetryLabel textequ @CatStr( RaceRetry, entries )
 
 LEAF_ENTRY StubName, _TEXT
 
@@ -32,6 +33,16 @@ LEAF_ENTRY StubName, _TEXT
         ;; r11 currently contains the indirection cell address.
         ;; load r10 to point to the cache block.
         mov     r10, [r11 + OFFSETOF__InterfaceDispatchCell__m_pCache]
+
+        ;; Validate r10 is a cache pointer matching the expected cache size.
+        ;; This compensates for a race where the stub was updated to expect a larger cache
+        ;; but we loaded a stale (smaller or non-cache) m_pCache value.
+        ;; On detection, re-dispatch through the indirection cell to retry with the current
+        ;; stub and cache pair.
+        test    r10, IDC_CACHE_POINTER_MASK
+        jnz     RaceRetryLabel
+        cmp     dword ptr [r10 + OFFSETOF__InterfaceDispatchCache__m_cEntries], entries
+        jne     RaceRetryLabel
 
         ;; Load the MethodTable from the object instance in rcx.
         ALTERNATE_ENTRY StubAVLocation
@@ -46,6 +57,9 @@ CurrentEntry = CurrentEntry + 1
         ;; r11 still contains the indirection cell address.
 
         jmp RhpInterfaceDispatchSlow
+
+RaceRetryLabel:
+        jmp     qword ptr [r11]
 
 LEAF_END StubName, _TEXT
 

--- a/src/coreclr/runtime/arm/StubDispatch.S
+++ b/src/coreclr/runtime/arm/StubDispatch.S
@@ -20,6 +20,15 @@ NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT, NoHandler
         // r12 currently holds the indirection cell address. We need to get the cache structure instead.
         ldr         r2, [r12, #OFFSETOF__InterfaceDispatchCell__m_pCache]
 
+        // Validate r2 is a cache pointer matching the expected cache size.
+        // This compensates for a race where the stub was updated to expect a larger cache
+        // but we loaded a stale (smaller or non-cache) m_pCache value.
+        tst         r2, #IDC_CACHE_POINTER_MASK
+        bne         LOCAL_LABEL(RaceRetry_\entries)
+        ldr         r1, [r2, #OFFSETOF__InterfaceDispatchCache__m_cEntries]
+        cmp         r1, #\entries
+        bne         LOCAL_LABEL(RaceRetry_\entries)
+
         // Load the MethodTable from the object instance in r0.
         GLOBAL_LABEL RhpInterfaceDispatchAVLocation\entries
         ldr         r1, [r0]
@@ -46,6 +55,14 @@ NESTED_ENTRY RhpInterfaceDispatch\entries, _TEXT, NoHandler
         ldr         r1, [sp, #-8]
         ldr         r2, [sp, #-4]
         b           C_FUNC(RhpInterfaceDispatchSlow)
+
+        // Race detected: r12 still holds the indirection cell address (not yet clobbered).
+        // Re-dispatch through the indirection cell to retry with the current stub and cache pair.
+        // ldr pc, [r12] branches to the current m_pStub without clobbering r12.
+LOCAL_LABEL(RaceRetry_\entries):
+        ldr         r1, [sp, #-8]
+        ldr         r2, [sp, #-4]
+        ldr         pc, [r12]
 
         // Common epilog for cache hits. Have to out of line it here due to limitation on the number of
         // epilogs imposed by the unwind code macros.

--- a/src/coreclr/runtime/arm64/StubDispatch.S
+++ b/src/coreclr/runtime/arm64/StubDispatch.S
@@ -38,6 +38,17 @@
         // x11 holds the indirection cell address. Load the cache pointer.
         ldr     x9, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
 
+        // Validate x9 is a cache pointer matching the expected cache size.
+        // This compensates for a race where the stub was updated to expect a larger cache
+        // but we loaded a stale (smaller or non-cache) m_pCache value.
+        // On detection, re-dispatch through the indirection cell to retry with the current
+        // stub and cache pair.
+        tst     x9, #IDC_CACHE_POINTER_MASK
+        bne     LOCAL_LABEL(RaceRetry_\entries)
+        ldr     w12, [x9, #OFFSETOF__InterfaceDispatchCache__m_cEntries]
+        cmp     w12, #\entries
+        bne     LOCAL_LABEL(RaceRetry_\entries)
+
         // Load the MethodTable from the object instance in x0.
 #ifdef TARGET_APPLE
 // Apple's linker has issues which break unwind info if
@@ -60,6 +71,11 @@
 
         // x11 still contains the indirection cell address.
         b C_FUNC(RhpInterfaceDispatchSlow)
+
+LOCAL_LABEL(RaceRetry_\entries):
+        // Race detected: re-dispatch through the indirection cell
+        ldr     x9, [x11]
+        br      x9
 
     NESTED_END "RhpInterfaceDispatch\entries", _TEXT
 

--- a/src/coreclr/runtime/arm64/StubDispatch.asm
+++ b/src/coreclr/runtime/arm64/StubDispatch.asm
@@ -37,6 +37,17 @@
         ;; x11 holds the indirection cell address. Load the cache pointer.
         ldr     x9, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
 
+        ;; Validate x9 is a cache pointer matching the expected cache size.
+        ;; This compensates for a race where the stub was updated to expect a larger cache
+        ;; but we loaded a stale (smaller or non-cache) m_pCache value.
+        ;; On detection, re-dispatch through the indirection cell to retry with the current
+        ;; stub and cache pair.
+        tst     x9, #IDC_CACHE_POINTER_MASK
+        bne     CidRaceRetry_$entries
+        ldr     w12, [x9, #OFFSETOF__InterfaceDispatchCache__m_cEntries]
+        cmp     w12, #$entries
+        bne     CidRaceRetry_$entries
+
         ;; Load the MethodTable from the object instance in x0.
         ALTERNATE_ENTRY RhpInterfaceDispatchAVLocation$entries
         ldr     x10, [x0]
@@ -51,6 +62,11 @@ CurrentEntry SETA CurrentEntry + 1
 
         ;; x11 still contains the indirection cell address.
         b RhpInterfaceDispatchSlow
+
+CidRaceRetry_$entries
+        ;; Race detected: re-dispatch through the indirection cell
+        ldr     x9, [x11]
+        br      x9
 
     NESTED_END RhpInterfaceDispatch$entries
 

--- a/src/coreclr/runtime/i386/StubDispatch.asm
+++ b/src/coreclr/runtime/i386/StubDispatch.asm
@@ -32,6 +32,7 @@ DEFINE_INTERFACE_DISPATCH_STUB macro entries
 
 StubName textequ @CatStr( _RhpInterfaceDispatch, entries, <@0> )
 StubAVLocation textequ @CatStr( _RhpInterfaceDispatchAVLocation, entries )
+RaceRetryLabel textequ @CatStr( RaceRetry, entries )
 
     StubName proc public
 
@@ -43,13 +44,24 @@ StubAVLocation textequ @CatStr( _RhpInterfaceDispatchAVLocation, entries )
     ALTERNATE_ENTRY StubAVLocation
         cmp     dword ptr [ecx], ecx
 
+        ;; Save cell address on the stack before overwriting eax.
+        push    eax
+
         ;; eax currently contains the indirection cell address. We need to update it to point to the cache
         ;; block instead.
         mov     eax, [eax + OFFSETOF__InterfaceDispatchCell__m_pCache]
 
-        ;; Cache pointer is already loaded in the only scratch register we have so far, eax. We need
-        ;; another scratch register to hold the instance type so save the value of ebx and use that.
-        push    ebx
+        ;; Validate eax is a cache pointer matching the expected cache size.
+        ;; This compensates for a race where the stub was updated to expect a larger cache
+        ;; but we loaded a stale (smaller or non-cache) m_pCache value.
+        test    eax, IDC_CACHE_POINTER_MASK
+        jnz     RaceRetryLabel
+        cmp     dword ptr [eax + OFFSETOF__InterfaceDispatchCache__m_cEntries], entries
+        jne     RaceRetryLabel
+
+        ;; Cache pointer is validated. Replace saved cell address with ebx for the normal
+        ;; save/restore flow.
+        mov     dword ptr [esp], ebx
 
         ;; Load the MethodTable from the object instance in ebx.
         mov     ebx, [ecx]
@@ -65,6 +77,11 @@ CurrentEntry = CurrentEntry + 1
         mov     eax, [eax + OFFSETOF__InterfaceDispatchCache__m_pCell]
         pop     ebx
         jmp     RhpInterfaceDispatchSlow
+
+    RaceRetryLabel:
+        ;; Race detected: restore cell address and re-dispatch through the indirection cell
+        pop     eax
+        jmp     dword ptr [eax]
 
     StubName endp
 

--- a/src/coreclr/runtime/loongarch64/StubDispatch.S
+++ b/src/coreclr/runtime/loongarch64/StubDispatch.S
@@ -32,6 +32,17 @@
         // t8 holds the indirection cell address. Load the cache pointer.
         ld.d  $t0, $t8, OFFSETOF__InterfaceDispatchCell__m_pCache
 
+        // Validate t0 is a cache pointer matching the expected cache size.
+        // This compensates for a race where the stub was updated to expect a larger cache
+        // but we loaded a stale (smaller or non-cache) m_pCache value.
+        // On detection, re-dispatch through the indirection cell to retry with the current
+        // stub and cache pair.
+        andi  $t3, $t0, IDC_CACHE_POINTER_MASK
+        bnez  $t3, LOCAL_LABEL(RaceRetry_\entries)
+        ld.w  $t3, $t0, OFFSETOF__InterfaceDispatchCache__m_cEntries
+        ori   $t4, $zero, \entries
+        bne   $t3, $t4, LOCAL_LABEL(RaceRetry_\entries)
+
         // Load the MethodTable from the object instance in a0.
         ALTERNATE_ENTRY RhpInterfaceDispatchAVLocation\entries
         ld.d  $t1, $a0, 0
@@ -46,6 +57,11 @@
 
         // t8 still contains the indirection cell address.
         b  C_FUNC(RhpInterfaceDispatchSlow)
+
+LOCAL_LABEL(RaceRetry_\entries):
+        // Race detected: re-dispatch through the indirection cell
+        ld.d  $t0, $t8, 0
+        jirl  $r0, $t0, 0
 
     NESTED_END "RhpInterfaceDispatch\entries", _TEXT
 

--- a/src/coreclr/runtime/riscv64/StubDispatch.S
+++ b/src/coreclr/runtime/riscv64/StubDispatch.S
@@ -35,6 +35,17 @@
             // t5 holds the indirection cell address. Load the cache pointer.
             ld  t0, OFFSETOF__InterfaceDispatchCell__m_pCache(t5)  // Using a1 as an alternative base register
 
+            // Validate t0 is a cache pointer matching the expected cache size.
+            // This compensates for a race where the stub was updated to expect a larger cache
+            // but we loaded a stale (smaller or non-cache) m_pCache value.
+            // On detection, re-dispatch through the indirection cell to retry with the current
+            // stub and cache pair.
+            andi t6, t0, IDC_CACHE_POINTER_MASK
+            bnez t6, LOCAL_LABEL(RaceRetry_\entries)
+            lw   t6, OFFSETOF__InterfaceDispatchCache__m_cEntries(t0)
+            li   t3, \entries
+            bne  t6, t3, LOCAL_LABEL(RaceRetry_\entries)
+
             // Load the MethodTable from the object instance in a0.
             ALTERNATE_ENTRY RhpInterfaceDispatchAVLocation\entries
             ld  t1, 0(a0)
@@ -47,8 +58,13 @@
             .set CurrentEntry, CurrentEntry + 1
         .endr
 
-            // t0 still contains the indirection cell address.
+            // t5 still contains the indirection cell address.
             tail  C_FUNC(RhpInterfaceDispatchSlow)
+
+        LOCAL_LABEL(RaceRetry_\entries):
+            // Race detected: re-dispatch through the indirection cell
+            ld   t0, 0(t5)
+            jr   t0
 
         NESTED_END RhpInterfaceDispatch\entries, _TEXT
 

--- a/src/coreclr/vm/amd64/CachedInterfaceDispatchCoreCLR.S
+++ b/src/coreclr/vm/amd64/CachedInterfaceDispatchCoreCLR.S
@@ -11,8 +11,17 @@
 LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
 
         // r11 currently contains the indirection cell address.
+        // Save it in r10 before overwriting, in case we need to re-dispatch on a race.
+        mov     r10, r11
         // load r11 to point to the vtable offset (which is stored in the m_pCache field).
         mov     r11, [r11 + OFFSETOF__InterfaceDispatchCell__m_pCache]
+
+        // Validate m_pCache has the vtable offset tag (low 2 bits == 0x2).
+        // A stale m_pCache from a race will have different low bits.
+        mov     eax, r11d
+        and     eax, IDC_CACHE_POINTER_MASK
+        cmp     eax, 2
+        jne     LOCAL_LABEL(RhpVTableOffsetRaceRetry)
 
         // r11 now contains the VTableOffset where the upper 32 bits are the offset to adjust
         // to get to the VTable chunk
@@ -42,6 +51,11 @@ LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
         mov     rax, [rax + r11]
 
         TAILJMP_RAX
+
+LOCAL_LABEL(RhpVTableOffsetRaceRetry):
+        // Restore cell address and re-dispatch through the indirection cell
+        mov     r11, r10
+        jmp     [r11]
 LEAF_END RhpVTableOffsetDispatch, _TEXT
 
 // On Input:

--- a/src/coreclr/vm/amd64/CachedInterfaceDispatchCoreCLR.asm
+++ b/src/coreclr/vm/amd64/CachedInterfaceDispatchCoreCLR.asm
@@ -12,8 +12,17 @@ ifdef FEATURE_CACHED_INTERFACE_DISPATCH
 ;; Stub dispatch routine for dispatch to a vtable slot
 LEAF_ENTRY RhpVTableOffsetDispatch, _TEXT
         ;; r11 currently contains the indirection cell address.
+        ;; Save it in r10 before overwriting, in case we need to re-dispatch on a race.
+        mov     r10, r11
         ;; load r11 to point to the vtable offset (which is stored in the m_pCache field).
         mov     r11, [r11 + OFFSETOF__InterfaceDispatchCell__m_pCache]
+
+        ;; Validate m_pCache has the vtable offset tag (low 2 bits == 0x2).
+        ;; A stale m_pCache from a race will have different low bits.
+        mov     eax, r11d
+        and     eax, IDC_CACHE_POINTER_MASK
+        cmp     eax, 2
+        jne     RhpVTableOffsetRaceRetry
 
         ;; r11 now contains the VTableOffset where the upper 32 bits are the offset to adjust
         ;; to get to the VTable chunk
@@ -35,6 +44,11 @@ ALTERNATE_ENTRY RhpVTableOffsetDispatchAVLocation
         mov     rax, [rax + r11]
 
         TAILJMP_RAX
+
+RhpVTableOffsetRaceRetry:
+        ;; Restore cell address and re-dispatch through the indirection cell
+        mov     r11, r10
+        jmp     qword ptr [r11]
 LEAF_END RhpVTableOffsetDispatch, _TEXT
 
 ;; On Input:

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -553,8 +553,14 @@ ASMCONSTANTS_C_ASSERT(CallCountingStubData__TargetForThresholdReached == offseto
 #define OFFSETOF__InterfaceDispatchCache__m_rgEntries 0x20
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCache__m_rgEntries == offsetof(InterfaceDispatchCache, m_rgEntries))
 
+#define OFFSETOF__InterfaceDispatchCache__m_cEntries 0x18
+ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCache__m_cEntries == offsetof(InterfaceDispatchCache, m_cEntries))
+
 #define OFFSETOF__InterfaceDispatchCell__m_pCache 0x08
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCell__m_pCache == offsetof(InterfaceDispatchCell, m_pCache))
+
+#define IDC_CACHE_POINTER_MASK 0x3
+ASMCONSTANTS_C_ASSERT(IDC_CACHE_POINTER_MASK == ::IDC_CachePointerMask)
 #endif // FEATURE_CACHED_INTERFACE_DISPATCH
 
 #define OFFSETOF__ThreadLocalInfo__m_pThread 0

--- a/src/coreclr/vm/arm64/CachedInterfaceDispatchCoreCLR.S
+++ b/src/coreclr/vm/arm64/CachedInterfaceDispatchCoreCLR.S
@@ -20,8 +20,17 @@
         ldr     x9, [x0]
 
         // x11 currently contains the indirection cell address.
+        // Save it in x12 before overwriting, in case we need to re-dispatch on a race.
+        mov     x12, x11
+
         // load x11 to point to the vtable offset (which is stored in the m_pCache field).
         ldr     x11, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
+
+        // Validate m_pCache has the vtable offset tag (low 2 bits == 0x2).
+        // A stale m_pCache from a race will have different low bits.
+        and     w10, w11, #IDC_CACHE_POINTER_MASK
+        cmp     w10, #2
+        bne     LOCAL_LABEL(RhpVTableOffsetRaceRetry)
 
         // x11 now contains the VTableOffset where the upper 32 bits are the offset to adjust
         // to get to the VTable chunk
@@ -41,6 +50,12 @@
         ldr     x9, [x9, x10]
 
         EPILOG_BRANCH_REG  x9
+
+LOCAL_LABEL(RhpVTableOffsetRaceRetry):
+        // Re-dispatch through the indirection cell
+        mov     x11, x12
+        ldr     x9, [x11]
+        br      x9
     LEAF_END RhpVTableOffsetDispatch, _TEXT
 
 //

--- a/src/coreclr/vm/arm64/CachedInterfaceDispatchCoreCLR.asm
+++ b/src/coreclr/vm/arm64/CachedInterfaceDispatchCoreCLR.asm
@@ -18,8 +18,16 @@
     LEAF_ENTRY RhpVTableOffsetDispatch
 
         ;; x11 currently contains the indirection cell address.
+        ;; Save it in x12 before overwriting, in case we need to re-dispatch on a race.
+        mov     x12, x11
         ;; load x11 to point to the vtable offset (which is stored in the m_pCache field).
         ldr     x11, [x11, #OFFSETOF__InterfaceDispatchCell__m_pCache]
+
+        ;; Validate m_pCache has the vtable offset tag (low 2 bits == 0x2).
+        ;; A stale m_pCache from a race will have different low bits.
+        and     w10, w11, #IDC_CACHE_POINTER_MASK
+        cmp     w10, #2
+        bne     RhpVTableOffsetRaceRetry
 
         ;; x11 now contains the VTableOffset where the upper 32 bits are the offset to adjust
         ;; to get to the VTable chunk
@@ -41,6 +49,12 @@
         ldr     x9, [x9, x10]
 
         EPILOG_BRANCH_REG  x9
+
+RhpVTableOffsetRaceRetry
+        ;; Restore cell address and re-dispatch through the indirection cell
+        mov     x11, x12
+        ldr     x9, [x11]
+        br      x9
     LEAF_END RhpVTableOffsetDispatch
 
 ;;

--- a/src/coreclr/vm/arm64/asmconstants.h
+++ b/src/coreclr/vm/arm64/asmconstants.h
@@ -289,8 +289,14 @@ ASMCONSTANTS_C_ASSERT(CallCountingStubData__TargetForThresholdReached == offseto
 #define OFFSETOF__InterfaceDispatchCache__m_rgEntries 0x20
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCache__m_rgEntries == offsetof(InterfaceDispatchCache, m_rgEntries))
 
+#define OFFSETOF__InterfaceDispatchCache__m_cEntries 0x18
+ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCache__m_cEntries == offsetof(InterfaceDispatchCache, m_cEntries))
+
 #define OFFSETOF__InterfaceDispatchCell__m_pCache 0x08
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterfaceDispatchCell__m_pCache == offsetof(InterfaceDispatchCell, m_pCache))
+
+#define IDC_CACHE_POINTER_MASK 0x3
+ASMCONSTANTS_C_ASSERT(IDC_CACHE_POINTER_MASK == ::IDC_CachePointerMask)
 #endif // FEATURE_CACHED_INTERFACE_DISPATCH
 
 #define OFFSETOF__ThreadLocalInfo__m_pThread 0


### PR DESCRIPTION
The dispatch cell has two fields (m_pStub, m_pCache) that are updated atomically together but read non-atomically by the caller and stub. A race during cache growth can cause a stub to read a stale m_pCache that doesn't match the expected cache size, reading past the cache allocation into unmapped memory.

Add validation in each RhpInterfaceDispatchN stub: after loading m_pCache, check that the low 2 bits are zero (not an encoded interface pointer) and that m_cEntries matches the expected entry count. On mismatch, re-dispatch through the indirection cell to retry with the current stub and cache pair.

Draft for now, I want to run more validation, but want to know if it compiles at all.

Fixes https://github.com/dotnet/runtime/issues/121632