### PR TITLE
[tests] Add check for X86Base.IsSupported before calling X86Base.CpuId

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512Bmm/HandwrittenProgram.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512Bmm/HandwrittenProgram.cs
@@ -99,10 +99,7 @@ namespace JIT.HardwareIntrinsics.X86._Avx512Bmm
         [Fact]
         public static void CheckSupported()
         {
-            if (!X86Base.IsSupported)
-            {
-                return;
-            }
+            if (!X86Base.IsSupported) return;
 
             (int Eax, int Ebx, int Ecx, int Edx) = X86Base.CpuId(unchecked((int)0x80000021), (int)0x0);
             bool isSupported = (Eax & (1 << 23)) != 0;

--- a/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512Bmm/HandwrittenProgram.cs
+++ b/src/tests/JIT/HardwareIntrinsics/X86_Avx512/Avx512Bmm/HandwrittenProgram.cs
@@ -99,6 +99,11 @@ namespace JIT.HardwareIntrinsics.X86._Avx512Bmm
         [Fact]
         public static void CheckSupported()
         {
+            if (!X86Base.IsSupported)
+            {
+                return;
+            }
+
             (int Eax, int Ebx, int Ecx, int Edx) = X86Base.CpuId(unchecked((int)0x80000021), (int)0x0);
             bool isSupported = (Eax & (1 << 23)) != 0;
             Assert.Equal(isSupported, Avx512Bmm.IsSupported);


### PR DESCRIPTION
This test was falling on interpreter with PlatformNotSupportedException