### PR TITLE
Fix quotientBuffer being returned to ArrayPool while in use

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -923,7 +923,7 @@ namespace System.Numerics
                 BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
 
                 remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
-                BigInteger result = BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
+                BigInteger result = new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
 
                 quotientBuffer.Dispose();
 

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -922,10 +922,12 @@ namespace System.Numerics
                 // may throw DivideByZeroException
                 BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
 
+                remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
+                BigInteger result = BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
+
                 quotientBuffer.Dispose();
 
-                remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
-                return new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
+                return result;
             }
 
             Debug.Assert(divisor._bits is not null);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -918,15 +918,13 @@ namespace System.Numerics
             {
                 int size = dividend._bits.Length;
                 Span<nuint> quotient = RentedBuffer.Create(size, out RentedBuffer quotientBuffer);
+                using var _ = quotientBuffer;
 
-                using (quotientBuffer)
-                {
-                    // may throw DivideByZeroException
-                    BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
+                // may throw DivideByZeroException
+                BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
 
-                    remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
-                    return new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
-                }
+                remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
+                return new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
             }
 
             Debug.Assert(divisor._bits is not null);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -919,15 +919,14 @@ namespace System.Numerics
                 int size = dividend._bits.Length;
                 Span<nuint> quotient = RentedBuffer.Create(size, out RentedBuffer quotientBuffer);
 
-                // may throw DivideByZeroException
-                BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
+                using (quotientBuffer)
+                {
+                    // may throw DivideByZeroException
+                    BigIntegerCalculator.Divide(dividend._bits, NumericsHelpers.Abs(divisor._sign), quotient, out nuint rest);
 
-                remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
-                BigInteger result = new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
-
-                quotientBuffer.Dispose();
-
-                return result;
+                    remainder = dividend._sign < 0 ? -(long)rest : (long)rest;
+                    return new BigInteger(quotient, (dividend._sign < 0) ^ (divisor._sign < 0));
+                }
             }
 
             Debug.Assert(divisor._bits is not null);


### PR DESCRIPTION
`quotientBuffer` is, potentially, a buffer that is backed by `ArrayPool<nuint>.Shared` if the rental exceeds a value.

`Dispose` on the buffer for rented values will return it to the pool.

In `DivRem` there is a path where `Dispose`, thus `Return`, was being called before the array was done being used.

In this path `quotient` is a slice of the rented buffer and is passed to the constructor of `BigInteger` _after_ the return. `BigInteger` does make a copy of the value for itself, but this happens after the return.

This fixes it by ensuring the BigInteger constructor makes a copy for itself before the return is done.

This was introduced in the BigInteger re-write and does not impact any released versions of .NET.