### PR TITLE
[minipal] Add getentropy() fallback for platforms without getrandom()

### DIFF
--- a/src/native/minipal/configure.cmake
+++ b/src/native/minipal/configure.cmake
@@ -12,6 +12,7 @@ check_function_exists(fsync HAVE_FSYNC)
 
 check_symbol_exists(arc4random_buf "stdlib.h" HAVE_ARC4RANDOM_BUF)
 check_symbol_exists(getrandom "sys/random.h" HAVE_GETRANDOM)
+check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)
 check_symbol_exists(O_CLOEXEC fcntl.h HAVE_O_CLOEXEC)
 check_symbol_exists(CLOCK_MONOTONIC_COARSE time.h HAVE_CLOCK_MONOTONIC_COARSE)
 check_symbol_exists(clock_gettime_nsec_np time.h HAVE_CLOCK_GETTIME_NSEC_NP)

--- a/src/native/minipal/minipalconfig.h.in
+++ b/src/native/minipal/minipalconfig.h.in
@@ -3,6 +3,7 @@
 
 #cmakedefine01 HAVE_ARC4RANDOM_BUF
 #cmakedefine01 HAVE_GETRANDOM
+#cmakedefine01 HAVE_GETENTROPY
 #cmakedefine01 HAVE_AUXV_HWCAP_H
 #cmakedefine01 HAVE_HWPROBE_H
 #cmakedefine01 HAVE_RESOURCE_H

--- a/src/native/minipal/random.c
+++ b/src/native/minipal/random.c
@@ -152,9 +152,13 @@ int32_t minipal_get_cryptographically_secure_random_bytes(uint8_t* buffer, int32
             // getentropy() is limited to 256 bytes per call
             size_t chunk = (size_t)(bufferLength - offset);
             if (chunk > 256)
+            {
                 chunk = 256;
+            }
             if (getentropy(buffer + offset, chunk) != 0)
+            {
                 return -1;
+            }
             offset += (int32_t)chunk;
         }
         return 0;

--- a/src/native/minipal/random.c
+++ b/src/native/minipal/random.c
@@ -155,13 +155,18 @@ int32_t minipal_get_cryptographically_secure_random_bytes(uint8_t* buffer, int32
             {
                 chunk = 256;
             }
-            if (getentropy(buffer + offset, chunk) != 0)
+            if (getentropy(buffer + offset, chunk) < 0)
             {
-                return -1;
+                break; // fallback to /dev/urandom
             }
+
             offset += (int32_t)chunk;
         }
-        return 0;
+
+        if (offset == bufferLength)
+        {
+            return 0;
+        }
     }
 #endif
 

--- a/src/native/minipal/random.c
+++ b/src/native/minipal/random.c
@@ -141,6 +141,26 @@ int32_t minipal_get_cryptographically_secure_random_bytes(uint8_t* buffer, int32
     }
 #endif
 
+#if HAVE_GETENTROPY
+    // getentropy() is available on platforms like WASI (via wasi-libc, backed by
+    // __wasi_random_get()) and other libc implementations. Used as a fallback when
+    // getrandom() is not available or fails.
+    {
+        int32_t offset = 0;
+        while (offset < bufferLength)
+        {
+            // getentropy() is limited to 256 bytes per call
+            size_t chunk = (size_t)(bufferLength - offset);
+            if (chunk > 256)
+                chunk = 256;
+            if (getentropy(buffer + offset, chunk) != 0)
+                return -1;
+            offset += (int32_t)chunk;
+        }
+        return 0;
+    }
+#endif
+
     // Fallback to /dev/urandom
     static volatile int rand_des = -1;
     static bool sMissingDevURandom;


### PR DESCRIPTION
Adds `getentropy()` as a fallback in `minipal/random.c` for platforms that provide it but lack `getrandom()` — notably WASI (via wasi-libc → `__wasi_random_get()`).

## Changes

- **`random.c`** — Add `#elif HAVE_GETENTROPY` fallback between `HAVE_BCRYPT_H` and `HAVE_GETRANDOM` in the RNG chain
- **`configure.cmake`** — Add `check_symbol_exists(getentropy "unistd.h" HAVE_GETENTROPY)`
- **`minipalconfig.h.in`** — Add `#cmakedefine01 HAVE_GETENTROPY`

## Motivation

NativeAOT-LLVM targeting `wasi-wasm` currently fails at `RandomNumberGenerator.Fill()` with `PlatformNotSupportedException` because `minipal_get_cryptographically_random_bytes` returns `-1` — `getrandom()` returns `ENOSYS` and `/dev/urandom` doesn't exist on WASI.

However, wasi-libc already provides `getentropy()` backed by `__wasi_random_get()`. The C runtime startup already uses this path (`arc4random_buf` → `getentropy` → `__wasi_random_get`) for stack canaries, so the symbol is linked and functional.

Uses CMake feature detection (`check_symbol_exists`) rather than a hardcoded `__wasi__` check, so this also covers other platforms with `getentropy()` but not `getrandom()`.

Fixes #126480