### PR TITLE
Fix dotnet.thread_pool.queue.length to use ObservableUpDownCounter

### DIFF
--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/RuntimeMetrics.cs
@@ -107,7 +107,7 @@ namespace System.Diagnostics.Metrics
                 unit: "{work_item}",
                 description: "The number of work items that the thread pool has completed since the process has started.");
 
-            s_meter.CreateObservableCounter(
+            s_meter.CreateObservableUpDownCounter(
                 "dotnet.thread_pool.queue.length",
                 () => ThreadPool.PendingWorkItemCount,
                 unit: "{work_item}",

--- a/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/tests/RuntimeMetricsTests.cs
@@ -324,6 +324,26 @@ namespace System.Diagnostics.Metrics.Tests
             }
         }
 
+        [Fact]
+        public void ThreadPoolQueueLengthIsUpDownCounter()
+        {
+            using MeterListener listener = new();
+            Instrument? instrument = null;
+
+            listener.InstrumentPublished = (inst, l) =>
+            {
+                if (inst.Meter.Name == "System.Runtime" && inst.Name == "dotnet.thread_pool.queue.length")
+                {
+                    instrument = inst;
+                }
+            };
+
+            listener.Start();
+
+            Assert.NotNull(instrument);
+            Assert.IsType<ObservableUpDownCounter<long>>(instrument);
+        }
+
         private sealed class RuntimeMeterException() : Exception { }
 
         private sealed class InstrumentRecorderException() : Exception { }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/126167

Change `dotnet.thread_pool.queue.length` from `CreateObservableCounter` to `CreateObservableUpDownCounter`. `ThreadPool.PendingWorkItemCount` reports a current snapshot that can decrease as work items are dequeued, so a monotonically increasing counter is incorrect. This is consistent with `dotnet.thread_pool.thread.count` which already uses `CreateObservableUpDownCounter` for the same reason.

Includes a test to verify the instrument type.