### PR TITLE
[cDAC] Add ThreadState.ReportDead to thread state enum

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -24,6 +24,7 @@ enum ThreadState
     Background          = 0x00000200,    // Thread is a background thread
     Unstarted           = 0x00000400,    // Thread has never been started
     Dead                = 0x00000800,    // Thread is dead
+    ReportDead          = 0x00010000,    // In WaitForOtherThreads; GetSnapshotState synthesizes Dead from this
     ThreadPoolWorker    = 0x01000000,    // is this a threadpool worker thread?
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -25,6 +25,7 @@ public enum ThreadState
     Background          = 0x00000200,   // Thread is a background thread
     Unstarted           = 0x00000400,   // Thread has never been started
     Dead                = 0x00000800,   // Thread is dead
+    ReportDead          = 0x00010000,   // In WaitForOtherThreads; GetSnapshotState synthesizes Dead from this
     ThreadPoolWorker    = 0x01000000,   // Thread is a thread pool worker thread
 }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -338,8 +338,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             while (currentThread != TargetPointer.Null)
             {
                 Contracts.ThreadData threadData = threadContract.GetThreadData(currentThread);
-                // Match native: skip dead and unstarted threads
-                if ((threadData.State & (Contracts.ThreadState.Dead | Contracts.ThreadState.Unstarted)) == 0)
+                // Match native: skip dead and unstarted threads (ReportDead synthesizes Dead)
+                if ((threadData.State & (Contracts.ThreadState.Dead | Contracts.ThreadState.ReportDead | Contracts.ThreadState.Unstarted)) == 0)
                 {
                     callback(currentThread.Value, pUserData);
 #if DEBUG
@@ -390,7 +390,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         try
         {
             Contracts.ThreadData threadData = _target.Contracts.Thread.GetThreadData(new TargetPointer(vmThread));
-            *pResult = (threadData.State & Contracts.ThreadState.Dead) != 0 ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+            // Match native GetSnapshotState: TS_ReportDead synthesizes TS_Dead
+            *pResult = (threadData.State & (Contracts.ThreadState.Dead | Contracts.ThreadState.ReportDead)) != 0 ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/tests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/ThreadTests.cs
@@ -89,6 +89,30 @@ public unsafe class ThreadTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void GetThreadData_ReportDead_IncludesDeadAndReportDeadFlags(MockTarget.Architecture arch)
+    {
+        TargetTestHelpers helpers = new(arch);
+        MockMemorySpace.Builder builder = new(helpers);
+        MockDescriptors.Thread thread = new(builder);
+
+        TargetPointer addr = thread.AddThread(1, new TargetNUInt(1234));
+
+        // Set the thread state to ReportDead (0x00010000) - simulates WaitForOtherThreads
+        Target.TypeInfo threadType = thread.Types[DataType.Thread];
+        int stateOffset = threadType.Fields[nameof(Data.Thread.State)].Offset;
+        helpers.Write(
+            builder.BorrowAddressRange(addr + (ulong)stateOffset, sizeof(uint)),
+            (uint)ThreadState.ReportDead);
+
+        Target target = CreateTarget(thread);
+        IThread contract = target.Contracts.Thread;
+
+        ThreadData data = contract.GetThreadData(addr);
+        Assert.True((data.State & ThreadState.ReportDead) != 0, "ReportDead flag should be set");
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void IterateThreads(MockTarget.Architecture arch)
     {
         // Set up the target


### PR DESCRIPTION
## Summary

Add `ThreadState.ReportDead` (0x00010000) to the cDAC thread state enum. The DBI API checks this value. I had previously missed it in the DacDbi PR. This brings the cDAC DacDbi in line with the DAC version.

The native DAC's `GetSnapshotState()` synthesizes `TS_Dead` from `TS_ReportDead`, which is set during `WaitForOtherThreads`. Without this flag, cDAC consumers checking for dead threads miss threads that are in the `ReportDead` state but don't yet have `TS_Dead` set.

This was discovered via internal stepping tests where `IsThreadMarkedDead` returned `FALSE` for a thread the native DAC reported as dead.

### Changes
- Add `ReportDead = 0x00010000` to `ThreadState` enum in `IThread.cs`
- Add unit test verifying the flag is preserved through `GetThreadData`