### PR TITLE
Increase Playwright timeouts in Blazor counter test to reduce CI flakes

### DIFF
--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -53,13 +53,24 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestsBase
         {
             if (runOptions is BlazorRunOptions bro && bro.CheckCounter)
             {
-                await page.Locator("text=Counter").ClickAsync();
-                var txt = await page.Locator("p[role='status']").InnerHTMLAsync();
+                // Wait for the Counter nav link to be visible and stable before clicking.
+                // On slow CI machines (Windows Docker containers), Blazor's layout reflows
+                // can prevent the element from being considered "stable" within the default
+                // Playwright timeout, causing flaky TimeoutExceptions.
+                var counterLink = page.Locator("text=Counter");
+                await counterLink.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+                await counterLink.ClickAsync(new() { Timeout = 60_000 });
+
+                var status = page.Locator("p[role='status']");
+                await status.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+                var txt = await status.InnerHTMLAsync();
                 Assert.Equal("Current count: 0", txt);
 
-                await page.Locator("text=\"Click me\"").ClickAsync();
+                var clickMe = page.Locator("text=\"Click me\"");
+                await clickMe.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+                await clickMe.ClickAsync(new() { Timeout = 60_000 });
                 await Task.Delay(300);
-                txt = await page.Locator("p[role='status']").InnerHTMLAsync();
+                txt = await status.InnerHTMLAsync();
                 Assert.Equal("Current count: 1", txt);
             }
         };

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -49,29 +49,34 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestsBase
                 """ }
         };
 
+    private const int InteractionTimeoutMs = 60_000;
+
     private Func<RunOptions, IPage, Task>? _executeAfterLoaded = async (runOptions, page) =>
         {
             if (runOptions is BlazorRunOptions bro && bro.CheckCounter)
             {
-                // Wait for the Counter nav link to be visible and stable before clicking.
-                // On slow CI machines (Windows Docker containers), Blazor's layout reflows
-                // can prevent the element from being considered "stable" within the default
-                // Playwright timeout, causing flaky TimeoutExceptions.
+                // Wait for the Counter nav link to be visible, then use an extended click
+                // timeout so Playwright can wait for the element to become stable before
+                // clicking. On slow CI machines (Windows Docker containers), Blazor's
+                // layout reflows can otherwise trigger flaky TimeoutExceptions.
                 var counterLink = page.Locator("text=Counter");
-                await counterLink.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
-                await counterLink.ClickAsync(new() { Timeout = 60_000 });
+                await counterLink.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = InteractionTimeoutMs });
+                await counterLink.ClickAsync(new() { Timeout = InteractionTimeoutMs });
 
                 var status = page.Locator("p[role='status']");
-                await status.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
+                await status.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = InteractionTimeoutMs });
                 var txt = await status.InnerHTMLAsync();
                 Assert.Equal("Current count: 0", txt);
 
                 var clickMe = page.Locator("text=\"Click me\"");
-                await clickMe.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = 60_000 });
-                await clickMe.ClickAsync(new() { Timeout = 60_000 });
-                await Task.Delay(300);
-                txt = await status.InnerHTMLAsync();
-                Assert.Equal("Current count: 1", txt);
+                await clickMe.WaitForAsync(new() { State = WaitForSelectorState.Visible, Timeout = InteractionTimeoutMs });
+                await clickMe.ClickAsync(new() { Timeout = InteractionTimeoutMs });
+
+                // Wait for the counter to reflect the click instead of a fixed delay
+                await page.WaitForFunctionAsync(
+                    """selector => document.querySelector(selector)?.textContent?.trim() === 'Current count: 1'""",
+                    "p[role='status']",
+                    new() { Timeout = InteractionTimeoutMs });
             }
         };
 


### PR DESCRIPTION
## Summary

Adds explicit `WaitForAsync(Visible)` calls and increases `ClickAsync` timeouts from the default 30s to 60s for all Playwright element interactions in the `BlazorWasmTestBase._executeAfterLoaded` callback.

## Problem

On slow Windows Helix Docker containers, Blazor's CSS transitions and layout reflows can prevent nav elements from being considered "stable" by Playwright within the default 30s timeout, causing flaky `TimeoutException`s:

```
System.TimeoutException: Timeout 30000ms exceeded.
  waiting for Locator("text=Counter")
    - locator resolved to <a href="counter" class="nav-link">…</a>
    - attempting click action
    - waiting for element to be visible, enabled and stable
```

This has a long history of CI flakes: #94240, #99961, #107865

## Fix

- Add `WaitForAsync(State = Visible, Timeout = 60s)` before each `ClickAsync` to ensure the element is fully rendered
- Increase `ClickAsync` timeouts to 60s (matching the page load timeouts)
- Cache locator references to avoid re-querying the DOM

## Testing

The change only affects test infrastructure timeouts — no behavioral changes to what's being tested.
