### PR TITLE
[STJ Source Gen] Propagate type parameter constraints to generic UnsafeAccessor wrapper classes

### DIFF
--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Emitter.cs
@@ -1035,6 +1035,17 @@ namespace System.Text.Json.SourceGeneration
 
                         writer.WriteLine();
                         writer.WriteLine($"private static class __GenericAccessors_{typeFriendlyName}<{typeParamList}>");
+
+                        if (firstProperty.DeclaringTypeParameterConstraints is { } constraints)
+                        {
+                            writer.Indentation++;
+                            foreach (string constraint in constraints)
+                            {
+                                writer.WriteLine(constraint);
+                            }
+                            writer.Indentation--;
+                        }
+
                         writer.WriteLine('{');
                         writer.Indentation++;
 

--- a/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
+++ b/src/libraries/System.Text.Json/gen/JsonSourceGenerator.Parser.cs
@@ -1397,6 +1397,8 @@ namespace System.Text.Json.SourceGeneration
                         ? memberInfo.OriginalDefinition.GetMemberType().GetFullyQualifiedName() : null,
                     DeclaringTypeParameterNames = memberInfo.ContainingType is INamedTypeSymbol { IsGenericType: true } namedType && _knownSymbols.SupportsGenericUnsafeAccessors
                         ? namedType.OriginalDefinition.TypeParameters.Select(tp => tp.Name).ToImmutableEquatableArray() : null,
+                    DeclaringTypeParameterConstraints = memberInfo.ContainingType is INamedTypeSymbol { IsGenericType: true } namedType2 && _knownSymbols.SupportsGenericUnsafeAccessors
+                        ? GetTypeParameterConstraints(namedType2.OriginalDefinition.TypeParameters) : null,
                     IsExtensionData = isExtensionData,
                     PropertyType = propertyTypeRef,
                     DeclaringType = declaringType,
@@ -1849,6 +1851,52 @@ namespace System.Text.Json.SourceGeneration
                     current = current.ContainingType;
                 }
                 return count;
+            }
+
+            /// <summary>
+            /// Builds the set of "where T : ..." constraint clauses for the given type parameters.
+            /// Returns null when no type parameter has any constraint.
+            /// </summary>
+            private static ImmutableEquatableArray<string>? GetTypeParameterConstraints(
+                ImmutableArray<ITypeParameterSymbol> typeParameters)
+            {
+                List<string>? clauses = null;
+
+                foreach (ITypeParameterSymbol tp in typeParameters)
+                {
+                    List<string>? parts = null;
+
+                    if (tp.HasNotNullConstraint)
+                    {
+                        (parts ??= new()).Add("notnull");
+                    }
+                    else if (tp.HasValueTypeConstraint)
+                    {
+                        (parts ??= new()).Add(tp.HasUnmanagedTypeConstraint ? "unmanaged" : "struct");
+                    }
+                    else if (tp.HasReferenceTypeConstraint)
+                    {
+                        (parts ??= new()).Add("class");
+                    }
+
+                    foreach (ITypeSymbol constraintType in tp.ConstraintTypes)
+                    {
+                        (parts ??= new()).Add(constraintType.GetFullyQualifiedName());
+                    }
+
+                    if (tp.HasConstructorConstraint && !tp.HasValueTypeConstraint)
+                    {
+                        (parts ??= new()).Add("new()");
+                    }
+
+                    if (parts is not null)
+                    {
+                        string clause = $"where {tp.Name} : {string.Join(", ", parts)}";
+                        (clauses ??= new()).Add(clause);
+                    }
+                }
+
+                return clauses?.ToImmutableEquatableArray();
             }
 
             /// <summary>

--- a/src/libraries/System.Text.Json/gen/Model/PropertyGenerationSpec.cs
+++ b/src/libraries/System.Text.Json/gen/Model/PropertyGenerationSpec.cs
@@ -160,6 +160,13 @@ namespace System.Text.Json.SourceGeneration
         public ImmutableEquatableArray<string>? DeclaringTypeParameterNames { get; init; }
 
         /// <summary>
+        /// The constraint clauses for the generic declaring type's type parameters
+        /// (e.g., ["where T : notnull, Base"]). Null when the declaring type is not generic
+        /// or has no constraints.
+        /// </summary>
+        public ImmutableEquatableArray<string>? DeclaringTypeParameterConstraints { get; init; }
+
+        /// <summary>
         /// Whether the property has the JsonExtensionDataAttribute.
         /// </summary>
         public required bool IsExtensionData { get; init; }


### PR DESCRIPTION
## Description

Fixes the regression introduced in #124650 where the STJ source generator emits generic wrapper classes for `[UnsafeAccessor]` methods without propagating the type parameter constraints from the declaring type.

### The Problem

When a generic type has constrained type parameters (e.g., `PublicKeyCredential<TResponse> where TResponse : notnull, AuthenticatorResponse`) and `init`-only properties, the source generator emits a wrapper class like:

```csharp
private static class __GenericAccessors_PublicKeyCredential<TResponse>
// Missing: where TResponse : notnull, AuthenticatorResponse
{
    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Id")]
    private static extern void __set_Id(PublicKeyCredential<TResponse> obj, BufferSource value);
    //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    //                                  CS0314: TResponse doesn't satisfy constraint
}
```

This causes `CS0314` compilation errors. Reported by @akoeplinger in https://github.com/dotnet/dotnet/pull/5880#issuecomment-4182510988 — aspnetcore's `IdentityJsonSerializerContext` uses `PublicKeyCredential<TResponse> where TResponse : notnull, AuthenticatorResponse` with `init`-only properties.

### The Fix

Three changes across the source generator:

1. **Model** (`PropertyGenerationSpec`): Added `DeclaringTypeParameterConstraints` property to carry the constraint clauses (e.g., `["where TResponse : notnull, global::Microsoft.AspNetCore.Identity.AuthenticatorResponse"]`).

2. **Parser**: Added `GetTypeParameterConstraints()` helper that reads `ITypeParameterSymbol` properties (`HasNotNullConstraint`, `HasValueTypeConstraint`, `HasReferenceTypeConstraint`, `HasUnmanagedTypeConstraint`, `HasConstructorConstraint`, `ConstraintTypes`) and builds the corresponding `where` clauses.

3. **Emitter**: Emits the constraint clauses on the generated wrapper class:

```csharp
private static class __GenericAccessors_PublicKeyCredential<TResponse>
    where TResponse : notnull, global::Microsoft.AspNetCore.Identity.AuthenticatorResponse
{
    // UnsafeAccessor externs now compile correctly
}
```

cc @eiriktsarpalis @stephentoub