### PR TITLE
Clarify baseline build guidance for update-os-coverage skill

### DIFF
--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -13,6 +13,10 @@ description: >
 
 Update OS version references in Helix queue definition files. These files control which operating system versions are used for CI/CD testing via Helix.
 
+## Prerequisites
+
+> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from [`copilot-instructions.md`](/.github/copilot-instructions.md) unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
+
 ## When to use
 
 - An OS version is approaching or has reached EOL and should be replaced


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with GitHub Copilot.

## Summary
- add a Prerequisites section to `update-os-coverage`
- clarify that repo-wide baseline builds are not required for YAML/docs-only Helix queue and image reference updates
- point readers back to `copilot-instructions.md` only when the task expands into product code changes

## Testing
- not run (documentation-only change)