### PR TITLE
Fix regex compiler/source generator resumeAt handling of conditionals inside loops

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -2527,7 +2527,7 @@ namespace System.Text.RegularExpressions.Generator
                 writer.WriteLine();
                 TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                 string postYesDoneLabel = doneLabel;
-                if (!isAtomic && postYesDoneLabel != originalDoneLabel)
+                if ((!isAtomic && postYesDoneLabel != originalDoneLabel) || isInLoop)
                 {
                     writer.WriteLine($"{resumeAt} = 0;");
                 }
@@ -2556,7 +2556,7 @@ namespace System.Text.RegularExpressions.Generator
                     writer.WriteLine();
                     TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                     postNoDoneLabel = doneLabel;
-                    if (!isAtomic && postNoDoneLabel != originalDoneLabel)
+                    if ((!isAtomic && postNoDoneLabel != originalDoneLabel) || isInLoop)
                     {
                         writer.WriteLine($"{resumeAt} = 1;");
                     }
@@ -2566,7 +2566,7 @@ namespace System.Text.RegularExpressions.Generator
                     // There's only a yes branch.  If it's going to cause us to output a backtracking
                     // label but code may not end up taking the yes branch path, we need to emit a resumeAt
                     // that will cause the backtracking to immediately pass through this node.
-                    if (!isAtomic && postYesDoneLabel != originalDoneLabel)
+                    if ((!isAtomic && postYesDoneLabel != originalDoneLabel) || isInLoop)
                     {
                         writer.WriteLine($"{resumeAt} = 2;");
                     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -2529,7 +2529,7 @@ namespace System.Text.RegularExpressions
                 EmitNode(yesBranch);
                 TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                 Label postYesDoneLabel = doneLabel;
-                if (!isAtomic && postYesDoneLabel != originalDoneLabel)
+                if ((!isAtomic && postYesDoneLabel != originalDoneLabel) || isInLoop)
                 {
                     // resumeAt = 0;
                     Ldc(0);
@@ -2560,7 +2560,7 @@ namespace System.Text.RegularExpressions
                     EmitNode(noBranch);
                     TransferSliceStaticPosToPos(); // make sure sliceStaticPos is 0 after each branch
                     postNoDoneLabel = doneLabel;
-                    if (!isAtomic && postNoDoneLabel != originalDoneLabel)
+                    if ((!isAtomic && postNoDoneLabel != originalDoneLabel) || isInLoop)
                     {
                         // resumeAt = 1;
                         Ldc(1);
@@ -2572,7 +2572,7 @@ namespace System.Text.RegularExpressions
                     // There's only a yes branch.  If it's going to cause us to output a backtracking
                     // label but code may not end up taking the yes branch path, we need to emit a resumeAt
                     // that will cause the backtracking to immediately pass through this node.
-                    if (!isAtomic && postYesDoneLabel != originalDoneLabel)
+                    if ((!isAtomic && postYesDoneLabel != originalDoneLabel) || isInLoop)
                     {
                         // resumeAt = 2;
                         Ldc(2);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
@@ -461,6 +461,112 @@ namespace System.Text.RegularExpressions.Tests
                             new CaptureData("anyexpress1", 10, 11),
                         }
                     };
+
+                    // ExpressionConditional with balancing groups inside a loop
+
+                    // Balancing group conditional with alternation in no-branch, no match
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|((?'1'\S)+|(?'1'\s)))+(?!(?'-1'))", "abc", RegexOptions.None,
+                        Array.Empty<CaptureData>()
+                    };
+
+                    // Balancing group conditional with nested captures in alternation
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'){6})|((?'1'(?'2'\S))+|(?'1'(?'2'\s))))+(?!(?'-1'))", "it not", RegexOptions.None, new[]
+                        {
+                            new CaptureData("it ", 0, 3),
+                            new CaptureData("not", 3, 3),
+                        }
+                    };
+
+                    // Alternation in capturing group in no-branch, no match expected
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|((?'1'a)+|(?'1'b)))+(?!(?'-1'))", "abc", RegexOptions.None,
+                        Array.Empty<CaptureData>()
+                    };
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|((?'1'a)+|(?'1'b)))+(?!(?'-1'))", "aaa", RegexOptions.None,
+                        Array.Empty<CaptureData>()
+                    };
+
+                    // No-branch with quantifier but no wrapping capture group
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?'1'\S)+)+(?!(?'-1'))", "abc", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("b", 1, 1),
+                            new CaptureData("c", 2, 1),
+                        }
+                    };
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?'1'a)+)+(?!(?'-1'))", "aaa", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("a", 1, 1),
+                            new CaptureData("a", 2, 1),
+                        }
+                    };
+
+                    // No-branch with quantifier inside wrapping capture group
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|((?'1'\S)+))+(?!(?'-1'))", "abc", RegexOptions.None,
+                        Array.Empty<CaptureData>()
+                    };
+
+                    // Non-capturing group wrapping alternation in no-branch
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?:(?'1'a)+|(?'1'b)))+(?!(?'-1'))", "aaa", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("a", 1, 1),
+                            new CaptureData("a", 2, 1),
+                        }
+                    };
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?:(?'1'a)+|(?'1'b)))+(?!(?'-1'))", "abc", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("b", 1, 1),
+                        }
+                    };
+
+                    // Balancing group conditional with single char in no-branch
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?'1'a))+(?!(?'-1'))", "aaa", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("a", 1, 1),
+                            new CaptureData("a", 2, 1),
+                        }
+                    };
+
+                    // Balancing group conditional with multi-word input
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|(?'1'\S)+)+(?!(?'-1'))", "hello world", RegexOptions.None, new[]
+                        {
+                            new CaptureData("h", 0, 1),
+                            new CaptureData("e", 1, 1),
+                            new CaptureData("l", 2, 1),
+                            new CaptureData("l", 3, 1),
+                            new CaptureData("o", 4, 1),
+                            new CaptureData("w", 6, 1),
+                            new CaptureData("o", 7, 1),
+                            new CaptureData("r", 8, 1),
+                            new CaptureData("l", 9, 1),
+                            new CaptureData("d", 10, 1),
+                        }
+                    };
                 }
 
                 // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/62094

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.MultipleMatches.Tests.cs
@@ -434,31 +434,46 @@ namespace System.Text.RegularExpressions.Tests
                     }
                 }
 
-#if !NETFRAMEWORK // these tests currently fail on .NET Framework, and we need to check IsDynamicCodeCompiled but that doesn't exist on .NET Framework
-                yield return new object[]
+                if (!RegexHelpers.IsNonBacktracking(engine)) // balancing groups aren't supported
                 {
-                    engine, "@(a*)+?", "@", RegexOptions.None, new[]
-                    {
-                        new CaptureData("@", 0, 1)
-                    }
-                };
+                    // ExpressionConditional with balancing groups inside a loop, auto-numbered capture groups
 
-                if (!RegexHelpers.IsNonBacktracking(engine)) // atomic subexpressions aren't supported
-                {
+                    // Balancing group conditional with auto-numbered capture group and dot
                     yield return new object[]
                     {
-                        engine, @"()(?>\1+?).\b", "xxxx", RegexOptions.None, new[]
+                        engine, @"(?((?'-1'))|(.)+)+(?!(?'-1'))", "abc", RegexOptions.None, new[]
                         {
-                            new CaptureData("x", 3, 1),
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("b", 1, 1),
+                            new CaptureData("c", 2, 1),
                         }
                     };
 
-                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/111051
+                    // Balancing group conditional with auto-numbered capture group and literal
                     yield return new object[]
                     {
-                        engine, @"anyexpress1(?<=(.(any express|(any express)*)+?)anyexpress1)", "anystring anyexpress1", RegexOptions.None, new[]
+                        engine, @"(?((?'-1'))|(a)+)+(?!(?'-1'))", "aaa", RegexOptions.None, new[]
                         {
-                            new CaptureData("anyexpress1", 10, 11),
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("a", 1, 1),
+                            new CaptureData("a", 2, 1),
+                        }
+                    };
+
+                    // Alternation in no-branch with empty second branch, no match expected
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'))|((?'1'.)+|()))+(?!(?'-1'))", "a", RegexOptions.None,
+                        Array.Empty<CaptureData>()
+                    };
+
+                    // Balancing group conditional with quantified pop {2}
+                    yield return new object[]
+                    {
+                        engine, @"(?((?'-1'){2})|((?'1'a)+))+(?!(?'-1'))", "aa", RegexOptions.None, new[]
+                        {
+                            new CaptureData("a", 0, 1),
+                            new CaptureData("a", 1, 1),
                         }
                     };
 
@@ -565,6 +580,35 @@ namespace System.Text.RegularExpressions.Tests
                             new CaptureData("r", 8, 1),
                             new CaptureData("l", 9, 1),
                             new CaptureData("d", 10, 1),
+                        }
+                    };
+                }
+
+#if !NETFRAMEWORK // these tests currently fail on .NET Framework
+                yield return new object[]
+                {
+                    engine, "@(a*)+?", "@", RegexOptions.None, new[]
+                    {
+                        new CaptureData("@", 0, 1)
+                    }
+                };
+
+                if (!RegexHelpers.IsNonBacktracking(engine)) // atomic subexpressions aren't supported
+                {
+                    yield return new object[]
+                    {
+                        engine, @"()(?>\1+?).\b", "xxxx", RegexOptions.None, new[]
+                        {
+                            new CaptureData("x", 3, 1),
+                        }
+                    };
+
+                    // Fails on .NET Framework: https://github.com/dotnet/runtime/issues/111051
+                    yield return new object[]
+                    {
+                        engine, @"anyexpress1(?<=(.(any express|(any express)*)+?)anyexpress1)", "anystring anyexpress1", RegexOptions.None, new[]
+                        {
+                            new CaptureData("anyexpress1", 10, 11),
                         }
                     };
                 }


### PR DESCRIPTION
Update EmitExpressionConditional to reset resumeAt when inside loops, preventing stale values and incorrect matches.

Fixes https://github.com/dotnet/runtime/issues/126556