### PR TITLE
[infra] Fix jq example in update-os-coverage skill

### DIFF
--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -94,7 +94,7 @@ Before making any changes, confirm the **exact target container tag** exists in 
 ```bash
 TARGET_TAG="<exact-image-tag>"
 curl -sL https://github.com/dotnet/versions/raw/refs/heads/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json \
-  | jq -r --arg tag "$TARGET_TAG" '[.repos[].images[].platforms[].simpleTags[]] | unique | map(select(. == $tag)) | .[]'
+  | jq -e --arg tag "$TARGET_TAG" 'any(.repos[].images[].platforms[].simpleTags[]; . == $tag)'
 ```
 
 If the exact tag is **not found in `image-info`**, stop and inform the user. Treat that as authoritative even if a registry lookup appears to work. The image must be created first at [dotnet/dotnet-buildtools-prereqs-docker](https://github.com/dotnet/dotnet-buildtools-prereqs-docker). Check if an open issue or PR already exists, for example:


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

This updates the `update-os-coverage` skill guidance so the example tag check fails explicitly when the requested prereqs image tag is missing.

- replace the `jq -r ... | .[]` example with `jq -e ... any(...)`
- make the missing-tag case unambiguous and easier to script

Addresses skipped review feedback from #126524 (discussion_r3034880248).