### PR TITLE
[release/8.0] Update markdownlint workflow to Node LTS

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v6
       with:
-        node-version: 'lts/*'
+        node-version: '22.x'
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v6
       with:
-        node-version: 16.x
+        node-version: 'lts/*'
     - name: Run Markdownlint
       run: |
         echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

This fixes the release/8.0 Markdownlint workflow failure caused by running the current `markdownlint-cli` on the old Node 16 runtime.

- update `actions/checkout` to `@v6`
- update `actions/setup-node` to `@v6`
- switch the workflow to `node-version: 'lts/*'`\n\nThis restores markdownlint for PRs like #126528 where the markdown files themselves were already clean.