### PR TITLE
Fix JsonException message property type info in class parameterized constructor

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs
@@ -540,7 +540,9 @@ namespace System.Text.Json
             if (string.IsNullOrEmpty(message))
             {
                 // Use a default message.
-                Type propertyType = state.Current.JsonPropertyInfo?.PropertyType ?? state.Current.JsonTypeInfo.Type;
+                Type propertyType = state.Current.JsonPropertyInfo?.PropertyType ??
+                    state.Current.CtorArgumentState?.JsonParameterInfo?.ParameterType ??
+                    state.Current.JsonTypeInfo.Type;
                 message = SR.Format(SR.DeserializeUnableToConvertValue, propertyType);
                 ex.AppendPathInformation = true;
             }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -370,11 +370,11 @@ namespace System.Text.Json.Serialization.Tests
             Assert.DoesNotContain(nameof(ParameterizedRecord_WithStringProperty), e.Message);
         }
 
-        private class ParameterizedClass_WithStringProperty(string text)
+        public class ParameterizedClass_WithStringProperty(string text)
         {
             public string Text { get; set; } = text;
         }
 
-        private record ParameterizedRecord_WithStringProperty(string Text);
+        public record ParameterizedRecord_WithStringProperty(string Text);
     }
 }

--- a/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
+++ b/src/libraries/System.Text.Json/tests/Common/ConstructorTests/ConstructorTests.Exceptions.cs
@@ -350,5 +350,31 @@ namespace System.Text.Json.Serialization.Tests
                 UnsupportedDictionary = unsupportedDictionary;
             }
         }
+
+        [Fact]
+        public async Task ParameterizedConstructor_ExceptionMessage_ReportsPropertyType()
+        {
+            // Regression test: classes with parameterized constructors should report the
+            // property type (System.String), not the declaring class type, in the JsonException message.
+            // https://github.com/dotnet/runtime/pull/126575
+            JsonException e;
+
+            e = await Assert.ThrowsAsync<JsonException>(() =>
+                Serializer.DeserializeWrapper<ParameterizedClass_WithStringProperty>("""{"Text":{}}"""));
+            Assert.Contains("System.String", e.Message);
+            Assert.DoesNotContain(nameof(ParameterizedClass_WithStringProperty), e.Message);
+
+            e = await Assert.ThrowsAsync<JsonException>(() =>
+                Serializer.DeserializeWrapper<ParameterizedRecord_WithStringProperty>("""{"Text":{}}"""));
+            Assert.Contains("System.String", e.Message);
+            Assert.DoesNotContain(nameof(ParameterizedRecord_WithStringProperty), e.Message);
+        }
+
+        private class ParameterizedClass_WithStringProperty(string text)
+        {
+            public string Text { get; set; } = text;
+        }
+
+        private record ParameterizedRecord_WithStringProperty(string Text);
     }
 }

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.SourceGeneration.Tests/Serialization/ConstructorTests.cs
@@ -177,6 +177,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_Primitive))]
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_Struct))]
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_ReferenceType))]
+        [JsonSerializable(typeof(ParameterizedClass_WithStringProperty))]
+        [JsonSerializable(typeof(ParameterizedRecord_WithStringProperty))]
         internal sealed partial class ConstructorTestsContext_Metadata : JsonSerializerContext
         {
         }
@@ -349,6 +351,8 @@ namespace System.Text.Json.SourceGeneration.Tests
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_Primitive))]
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_Struct))]
         [JsonSerializable(typeof(TypeWith_RefReadonlyParameter_ReferenceType))]
+        [JsonSerializable(typeof(ParameterizedClass_WithStringProperty))]
+        [JsonSerializable(typeof(ParameterizedRecord_WithStringProperty))]
         internal sealed partial class ConstructorTestsContext_Default : JsonSerializerContext
         {
         }


### PR DESCRIPTION
This pull request fixes an **incorrect type hint** in the thrown `JsonException` when deserialization fails for **classes with parameterized constructors**.

## Reproduction
```csharp
using System.Text.Json;

Test<NormalClass>();
Test<ParameterizedNormalClass>();
Test<RecordClass>();
Test<NormalStruct>();
Test<ParameterizedNormalStruct>();
Test<RecordStruct>();

static void Test<T>()
{
	try
	{
		JsonSerializer.Deserialize<T>("{\"Text\":{}}"); // create json convert exception manually
	}
	catch (Exception e)
	{
		Console.WriteLine(e.Message);
	}
}

class NormalClass
{
	public string Text { get; set; } = null!;
}

class ParameterizedNormalClass(string text)
{
	public string Text { get; set; } = text;
}

record RecordClass(string Text);

struct NormalStruct()
{
	public string Text { get; set; } = null!;
}

struct ParameterizedNormalStruct(string text)
{
	public string Text { get; set; } = text;
}

record struct RecordStruct(string Text);
```

## Expected Output
```txt
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
```

## Actual Output
```txt
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to ParameterizedNormalClass. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to RecordClass. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
The JSON value could not be converted to System.String. Path: $.Text | LineNumber: 0 | BytePositionInLine: 9.
```

## Root Cause
For classes with parameterized constructors, `state.Current.CtorArgumentState.JsonParameterInfo` was used instead of `state.Current.JsonPropertyInfo`.
(All structs, including parameterized structs and record structs, work correctly without this issue.)

https://github.com/dotnet/runtime/blob/3f14c31b74e2324a72aec383e92b9aabf65d1f22/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Object/ObjectWithParameterizedConstructorConverter.cs#L636-L642

As a result, the exception message fell back to `state.Current.JsonTypeInfo.Type` for affected classes.

https://github.com/dotnet/runtime/blob/3f14c31b74e2324a72aec383e92b9aabf65d1f22/src/libraries/System.Text.Json/src/System/Text/Json/ThrowHelper.Serialization.cs#L542-L544

## Fix
Added logic to retrieve type information from `state.Current.CtorArgumentState.JsonParameterInfo.ParameterType`, ensuring correct type resolution for classes with parameterized constructors.