### PR TITLE
Add Utf8JsonWriter.Reset overloads accepting JsonWriterOptions

### DIFF
--- a/src/libraries/System.Text.Json/ref/System.Text.Json.cs
+++ b/src/libraries/System.Text.Json/ref/System.Text.Json.cs
@@ -587,7 +587,9 @@ namespace System.Text.Json
         public System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public void Reset() { }
         public void Reset(System.Buffers.IBufferWriter<byte> bufferWriter) { }
+        public void Reset(System.Buffers.IBufferWriter<byte> bufferWriter, System.Text.Json.JsonWriterOptions options) { }
         public void Reset(System.IO.Stream utf8Json) { }
+        public void Reset(System.IO.Stream utf8Json, System.Text.Json.JsonWriterOptions options) { }
         public void WriteBase64String(System.ReadOnlySpan<byte> utf8PropertyName, System.ReadOnlySpan<byte> bytes) { }
         public void WriteBase64String(System.ReadOnlySpan<char> propertyName, System.ReadOnlySpan<byte> bytes) { }
         public void WriteBase64String(string propertyName, System.ReadOnlySpan<byte> bytes) { }

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -334,31 +334,8 @@ namespace System.Text.Json
         /// </exception>
         public void Reset(Stream utf8Json, JsonWriterOptions options)
         {
-            CheckNotDisposed();
-
-            if (utf8Json == null)
-            {
-                throw new ArgumentNullException(nameof(utf8Json));
-            }
-
-            if (!utf8Json.CanWrite)
-            {
-                throw new ArgumentException(SR.StreamNotWritable);
-            }
-
-            _stream = utf8Json;
-            if (_arrayBufferWriter == null)
-            {
-                _arrayBufferWriter = new ArrayBufferWriter<byte>();
-            }
-            else
-            {
-                _arrayBufferWriter.Clear();
-            }
-
-            _output = null;
+            Reset(utf8Json);
             SetOptions(options);
-            ResetHelper();
         }
 
         /// <summary>
@@ -400,14 +377,8 @@ namespace System.Text.Json
         /// </exception>
         public void Reset(IBufferWriter<byte> bufferWriter, JsonWriterOptions options)
         {
-            CheckNotDisposed();
-
-            _output = bufferWriter ?? throw new ArgumentNullException(nameof(bufferWriter));
-            _stream = null;
-            _arrayBufferWriter = null;
-
+            Reset(bufferWriter);
             SetOptions(options);
-            ResetHelper();
         }
 
         internal void ResetAllStateForCacheReuse()

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -289,6 +289,9 @@ namespace System.Text.Json
         /// <exception cref="ArgumentNullException">
         /// Thrown when the instance of <see cref="Stream" /> that is passed in is null.
         /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the instance of <see cref="Stream" /> that is passed in does not support writing.
+        /// </exception>
         /// <exception cref="ObjectDisposedException">
         ///   The instance of <see cref="Utf8JsonWriter"/> has been disposed.
         /// </exception>
@@ -328,6 +331,9 @@ namespace System.Text.Json
         /// <param name="options">Defines the customized behavior of the <see cref="Utf8JsonWriter"/>.</param>
         /// <exception cref="ArgumentNullException">
         /// Thrown when the instance of <see cref="Stream" /> that is passed in is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown when the instance of <see cref="Stream" /> that is passed in does not support writing.
         /// </exception>
         /// <exception cref="ObjectDisposedException">
         ///   The instance of <see cref="Utf8JsonWriter"/> has been disposed.

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.cs
@@ -297,9 +297,14 @@ namespace System.Text.Json
             CheckNotDisposed();
 
             if (utf8Json == null)
+            {
                 throw new ArgumentNullException(nameof(utf8Json));
+            }
+
             if (!utf8Json.CanWrite)
+            {
                 throw new ArgumentException(SR.StreamNotWritable);
+            }
 
             _stream = utf8Json;
             if (_arrayBufferWriter == null)
@@ -310,8 +315,49 @@ namespace System.Text.Json
             {
                 _arrayBufferWriter.Clear();
             }
-            _output = null;
 
+            _output = null;
+            ResetHelper();
+        }
+
+        /// <summary>
+        /// Resets the <see cref="Utf8JsonWriter"/> internal state so that it can be re-used with the new instance of <see cref="Stream" />
+        /// and the specified <see cref="JsonWriterOptions"/>.
+        /// </summary>
+        /// <param name="utf8Json">An instance of <see cref="Stream" /> used as a destination for writing JSON text into.</param>
+        /// <param name="options">Defines the customized behavior of the <see cref="Utf8JsonWriter"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the instance of <see cref="Stream" /> that is passed in is null.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The instance of <see cref="Utf8JsonWriter"/> has been disposed.
+        /// </exception>
+        public void Reset(Stream utf8Json, JsonWriterOptions options)
+        {
+            CheckNotDisposed();
+
+            if (utf8Json == null)
+            {
+                throw new ArgumentNullException(nameof(utf8Json));
+            }
+
+            if (!utf8Json.CanWrite)
+            {
+                throw new ArgumentException(SR.StreamNotWritable);
+            }
+
+            _stream = utf8Json;
+            if (_arrayBufferWriter == null)
+            {
+                _arrayBufferWriter = new ArrayBufferWriter<byte>();
+            }
+            else
+            {
+                _arrayBufferWriter.Clear();
+            }
+
+            _output = null;
+            SetOptions(options);
             ResetHelper();
         }
 
@@ -340,6 +386,30 @@ namespace System.Text.Json
             ResetHelper();
         }
 
+        /// <summary>
+        /// Resets the <see cref="Utf8JsonWriter"/> internal state so that it can be re-used with the new instance of <see cref="IBufferWriter{Byte}" />
+        /// and the specified <see cref="JsonWriterOptions"/>.
+        /// </summary>
+        /// <param name="bufferWriter">An instance of <see cref="IBufferWriter{Byte}" /> used as a destination for writing JSON text into.</param>
+        /// <param name="options">Defines the customized behavior of the <see cref="Utf8JsonWriter"/>.</param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when the instance of <see cref="IBufferWriter{Byte}" /> that is passed in is null.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The instance of <see cref="Utf8JsonWriter"/> has been disposed.
+        /// </exception>
+        public void Reset(IBufferWriter<byte> bufferWriter, JsonWriterOptions options)
+        {
+            CheckNotDisposed();
+
+            _output = bufferWriter ?? throw new ArgumentNullException(nameof(bufferWriter));
+            _stream = null;
+            _arrayBufferWriter = null;
+
+            SetOptions(options);
+            ResetHelper();
+        }
+
         internal void ResetAllStateForCacheReuse()
         {
             ResetHelper();
@@ -349,7 +419,7 @@ namespace System.Text.Json
             _output = null;
         }
 
-        internal void Reset(IBufferWriter<byte> bufferWriter, JsonWriterOptions options)
+        internal void ConfigureForCacheReuse(IBufferWriter<byte> bufferWriter, JsonWriterOptions options)
         {
             Debug.Assert(_output is null && _stream is null && _arrayBufferWriter is null);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriterCache.cs
@@ -29,7 +29,7 @@ namespace System.Text.Json
                 writer = state.Writer;
 
                 bufferWriter.InitializeEmptyInstance(defaultBufferSize);
-                writer.Reset(bufferWriter, options);
+                writer.ConfigureForCacheReuse(bufferWriter, options);
             }
             else
             {
@@ -50,7 +50,7 @@ namespace System.Text.Json
             {
                 // First JsonSerializer call in the stack -- initialize & return the cached instance.
                 writer = state.Writer;
-                writer.Reset(bufferWriter, options.GetWriterOptions());
+                writer.ConfigureForCacheReuse(bufferWriter, options.GetWriterOptions());
             }
             else
             {

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -1180,18 +1180,168 @@ namespace System.Text.Json.Tests
 
             Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((Stream)null));
             Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((IBufferWriter<byte>)null));
+            Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((Stream)null, options));
+            Assert.Throws<ArgumentNullException>(() => writeToStream.Reset((IBufferWriter<byte>)null, options));
 
             stream.Dispose();
 
             Assert.Throws<ArgumentException>(() => writeToStream.Reset(stream));
+            Assert.Throws<ArgumentException>(() => writeToStream.Reset(stream, options));
 
             var output = new FixedSizedBufferWriter(256);
             using var writeToIBW = new Utf8JsonWriter(output, options);
 
             Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((Stream)null));
             Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((IBufferWriter<byte>)null));
+            Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((Stream)null, options));
+            Assert.Throws<ArgumentNullException>(() => writeToIBW.Reset((IBufferWriter<byte>)null, options));
 
             Assert.Throws<ArgumentException>(() => writeToIBW.Reset(stream));
+            Assert.Throws<ArgumentException>(() => writeToIBW.Reset(stream, options));
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonOptions_TestData))]
+        public void ResetWithNewOptions(JsonWriterOptions options)
+        {
+            var newOptions = new JsonWriterOptions
+            {
+                Indented = !options.Indented,
+                SkipValidation = !options.SkipValidation,
+                MaxDepth = 500,
+                IndentCharacter = '\t',
+                IndentSize = 4,
+            };
+
+            var stream = new MemoryStream();
+            using var writeToStream = new Utf8JsonWriter(stream, options);
+            writeToStream.WriteNumberValue(1);
+            writeToStream.Flush();
+
+            Assert.True(writeToStream.BytesCommitted != 0);
+
+            writeToStream.Reset(stream, newOptions);
+            Assert.Equal(0, writeToStream.BytesCommitted);
+            Assert.Equal(0, writeToStream.BytesPending);
+            Assert.Equal(0, writeToStream.CurrentDepth);
+            Assert.Equal(newOptions.Indented, writeToStream.Options.Indented);
+            Assert.Equal(newOptions.SkipValidation, writeToStream.Options.SkipValidation);
+            Assert.Equal(500, writeToStream.Options.MaxDepth);
+            Assert.Equal('\t', writeToStream.Options.IndentCharacter);
+            Assert.Equal(4, writeToStream.Options.IndentSize);
+
+            long previousWritten = stream.Position;
+            writeToStream.Flush();
+            Assert.Equal(previousWritten, stream.Position);
+
+            writeToStream.WriteNumberValue(1);
+            writeToStream.Flush();
+
+            Assert.NotEqual(previousWritten, stream.Position);
+
+            var output = new FixedSizedBufferWriter(257);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
+            writeToIBW.WriteNumberValue(1);
+            writeToIBW.Flush();
+
+            Assert.True(writeToIBW.BytesCommitted != 0);
+
+            writeToIBW.Reset(output, newOptions);
+            Assert.Equal(0, writeToIBW.BytesCommitted);
+            Assert.Equal(0, writeToIBW.BytesPending);
+            Assert.Equal(0, writeToIBW.CurrentDepth);
+            Assert.Equal(newOptions.Indented, writeToIBW.Options.Indented);
+            Assert.Equal(newOptions.SkipValidation, writeToIBW.Options.SkipValidation);
+            Assert.Equal(500, writeToIBW.Options.MaxDepth);
+            Assert.Equal('\t', writeToIBW.Options.IndentCharacter);
+            Assert.Equal(4, writeToIBW.Options.IndentSize);
+
+            previousWritten = output.FormattedCount;
+            writeToIBW.Flush();
+            Assert.Equal(previousWritten, output.FormattedCount);
+
+            writeToIBW.WriteNumberValue(1);
+            writeToIBW.Flush();
+
+            Assert.NotEqual(previousWritten, output.FormattedCount);
+        }
+
+        [Theory]
+        [MemberData(nameof(JsonOptions_TestData))]
+        public void ResetChangeOutputModeWithNewOptions(JsonWriterOptions options)
+        {
+            var newOptions = new JsonWriterOptions
+            {
+                Indented = !options.Indented,
+                SkipValidation = !options.SkipValidation,
+            };
+
+            var stream = new MemoryStream();
+            using var writeToStream = new Utf8JsonWriter(stream, options);
+            writeToStream.WriteNumberValue(1);
+            writeToStream.Flush();
+
+            Assert.True(writeToStream.BytesCommitted != 0);
+
+            var output = new FixedSizedBufferWriter(256);
+            writeToStream.Reset(output, newOptions);
+            Assert.Equal(0, writeToStream.BytesCommitted);
+            Assert.Equal(0, writeToStream.BytesPending);
+            Assert.Equal(0, writeToStream.CurrentDepth);
+            Assert.Equal(newOptions.Indented, writeToStream.Options.Indented);
+            Assert.Equal(newOptions.SkipValidation, writeToStream.Options.SkipValidation);
+
+            writeToStream.WriteNumberValue(1);
+            writeToStream.Flush();
+            Assert.True(writeToStream.BytesCommitted != 0);
+            Assert.True(output.FormattedCount != 0);
+
+            output = new FixedSizedBufferWriter(256);
+            using var writeToIBW = new Utf8JsonWriter(output, options);
+            writeToIBW.WriteNumberValue(1);
+            writeToIBW.Flush();
+
+            Assert.True(writeToIBW.BytesCommitted != 0);
+
+            stream = new MemoryStream();
+            writeToIBW.Reset(stream, newOptions);
+            Assert.Equal(0, writeToIBW.BytesCommitted);
+            Assert.Equal(0, writeToIBW.BytesPending);
+            Assert.Equal(0, writeToIBW.CurrentDepth);
+            Assert.Equal(newOptions.Indented, writeToIBW.Options.Indented);
+            Assert.Equal(newOptions.SkipValidation, writeToIBW.Options.SkipValidation);
+
+            writeToIBW.WriteNumberValue(1);
+            writeToIBW.Flush();
+            Assert.True(writeToIBW.BytesCommitted != 0);
+            Assert.True(stream.Position != 0);
+        }
+
+        [Fact]
+        public void ResetWithNewOptions_ProducesExpectedOutput()
+        {
+            var output = new ArrayBufferWriter<byte>();
+            using var writer = new Utf8JsonWriter(output, new JsonWriterOptions { Indented = false });
+
+            writer.WriteStartObject();
+            writer.WriteNumber("x", 1);
+            writer.WriteEndObject();
+            writer.Flush();
+
+            string compact = Encoding.UTF8.GetString(output.WrittenSpan.ToArray());
+            Assert.Equal("""{"x":1}""", compact);
+
+            output.Clear();
+            writer.Reset(output, new JsonWriterOptions { Indented = true });
+
+            writer.WriteStartObject();
+            writer.WriteNumber("x", 1);
+            writer.WriteEndObject();
+            writer.Flush();
+
+            string indented = Encoding.UTF8.GetString(output.WrittenSpan.ToArray());
+            Assert.Contains("\n", indented);
+            Assert.Contains("\"x\": 1", indented);
         }
 
         [Theory]
@@ -1381,6 +1531,7 @@ namespace System.Text.Json.Tests
 
             var stream = new MemoryStream();
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream));
+            Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream, options));
 
             using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
@@ -1398,6 +1549,7 @@ namespace System.Text.Json.Tests
             Assert.Throws<ObjectDisposedException>(() => writeToStream.Reset());
 
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(output));
+            Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(output, options));
         }
 
         [Theory]
@@ -1423,6 +1575,7 @@ namespace System.Text.Json.Tests
 
             var stream = new MemoryStream();
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream));
+            Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(stream, options));
 
             using var writeToStream = new Utf8JsonWriter(stream, options);
             writeToStream.WriteStartObject();
@@ -1440,6 +1593,7 @@ namespace System.Text.Json.Tests
             Assert.Throws<ObjectDisposedException>(() => writeToStream.Reset());
 
             Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(output));
+            Assert.Throws<ObjectDisposedException>(() => jsonUtf8.Reset(output, options));
         }
 
         [Theory]

--- a/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
+++ b/src/libraries/System.Text.Json/tests/System.Text.Json.Tests/Utf8JsonWriterTests.cs
@@ -1200,6 +1200,16 @@ namespace System.Text.Json.Tests
             Assert.Throws<ArgumentException>(() => writeToIBW.Reset(stream, options));
         }
 
+        [Fact]
+        public static void JsonSerializerCacheNotPoisonedByDisposedWriter()
+        {
+            var options = new JsonSerializerOptions();
+            options.Converters.Add(new DisposingInt32Converter());
+
+            Assert.Throws<InvalidOperationException>(() => JsonSerializer.Serialize(1, options));
+            Assert.Equal("2", JsonSerializer.Serialize(2));
+        }
+
         [Theory]
         [MemberData(nameof(JsonOptions_TestData))]
         public void ResetWithNewOptions(JsonWriterOptions options)
@@ -1264,6 +1274,18 @@ namespace System.Text.Json.Tests
             writeToIBW.Flush();
 
             Assert.NotEqual(previousWritten, output.FormattedCount);
+        }
+
+        private sealed class DisposingInt32Converter : System.Text.Json.Serialization.JsonConverter<int>
+        {
+            public override int Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+                throw new NotSupportedException();
+
+            public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options)
+            {
+                writer.Dispose();
+                throw new InvalidOperationException();
+            }
         }
 
         [Theory]


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with GitHub Copilot.

Resolves #123221.

## Summary
- Adds the approved `Utf8JsonWriter.Reset` overloads that accept `JsonWriterOptions` for both `Stream` and `IBufferWriter<byte>` outputs.
- Keeps the existing `Dispose`, `CheckNotDisposed`, and internal serializer cache behavior unchanged.
- Adds test coverage for the new reset overloads and option-reset behavior.

## Testing
- `dotnet build src\\libraries\\System.Text.Json\\src\\System.Text.Json.csproj -c Debug`
- `dotnet test src\\libraries\\System.Text.Json\\tests\\System.Text.Json.Tests\\System.Text.Json.Tests.csproj -c Debug -f net11.0 --logger "console;verbosity=minimal"`