### PR TITLE
Fix initialization of t_MostRecentUMEntryThunkData in reverse pinvokes 

### DIFF
--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -309,6 +309,11 @@ extern "C" PCODE ComPreStubWorker(UMEntryThunkData* pEntryThunk)
     INSTALL_MANAGED_EXCEPTION_DISPATCHER;
     INSTALL_UNWIND_AND_CONTINUE_HANDLER;
 
+#ifdef FEATURE_INTERPRETER
+    // If we add support for COM interop on interpreter, this will need to update t_MostRecentUMEntryThunkData
+    _ASSERTE(pEntryThunk->GetInterpreterTarget() == (PCODE)0);
+#endif // FEATURE_INTERPRETER
+
     if (pThread->PreemptiveGCDisabled())
     {
         EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -286,10 +286,6 @@ ComCallMethodDesc* ComMethodTable::ComCallMethodDescFromSlot(unsigned i)
     RETURN pMarshInfo->GetComCallMethodDesc();
 }
 
-#ifdef FEATURE_INTERPRETER
-extern PLATFORM_THREAD_LOCAL UMEntryThunkData * t_MostRecentUMEntryThunkData;
-#endif
-
 //--------------------------------------------------------------------------
 // This routine is called anytime a com method is invoked for the first time.
 // It is responsible for generating the real stub.
@@ -312,15 +308,6 @@ extern "C" PCODE ComPreStubWorker(UMEntryThunkData* pEntryThunk)
 
     INSTALL_MANAGED_EXCEPTION_DISPATCHER;
     INSTALL_UNWIND_AND_CONTINUE_HANDLER;
-
-#ifdef FEATURE_INTERPRETER
-    PCODE pInterpreterTarget = pEntryThunk->GetInterpreterTarget();
-    if (pInterpreterTarget != (PCODE)0)
-    {
-        t_MostRecentUMEntryThunkData = pEntryThunk;
-        return pInterpreterTarget;
-    }
-#endif // FEATURE_INTERPRETER
 
     if (pThread->PreemptiveGCDisabled())
     {

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -249,7 +249,11 @@ PCODE TheUMEntryPrestubWorker(UMEntryThunkData* pUMEntryThunkData)
     entryPoint = pUMEntryThunkData->RunTimeInit(&targetIsPrecode);
 
 #ifdef FEATURE_INTERPRETER
-    _ASSERTE(targetIsPrecode || pUMEntryThunkData->GetInterpreterTarget() != (PCODE)0);
+    if (!targetIsPrecode)
+    {
+        _ASSERTE(pUMEntryThunkData->GetInterpreterTarget() != (PCODE)0);
+        t_MostRecentUMEntryThunkData = pUMEntryThunkData;
+    }
 #else
     _ASSERTE(targetIsPrecode);
 #endif

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -245,17 +245,17 @@ PCODE TheUMEntryPrestubWorker(UMEntryThunkData* pUMEntryThunkData)
     // exceptions don't leak out into managed code.
     INSTALL_UNWIND_AND_CONTINUE_HANDLER;
 
-    bool targetIsPrecode;
-    entryPoint = pUMEntryThunkData->RunTimeInit(&targetIsPrecode);
+    bool canSkipPreStub;
+    entryPoint = pUMEntryThunkData->RunTimeInit(&canSkipPreStub);
 
 #ifdef FEATURE_INTERPRETER
-    if (!targetIsPrecode)
+    if (!canSkipPreStub)
     {
         _ASSERTE(pUMEntryThunkData->GetInterpreterTarget() != (PCODE)0);
         t_MostRecentUMEntryThunkData = pUMEntryThunkData;
     }
 #else
-    _ASSERTE(targetIsPrecode);
+    _ASSERTE(canSkipPreStub);
 #endif
 
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;


### PR DESCRIPTION
In reverse pinvokes, the interpreter receives  the `UMEntryThunkData` in this TLS variable as a hidden argument. The way this is implemented is that reverse pinvokes always go through the prestub which checks whether the target is interpreter, in which case it writes this TLS variable. This means that first call was going through the prestub twice, first to initialize the thunk data and secondly to set this argument (`TheUMEntryPrestubWorker` was returning itself so it gets called again).

Following https://github.com/dotnet/runtime/commit/60f1dc1b6d553754a1f23de0fb00af0b2702073e, we obtain the entryPoint so we end up calling the interpreter precode directly. The problem is that we failed to set the TLS variable, which is what this PR is doing.

This also does minor cleanup by removing dead interpreter code from COM sources and renaming `targetIsPrecode` to `canSkipPreStub`, because the first name was misleading (it was false when `entryPoint` was pointing to interpreter precode).