### PR TITLE
Add linux_arm64 platform to coreclr_r2r_interpreter build

### DIFF
--- a/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
@@ -65,7 +65,7 @@ jobs:
         jobTemplate: /eng/pipelines/common/global-build-job.yml
         buildConfig: release
         platforms:
-        - linux_x64
+        - linux_arm64
         jobParameters:
           nameSuffix: coreclr_r2r_interpreter
           buildArgs: -s clr+libs+packs -c $(_BuildConfig) -dynamiccodecompiled false


### PR DESCRIPTION
Add arm64 to the composite R2R with interpreter fallback build so that arm64 cobalt perf runs can consume the build artifacts.