### PR TITLE
[PERF] Add wasm_coreclr and coreclr_r2r_interpreter to perf-build pipeline

### DIFF
--- a/eng/pipelines/performance/perf-build.yml
+++ b/eng/pipelines/performance/perf-build.yml
@@ -70,6 +70,14 @@ parameters:
   displayName: Build CoreCLR Arm64 iOS
   type: boolean
   default: true
+- name: wasm_coreclr
+  displayName: Build WebAssembly CoreCLR (wasm_coreclr)
+  type: boolean
+  default: true
+- name: coreclr_r2r_interpreter
+  displayName: Build Coreclr R2R Interpreter
+  type: boolean
+  default: true
 
 trigger:
   batch: false # we want to build every single commit
@@ -138,6 +146,10 @@ extends:
                 - nativeAot_arm64_ios
               - ${{ if eq(parameters.coreclr_arm64_ios, true) }}:
                 - coreclr_arm64_ios
+              - ${{ if eq(parameters.wasm_coreclr, true) }}:
+                - wasm_coreclr
+              - ${{ if eq(parameters.coreclr_r2r_interpreter, true) }}:
+                - coreclr_r2r_interpreter
 
     - stage: Build
       displayName: 'Build'
@@ -180,6 +192,10 @@ extends:
               - nativeAot_arm64_ios
             - ${{ if eq(parameters.coreclr_arm64_ios, true) }}:
               - coreclr_arm64_ios
+            - ${{ if eq(parameters.wasm_coreclr, true) }}:
+              - wasm_coreclr
+            - ${{ if eq(parameters.coreclr_r2r_interpreter, true) }}:
+              - coreclr_r2r_interpreter
           ${{ if parameters.mauiFramework }}:
             mauiFramework: ${{ parameters.mauiFramework }}
 
@@ -228,3 +244,7 @@ extends:
                 - nativeAot_arm64_ios
               - ${{ if eq(parameters.coreclr_arm64_ios, true) }}:
                 - coreclr_arm64_ios
+              - ${{ if eq(parameters.wasm_coreclr, true) }}:
+                - wasm_coreclr
+              - ${{ if eq(parameters.coreclr_r2r_interpreter, true) }}:
+                - coreclr_r2r_interpreter


### PR DESCRIPTION
Include the two new build types (wasm_coreclr and coreclr_r2r_interpreter) in the every-commit perf build pipeline so they are registered, built, and uploaded to the build cache system (BCS).

Should be merged with: https://github.com/dotnet/performance/pull/5191
Test run: https://dev.azure.com/dnceng/internal/_build/results?buildId=2944775&view=results