### PR TITLE
Add logic to muxer to invoke AOT-ed SDK

### DIFF
--- a/docs/design/features/sharedfx-lookup.md
+++ b/docs/design/features/sharedfx-lookup.md
@@ -44,6 +44,20 @@ In the first case the app file path should have been specified as an argument to
 In the second case the `dotnet.dll` from SDK must be invoked as a framework-dependent app. At first the running program searches for the `global.json` file which may have specified a CLI version. It starts from the current working directory and looks for it inside all parent folder hierarchy. After that, it searches for the dotnet.dll file inside the `sdk\<CLI_version>` sub-folder in the executable directory.
 The exact algorithm how versions as matched is described (with some history) in the [docs](https://learn.microsoft.com/dotnet/core/tools/global-json#matching-rules)
 
+Starting in .NET 11, once the SDK directory is resolved, the muxer checks for a `dotnet-aot` shared library in that directory. If the library exists and exports the `dotnet_execute` entry point, the muxer invokes it instead of running the managed `dotnet.dll`:
+
+``` C
+int dotnet_execute(
+    const char_t *host_path,     // path to the dotnet host executable
+    const char_t *dotnet_root,   // path to the dotnet root directory
+    const char_t *sdk_dir,       // path to the resolved SDK directory
+    const char_t *hostfxr_path,  // path to the hostfxr library
+    int argc,                    // user's command-line arguments (excluding dotnet executable itself)
+    const char_t **argv)
+```
+
+If the `dotnet-aot` library is not found or does not have the expected entry point, the muxer falls back to running the managed `dotnet.dll` as a framework-dependent app.
+
 Note: if the SDK lookup is invoked through `hostfxr_resolve_sdk2` the algorithm is the same, expect that the function can disallow pre-release versions via the `hostfxr_resolve_sdk2_flags_t::disallow_prerelease` flag.
 
 ### Framework search and rolling forward

--- a/docs/design/features/sharedfx-lookup.md
+++ b/docs/design/features/sharedfx-lookup.md
@@ -53,7 +53,7 @@ int dotnet_execute(
     const char_t *sdk_dir,       // path to the resolved SDK directory
     const char_t *hostfxr_path,  // path to the hostfxr library
     int argc,                    // user's command-line arguments (excluding dotnet executable itself)
-    const char_t **argv)
+    const char_t **argv);
 ```
 
 If the `dotnet-aot` library is not found or does not have the expected entry point, the muxer falls back to running the managed `dotnet.dll` as a framework-dependent app.

--- a/src/installer/tests/HostActivation.Tests/SDKLookup.cs
+++ b/src/installer/tests/HostActivation.Tests/SDKLookup.cs
@@ -1177,6 +1177,30 @@ namespace HostActivation.Tests
             }
         }
 
+        [Fact]
+        public void DispatchToAotSdk()
+        {
+            GlobalJson.CreateEmpty(SharedState.CurrentWorkingDir);
+
+            AddAvailableSdkVersions("9999.1.0");
+
+            string sdkDir = Path.Combine(ExecutableDotNet.BinPath, "sdk", "9999.1.0");
+            string aotSdkPath = Path.Combine(sdkDir, Binaries.DotNetAot.FileName);
+            File.Copy(Binaries.DotNetAot.MockPath, aotSdkPath);
+
+            RunTest()
+                .Should().Pass()
+                .And.HaveStdErrContaining($"Using AOT-ed SDK=[{aotSdkPath}]")
+                .And.HaveStdOutContaining("mock AOT SDK invoked")
+                .And.HaveStdOutContaining($"mock host_path: {ExecutableDotNet.DotnetExecutablePath}")
+                .And.HaveStdOutContaining($"mock dotnet_root: {ExecutableDotNet.BinPath}")
+                .And.HaveStdOutContaining($"mock sdk_dir: {sdkDir}")
+                .And.HaveStdOutContaining($"mock hostfxr_path: {ExecutableDotNet.GreatestVersionHostFxrFilePath}")
+                .And.HaveStdOutContaining("mock argc: 1")
+                .And.HaveStdOutContaining("mock argv[0]: help")
+                .And.NotHaveStdErrContaining("Using .NET SDK dll=");
+        }
+
         private static void AddSdkToCustomPath(string sdkRoot, string version)
         {
             DotNetBuilder.AddMockSDK(sdkRoot, version, version);

--- a/src/installer/tests/TestUtils/Binaries.cs
+++ b/src/installer/tests/TestUtils/Binaries.cs
@@ -76,6 +76,14 @@ namespace Microsoft.DotNet.CoreSetup.Test
             public static string MockPath = Path.Combine(RepoDirectoriesProvider.Default.HostTestArtifacts, MockName);
         }
 
+        public static class DotNetAot
+        {
+            public static string FileName = GetSharedLibraryFileNameForCurrentPlatform("dotnet-aot");
+
+            public static string MockName = GetSharedLibraryFileNameForCurrentPlatform("mockaotsdk");
+            public static string MockPath = Path.Combine(RepoDirectoriesProvider.Default.HostTestArtifacts, MockName);
+        }
+
         public static class NetHost
         {
             public static string FileName = GetSharedLibraryFileNameForCurrentPlatform("nethost");

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -63,6 +63,69 @@ namespace
 
         g_context_initializing_cv.notify_all();
     }
+
+    // Try to load and invoke the AOT-ed SDK from the resolved SDK directory.
+    // Returns true if the AOT entry point was found and invoked, with the result in exit_code.
+    // Returns false if the AOT library is not available or cannot be used.
+    bool try_invoke_aot_sdk(
+        const host_startup_info_t& host_info,
+        const pal::string_t& sdk_dir,
+        const pal::string_t& sdk_root,
+        int argc,
+        const pal::char_t* argv[],
+        int* exit_code)
+    {
+        pal::string_t sdk_aot_path(sdk_dir);
+        append_path(&sdk_aot_path, LIB_FILE_NAME_X("dotnet-aot"));
+        if (!pal::file_exists(sdk_aot_path))
+            return false;
+
+        trace::verbose(_X("Found AOT-ed SDK [%s]"), sdk_aot_path.c_str());
+
+        pal::dll_t aot_dll = nullptr;
+        if (!pal::load_library(&sdk_aot_path, &aot_dll))
+        {
+            trace::info(_X("Failed to load AOT-ed SDK [%s]."), sdk_aot_path.c_str());
+            return false;
+        }
+
+        typedef int (*dotnet_execute_fn)(
+            const pal::char_t* host_path,
+            const pal::char_t* dotnet_root,
+            const pal::char_t* sdk_dir,
+            const pal::char_t* hostfxr_path,
+            int argc,
+            const pal::char_t** argv);
+        auto dotnet_execute = reinterpret_cast<dotnet_execute_fn>(pal::get_symbol(aot_dll, "dotnet_execute"));
+        if (dotnet_execute == nullptr)
+        {
+            trace::info(_X("AOT-ed SDK [%s] does not contain 'dotnet_execute' entry point."), sdk_aot_path.c_str());
+            pal::unload_library(aot_dll);
+            return false;
+        }
+
+        pal::string_t hostfxr_path;
+        if (!pal::get_own_module_path(&hostfxr_path))
+        {
+            trace::info(_X("Failed to determine hostfxr path."));
+            pal::unload_library(aot_dll);
+            return false;
+        }
+
+        const pal::char_t* dotnet_root = sdk_root.empty()
+            ? host_info.dotnet_root.c_str()
+            : sdk_root.c_str();
+
+        *exit_code = dotnet_execute(
+            host_info.host_path.c_str(),
+            dotnet_root,
+            sdk_dir.c_str(),
+            hostfxr_path.c_str(),
+            argc - 1, // skip 'dotnet' (first argument)
+            argv + 1);
+
+        return true;
+    }
 }
 
 int load_hostpolicy(
@@ -1116,6 +1179,18 @@ int fx_muxer_t::handle_cli(
         resolver.print_resolution_error(host_info.dotnet_root, _X("      "));
 
         return StatusCode::SdkResolveFailure;
+    }
+
+    // Try to use the AOT-ed SDK if available in the resolved SDK directory
+    int aot_exit_code;
+    if (try_invoke_aot_sdk(host_info, sdk_dotnet, sdk_root, argc, argv, &aot_exit_code))
+    {
+        if (pal::strcasecmp(_X("--info"), argv[1]) == 0)
+        {
+            command_line::print_muxer_info(host_info.dotnet_root, resolver.global_file(), aot_exit_code == 0 /*skip_sdk_info_output*/);
+        }
+
+        return aot_exit_code;
     }
 
     append_path(&sdk_dotnet, SDK_DOTNET_DLL);

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -84,10 +84,7 @@ namespace
 
         pal::dll_t aot_dll = nullptr;
         if (!pal::load_library(&sdk_aot_path, &aot_dll))
-        {
-            trace::info(_X("Failed to load AOT-ed SDK [%s]."), sdk_aot_path.c_str());
             return false;
-        }
 
         typedef int (*dotnet_execute_fn)(
             const pal::char_t* host_path,
@@ -115,6 +112,8 @@ namespace
         const pal::char_t* dotnet_root = sdk_root.empty()
             ? host_info.dotnet_root.c_str()
             : sdk_root.c_str();
+
+        trace::info(_X("Using AOT-ed SDK=[%s]"), sdk_aot_path.c_str());
 
         *exit_code = dotnet_execute(
             host_info.host_path.c_str(),

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -86,6 +86,7 @@ namespace
         if (!pal::load_library(&sdk_aot_path, &aot_dll))
             return false;
 
+        // See docs/design/features/sharedfx-lookup.md#sdk-search
         typedef int (*dotnet_execute_fn)(
             const pal::char_t* host_path,
             const pal::char_t* dotnet_root,
@@ -93,6 +94,7 @@ namespace
             const pal::char_t* hostfxr_path,
             int argc,
             const pal::char_t** argv);
+
         auto dotnet_execute = reinterpret_cast<dotnet_execute_fn>(pal::get_symbol(aot_dll, "dotnet_execute"));
         if (dotnet_execute == nullptr)
         {

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -87,7 +87,7 @@ namespace
             return false;
 
         // See docs/design/features/sharedfx-lookup.md#sdk-search
-        typedef int (*dotnet_execute_fn)(
+        typedef int (__cdecl *dotnet_execute_fn)(
             const pal::char_t* host_path,
             const pal::char_t* dotnet_root,
             const pal::char_t* sdk_dir,

--- a/src/native/corehost/test/CMakeLists.txt
+++ b/src/native/corehost/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(fx_ver)
+add_subdirectory(mockaotsdk)
 add_subdirectory(mockcoreclr)
 add_subdirectory(mockhostfxr)
 add_subdirectory(mockhostpolicy)

--- a/src/native/corehost/test/mockaotsdk/CMakeLists.txt
+++ b/src/native/corehost/test/mockaotsdk/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+
+add_library(mockaotsdk SHARED mockaotsdk.cpp)
+
+target_link_libraries(mockaotsdk PRIVATE hostmisc)
+
+target_compile_definitions(mockaotsdk PRIVATE EXPORT_SHARED_API)
+
+install_with_stripped_symbols(mockaotsdk TARGETS corehost_test)

--- a/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
+++ b/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
@@ -1,0 +1,34 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include <iostream>
+#include <pal.h>
+
+std::vector<char> tostr(const pal::char_t* value)
+{
+    std::vector<char> vect;
+    pal::pal_utf8string(pal::string_t(value), &vect);
+    return vect;
+}
+
+SHARED_API int dotnet_execute(
+    const pal::char_t* host_path,
+    const pal::char_t* dotnet_root,
+    const pal::char_t* sdk_dir,
+    const pal::char_t* hostfxr_path,
+    int argc,
+    const pal::char_t** argv)
+{
+    std::cout << "mock AOT SDK invoked" << std::endl;
+    std::cout << "mock host_path: " << tostr(host_path).data() << std::endl;
+    std::cout << "mock dotnet_root: " << tostr(dotnet_root).data() << std::endl;
+    std::cout << "mock sdk_dir: " << tostr(sdk_dir).data() << std::endl;
+    std::cout << "mock hostfxr_path: " << tostr(hostfxr_path).data() << std::endl;
+    std::cout << "mock argc: " << argc << std::endl;
+    for (int i = 0; i < argc; i++)
+    {
+        std::cout << "mock argv[" << i << "]: " << tostr(argv[i]).data() << std::endl;
+    }
+
+    return 0;
+}

--- a/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
+++ b/src/native/corehost/test/mockaotsdk/mockaotsdk.cpp
@@ -11,7 +11,7 @@ std::vector<char> tostr(const pal::char_t* value)
     return vect;
 }
 
-SHARED_API int dotnet_execute(
+SHARED_API int __cdecl dotnet_execute(
     const pal::char_t* host_path,
     const pal::char_t* dotnet_root,
     const pal::char_t* sdk_dir,


### PR DESCRIPTION
Fixes #126171

Updates the muxer to look for and natively invoke a \dotnet-aot\ shared library when it exists in the resolved SDK directory. When present, the muxer loads the library, resolves the \dotnet_execute\ entry point, and calls it with the host path, dotnet root, SDK directory, hostfxr path, and user arguments. If the AOT library is not available or doesn't have the expected entry point, the muxer falls back to the existing managed SDK path.

## Changes

### Native host
- Add `try_invoke_aot_sdk` helper in `fx_muxer_t::handle_cli` that attempts to load `dotnet-aot` from the resolved SDK directory
- Fall through to the existing `dotnet.dll` path if the AOT library is absent

### Tests
- Add `mockaotsdk` native test library that implements the `dotnet_execute` entry point and prints received arguments
- Add `DispatchToAotSdk` test in `SDKLookup.cs` validating the muxer dispatches to the AOT SDK with the correct arguments

cc @JeremyKuhne @dotnet/appmodel @AaronRobinsonMSFT 