### PR TITLE
[wasm][coreclr] Fix Regressions test crash by increasing Node.js stack size

### DIFF
--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -384,7 +384,7 @@ else
     echo CLRTestExecutionArguments: ${CLRTestExecutionArguments[@]}
     echo node version: `node -v`
     echo Timeout in ms: $__TestTimeout
-    cmd=( node "${CORE_ROOT}/corerun.js" -c "${CORE_ROOT}" "${PWD}/${ExePath}" "${CLRTestExecutionArguments[@]}" )
+    cmd=( node --stack-size=8192 "${CORE_ROOT}/corerun.js" -c "${CORE_ROOT}" "${PWD}/${ExePath}" "${CLRTestExecutionArguments[@]}" )
     echo Running: "${cmd[@]}"
     run_with_timeout $__TestTimeout "${cmd[@]}"
 fi

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -341,7 +341,7 @@ IF NOT DEFINED RunWithNodeJS (
     ECHO CLRTestExecutionArguments: %CLRTestExecutionArguments%
     ECHO Timeout in ms: !__TestTimeout!
     
-    set "__RunCmd=node "!__CoreRootWin!\corerun.js" -c "!__CoreRootUnix!" "!__ExePathUnix!" %CLRTestExecutionArguments%"
+    set "__RunCmd=node --stack-size=8192 "!__CoreRootWin!\corerun.js" -c "!__CoreRootUnix!" "!__ExePathUnix!" %CLRTestExecutionArguments%"
     ECHO Running: !__RunCmd!
     call :RunWithTimeout !__TestTimeout!
     set CLRTestExitCode=!ERRORLEVEL!

--- a/src/tests/Regressions/coreclr/GitHub_100536/test100536.cs
+++ b/src/tests/Regressions/coreclr/GitHub_100536/test100536.cs
@@ -31,6 +31,7 @@ public class Test100536
     }
 
     [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsSimulator))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/123946", typeof(PlatformDetection), nameof(PlatformDetection.PlatformDoesNotSupportNativeTestAssets))]
     [Fact]
     public static void TestEntryPoint()
     {


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the help of GitHub Copilot.

## Summary

Tests running CoreCLR on WASM via Node.js can overflow V8's JavaScript call stack when the test suite loads many assemblies and a test exercises deep recursive exception handling (e.g. `test104820` with 100 levels of recursion and `when` filter funclets).

## Changes

- Increase the Node.js stack size from the default (~1MB) to 8MB via `--stack-size=8192` in the WASM test runner scripts for both Linux/macOS (`CLRTest.Execute.Bash.targets`) and Windows (`CLRTest.Execute.Batch.targets`).
- Disable `test100536` on platforms without native test assets (P/Invoke test).

## Root Cause

In the full Regressions suite, 87 test assemblies are loaded into a single process. The combined V8 call stack usage from assembly loading + xunit infrastructure + the deep recursive EH in `test104820` (100,000 filter funclet invocations) exceeds V8's default stack limit, causing a silent crash (exit 0). The test passes in isolation because less V8 stack is consumed.