### PR TITLE
Disable HTTP/3 tests on AzureLinux 3 VMs due to QUIC OOM

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTestBase.SocketsHttpHandler.cs
@@ -37,6 +37,7 @@ namespace System.Net.Http.Functional.Tests
                 try
                 {
                     return QuicConnection.IsSupported
+                        && IsNotAzureLinux3VM
                         && (bool)Type.GetType("System.Net.Http.GlobalHttpSettings+SocketsHttpHandler, System.Net.Http").GetProperty("AllowHttp3").GetValue(null);
                 }
                 catch (System.PlatformNotSupportedException)
@@ -45,6 +46,9 @@ namespace System.Net.Http.Functional.Tests
                 }
             }
         }
+
+        // https://github.com/dotnet/runtime/issues/123216
+        public static bool IsNotAzureLinux3VM => !PlatformDetection.IsAzureLinux || PlatformDetection.IsInContainer;
 
         protected static HttpClientHandler CreateHttpClientHandler(Version useVersion = null, bool allowAllCertificates = true)
         {


### PR DESCRIPTION
HTTP/3 tests (`TelemetryTest_Http30`, and potentially other `*_Http3` / `*_Http30` classes) consistently fail on `azurelinux.3.amd64.open.rt` because the underlying MsQuic library fails with `QUIC_STATUS_OUT_OF_MEMORY` on that queue.

The QUIC tests were already disabled for the same reason in PRs #125665 and #125772 using the `IsNotAzureLinux3VM` condition on `[ConditionalClass]`. However, the HTTP/3 test classes use `IsHttp3Supported` from `HttpClientHandlerTestBase` as their gate, so they were not covered by the QUIC-side fix.

This PR adds the same `IsNotAzureLinux3VM` check to `IsHttp3Supported`, which will skip all HTTP/3 test classes on AzureLinux 3 VMs where QUIC is broken.

Relates to #123216