### PR TITLE
Adjust breaking change workflow based on issues seen

### DIFF
--- a/.github/skills/breaking-change-doc/Build-IssueComment.ps1
+++ b/.github/skills/breaking-change-doc/Build-IssueComment.ps1
@@ -1,8 +1,8 @@
 # Build-IssueComment.ps1
 # Reads a breaking change issue draft markdown file, URL-encodes the title,
-# body, and labels, and produces a PR comment markdown file containing:
-#   - A header
-#   - The full draft for inline review
+# body, and labels, and produces a brief PR comment markdown file containing:
+#   - A short header with instructions
+#   - @mentions of the PR assignees so they get notified
 #   - A clickable link that pre-fills a new issue in dotnet/docs
 #   - An email reminder
 #
@@ -10,6 +10,7 @@
 #   pwsh .github/skills/breaking-change-doc/Build-IssueComment.ps1 `
 #       -IssueDraftPath issue-draft.md `
 #       -Title "[Breaking change]: Something changed" `
+#       -Assignees "@user1 @user2" `
 #       -OutputPath pr-comment.md
 #
 # The issue draft file should contain only the issue body markdown (no title).
@@ -20,6 +21,8 @@ param(
 
     [Parameter(Mandatory = $true)]
     [string]$Title,
+
+    [string]$Assignees = "",
 
     [string]$OutputPath = "pr-comment.md",
 
@@ -46,43 +49,31 @@ $encodedEmailSubject = [Uri]::EscapeDataString("[Breaking Change] $Title")
 $issueUrl = "https://github.com/$DocsRepo/issues/new?title=$encodedTitle&body=$encodedBody&labels=$encodedLabels"
 $notificationEmailUrl = "mailto:dotnetbcn@microsoft.com?subject=$encodedEmailSubject"
 
+# Build a brief assignee mention line (if any)
+$mentionLine = ""
+if ($Assignees.Trim()) {
+    $mentionLine = "`n`n/cc $($Assignees.Trim())"
+}
+
 $comment = @"
 ## Breaking Change Documentation
 
-$issueBody
-
----
-
-> [!NOTE]
-> This documentation was generated with AI assistance from Copilot.
+A breaking change draft has been prepared for this PR.
 
 :point_right: **[Click here to create the issue in dotnet/docs]($issueUrl)**
 
 After creating the issue, please email a link to it to
-[.NET Breaking Change Notifications]($notificationEmailUrl).
+[.NET Breaking Change Notifications]($notificationEmailUrl).$mentionLine
+
+> [!NOTE]
+> This documentation was generated with AI assistance from Copilot.
 "@
 
-# GitHub comment body limit is 65536 characters. If the comment exceeds this,
-# replace the inline draft with a short summary pointing at the file.
+# GitHub comment body limit is 65536 characters. The comment is now brief,
+# but the URL itself can be very long. Warn if close to limits.
 $maxCommentLength = 65000
 if ($comment.Length -gt $maxCommentLength) {
-    Write-Warning "Comment body ($($comment.Length) chars) exceeds GitHub limit. Truncating inline draft."
-    $comment = @"
-## Breaking Change Documentation
-
-The full draft is too large to display inline. See ``issue-draft.md`` in the
-workflow artifacts for the complete content.
-
----
-
-> [!NOTE]
-> This documentation was generated with AI assistance from Copilot.
-
-:point_right: **[Click here to create the issue in dotnet/docs]($issueUrl)**
-
-After creating the issue, please email a link to it to
-[.NET Breaking Change Notifications]($notificationEmailUrl).
-"@
+    Write-Warning "Comment body ($($comment.Length) chars) exceeds GitHub limit."
 }
 
 $comment | Out-File -FilePath $OutputPath -Encoding UTF8 -NoNewline

--- a/.github/skills/breaking-change-doc/Build-IssueComment.ps1
+++ b/.github/skills/breaking-change-doc/Build-IssueComment.ps1
@@ -51,8 +51,10 @@ $notificationEmailUrl = "mailto:dotnetbcn@microsoft.com?subject=$encodedEmailSub
 
 # Build a brief assignee mention line (if any)
 $mentionLine = ""
-if ($Assignees.Trim()) {
-    $mentionLine = "`n`n/cc $($Assignees.Trim())"
+$trimmedAssignees = ""
+if (-not [string]::IsNullOrWhiteSpace($Assignees)) {
+    $trimmedAssignees = $Assignees.Trim()
+    $mentionLine = "`n`n/cc $trimmedAssignees"
 }
 
 $comment = @"

--- a/.github/skills/breaking-change-doc/Build-IssueComment.ps1
+++ b/.github/skills/breaking-change-doc/Build-IssueComment.ps1
@@ -62,7 +62,7 @@ $comment = @"
 
 A breaking change draft has been prepared for this PR.
 
-:point_right: **[Click here to create the issue in dotnet/docs]($issueUrl)**
+:point_right: **[Click here to create the issue in $DocsRepo]($issueUrl)**
 
 After creating the issue, please email a link to it to
 [.NET Breaking Change Notifications]($notificationEmailUrl).$mentionLine
@@ -72,7 +72,8 @@ After creating the issue, please email a link to it to
 "@
 
 # GitHub comment body limit is 65536 characters. The comment is now brief,
-# but the URL itself can be very long. Warn if close to limits.
+# but the URL itself can be very long. Warn if the comment exceeds the
+# configured comment-length threshold; the URL length is checked separately below.
 $maxCommentLength = 65000
 if ($comment.Length -gt $maxCommentLength) {
     Write-Warning "Comment body ($($comment.Length) chars) exceeds GitHub limit."

--- a/.github/skills/breaking-change-doc/SKILL.md
+++ b/.github/skills/breaking-change-doc/SKILL.md
@@ -64,7 +64,7 @@ Extract the PR number. The source repository is always `dotnet/runtime`.
 
 Use GitHub tools to read comprehensive PR data. Collect **all** of the following:
 
-1. **PR metadata**: title, author, base branch, merge commit SHA, merged-at date, labels, state.
+1. **PR metadata**: title, author, assignees, base branch, merge commit SHA, merged-at date, labels, state.
 2. **PR body**: the full description.
 3. **Changed files**: list of file paths modified.
 4. **PR comments and reviews**: read all comments and review comments for context about the change's impact.
@@ -105,17 +105,23 @@ Run the helper script to determine the .NET version context:
 pwsh .github/skills/breaking-change-doc/Get-VersionInfo.ps1 -PrNumber <number>
 ```
 
-The script outputs JSON with:
+**You MUST display the complete script output.** The script outputs JSON with:
 - `LastTagBeforeMerge` — the closest release tag before the merge commit
 - `FirstTagWithChange` — the first tag that contains this commit (or "Not yet released")
 - `EstimatedVersion` — human-readable version string like ".NET 11 Preview 3"
 - `MergeCommit` — the merge commit SHA
 - `MergedAt` — when the PR was merged
 
-Use `EstimatedVersion` as the version for the breaking change issue.
+After running the script, **print the full JSON output** so it is visible in the
+workflow log. Then check the JSON:
 
-If the script returns an error, fall back to reading the PR's base branch and recent
-tags manually to estimate the version.
+- If the JSON contains an `Error` field, report the error and fall back to
+  reading the PR's base branch and recent tags manually to estimate the version.
+- If the JSON does **not** contain an `Error` field, use `EstimatedVersion` as
+  the version for the breaking change issue. **Do not fall back to manual
+  detection when the script succeeds.**
+
+Use `EstimatedVersion` as the version for the breaking change issue.
 
 ---
 
@@ -229,20 +235,31 @@ mkdir -p artifacts/docs/breakingChanges
 
 ### Build the PR comment file
 
-Run the helper script to produce a PR comment with a URL-encoded issue link:
+Run the helper script to produce a PR comment with a URL-encoded issue link.
+Pass the PR assignees so they are `@`-mentioned in the comment and receive a
+GitHub notification:
 
 ```bash
 pwsh .github/skills/breaking-change-doc/Build-IssueComment.ps1 \
   -IssueDraftPath artifacts/docs/breakingChanges/issue-draft.md \
   -Title "<the [Breaking change]: ... title from Step 5>" \
+  -Assignees "@user1 @user2" \
   -OutputPath artifacts/docs/breakingChanges/pr-comment.md
 ```
+
+Build the `-Assignees` value from the PR's assignee list (from Step 1 metadata),
+prefixing each GitHub username with `@` and separating with spaces.
 
 The script:
 - URL-encodes the title, body, and labels using `[Uri]::EscapeDataString`
 - Builds a clickable `https://github.com/dotnet/docs/issues/new?...` link
-- Writes `pr-comment.md` containing the full draft, the link, and an email reminder
+- Writes a **brief** `pr-comment.md` with instructions, the link, an email
+  reminder, and `/cc` mentions of the assignees
 - Warns if the URL exceeds browser length limits
+
+The comment intentionally does **not** duplicate the full issue draft. The draft
+is available in the `issue-draft.md` workflow artifact and is pre-filled in the
+issue creation link.
 
 ### Post the comment
 

--- a/.github/skills/breaking-change-doc/SKILL.md
+++ b/.github/skills/breaking-change-doc/SKILL.md
@@ -121,8 +121,6 @@ workflow log. Then check the JSON:
   the version for the breaking change issue. **Do not fall back to manual
   detection when the script succeeds.**
 
-Use `EstimatedVersion` as the version for the breaking change issue.
-
 ---
 
 ## Step 3: Check for Existing Documentation

--- a/.github/skills/breaking-change-doc/SKILL.md
+++ b/.github/skills/breaking-change-doc/SKILL.md
@@ -105,12 +105,13 @@ Run the helper script to determine the .NET version context:
 pwsh .github/skills/breaking-change-doc/Get-VersionInfo.ps1 -PrNumber <number>
 ```
 
-**You MUST display the complete script output.** The script outputs JSON with:
+**You MUST display the complete script output.** The script outputs JSON that includes:
 - `LastTagBeforeMerge` — the closest release tag before the merge commit
 - `FirstTagWithChange` — the first tag that contains this commit (or "Not yet released")
 - `EstimatedVersion` — human-readable version string like ".NET 11 Preview 3"
 - `MergeCommit` — the merge commit SHA
 - `MergedAt` — when the PR was merged
+- `BaseRef` — the PR base branch used to determine version context
 
 After running the script, **print the full JSON output** so it is visible in the
 workflow log. Then check the JSON:


### PR DESCRIPTION
1. Agent is sometimes ignoring the result of the version calculation script - make it more clear how to handle results.
2. Comment was duplicating issue body.  Remove this.
3. Tag the PR's assignees to get attention.