### PR TITLE
Remove contract system support for RETURN/RETVAL/POSTCONDITION

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5763,13 +5763,12 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
 MethodDesc * ClrDataAccess::FindLoadedMethodRefOrDef(Module* pModule,
     mdToken memberRef)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Must have a MemberRef or a MethodDef
     mdToken tkType = TypeFromToken(memberRef);
@@ -5777,10 +5776,10 @@ MethodDesc * ClrDataAccess::FindLoadedMethodRefOrDef(Module* pModule,
 
     if (tkType == mdtMemberRef)
     {
-        RETURN pModule->LookupMemberRefAsMethod(memberRef);
+        return pModule->LookupMemberRefAsMethod(memberRef);
     }
 
-    RETURN pModule->LookupMethodDef(memberRef);
+    return pModule->LookupMethodDef(memberRef);
 } // FindLoadedMethodRefOrDef
 
 //

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1107,7 +1107,6 @@ DebuggerController::DebuggerController(Thread * pThread, AppDomain * pAppDomain)
     {
         NOTHROW;
         GC_NOTRIGGER;
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1069,7 +1069,6 @@ HRESULT DebuggerController::Initialize()
 
     _ASSERTE(g_patches != NULL);
 
-    _ASSERTE((S_OK) == S_OK);
     return (S_OK);
 }
 

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -1030,17 +1030,15 @@ void DebuggerController::CancelOutstandingThreadStarter(Thread * pThread)
 // How: initializes the critical section
 HRESULT DebuggerController::Initialize()
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         // This can be called in an "early attach" case, so DebuggerIsInvolved()
         // will be b/c we don't realize the debugger's attaching to us.
         //PRECONDITION(DebuggerIsInvolved());
-        POSTCONDITION(CheckPointer(g_patches));
-        POSTCONDITION(RETVAL == S_OK);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (g_patches == NULL)
     {
@@ -1071,7 +1069,8 @@ HRESULT DebuggerController::Initialize()
 
     _ASSERTE(g_patches != NULL);
 
-    RETURN (S_OK);
+    _ASSERTE((S_OK) == S_OK);
+    return (S_OK);
 }
 
 
@@ -3114,7 +3113,7 @@ DPOSS_ACTION DebuggerController::DispatchPatchOrSingleStep(Thread *thread, CONTE
 #endif
 )
 {
-    CONTRACT(DPOSS_ACTION)
+    CONTRACTL
     {
         // @todo - should this throw or not?
         NOTHROW;
@@ -3126,9 +3125,8 @@ DPOSS_ACTION DebuggerController::DispatchPatchOrSingleStep(Thread *thread, CONTE
         PRECONDITION(CheckPointer(address));
         PRECONDITION(!HasLock());
 
-        POSTCONDITION(!HasLock()); // make sure we're not leaking the controller lock
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CONTRACT_VIOLATION(ThrowsViolation);
 
@@ -3145,7 +3143,8 @@ DPOSS_ACTION DebuggerController::DispatchPatchOrSingleStep(Thread *thread, CONTE
     {
 
         LOG((LF_CORDB|LF_ENC, LL_INFO1000, "DC::DPOSS returning, no patch table.\n"));
-        RETURN (used);
+        _ASSERTE(!HasLock());
+        return (used);
     }
     _ASSERTE(g_patches != NULL);
 
@@ -3340,7 +3339,8 @@ Exit:
 
     }
 
-    RETURN used;
+    _ASSERTE(!HasLock());
+    return used;
 }
 
 bool DebuggerController::IsSingleStepEnabled()

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -940,7 +940,6 @@ Debugger::Debugger()
     {
         WRAPPER(THROWS);
         WRAPPER(GC_TRIGGERS);
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -1170,7 +1170,6 @@ HRESULT Debugger::CheckInitModuleTable()
 
         if (pModules == NULL)
         {
-            _ASSERTE(m_pModules != NULL);
             return (E_OUTOFMEMORY);
         }
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -658,13 +658,12 @@ Debugger *CreateDebugger(void)
 extern "C"{
 HRESULT __cdecl CorDBGetInterface(DebugInterface** rcInterface)
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         NOTHROW; // use HRESULTS instead
         GC_NOTRIGGER;
-        POSTCONDITION(FAILED(RETVAL) || (rcInterface == NULL) || (*rcInterface != NULL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hr = S_OK;
 
@@ -685,7 +684,8 @@ HRESULT __cdecl CorDBGetInterface(DebugInterface** rcInterface)
         *rcInterface = g_pDebugger;
     }
 
-    RETURN hr;
+    _ASSERTE(FAILED(hr) || (rcInterface == NULL) || (*rcInterface != NULL));
+    return hr;
 }
 }
 
@@ -1158,13 +1158,12 @@ HRESULT Debugger::CheckInitMethodInfoTable()
 // Checks if the m_pModules table has been allocated, and if not does so.
 HRESULT Debugger::CheckInitModuleTable()
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(m_pModules != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pModules == NULL)
     {
@@ -1172,7 +1171,8 @@ HRESULT Debugger::CheckInitModuleTable()
 
         if (pModules == NULL)
         {
-            RETURN (E_OUTOFMEMORY);
+            _ASSERTE(m_pModules != NULL);
+            return (E_OUTOFMEMORY);
         }
 
         if (InterlockedCompareExchangeT(&m_pModules, pModules, NULL) != NULL)
@@ -1181,19 +1181,19 @@ HRESULT Debugger::CheckInitModuleTable()
         }
     }
 
-    RETURN (S_OK);
+    _ASSERTE(m_pModules != NULL);
+    return (S_OK);
 }
 
 // Checks if the m_pModules table has been allocated, and if not does so.
 HRESULT Debugger::CheckInitPendingFuncEvalTable()
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(GetPendingEvals() != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifndef DACCESS_COMPILE
 
@@ -1203,7 +1203,7 @@ HRESULT Debugger::CheckInitPendingFuncEvalTable()
 
         if (pPendingEvals == NULL)
         {
-            RETURN(E_OUTOFMEMORY);
+            return(E_OUTOFMEMORY);
         }
 
         // Since we're setting, we need an LValue and not just an accessor.
@@ -1214,7 +1214,8 @@ HRESULT Debugger::CheckInitPendingFuncEvalTable()
     }
 #endif
 
-    RETURN (S_OK);
+    _ASSERTE(GetPendingEvals() != NULL);
+    return (S_OK);
 }
 
 

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -2350,37 +2350,37 @@ DebuggerMethodInfo *DebuggerMethodInfoTable::GetMethodInfo(Module *pModule, mdMe
 
 DebuggerMethodInfo *DebuggerMethodInfoTable::GetFirstMethodInfo(HASHFIND *info)
 {
-    CONTRACT(DebuggerMethodInfo*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
 
         PRECONDITION(CheckPointer(info));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(g_pDebugger->HasDebuggerDataLock());
 
     DebuggerMethodInfoEntry *entry = PTR_DebuggerMethodInfoEntry
         (PTR_HOST_TO_TADDR(FindFirstEntry(info)));
     if (entry == NULL)
-        RETURN NULL;
+        return NULL;
     else
-        RETURN entry->mi;
+        {
+            return entry->mi;
+        }
 }
 
 DebuggerMethodInfo *DebuggerMethodInfoTable::GetNextMethodInfo(HASHFIND *info)
 {
-    CONTRACT(DebuggerMethodInfo*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
 
         PRECONDITION(CheckPointer(info));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(g_pDebugger->HasDebuggerDataLock());
 
@@ -2398,9 +2398,11 @@ DebuggerMethodInfo *DebuggerMethodInfoTable::GetNextMethodInfo(HASHFIND *info)
     }
 
     if (entry == NULL)
-        RETURN NULL;
+        return NULL;
     else
-        RETURN entry->mi;
+        {
+            return entry->mi;
+        }
 }
 
 

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1401,7 +1401,6 @@ DebuggerMethodInfo::DebuggerMethodInfo(Module *module, mdMethodDef token) :
     {
         WRAPPER(THROWS);
         WRAPPER(GC_TRIGGERS);
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 
@@ -2113,7 +2112,6 @@ DebuggerMethodInfoTable::DebuggerMethodInfoTable() : CHashTableAndData<CNewZeroD
         WRAPPER(THROWS);
         GC_NOTRIGGER;
 
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -116,14 +116,13 @@ HANDLE CreateWin32EventOrThrow(
     BOOL bInitialState
 )
 {
-    CONTRACT(HANDLE)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(lpEventAttributes, NULL_OK));
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HANDLE h = NULL;
     h = CreateEvent(lpEventAttributes, (BOOL) eType, bInitialState, NULL);
@@ -131,7 +130,8 @@ HANDLE CreateWin32EventOrThrow(
     if (h == NULL)
         ThrowLastError();
 
-    RETURN h;
+    _ASSERTE(h != NULL);
+    return h;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/coreclr/debug/ee/rcthread.cpp
+++ b/src/coreclr/debug/ee/rcthread.cpp
@@ -39,7 +39,6 @@ DebuggerRCThread::DebuggerRCThread(Debugger * pDebugger)
     {
         WRAPPER(THROWS);
         GC_NOTRIGGER;
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/debug/inc/dacdbistructures.inl
+++ b/src/coreclr/debug/inc/dacdbistructures.inl
@@ -63,11 +63,11 @@ template<class T>
 inline
 void DacDbiArrayList<T>::Dealloc()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pList != NULL)
     {
@@ -75,7 +75,7 @@ void DacDbiArrayList<T>::Dealloc()
         m_pList = NULL;
     }
     m_nEntries = 0;
-    RETURN;
+    return;
 }
 
 // Alloc and Init are very similar.  Both preallocate the array; but Alloc leaves the

--- a/src/coreclr/gc/env/gcenv.base.h
+++ b/src/coreclr/gc/env/gcenv.base.h
@@ -392,7 +392,6 @@ inline void* ALIGN_DOWN(void* ptr, size_t alignment)
 #define SUPPORTS_DAC
 #define FORBID_FAULT
 #define CONTRACTL_END
-#define CONTRACT_END
 #define TRIGGERSGC()
 #define WRAPPER(_contract)
 #define DISABLED(_contract)
@@ -405,8 +404,6 @@ inline void* ALIGN_DOWN(void* ptr, size_t alignment)
 #define END_GETTHREAD_ALLOWED
 #define LEAF_DAC_CONTRACT
 #define PRECONDITION(_expr)
-#define POSTCONDITION(_expr)
-#define RETURN return
 #define CONDITIONAL_CONTRACT_VIOLATION(_violation, _expr)
 
 // -----------------------------------------------------------------------------------------------------------

--- a/src/coreclr/inc/contract.h
+++ b/src/coreclr/inc/contract.h
@@ -72,9 +72,6 @@
 //
 //      INSTANCE_CHECK -    equivalent of:
 //                          PRECONDITION(CheckPointer(this));
-//      INSTANCE_CHECK_NULL - equivalent of:
-//                          PRECONDITION(CheckPointer(this, NULL_OK));
-//      CONSTRUCTOR_CHECK - (no-op, reserved for future use)
 //      DESTRUCTOR_CHECK -  equivalent of:
 //                          PRECONDITION(CheckPointer(this));
 //
@@ -1089,14 +1086,6 @@ static UINT ___testmask;
         if ((___op&Contract::Preconditions) && !___disabled)                                \
             ASSERT_CHECK(CheckPointer(this), NULL, "Instance precheck failure");
 
-#define INSTANCE_CHECK_NULL                                                                 \
-        ___CheckMustBeInside_CONTRACT;                                                      \
-        if ((___op&Contract::Preconditions) && !___disabled)                                \
-            ASSERT_CHECK(CheckPointer(this, NULL_OK), NULL, "Instance precheck failure");
-
-#define CONSTRUCTOR_CHECK                                                                   \
-        ___CheckMustBeInside_CONTRACT;
-
 #define DESTRUCTOR_CHECK                                                                    \
         ___CheckMustBeInside_CONTRACT;                                                      \
         NOTHROW;                                                                            \
@@ -1108,8 +1097,6 @@ static UINT ___testmask;
 #define PRECONDITION_MSG(_expression, _message)     do { } while(0)
 #define PRECONDITION(_expression)                   do { } while(0)
 #define INSTANCE_CHECK
-#define INSTANCE_CHECK_NULL
-#define CONSTRUCTOR_CHECK
 #define DESTRUCTOR_CHECK
 
 #endif // __DISABLE_PREPOST_CONDITIONS__
@@ -1217,8 +1204,6 @@ static UINT ___testmask;
 #define PRECONDITION_MSG(_expression, _message)     do { } while(0)
 #define PRECONDITION(_expression)                   do { } while(0)
 #define INSTANCE_CHECK
-#define INSTANCE_CHECK_NULL
-#define CONSTRUCTOR_CHECK
 #define DESTRUCTOR_CHECK
 #define UNCHECKED(thecheck)
 #define DISABLED(thecheck)

--- a/src/coreclr/inc/contract.h
+++ b/src/coreclr/inc/contract.h
@@ -69,19 +69,12 @@
 //      PRECONDITION(X) -   generic CHECK or BOOL expression which should be true
 //                          on function entry
 //
-//      POSTCONDITION(X) -  generic CHECK or BOOL expression which should be true
-//                          on function entry.  Note that variable RETVAL will be
-//                          available for use in the expression.
-//
 //
 //      INSTANCE_CHECK -    equivalent of:
 //                          PRECONDITION(CheckPointer(this));
-//                          POSTCONDITION(CheckInvariant(this));
 //      INSTANCE_CHECK_NULL - equivalent of:
 //                          PRECONDITION(CheckPointer(this, NULL_OK));
-//                          POSTCONDITION(CheckInvariant(this, NULL_OK));
-//      CONSTRUCTOR_CHECK - equivalent of:
-//                          POSTCONDITION(CheckPointer(this));
+//      CONSTRUCTOR_CHECK - (no-op, reserved for future use)
 //      DESTRUCTOR_CHECK -  equivalent of:
 //                          PRECONDITION(CheckPointer(this));
 //
@@ -91,17 +84,7 @@
 //   Contracts come in the following flavors:
 //
 //     Dynamic:
-//        CONTRACTL          the standard version used for all dynamic contracts
-//                           except those including postconditions.
-//
-//        CONTRACT(rettype)  an uglier version of CONTRACTL that's unfortunately
-//                           needed to support postconditions. You must specify
-//                           the correct return type and it cannot be "void."
-//                           (Use CONTRACT_VOID instead) You must use the
-//                           RETURN macro rather than the "return" keyword.
-//
-//        CONTRACT_VOID      you can't supply "void" to a CONTRACT - use this
-//                           instead.
+//        CONTRACTL          the standard version used for all dynamic contracts.
 //
 //     Static:
 //        LIMITED_METHOD_CONTRACT
@@ -995,9 +978,6 @@ static UINT ___testmask;
 
 #ifndef __FORCE_NORUNTIME_CONTRACTS__
 
-#define CONTRACT_SETUP(_contracttype, _returntype, _returnexp)          \
-    CONTRACTL_SETUP(_contracttype)
-
 #define CONTRACTL_SETUP(_contracttype)                                  \
     _contracttype ___contract;                                          \
     BOOL ___contract_enabled = Contract::EnforceContract();             \
@@ -1018,12 +998,6 @@ static UINT ___testmask;
 
 #else // #ifndef __FORCE_NORUNTIME_CONTRACTS__
 
-#define CONTRACT_SETUP(_contracttype, _returntype, _returnexp)              \
-    CONTRACTL_SETUP(_contracttype)
-
-
-
-
 #define CONTRACTL_SETUP(_contracttype)                                  \
     BOOL ___contract_enabled = Contract::EnforceContract();             \
     enum {___disabled = 0};                                             \
@@ -1036,22 +1010,16 @@ static UINT ___testmask;
           ___run_preconditions:                                         \
             ___op = Contract::Preconditions;                            \
         }                                                               \
-        if (0)                                                          \
-        {                                                               \
-        /* define for CONTRACT_END even though we can't get here */     \
-          ___run_return:                                                \
-            UNREACHABLE();                                              \
-        }                                                               \
         UINT ___testmask = 0;                                           \
 
 #endif // __FORCE_NORUNTIME_CONTRACTS__
 
 
 #define CUSTOM_CONTRACT(_contracttype, _returntype)                     \
-        CONTRACT_SETUP(_contracttype, _returntype, RETVAL)
+        CONTRACTL_SETUP(_contracttype)
 
 #define CUSTOM_CONTRACT_VOID(_contracttype)                             \
-        CONTRACT_SETUP(_contracttype, int, ;)
+        CONTRACTL_SETUP(_contracttype)
 
 #define CUSTOM_CONTRACTL(_contracttype)                                 \
         CONTRACTL_SETUP(_contracttype)
@@ -1115,16 +1083,6 @@ static UINT ___testmask;
 
 #define PRECONDITION(_expression)                                                           \
         PRECONDITION_MSG(_expression, NULL)
-
-#define POSTCONDITION_MSG(_expression, _message)                                            \
-        ++___ran;                                                                           \
-        if ((!(0 && __PostConditionOK::safe_to_use_postcondition())) &&                     \
-            (___op&Contract::Postconditions) &&                                             \
-            !___disabled)                                                                   \
-        {                                                                                   \
-            ASSERT_CHECK(_expression, _message, "Postcondition failure");                   \
-        }
-
 
 #define INSTANCE_CHECK                                                                      \
         ___CheckMustBeInside_CONTRACT;                                                      \

--- a/src/coreclr/inc/contract.h
+++ b/src/coreclr/inc/contract.h
@@ -801,18 +801,6 @@ inline LPVOID GetViolationMask()
     }
 }
 
-// This is the default binding of the MAYBETEMPLATE identifier,
-// used in the RETURN macro
-template <int DUMMY>
-class ___maybetemplate
-{
-  public:
-    FORCEINLINE void *operator new (size_t size)
-    {
-        return NULL;
-    }
-};
-
 // This is an abstract base class for contracts. The main reason we have this is so that the dtor for many derived class can
 // be performant. If this class was not abstract and had a dtor, then the dtor for the derived class adds EH overhead (even if the derived
 // class did not anything special in its dtor)
@@ -886,7 +874,6 @@ class BaseContract
     {
         Setup = 0x01,
         Preconditions = 0x02,
-        Postconditions = 0x04,
     };
 
 
@@ -927,124 +914,6 @@ class BaseContract
     ContractStackRecord m_contractStackRecord;
 
   public:
-    // --------------------------------------------------------------------------------
-    // These classes and declarations are used to implement our fake return keyword.
-    // --------------------------------------------------------------------------------
-
-    // ___box is used to protect the "detected" return value from being combined with other parts
-    // of the return expression after we have processed it.  This can happen if the return
-    // expression is a non-parenthesized expression with an operator of lower precedence than
-    // ">".
-    //
-    // If you have such a case (and see this class listed in an error message),
-    // parenthesize your return value expression.
-    template <typename T>
-    class Box__USE_PARENS_WITH_THIS_EXPRESSION
-    {
-        const T &value;
-
-    public:
-
-        FORCEINLINE Box__USE_PARENS_WITH_THIS_EXPRESSION(const T &value)
-          : value(value)
-          {
-          }
-
-        FORCEINLINE const T& Unbox()
-          {
-              return value;
-          }
-    };
-
-    // PseudoTemplate is a class which can be instantiated with a template-like syntax, resulting
-    // in an expression which simply boxes a following value in a Box
-
-    template <typename T>
-    class PseudoTemplate
-    {
-      public:
-        FORCEINLINE void *operator new (size_t size)
-        {
-            return NULL;
-        }
-
-        FORCEINLINE Box__USE_PARENS_WITH_THIS_EXPRESSION<T> operator>(const T &value)
-        {
-            return Box__USE_PARENS_WITH_THIS_EXPRESSION<T>(value);
-        }
-
-        FORCEINLINE PseudoTemplate operator<(int dummy)
-        {
-            return PseudoTemplate();
-        }
-    };
-
-    // Returner is used to assign the return value to the RETVAL local.  Note the use of
-    // operator , because of its low precedence.
-
-    template <typename RETURNTYPE>
-    class Returner
-    {
-        RETURNTYPE      &m_value;
-        BOOL            m_got;
-    public:
-
-        FORCEINLINE Returner(RETURNTYPE &value)
-          : m_value(value),
-            m_got(FALSE)
-        {
-        }
-
-        template <typename T>
-        FORCEINLINE RETURNTYPE operator,(Box__USE_PARENS_WITH_THIS_EXPRESSION<T> value)
-        {
-            m_value = value.Unbox();
-            m_got = TRUE;
-            return m_value;
-        }
-
-        FORCEINLINE void operator,(___maybetemplate<0> &dummy)
-        {
-            m_got = TRUE;
-        }
-
-        FORCEINLINE BOOL GotReturn()
-        {
-            return m_got;
-        }
-    };
-
-    // This type ensures that postconditions were run via RETURN or RETURN_VOID
-    class RanPostconditions
-    {
-    public:
-        bool ran;
-        int count;
-        const char *function;
-
-        FORCEINLINE RanPostconditions(const char *function)
-          : ran(false),
-            count(0),
-            function(function)
-        {
-        }
-
-        FORCEINLINE int operator++()
-        {
-            return ++count;
-        }
-
-        FORCEINLINE ~RanPostconditions()
-        {
-            // Note: __uncaught_exception() is not a perfect check. It will return TRUE during any exception
-            // processing. So, if there is a contract called from an exception filter (like our
-            // COMPlusFrameHandler) then it will return TRUE and the saftey check below will not be performed.
-            if (!__uncaught_exception())
-                ASSERT_CHECK(count == 0 || ran, function, "Didn't run postconditions - be sure to use RETURN at the end of the function");
-        }
-
-    };
-
     // Set contract enforcement level
     static void SetUnconditionalContractEnforcement(BOOL enforceUnconditionally);
 
@@ -1111,9 +980,8 @@ enum ContractViolationBits
 
 #ifdef ENABLE_CONTRACTS_IMPL
 
-// Global variables allow PRECONDITION and POSTCONDITION to be used outside contracts
-static const BaseContract::Operation ___op = (Contract::Operation) (Contract::Preconditions
-                                                                |Contract::Postconditions);
+// Global variables allow PRECONDITION to be used outside contracts
+static const BaseContract::Operation ___op = Contract::Preconditions;
 enum {
     ___disabled = 0
 };
@@ -1122,62 +990,13 @@ static UINT ___testmask;
 
 // End of global variables
 
-static int ___ran;
-
-class __SafeToUsePostCondition {
-public:
-    static int safe_to_use_postcondition() {return 0;};
-};
-
-class __YouCannotUseAPostConditionHere {
-private:
-    static int safe_to_use_postcondition() {return 0;};
-};
-
-typedef __SafeToUsePostCondition __PostConditionOK;
-
-// Uncomment the following line to disable runtime contracts completely - PRE/POST conditions will still be present
+// Uncomment the following line to disable runtime contracts completely
 //#define __FORCE_NORUNTIME_CONTRACTS__ 1
 
 #ifndef __FORCE_NORUNTIME_CONTRACTS__
 
 #define CONTRACT_SETUP(_contracttype, _returntype, _returnexp)          \
-    _returntype RETVAL;                                                 \
-    _contracttype ___contract;                                          \
-    Contract::Returner<_returntype> ___returner(RETVAL);                \
-    Contract::RanPostconditions ___ran(__FUNCTION__);                   \
-    Contract::Operation ___op = Contract::Setup;                        \
-    BOOL ___contract_enabled = FALSE;                                   \
-    ___contract_enabled = Contract::EnforceContract();                  \
-    enum {___disabled = 0};                                             \
-    if (!___contract_enabled)                                           \
-        ___contract.Disable();                                          \
-    else                                                                \
-    {                                                                   \
-        enum { ___CheckMustBeInside_CONTRACT = 1 };                     \
-        if (0)                                                          \
-        {                                                               \
-        /* If you see an "unreferenced label" warning with this name, */\
-        /* Be sure that you have a RETURN at the end of your */         \
-        /* CONTRACT_VOID function */                                    \
-        ___run_postconditions_DID_YOU_FORGET_A_RETURN:                  \
-            if (___contract_enabled)                                    \
-            {                                                           \
-                ___op = Contract::Postconditions;                       \
-                ___ran.ran = true;                                      \
-            }                                                           \
-            else                                                        \
-            {                                                           \
-              ___run_return:                                            \
-                return _returnexp;                                      \
-            }                                                           \
-        }                                                               \
-        if (0)                                                          \
-        {                                                               \
-        ___run_preconditions:                                           \
-            ___op = Contract::Preconditions;                            \
-        }                                                               \
-        UINT ___testmask = 0;                                           \
+    CONTRACTL_SETUP(_contracttype)
 
 #define CONTRACTL_SETUP(_contracttype)                                  \
     _contracttype ___contract;                                          \
@@ -1187,7 +1006,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
         ___contract.Disable();                                          \
     else                                                                \
     {                                                                   \
-        typedef __YouCannotUseAPostConditionHere __PostConditionOK;     \
         enum { ___CheckMustBeInside_CONTRACT = 1 };                     \
         Contract::Operation ___op = Contract::Setup;                    \
         enum {___disabled = 0};                                         \
@@ -1196,48 +1014,12 @@ typedef __SafeToUsePostCondition __PostConditionOK;
           ___run_preconditions:                                         \
             ___op = Contract::Preconditions;                            \
         }                                                               \
-        if (0)                                                          \
-        {                                                               \
-        /* define for CONTRACT_END even though we can't get here */     \
-          ___run_return:                                                \
-            UNREACHABLE();                                              \
-        }                                                               \
         UINT ___testmask = 0;                                           \
 
 #else // #ifndef __FORCE_NORUNTIME_CONTRACTS__
 
 #define CONTRACT_SETUP(_contracttype, _returntype, _returnexp)              \
-        _returntype RETVAL;                                                 \
-        Contract::Returner<_returntype> ___returner(RETVAL);                \
-        Contract::RanPostconditions ___ran(__FUNCTION__);                   \
-        Contract::Operation ___op = Contract::Setup;                        \
-        BOOL ___contract_enabled = Contract::EnforceContract();             \
-        enum {___disabled = 0};                                             \
-        {                                                                   \
-            enum { ___CheckMustBeInside_CONTRACT = 1 };                     \
-            if (0)                                                          \
-            {                                                               \
-            /* If you see an "unreferenced label" warning with this name, */\
-            /* Be sure that you have a RETURN at the end of your */         \
-            /* CONTRACT_VOID function */                                    \
-            ___run_postconditions_DID_YOU_FORGET_A_RETURN:                  \
-                if (___contract_enabled)                                    \
-                {                                                           \
-                    ___op = Contract::Postconditions;                       \
-                    ___ran.ran = true;                                      \
-                }                                                           \
-                else                                                        \
-                {                                                           \
-                  ___run_return:                                            \
-                    return _returnexp;                                      \
-                }                                                           \
-            }                                                               \
-            if (0)                                                          \
-            {                                                               \
-            ___run_preconditions:                                           \
-                ___op = Contract::Preconditions;                            \
-            }                                                               \
-            UINT ___testmask = 0;                                           \
+    CONTRACTL_SETUP(_contracttype)
 
 
 
@@ -1246,7 +1028,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
     BOOL ___contract_enabled = Contract::EnforceContract();             \
     enum {___disabled = 0};                                             \
     {                                                                   \
-        typedef __YouCannotUseAPostConditionHere __PostConditionOK;     \
             enum { ___CheckMustBeInside_CONTRACT = 1 };                 \
         Contract::Operation ___op = Contract::Setup;                    \
         enum {___disabled = 0};                                         \
@@ -1267,7 +1048,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
 
 
 #define CUSTOM_CONTRACT(_contracttype, _returntype)                     \
-        typedef Contract::PseudoTemplate<_returntype> ___maybetemplate; \
         CONTRACT_SETUP(_contracttype, _returntype, RETVAL)
 
 #define CUSTOM_CONTRACT_VOID(_contracttype)                             \
@@ -1345,30 +1125,19 @@ typedef __SafeToUsePostCondition __PostConditionOK;
             ASSERT_CHECK(_expression, _message, "Postcondition failure");                   \
         }
 
-#define POSTCONDITION(_expression)                                                          \
-        POSTCONDITION_MSG(_expression, NULL)
 
 #define INSTANCE_CHECK                                                                      \
         ___CheckMustBeInside_CONTRACT;                                                      \
         if ((___op&Contract::Preconditions) && !___disabled)                                \
-            ASSERT_CHECK(CheckPointer(this), NULL, "Instance precheck failure");            \
-        ++___ran;                                                                           \
-        if ((___op&Contract::Postconditions) && !___disabled)                               \
-            ASSERT_CHECK(CheckPointer(this), NULL, "Instance postcheck failure");
+            ASSERT_CHECK(CheckPointer(this), NULL, "Instance precheck failure");
 
 #define INSTANCE_CHECK_NULL                                                                 \
         ___CheckMustBeInside_CONTRACT;                                                      \
         if ((___op&Contract::Preconditions) && !___disabled)                                \
-            ASSERT_CHECK(CheckPointer(this, NULL_OK), NULL, "Instance precheck failure");   \
-        ++___ran;                                                                           \
-        if ((___op&Contract::Postconditions) && !___disabled)                               \
-            ASSERT_CHECK(CheckPointer(this, NULL_OK), NULL, "Instance postcheck failure");
+            ASSERT_CHECK(CheckPointer(this, NULL_OK), NULL, "Instance precheck failure");
 
 #define CONSTRUCTOR_CHECK                                                                   \
-        ___CheckMustBeInside_CONTRACT;                                                      \
-        ++___ran;                                                                           \
-        if ((___op&Contract::Postconditions) && !___disabled)                               \
-            ASSERT_CHECK(CheckPointer(this), NULL, "Instance postcheck failure");
+        ___CheckMustBeInside_CONTRACT;
 
 #define DESTRUCTOR_CHECK                                                                    \
         ___CheckMustBeInside_CONTRACT;                                                      \
@@ -1380,8 +1149,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
 
 #define PRECONDITION_MSG(_expression, _message)     do { } while(0)
 #define PRECONDITION(_expression)                   do { } while(0)
-#define POSTCONDITION_MSG(_expression, _message)    do { } while(0)
-#define POSTCONDITION(_expression)                  do { } while(0)
 #define INSTANCE_CHECK
 #define INSTANCE_CHECK_NULL
 #define CONSTRUCTOR_CHECK
@@ -1415,10 +1182,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
                 goto ___run_preconditions;                                                  \
             }                                                                               \
         }                                                                                   \
-        else if (___op & Contract::Postconditions)                                          \
-        {                                                                                   \
-            goto ___run_return;                                                             \
-        }                                                                                   \
         ___CheckMustBeInside_CONTRACT;                                                      \
    }
 
@@ -1432,10 +1195,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
                 goto ___run_preconditions;                                                  \
             }                                                                               \
         }                                                                                   \
-        else if (___op & Contract::Postconditions)                                          \
-        {                                                                                   \
-            goto ___run_return;                                                             \
-        }                                                                                   \
         ___CheckMustBeInside_CONTRACT;                                                      \
    }                                                                                        \
 
@@ -1443,51 +1202,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
 
 #define CONTRACT_END   CONTRACTL_END
 
-
-// The final expression in the RETURN macro deserves special explanation (or something.)
-// The expression is constructed so as to be syntactically ambiguous, depending on whether
-// __maybetemplate is a template or not.  If it is a template, the expression is syntactically
-// correct as-is.  If it is not, the angle brackets are interpreted as
-// less than & greater than, and the expression is incomplete.  This is the point - we can
-// choose whether we need an expression or not based on the context in which the macro is used.
-// This allows the same RETURN macro to be used both in value-returning and void-returning
-// contracts.
-//
-// The "__returner ," portion of the expression is used instead of "RETVAL =", since ","
-// has lower precedence than "=". (Ain't overloaded operators fun.)
-//
-// Also note that the < and > operators on the non-template version of __maybetemplate
-// are overridden to "box" the return value in a special type and pass it
-// through to the __returner's "," operator.  This is so we can detect a case where an
-// operator with lower precedence than ">" is in the return expression - in such a case we
-// will get a type error message, which instructs that parens be placed around the return
-// value expression.
-
-#define RETURN_BODY                                                                         \
-    if (___returner.GotReturn())                                                            \
-        goto ___run_postconditions_DID_YOU_FORGET_A_RETURN;                                 \
-    else                                                                                    \
-        ___returner, * new ___maybetemplate < 0 >
-
-
-// We have two versions of the RETURN macro.  CONTRACT_RETURN is for use inside the CONTRACT
-// scope where it is OK to return this way, even though the CONTRACT macro itself does not
-// allow a return.  RETURN is for use inside the function body where it might not be OK
-// to return and we need to ensure that we don't allow a return where one should not happen
-//
-#define RETURN                                                                              \
-    while (TRUE)                                                                            \
-        RETURN_BODY                                                                         \
-
-#define RETURN_VOID                                                                         \
-    RETURN
-
-#define CONTRACT_RETURN                                                                     \
-    while (___CheckMustBeInside_CONTRACT, TRUE)                                             \
-        RETURN_BODY                                                                         \
-
-#define CONTRACT_RETURN_VOID                                                                \
-    CONTRACT_RETURN                                                                         \
 
 #if 0
 #define CUSTOM_LIMITED_METHOD_CONTRACT(_contracttype)                                                 \
@@ -1544,8 +1258,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
 
 #define PRECONDITION_MSG(_expression, _message)     do { } while(0)
 #define PRECONDITION(_expression)                   do { } while(0)
-#define POSTCONDITION_MSG(_expression, _message)    do { } while(0)
-#define POSTCONDITION(_expression)                  do { } while(0)
 #define INSTANCE_CHECK
 #define INSTANCE_CHECK_NULL
 #define CONSTRUCTOR_CHECK
@@ -1569,8 +1281,6 @@ typedef __SafeToUsePostCondition __PostConditionOK;
     }
 
 
-#define RETURN return
-#define RETURN_VOID RETURN
 
 #define CONTRACT_THROWS()
 #define CONTRACT_THROWSEX(__func, __file, __line)

--- a/src/coreclr/inc/cordecoderhelpers.h
+++ b/src/coreclr/inc/cordecoderhelpers.h
@@ -119,7 +119,7 @@ inline BOOL HasStrongNameSignature(const TDecoder& decoder)
 template<typename TDecoder>
 inline PTR_CVOID GetMetadata(const TDecoder& decoder, COUNT_T *pSize)
 {
-    CONTRACT(PTR_CVOID)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -127,7 +127,7 @@ inline PTR_CVOID GetMetadata(const TDecoder& decoder, COUNT_T *pSize)
         PRECONDITION(decoder.CheckCorHeader());
         PRECONDITION(CheckPointer(pSize, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_DATA_DIRECTORY *pDir = &decoder.GetCorHeader()->MetaData;
 
@@ -136,9 +136,9 @@ inline PTR_CVOID GetMetadata(const TDecoder& decoder, COUNT_T *pSize)
 
     RVA rva = VAL32(pDir->VirtualAddress);
     if (rva == 0)
-        RETURN NULL;
+        return NULL;
 
-    RETURN dac_cast<PTR_VOID>(decoder.GetRvaData(rva));
+    return dac_cast<PTR_VOID>(decoder.GetRvaData(rva));
 }
 
 // ------------------------------------------------------------
@@ -164,15 +164,15 @@ inline BOOL HasManagedEntryPoint(const TDecoder& decoder)
 template<typename TDecoder>
 inline ULONG GetEntryPointToken(const TDecoder& decoder)
 {
-    CONTRACT(ULONG)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(decoder.CheckCorHeader());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN VAL32(IMAGE_COR20_HEADER_FIELD(*decoder.GetCorHeader(), EntryPointToken));
+    return VAL32(IMAGE_COR20_HEADER_FIELD(*decoder.GetCorHeader(), EntryPointToken));
 }
 
 // ------------------------------------------------------------
@@ -182,14 +182,14 @@ inline ULONG GetEntryPointToken(const TDecoder& decoder)
 template<typename TDecoder>
 inline const void *GetResources(const TDecoder& decoder, COUNT_T *pSize)
 {
-    CONTRACT(const void *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(decoder.CheckCorHeader());
         PRECONDITION(CheckPointer(pSize, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_DATA_DIRECTORY *pDir = &decoder.GetCorHeader()->Resources;
 
@@ -198,9 +198,9 @@ inline const void *GetResources(const TDecoder& decoder, COUNT_T *pSize)
 
     RVA rva = VAL32(pDir->VirtualAddress);
     if (rva == 0)
-        RETURN NULL;
+        return NULL;
 
-    RETURN (void *)decoder.GetRvaData(rva);
+    return (void *)decoder.GetRvaData(rva);
 }
 
 template<typename TDecoder>
@@ -234,19 +234,19 @@ inline CHECK CheckResource(const TDecoder& decoder, COUNT_T offset)
 template<typename TDecoder>
 inline const void *GetResource(const TDecoder& decoder, COUNT_T offset, COUNT_T *pSize)
 {
-    CONTRACT(const void *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(decoder.CheckCorHeader());
         PRECONDITION(CheckPointer(pSize, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_DATA_DIRECTORY *pDir = &decoder.GetCorHeader()->Resources;
 
     if (CheckResource(decoder, offset) == FALSE)
-        RETURN NULL;
+        return NULL;
 
     void *resourceBlob = (void *)decoder.GetRvaData(VAL32(pDir->VirtualAddress) + offset);
     _ASSERTE(resourceBlob != NULL);
@@ -258,7 +258,7 @@ inline const void *GetResource(const TDecoder& decoder, COUNT_T offset, COUNT_T 
     }
 
     // ECMA-335 II.24.2.4: Each resource entry is preceded by a 4-byte length prefix.
-    RETURN (const void *)((BYTE *)resourceBlob + sizeof(DWORD));
+    return (const void *)((BYTE *)resourceBlob + sizeof(DWORD));
 }
 
 // ------------------------------------------------------------
@@ -268,31 +268,31 @@ inline const void *GetResource(const TDecoder& decoder, COUNT_T offset, COUNT_T 
 template<typename TDecoder>
 inline PTR_IMAGE_DEBUG_DIRECTORY GetDebugDirectoryEntry(const TDecoder& decoder, UINT index)
 {
-    CONTRACT(PTR_IMAGE_DEBUG_DIRECTORY)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!decoder.HasDirectoryEntry(IMAGE_DIRECTORY_ENTRY_DEBUG))
-        RETURN NULL;
+        return NULL;
 
     COUNT_T cbDebugDir;
     TADDR taDebugDir = decoder.GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_DEBUG, &cbDebugDir);
 
     if (taDebugDir == (TADDR)0)
-        RETURN NULL;
+        return NULL;
 
     UINT cNumEntries = cbDebugDir / sizeof(IMAGE_DEBUG_DIRECTORY);
     if (index >= cNumEntries)
-        RETURN NULL;
+        return NULL;
 
     PTR_IMAGE_DEBUG_DIRECTORY pDebugEntry = dac_cast<PTR_IMAGE_DEBUG_DIRECTORY>(taDebugDir);
     pDebugEntry += index;
 
-    RETURN pDebugEntry;
+    return pDebugEntry;
 }
 
 // ------------------------------------------------------------

--- a/src/coreclr/inc/pedecoder.inl
+++ b/src/coreclr/inc/pedecoder.inl
@@ -244,21 +244,21 @@ inline BOOL PEDecoder::Has32BitNTHeaders() const
 
 inline const void *PEDecoder::GetHeaders(COUNT_T *pSize) const
 {
-    CONTRACT(const void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     //even though some data in OptionalHeader is different for 32 and 64, this field is the same
     if (pSize != NULL)
         *pSize = VAL32(FindNTHeaders()->OptionalHeader.SizeOfHeaders);
 
-    RETURN (const void *) m_base;
+    _ASSERTE(CheckPointer((const void *) m_base));
+    return (const void *) m_base;
 }
 
 inline BOOL PEDecoder::IsDll() const
@@ -292,20 +292,19 @@ inline BOOL PEDecoder::HasBaseRelocations() const
 
 inline const void *PEDecoder::GetPreferredBase() const
 {
-    CONTRACT(const void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (Has32BitNTHeaders())
-        RETURN (const void *) (SIZE_T) VAL32(GetNTHeaders32()->OptionalHeader.ImageBase);
+        return (const void *) (SIZE_T) VAL32(GetNTHeaders32()->OptionalHeader.ImageBase);
     else
-        RETURN (const void *) (SIZE_T) VAL64(GetNTHeaders64()->OptionalHeader.ImageBase);
+        return (const void *) (SIZE_T) VAL64(GetNTHeaders64()->OptionalHeader.ImageBase);
 }
 
 inline COUNT_T PEDecoder::GetVirtualSize() const
@@ -518,25 +517,24 @@ inline BOOL PEDecoder::HasDirectoryEntry(int entry) const
 
 inline IMAGE_DATA_DIRECTORY *PEDecoder::GetDirectoryEntry(int entry) const
 {
-    CONTRACT(IMAGE_DATA_DIRECTORY *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (Has32BitNTHeaders())
-        RETURN dac_cast<PTR_IMAGE_DATA_DIRECTORY>(
+        return dac_cast<PTR_IMAGE_DATA_DIRECTORY>(
             dac_cast<TADDR>(GetNTHeaders32()) +
             offsetof(IMAGE_NT_HEADERS32, OptionalHeader.DataDirectory) +
             entry * sizeof(IMAGE_DATA_DIRECTORY));
     else
-        RETURN dac_cast<PTR_IMAGE_DATA_DIRECTORY>(
+        return dac_cast<PTR_IMAGE_DATA_DIRECTORY>(
             dac_cast<TADDR>(GetNTHeaders64()) +
             offsetof(IMAGE_NT_HEADERS64, OptionalHeader.DataDirectory) +
             entry * sizeof(IMAGE_DATA_DIRECTORY));
@@ -544,7 +542,7 @@ inline IMAGE_DATA_DIRECTORY *PEDecoder::GetDirectoryEntry(int entry) const
 
 inline TADDR PEDecoder::GetDirectoryEntryData(int entry, COUNT_T *pSize) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -552,23 +550,22 @@ inline TADDR PEDecoder::GetDirectoryEntryData(int entry, COUNT_T *pSize) const
         PRECONDITION(CheckPointer(pSize, NULL_OK));
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer((void *)RETVAL, NULL_OK));
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_DATA_DIRECTORY *pDir = GetDirectoryEntry(entry);
 
     if (pSize != NULL)
         *pSize = VAL32(pDir->Size);
 
-    RETURN GetDirectoryData(pDir);
+    return GetDirectoryData(pDir);
 }
 
 inline TADDR PEDecoder::GetDirectoryData(IMAGE_DATA_DIRECTORY *pDir) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -576,17 +573,16 @@ inline TADDR PEDecoder::GetDirectoryData(IMAGE_DATA_DIRECTORY *pDir) const
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
-        POSTCONDITION(CheckPointer((void *)RETVAL, NULL_OK));
         CANNOT_TAKE_LOCK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetRvaData(VAL32(pDir->VirtualAddress));
+    return GetRvaData(VAL32(pDir->VirtualAddress));
 }
 
 inline TADDR PEDecoder::GetDirectoryData(IMAGE_DATA_DIRECTORY *pDir, COUNT_T *pSize) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -595,30 +591,28 @@ inline TADDR PEDecoder::GetDirectoryData(IMAGE_DATA_DIRECTORY *pDir, COUNT_T *pS
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
-        POSTCONDITION(CheckPointer((void *)RETVAL, NULL_OK));
         CANNOT_TAKE_LOCK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     *pSize = VAL32(pDir->Size);
 
-    RETURN GetRvaData(VAL32(pDir->VirtualAddress));
+    return GetRvaData(VAL32(pDir->VirtualAddress));
 }
 
 inline TADDR PEDecoder::GetInternalAddressData(SIZE_T address) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         PRECONDITION(CheckInternalAddress(address, NULL_OK));
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer((void *)RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetRvaData(InternalAddressToRva(address));
+    return GetRvaData(InternalAddressToRva(address));
 }
 
 inline BOOL PEDecoder::HasCorHeader() const
@@ -770,7 +764,7 @@ inline CHECK PEDecoder::CheckTls() const
 
 inline PTR_VOID PEDecoder::GetTlsRange(COUNT_T * pSize) const
 {
-    CONTRACT(void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -778,9 +772,8 @@ inline PTR_VOID PEDecoder::GetTlsRange(COUNT_T * pSize) const
         PRECONDITION(CheckTls());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_TLS_DIRECTORY *pTlsHeader =
         PTR_IMAGE_TLS_DIRECTORY(GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_TLS));
@@ -788,7 +781,7 @@ inline PTR_VOID PEDecoder::GetTlsRange(COUNT_T * pSize) const
     if (pSize != 0)
         *pSize = (COUNT_T) (VALPTR(pTlsHeader->EndAddressOfRawData) - VALPTR(pTlsHeader->StartAddressOfRawData));
     _ASSERTE (pTlsHeader!=NULL);
-    RETURN PTR_VOID(GetInternalAddressData(pTlsHeader->StartAddressOfRawData));
+    return PTR_VOID(GetInternalAddressData(pTlsHeader->StartAddressOfRawData));
 }
 
 inline UINT32 PEDecoder::GetTlsIndex() const
@@ -811,24 +804,24 @@ inline UINT32 PEDecoder::GetTlsIndex() const
 
 inline IMAGE_COR20_HEADER *PEDecoder::GetCorHeader() const
 {
-    CONTRACT(IMAGE_COR20_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         PRECONDITION(HasCorHeader());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pCorHeader == NULL)
         const_cast<PEDecoder *>(this)->m_pCorHeader =
             dac_cast<PTR_IMAGE_COR20_HEADER>(FindCorHeader());
 
-    RETURN m_pCorHeader;
+    _ASSERTE(m_pCorHeader != NULL);
+    return m_pCorHeader;
 }
 
 inline BOOL PEDecoder::IsNativeMachineFormat() const
@@ -889,52 +882,50 @@ inline DWORD PEDecoder::GetImageIdentity() const
 
 inline PTR_IMAGE_SECTION_HEADER PEDecoder::FindFirstSection() const
 {
-    CONTRACT(IMAGE_SECTION_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN FindFirstSection(FindNTHeaders());
+    return FindFirstSection(FindNTHeaders());
 }
 
 inline IMAGE_NT_HEADERS *PEDecoder::FindNTHeaders() const
 {
-    CONTRACT(IMAGE_NT_HEADERS *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN PTR_IMAGE_NT_HEADERS(m_base + VAL32(PTR_IMAGE_DOS_HEADER(m_base)->e_lfanew));
+    return PTR_IMAGE_NT_HEADERS(m_base + VAL32(PTR_IMAGE_DOS_HEADER(m_base)->e_lfanew));
 }
 
 inline IMAGE_COR20_HEADER *PEDecoder::FindCorHeader() const
 {
-    CONTRACT(IMAGE_COR20_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(HasCorHeader());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     const IMAGE_COR20_HEADER * pCor=PTR_IMAGE_COR20_HEADER(GetDirectoryEntryData(IMAGE_DIRECTORY_ENTRY_COMHEADER));
-    RETURN ((IMAGE_COR20_HEADER*)pCor);
+    _ASSERTE(CheckPointer(((IMAGE_COR20_HEADER*)pCor)));
+    return ((IMAGE_COR20_HEADER*)pCor);
 }
 
 inline CHECK PEDecoder::CheckBounds(RVA rangeBase, COUNT_T rangeSize, RVA rva)
@@ -1093,7 +1084,7 @@ inline BOOL PEDecoder::HasReadyToRunHeader() const
 
 inline READYTORUN_HEADER * PEDecoder::GetReadyToRunHeader() const
 {
-    CONTRACT(READYTORUN_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -1101,16 +1092,15 @@ inline READYTORUN_HEADER * PEDecoder::GetReadyToRunHeader() const
         PRECONDITION(HasReadyToRunHeader());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         SUPPORTS_DAC;
         CANNOT_TAKE_LOCK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pReadyToRunHeader != NULL)
-        RETURN m_pReadyToRunHeader;
+        return m_pReadyToRunHeader;
 
-    RETURN FindReadyToRunHeader();
+    return FindReadyToRunHeader();
 }
 
 #endif // _PEDECODER_INL_

--- a/src/coreclr/inc/pedecoder.inl
+++ b/src/coreclr/inc/pedecoder.inl
@@ -25,7 +25,6 @@ inline PEDecoder::PEDecoder()
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         CANNOT_TAKE_LOCK;
         GC_NOTRIGGER;
@@ -99,7 +98,6 @@ inline PEDecoder::PEDecoder(PTR_VOID mappedBase, bool fixedUp /*= FALSE*/)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(mappedBase));
         PRECONDITION(PEDecoder(mappedBase,fixedUp).CheckNTHeaders());
         THROWS;
@@ -136,7 +134,6 @@ inline PEDecoder::PEDecoder(void *flatBase, COUNT_T size)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(flatBase));
         NOTHROW;
         GC_NOTRIGGER;

--- a/src/coreclr/inc/sbuffer.inl
+++ b/src/coreclr/inc/sbuffer.inl
@@ -23,7 +23,7 @@ inline SBuffer::SBuffer(PreallocFlag flag, void *buffer, COUNT_T size)
     m_flags(0),
     m_buffer(NULL)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
@@ -32,7 +32,7 @@ inline SBuffer::SBuffer(PreallocFlag flag, void *buffer, COUNT_T size)
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     m_buffer = UseBuffer((BYTE *) buffer, &size);
     m_allocation = size;
@@ -41,7 +41,7 @@ inline SBuffer::SBuffer(PreallocFlag flag, void *buffer, COUNT_T size)
     m_revision = 0;
 #endif
 
-    RETURN;
+    return;
 }
 
 inline SBuffer::SBuffer()
@@ -50,19 +50,19 @@ inline SBuffer::SBuffer()
     m_flags(0),
     m_buffer(NULL)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     m_revision = 0;
 #endif
 
-    RETURN;
+    return;
 }
 
 inline SBuffer::SBuffer(COUNT_T size)
@@ -71,14 +71,14 @@ inline SBuffer::SBuffer(COUNT_T size)
     m_flags(0),
     m_buffer(NULL)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {;
         CONSTRUCTOR_CHECK;
         PRECONDITION(CheckSize(size));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Resize(size);
 
@@ -86,7 +86,7 @@ inline SBuffer::SBuffer(COUNT_T size)
     m_revision = 0;
 #endif
 
-    RETURN;
+    return;
 }
 
 inline SBuffer::SBuffer(const SBuffer &buffer)
@@ -95,15 +95,14 @@ inline SBuffer::SBuffer(const SBuffer &buffer)
     m_flags(0),
     m_buffer(NULL)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         PRECONDITION(buffer.Check());
-        POSTCONDITION(Equals(buffer));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Set(buffer);
 
@@ -111,20 +110,20 @@ inline SBuffer::SBuffer(const SBuffer &buffer)
     m_revision = 0;
 #endif
 
-    RETURN;
+    _ASSERTE(Equals(buffer));
+    return;
 }
 
 inline SBuffer::SBuffer(SBuffer &&buffer)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         PRECONDITION(buffer.Check());
-        POSTCONDITION(Check());
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     m_size = buffer.m_size;
     m_allocation = buffer.m_allocation;
@@ -137,7 +136,8 @@ inline SBuffer::SBuffer(SBuffer &&buffer)
 
     buffer.InitializeInstance();
 
-    RETURN;
+    _ASSERTE(Check());
+    return;
 }
 
 inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
@@ -146,16 +146,15 @@ inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
     m_flags(0),
     m_buffer(NULL)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(Equals(buffer, size));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Set(buffer, size);
 
@@ -163,7 +162,8 @@ inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
     m_revision = 0;
 #endif
 
-    RETURN;
+    _ASSERTE(Equals(buffer, size));
+    return;
 }
 
 
@@ -173,35 +173,35 @@ inline SBuffer::SBuffer(ImmutableFlag immutable, const BYTE *buffer, COUNT_T siz
     m_flags(IMMUTABLE),
     m_buffer(const_cast<BYTE*>(buffer))
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(Equals(buffer, size));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     m_revision = 0;
 #endif
 
-    RETURN;
+    _ASSERTE(Equals(buffer, size));
+    return;
 }
 
 inline SBuffer::~SBuffer()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         DESTRUCTOR_CHECK;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsAllocated())
     {
@@ -212,7 +212,7 @@ inline SBuffer::~SBuffer()
     m_revision = 0;
 #endif
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::InitializeInstance()
@@ -229,16 +229,15 @@ inline void SBuffer::InitializeInstance()
 
 inline void SBuffer::Set(const SBuffer &buffer)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(buffer.Check());
-        POSTCONDITION(Equals(buffer));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (buffer.IsImmutable()
         && (IsImmutable() || m_allocation < buffer.GetSize()))
@@ -273,21 +272,21 @@ inline void SBuffer::Set(const SBuffer &buffer)
         MoveMemory(m_buffer, buffer.m_buffer, buffer.m_size);
     }
 
-    RETURN;
+    _ASSERTE(Equals(buffer));
+    return;
 }
 
 inline void SBuffer::Set(const BYTE *buffer, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(buffer, size == 0 ? NULL_OK : NULL_NOT_OK));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(Equals(buffer, size));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Resize(size);
     EnsureMutable();
@@ -299,23 +298,23 @@ inline void SBuffer::Set(const BYTE *buffer, COUNT_T size)
     if (size != 0)
         MoveMemory(m_buffer, buffer, size);
 
-    RETURN;
+    _ASSERTE(Equals(buffer, size));
+    return;
 }
 
 inline void SBuffer::SetImmutable(const BYTE *buffer, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(buffer, size == 0 ? NULL_OK : NULL_NOT_OK));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(Equals(buffer, size));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
 
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SBuffer temp(Immutable, buffer, size);
 
@@ -325,7 +324,8 @@ inline void SBuffer::SetImmutable(const BYTE *buffer, COUNT_T size)
         Set(temp);
     }
 
-    RETURN;
+    _ASSERTE(Equals(buffer, size));
+    return;
 }
 
 inline COUNT_T SBuffer::GetSize() const
@@ -338,53 +338,53 @@ inline COUNT_T SBuffer::GetSize() const
 
 inline void SBuffer::SetSize(COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckSize(size));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Resize(size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::MaximizeSize()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsImmutable())
         Resize(m_allocation);
 
-    RETURN;
+    return;
 }
 
 inline COUNT_T SBuffer::GetAllocation() const
 {
-    CONTRACT(COUNT_T)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN m_allocation;
+    return m_allocation;
 }
 
 inline void SBuffer::Preallocate(COUNT_T allocation)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         if (allocation) THROWS; else NOTHROW;
         INSTANCE_CHECK;
@@ -393,79 +393,79 @@ inline void SBuffer::Preallocate(COUNT_T allocation)
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (allocation > m_allocation)
         ReallocateBuffer(allocation, PRESERVE);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Trim()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsImmutable())
         ReallocateBuffer(m_size, PRESERVE);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Zero()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ZeroMemory(m_buffer, m_size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Fill(BYTE value)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     memset(m_buffer, value, m_size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Fill(const Iterator &i, BYTE value, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, size));
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     memset(i.m_ptr, value, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Copy(const Iterator &to, const CIterator &from, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(to, size));
@@ -473,18 +473,18 @@ inline void SBuffer::Copy(const Iterator &to, const CIterator &from, COUNT_T siz
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DebugDestructBuffer(to.m_ptr, size);
 
     DebugCopyConstructBuffer(to.m_ptr, from.m_ptr, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Move(const Iterator &to, const CIterator &from, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(to, size));
@@ -492,7 +492,7 @@ inline void SBuffer::Move(const Iterator &to, const CIterator &from, COUNT_T siz
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DebugDestructBuffer(to.m_ptr, size);
 
@@ -500,12 +500,12 @@ inline void SBuffer::Move(const Iterator &to, const CIterator &from, COUNT_T siz
 
     DebugConstructBuffer(from.m_ptr, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Copy(const Iterator &i, const SBuffer &source)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, source.GetSize()));
@@ -513,18 +513,18 @@ inline void SBuffer::Copy(const Iterator &i, const SBuffer &source)
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DebugDestructBuffer(i.m_ptr, source.m_size);
 
     DebugCopyConstructBuffer(i.m_ptr, source.m_buffer, source.m_size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Copy(const Iterator &i, const void *source, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckSize(size));
@@ -534,18 +534,18 @@ inline void SBuffer::Copy(const Iterator &i, const void *source, COUNT_T size)
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DebugDestructBuffer(i.m_ptr, size);
 
     DebugCopyConstructBuffer(i.m_ptr, (const BYTE *) source, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Copy(void *dest, const CIterator &i, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckSize(size));
@@ -554,121 +554,119 @@ inline void SBuffer::Copy(void *dest, const CIterator &i, COUNT_T size)
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     memcpy(dest, i.m_ptr, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Insert(const Iterator &i, const SBuffer &source)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         PRECONDITION(CheckIteratorRange(i,0));
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Replace(i, 0, source.GetSize());
     Copy(i, source, source.GetSize());
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Insert(const Iterator &i, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         PRECONDITION(CheckIteratorRange(i,0));
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Replace(i, 0, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Clear()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Delete(Begin(), GetSize());
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Delete(const Iterator &i, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, size));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Replace(i, size, 0);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::Replace(const Iterator &i, COUNT_T deleteSize, const SBuffer &insert)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, deleteSize));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Replace(i, deleteSize, insert.GetSize());
     Copy(i, insert, insert.GetSize());
 
-    RETURN;
+    return;
 }
 
 inline int SBuffer::Compare(const SBuffer &compare) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(compare.Check());
-        POSTCONDITION(RETVAL == -1 || RETVAL == 0 || RETVAL == 1);
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN Compare(compare.m_buffer, compare.m_size);
+    return Compare(compare.m_buffer, compare.m_size);
 }
 
 inline int SBuffer::Compare(const BYTE *compare, COUNT_T size) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(compare));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(RETVAL == -1 || RETVAL == 0 || RETVAL == 1);
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     COUNT_T smaller;
     int equals;
@@ -693,28 +691,34 @@ inline int SBuffer::Compare(const BYTE *compare, COUNT_T size) const
     result = memcmp(m_buffer, compare, size);
 
     if (result == 0)
-        RETURN equals;
+        {
+        _ASSERTE(equals == -1 || equals == 0 || equals == 1);
+            return equals;
+        }
     else
-        RETURN result;
+        {
+        _ASSERTE(result == -1 || result == 0 || result == 1);
+            return result;
+        }
 }
 
 inline BOOL SBuffer::Equals(const SBuffer &compare) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(compare.Check());
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN Equals(compare.m_buffer, compare.m_size);
+    return Equals(compare.m_buffer, compare.m_size);
 }
 
 inline BOOL SBuffer::Equals(const BYTE *compare, COUNT_T size) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(compare));
@@ -722,17 +726,17 @@ inline BOOL SBuffer::Equals(const BYTE *compare, COUNT_T size) const
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_size != size)
-        RETURN FALSE;
+        return FALSE;
     else
-        RETURN (memcmp(m_buffer, compare, size) == 0);
+        return (memcmp(m_buffer, compare, size) == 0);
 }
 
 inline BOOL SBuffer::Match(const CIterator &i, const SBuffer &match) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
@@ -740,14 +744,14 @@ inline BOOL SBuffer::Match(const CIterator &i, const SBuffer &match) const
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN Match(i, match.m_buffer, match.m_size);
+    return Match(i, match.m_buffer, match.m_size);
 }
 
 inline BOOL SBuffer::Match(const CIterator &i, const BYTE *match, COUNT_T size) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
@@ -756,14 +760,14 @@ inline BOOL SBuffer::Match(const CIterator &i, const BYTE *match, COUNT_T size) 
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     COUNT_T remaining = (COUNT_T) (m_buffer + m_size - i.m_ptr);
 
     if (remaining < size)
-        RETURN FALSE;
+        return FALSE;
 
-    RETURN (memcmp(i.m_ptr, match, size) == 0);
+    return (memcmp(i.m_ptr, match, size) == 0);
 }
 
 //----------------------------------------------------------------------------
@@ -772,7 +776,7 @@ inline BOOL SBuffer::Match(const CIterator &i, const BYTE *match, COUNT_T size) 
 //----------------------------------------------------------------------------
 inline void SBuffer::EnsureMutable() const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckBufferClosed());
@@ -780,12 +784,12 @@ inline void SBuffer::EnsureMutable() const
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsImmutable())
         const_cast<SBuffer *>(this)->ReallocateBuffer(m_allocation, PRESERVE);
 
-    RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -794,18 +798,15 @@ inline void SBuffer::EnsureMutable() const
 //----------------------------------------------------------------------------
 FORCEINLINE void SBuffer::Resize(COUNT_T size, Preserve preserve)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(GetSize() == size);
-        POSTCONDITION(m_allocation >= GetSize());
-        POSTCONDITION(CheckInvariant(*this));
         if (size > 0) THROWS; else NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     // Change our revision
@@ -826,7 +827,10 @@ FORCEINLINE void SBuffer::Resize(COUNT_T size, Preserve preserve)
 
     m_size = size;
 
-    RETURN;
+    _ASSERTE(GetSize() == size);
+    _ASSERTE(m_allocation >= GetSize());
+    _ASSERTE(CheckInvariant(*this));
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -836,18 +840,15 @@ FORCEINLINE void SBuffer::Resize(COUNT_T size, Preserve preserve)
 //----------------------------------------------------------------------------
 inline void SBuffer::ResizePadded(COUNT_T size, Preserve preserve)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(GetSize() == size);
-        POSTCONDITION(m_allocation >= GetSize());
-        POSTCONDITION(CheckInvariant(*this));
         if (size > 0) THROWS; else NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     // Change our revision
@@ -872,7 +873,10 @@ inline void SBuffer::ResizePadded(COUNT_T size, Preserve preserve)
 
     m_size = size;
 
-    RETURN;
+    _ASSERTE(GetSize() == size);
+    _ASSERTE(m_allocation >= GetSize());
+    _ASSERTE(CheckInvariant(*this));
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -882,18 +886,16 @@ inline void SBuffer::ResizePadded(COUNT_T size, Preserve preserve)
 //----------------------------------------------------------------------------
 inline void SBuffer::TweakSize(COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckSize(size));
         PRECONDITION(size <= GetAllocation());
-        POSTCONDITION(GetSize() == size);
-        POSTCONDITION(CheckInvariant(*this));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     // Change our revision
@@ -909,7 +911,9 @@ inline void SBuffer::TweakSize(COUNT_T size)
 
     m_size = size;
 
-    RETURN;
+    _ASSERTE(GetSize() == size);
+    _ASSERTE(CheckInvariant(*this));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -954,16 +958,15 @@ static const int SBUFFER_ALIGNMENT = 4;
 //----------------------------------------------------------------------------
 inline BYTE *SBuffer::NewBuffer(COUNT_T allocation)
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
         PRECONDITION(CheckSize(allocation));
         PRECONDITION(allocation > 0);
-        POSTCONDITION(CheckPointer(RETVAL));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef SBUFFER_CANARY_CHECKS
 
@@ -986,7 +989,7 @@ inline BYTE *SBuffer::NewBuffer(COUNT_T allocation)
 
     CONSISTENCY_CHECK(CheckBuffer(buffer, allocation));
 
-    RETURN buffer;
+    return buffer;
 }
 
 //----------------------------------------------------------------------------
@@ -994,7 +997,7 @@ inline BYTE *SBuffer::NewBuffer(COUNT_T allocation)
 //----------------------------------------------------------------------------
 inline BYTE *SBuffer::UseBuffer(BYTE *buffer, COUNT_T *allocation)
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -1003,9 +1006,8 @@ inline BYTE *SBuffer::UseBuffer(BYTE *buffer, COUNT_T *allocation)
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(*allocation));
 //        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(CheckSize(*allocation));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef SBUFFER_CANARY_CHECKS
 
@@ -1035,7 +1037,8 @@ inline BYTE *SBuffer::UseBuffer(BYTE *buffer, COUNT_T *allocation)
 
     CONSISTENCY_CHECK(CheckBuffer(buffer, *allocation));
 
-    RETURN buffer;
+    _ASSERTE(CheckSize(*allocation));
+    return buffer;
 }
 
 //----------------------------------------------------------------------------
@@ -1043,15 +1046,14 @@ inline BYTE *SBuffer::UseBuffer(BYTE *buffer, COUNT_T *allocation)
 //----------------------------------------------------------------------------
 inline void SBuffer::DeleteBuffer(BYTE *buffer, COUNT_T allocation)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckSize(allocation));
-        POSTCONDITION(CheckPointer(buffer));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CONSISTENCY_CHECK(CheckBuffer(buffer, allocation));
 
@@ -1065,7 +1067,7 @@ inline void SBuffer::DeleteBuffer(BYTE *buffer, COUNT_T allocation)
 
 #endif
 
-    RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1104,17 +1106,16 @@ inline CHECK SBuffer::CheckBuffer(const BYTE *buffer, COUNT_T allocation) const
 
 inline BYTE *SBuffer::OpenRawBuffer(COUNT_T size)
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
 #if _DEBUG
         PRECONDITION_MSG(!IsOpened(), "Can't nest calls to OpenBuffer()");
 #endif
         PRECONDITION(CheckSize(size));
-        POSTCONDITION(GetSize() == size);
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Resize(size);
     EnsureMutable();
@@ -1123,7 +1124,8 @@ inline BYTE *SBuffer::OpenRawBuffer(COUNT_T size)
     SetOpened();
 #endif
 
-    RETURN m_buffer;
+    _ASSERTE(GetSize() == size);
+    return m_buffer;
 }
 
 //----------------------------------------------------------------------------
@@ -1132,7 +1134,7 @@ inline BYTE *SBuffer::OpenRawBuffer(COUNT_T size)
 //----------------------------------------------------------------------------
 inline void SBuffer::CloseRawBuffer()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
 #if _DEBUG
         PRECONDITION(IsOpened());
@@ -1140,11 +1142,11 @@ inline void SBuffer::CloseRawBuffer()
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CloseRawBuffer(m_size);
 
-    RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1155,7 +1157,7 @@ inline void SBuffer::CloseRawBuffer()
 //----------------------------------------------------------------------------
 inline void SBuffer::CloseRawBuffer(COUNT_T finalSize)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
 #if _DEBUG
         PRECONDITION_MSG(IsOpened(),  "Can only CloseRawBuffer() after a call to OpenRawBuffer()");
@@ -1165,7 +1167,7 @@ inline void SBuffer::CloseRawBuffer(COUNT_T finalSize)
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #if _DEBUG
     ClearOpened();
@@ -1175,7 +1177,7 @@ inline void SBuffer::CloseRawBuffer(COUNT_T finalSize)
 
     CONSISTENCY_CHECK(CheckBuffer(m_buffer, m_allocation));
 
-    RETURN;
+    return;
 }
 
 inline SBuffer::operator const void *() const
@@ -1208,63 +1210,63 @@ inline const BYTE &SBuffer::operator[](int index) const
 
 inline SBuffer::Iterator SBuffer::Begin()
 {
-    CONTRACT(SBuffer::Iterator)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This is a bit unfortunate to have to do here, but it's our
     // last opportunity before possibly doing a *i= with the iterator
     EnsureMutable();
 
-    RETURN Iterator(this, 0);
+    return Iterator(this, 0);
 }
 
 inline SBuffer::Iterator SBuffer::End()
 {
-    CONTRACT(SBuffer::Iterator)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This is a bit unfortunate to have to do here, but it's our
     // last opportunity before possibly doing a *i= with the iterator
     EnsureMutable();
 
-    RETURN Iterator(this, m_size);
+    return Iterator(this, m_size);
 }
 
 inline SBuffer::CIterator SBuffer::Begin() const
 {
-    CONTRACT(SBuffer::CIterator)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN SBuffer::CIterator(this, 0);
+    return SBuffer::CIterator(this, 0);
 }
 
 inline SBuffer::CIterator SBuffer::End() const
 {
-    CONTRACT(SBuffer::CIterator)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN CIterator(const_cast<SBuffer*>(this), m_size);
+    return CIterator(const_cast<SBuffer*>(this), m_size);
 }
 
 inline BOOL SBuffer::IsAllocated() const
@@ -1386,19 +1388,19 @@ inline int SBuffer::GetRepresentationField() const
 
 inline void SBuffer::SetRepresentationField(int value)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION((value & ~REPRESENTATION_MASK) == 0);
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     m_flags &= ~REPRESENTATION_MASK;
     m_flags |= value;
 
-    RETURN;
+    return;
 }
 
 #if _DEBUG
@@ -1426,7 +1428,7 @@ inline void SBuffer::ClearOpened()
 
 inline void SBuffer::DebugMoveBuffer(_Out_writes_bytes_(size) BYTE *to, BYTE *from, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(to, size == 0 ? NULL_OK : NULL_NOT_OK));
@@ -1436,10 +1438,10 @@ inline void SBuffer::DebugMoveBuffer(_Out_writes_bytes_(size) BYTE *to, BYTE *fr
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (size == 0) // special case
-      RETURN;
+      return;
 
     // Handle overlapping ranges
     if (to > from && to < from + size)
@@ -1459,12 +1461,12 @@ inline void SBuffer::DebugMoveBuffer(_Out_writes_bytes_(size) BYTE *to, BYTE *fr
     else
         DebugStompUnusedBuffer(from, size);
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::DebugCopyConstructBuffer(_Out_writes_bytes_(size) BYTE *to, const BYTE *from, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(to, size == 0 ? NULL_OK : NULL_NOT_OK));
@@ -1474,19 +1476,19 @@ inline void SBuffer::DebugCopyConstructBuffer(_Out_writes_bytes_(size) BYTE *to,
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (size != 0) {
         CONSISTENCY_CHECK(CheckUnusedBuffer(to, size));
         memmove(to, from, size);
     }
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::DebugConstructBuffer(BYTE *buffer, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(buffer, size == 0 ? NULL_OK : NULL_NOT_OK));
@@ -1496,18 +1498,18 @@ inline void SBuffer::DebugConstructBuffer(BYTE *buffer, COUNT_T size)
         SUPPORTS_DAC;
         DEBUG_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (size != 0) {
       CONSISTENCY_CHECK(CheckUnusedBuffer(buffer, size));
     }
 
-    RETURN;
+    return;
 }
 
 inline void SBuffer::DebugDestructBuffer(BYTE *buffer, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(buffer, size == 0 ? NULL_OK : NULL_NOT_OK));
@@ -1517,14 +1519,14 @@ inline void SBuffer::DebugDestructBuffer(BYTE *buffer, COUNT_T size)
         DEBUG_ONLY;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (size != 0)
     {
         DebugStompUnusedBuffer(buffer, size);
     }
 
-    RETURN;
+    return;
 }
 
 static const BYTE GARBAGE_FILL_CHARACTER = '$';
@@ -1533,7 +1535,7 @@ extern const DWORD g_garbageFillBuffer[];
 
 inline void SBuffer::DebugStompUnusedBuffer(BYTE *buffer, COUNT_T size)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(buffer, size == 0 ? NULL_OK : NULL_NOT_OK));
@@ -1544,7 +1546,7 @@ inline void SBuffer::DebugStompUnusedBuffer(BYTE *buffer, COUNT_T size)
         DEBUG_ONLY;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #if _DEBUG
     if (!IsImmutable()
@@ -1556,7 +1558,7 @@ inline void SBuffer::DebugStompUnusedBuffer(BYTE *buffer, COUNT_T size)
     }
 #endif
 
-    RETURN;
+    return;
 }
 
 #if _DEBUG
@@ -1715,21 +1717,20 @@ inline CHECK SBuffer::Index::DoCheck(SCOUNT_T delta) const
 
 inline void SBuffer::Index::Resync(const SBuffer *buffer, BYTE *value) const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         // INSTANCE_CHECK -  Iterator is out of sync with its object now by definition
-        POSTCONDITION(CheckPointer(this));
         PRECONDITION(CheckPointer(buffer));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     const_cast<Index*>(this)->CheckedIteratorBase<SBuffer>::Resync(const_cast<SBuffer*>(buffer));
     const_cast<Index*>(this)->m_ptr = value;
 
-    RETURN;
+    return;
 }
 
 #ifdef _MSC_VER

--- a/src/coreclr/inc/sbuffer.inl
+++ b/src/coreclr/inc/sbuffer.inl
@@ -25,7 +25,6 @@ inline SBuffer::SBuffer(PreallocFlag flag, void *buffer, COUNT_T size)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
         NOTHROW;
@@ -41,7 +40,7 @@ inline SBuffer::SBuffer(PreallocFlag flag, void *buffer, COUNT_T size)
     m_revision = 0;
 #endif
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::SBuffer()
@@ -52,7 +51,6 @@ inline SBuffer::SBuffer()
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
@@ -62,7 +60,7 @@ inline SBuffer::SBuffer()
     m_revision = 0;
 #endif
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::SBuffer(COUNT_T size)
@@ -73,7 +71,6 @@ inline SBuffer::SBuffer(COUNT_T size)
 {
     CONTRACTL
     {;
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckSize(size));
         THROWS;
         GC_NOTRIGGER;
@@ -86,7 +83,7 @@ inline SBuffer::SBuffer(COUNT_T size)
     m_revision = 0;
 #endif
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::SBuffer(const SBuffer &buffer)
@@ -97,7 +94,6 @@ inline SBuffer::SBuffer(const SBuffer &buffer)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(buffer.Check());
         THROWS;
         GC_NOTRIGGER;
@@ -111,14 +107,13 @@ inline SBuffer::SBuffer(const SBuffer &buffer)
 #endif
 
     _ASSERTE(Equals(buffer));
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::SBuffer(SBuffer &&buffer)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(buffer.Check());
         THROWS;
         GC_NOTRIGGER;
@@ -137,7 +132,7 @@ inline SBuffer::SBuffer(SBuffer &&buffer)
     buffer.InitializeInstance();
 
     _ASSERTE(Check());
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
@@ -148,7 +143,6 @@ inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
         THROWS;
@@ -163,7 +157,7 @@ inline SBuffer::SBuffer(const BYTE *buffer, COUNT_T size)
 #endif
 
     _ASSERTE(Equals(buffer, size));
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 
@@ -175,7 +169,6 @@ inline SBuffer::SBuffer(ImmutableFlag immutable, const BYTE *buffer, COUNT_T siz
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
         NOTHROW;
@@ -189,7 +182,7 @@ inline SBuffer::SBuffer(ImmutableFlag immutable, const BYTE *buffer, COUNT_T siz
 #endif
 
     _ASSERTE(Equals(buffer, size));
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SBuffer::~SBuffer()

--- a/src/coreclr/inc/shash.inl
+++ b/src/coreclr/inc/shash.inl
@@ -71,39 +71,37 @@ typename SHash<TRAITS>::count_t SHash<TRAITS>::GetCapacity() const
 template <typename TRAITS>
 typename SHash<TRAITS>::element_t SHash<TRAITS>::Lookup(key_t key) const
 {
-    CONTRACT(element_t)
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
-        POSTCONDITION(TRAITS::IsNull(RETVAL) || TRAITS::Equals(key, TRAITS::GetKey(RETVAL)));
         SUPPORTS_DAC_WRAPPER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     const element_t *pRet = Lookup(m_table, m_tableSize, key);
-    RETURN ((pRet != NULL) ? (*pRet) : TRAITS::Null());
+    return ((pRet != NULL) ? (*pRet) : TRAITS::Null());
 }
 
 template <typename TRAITS>
 const typename SHash<TRAITS>::element_t * SHash<TRAITS>::LookupPtr(key_t key) const
 {
-    CONTRACT(const element_t *)
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
-        POSTCONDITION(RETVAL == NULL || TRAITS::Equals(key, TRAITS::GetKey(*RETVAL)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN Lookup(m_table, m_tableSize, key);
+    return Lookup(m_table, m_tableSize, key);
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::ReplacePtr(const element_t *elementPtr, const element_t &newElement, bool invokeCleanupAction)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -116,7 +114,7 @@ void SHash<TRAITS>::ReplacePtr(const element_t *elementPtr, const element_t &new
         PRECONDITION(!TRAITS::IsDeleted(newElement));
         PRECONDITION(TRAITS::Equals(TRAITS::GetKey(newElement), TRAITS::GetKey(*elementPtr)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (TRAITS::s_RemovePerEntryCleanupAction && invokeCleanupAction)
     {
@@ -124,39 +122,37 @@ void SHash<TRAITS>::ReplacePtr(const element_t *elementPtr, const element_t &new
     }
 
     *const_cast<element_t *>(elementPtr) = newElement;
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Add(const element_t & element)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CheckGrowth();
 
     Add_GrowthChecked(element);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 BOOL SHash<TRAITS>::AddNoThrow(const element_t & element)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     static_assert(TRAITS::s_NoThrow, "This SHash does not support NOTHROW.");
 
@@ -164,60 +160,57 @@ BOOL SHash<TRAITS>::AddNoThrow(const element_t & element)
     if (haveSpace)
         Add_GrowthChecked(element);
 
-    RETURN haveSpace;
+    return haveSpace;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Add_GrowthChecked(const element_t & element)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (Add(m_table, m_tableSize, element))
         m_tableOccupied++;
     m_tableCount++;
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::AddOrReplace(const element_t &element)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         static_assert(!TRAITS::s_supports_remove, "SHash::AddOrReplace is not implemented for SHash with support for remove operations.");
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CheckGrowth();
 
     AddOrReplace(m_table, m_tableSize, element);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 BOOL SHash<TRAITS>::AddOrReplaceNoThrow(const element_t &element)
 {
-     CONTRACT(BOOL)
+     CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         static_assert(!TRAITS::s_supports_remove, "SHash::AddOrReplaceNoThrow is not implemented for SHash with support for remove operations.");
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*LookupPtr(TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     static_assert(TRAITS::s_NoThrow, "This SHash does not support NOTHROW.");
 
@@ -225,13 +218,13 @@ BOOL SHash<TRAITS>::AddOrReplaceNoThrow(const element_t &element)
     if (haveSpace)
         AddOrReplace(m_table, m_tableSize, element);
 
-    RETURN haveSpace;
+    return haveSpace;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Remove(key_t key)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
@@ -239,17 +232,17 @@ void SHash<TRAITS>::Remove(key_t key)
         static_assert(TRAITS::s_supports_remove, "This SHash does not support remove operations.");
         PRECONDITION(!(TRAITS::IsNull(Lookup(key))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Remove(m_table, m_tableSize, key);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Remove(Iterator& i)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -258,17 +251,17 @@ void SHash<TRAITS>::Remove(Iterator& i)
         PRECONDITION(!(TRAITS::IsNull(*i)));
         PRECONDITION(!(TRAITS::IsDeleted(*i)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     RemoveElement(m_table, m_tableSize, (element_t*)&(*i));
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Remove(KeyIterator& i)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -277,17 +270,17 @@ void SHash<TRAITS>::Remove(KeyIterator& i)
         PRECONDITION(!(TRAITS::IsNull(*i)));
         PRECONDITION(!(TRAITS::IsDeleted(*i)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     RemoveElement(m_table, m_tableSize, (element_t*)&(*i));
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::RemovePtr(element_t * p)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -296,23 +289,23 @@ void SHash<TRAITS>::RemovePtr(element_t * p)
         PRECONDITION(!(TRAITS::IsNull(*p)));
         PRECONDITION(!(TRAITS::IsDeleted(*p)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     RemoveElement(m_table, m_tableSize, p);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::RemoveAll()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (TRAITS::s_RemovePerEntryCleanupAction)
     {
@@ -330,7 +323,7 @@ void SHash<TRAITS>::RemoveAll()
     m_tableOccupied = 0;
     m_tableMax = 0;
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
@@ -372,33 +365,33 @@ typename SHash<TRAITS>::KeyIterator SHash<TRAITS>::End(key_t key) const
 template <typename TRAITS>
 BOOL SHash<TRAITS>::CheckGrowth()
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_tableOccupied == m_tableMax)
     {
         Grow();
-        RETURN TRUE;
+        return TRUE;
     }
 
-    RETURN FALSE;
+    return FALSE;
 }
 
 template <typename TRAITS>
 BOOL SHash<TRAITS>::CheckGrowthNoThrow()
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     static_assert(TRAITS::s_NoThrow, "This SHash does not support NOTHROW.");
 
@@ -408,39 +401,39 @@ BOOL SHash<TRAITS>::CheckGrowthNoThrow()
         result = GrowNoThrow();
     }
 
-    RETURN result;
+    return result;
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Grow()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t     newSize;
     element_t * newTable = Grow_OnlyAllocateNewTable(&newSize);
     element_t * oldTable = ReplaceTable(newTable, newSize);
     DeleteOldTable(oldTable);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 BOOL SHash<TRAITS>::GrowNoThrow()
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         PRECONDITION(TRAITS::s_NoThrow);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t     newSize;
     element_t * newTable = Grow_OnlyAllocateNewTableNoThrow(&newSize);
@@ -450,20 +443,20 @@ BOOL SHash<TRAITS>::GrowNoThrow()
         DeleteOldTable(oldTable);
     }
 
-    RETURN (newTable != NULL);
+    return (newTable != NULL);
 }
 
 template <typename TRAITS>
 typename SHash<TRAITS>::element_t *
 SHash<TRAITS>::Grow_OnlyAllocateNewTable(count_t * pcNewSize)
 {
-    CONTRACT(element_t *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t newSize = (count_t) (m_tableCount
                                  * TRAITS::s_growth_factor_numerator / TRAITS::s_growth_factor_denominator
@@ -475,21 +468,21 @@ SHash<TRAITS>::Grow_OnlyAllocateNewTable(count_t * pcNewSize)
     if (newSize < m_tableCount)
         ThrowOutOfMemory();
 
-    RETURN AllocateNewTable(newSize, pcNewSize);
+    return AllocateNewTable(newSize, pcNewSize);
 }
 
 template <typename TRAITS>
 typename SHash<TRAITS>::element_t *
 SHash<TRAITS>::Grow_OnlyAllocateNewTableNoThrow(count_t * pcNewSize)
 {
-    CONTRACT(element_t *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
         PRECONDITION(TRAITS::s_NoThrow);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t newSize = (count_t) (m_tableCount
                                  * TRAITS::s_growth_factor_numerator / TRAITS::s_growth_factor_denominator
@@ -501,26 +494,26 @@ SHash<TRAITS>::Grow_OnlyAllocateNewTableNoThrow(count_t * pcNewSize)
     if (newSize < m_tableCount)
         return NULL;
 
-    RETURN AllocateNewTableNoThrow(newSize, pcNewSize);
+    return AllocateNewTableNoThrow(newSize, pcNewSize);
 }
 
 template <typename TRAITS>
 void SHash<TRAITS>::Reallocate(count_t requestedSize)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INSTANCE_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t newTableSize;
     element_t * newTable = AllocateNewTable(requestedSize, &newTableSize);
     element_t * oldTable = ReplaceTable(newTable, newTableSize);
     DeleteOldTable(oldTable);
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
@@ -551,7 +544,7 @@ template <typename TRAITS>
 typename SHash<TRAITS>::element_t *
 SHash<TRAITS>::AllocateNewTable(count_t requestedSize, count_t * pcNewTableSize)
 {
-    CONTRACT(element_t *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
@@ -559,7 +552,7 @@ SHash<TRAITS>::AllocateNewTable(count_t requestedSize, count_t * pcNewTableSize)
         PRECONDITION(requestedSize >=
                      (count_t) (GetCount() * TRAITS::s_density_factor_denominator / TRAITS::s_density_factor_numerator));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Allocation size must be a prime number.  This is necessary so that hashes uniformly
     // distribute to all indices, and so that chaining will visit all indices in the hash table.
@@ -575,14 +568,14 @@ SHash<TRAITS>::AllocateNewTable(count_t requestedSize, count_t * pcNewTableSize)
         p++;
     }
 
-    RETURN newTable;
+    return newTable;
 }
 
 template <typename TRAITS>
 typename SHash<TRAITS>::element_t *
 SHash<TRAITS>::AllocateNewTableNoThrow(count_t requestedSize, count_t * pcNewTableSize)
 {
-    CONTRACT(element_t *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -591,7 +584,7 @@ SHash<TRAITS>::AllocateNewTableNoThrow(count_t requestedSize, count_t * pcNewTab
                      (count_t) (GetCount() * TRAITS::s_density_factor_denominator / TRAITS::s_density_factor_numerator));
         PRECONDITION(TRAITS::s_NoThrow);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Allocation size must be a prime number.  This is necessary so that hashes uniformly
     // distribute to all indices, and so that chaining will visit all indices in the hash table.
@@ -609,14 +602,14 @@ SHash<TRAITS>::AllocateNewTableNoThrow(count_t requestedSize, count_t * pcNewTab
         }
     }
 
-    RETURN newTable;
+    return newTable;
 }
 
 template <typename TRAITS>
 typename SHash<TRAITS>::element_t *
 SHash<TRAITS>::ReplaceTable(element_t * newTable, count_t newTableSize)
 {
-    CONTRACT(element_t *)
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
@@ -624,7 +617,7 @@ SHash<TRAITS>::ReplaceTable(element_t * newTable, count_t newTableSize)
         PRECONDITION(newTableSize >=
                      (count_t) (GetCount() * TRAITS::s_density_factor_denominator / TRAITS::s_density_factor_numerator));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     element_t * oldTable = m_table;
 
@@ -642,42 +635,41 @@ SHash<TRAITS>::ReplaceTable(element_t * newTable, count_t newTableSize)
     m_tableMax = (count_t) (newTableSize * TRAITS::s_density_factor_numerator / TRAITS::s_density_factor_denominator);
     m_tableOccupied = m_tableCount;
 
-    RETURN oldTable;
+    return oldTable;
 }
 
 template <typename TRAITS>
 void
 SHash<TRAITS>::DeleteOldTable(element_t * oldTable)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // @todo:
     // We might want to try to delay this cleanup to allow asynchronous readers
     if (oldTable != NULL)
         delete [] oldTable;
 
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 const typename SHash<TRAITS>::element_t * SHash<TRAITS>::Lookup(PTR_element_t table, count_t tableSize, key_t key) const
 {
-    CONTRACT(const element_t *)
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
-        POSTCONDITION(RETVAL == NULL || TRAITS::Equals(key, TRAITS::GetKey(*RETVAL)));
         SUPPORTS_DAC_WRAPPER;   // supports DAC only if the traits class does
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (tableSize == 0)
-        RETURN NULL;
+        return NULL;
 
     count_t hash = TRAITS::Hash(key);
     count_t index = hash % tableSize;
@@ -688,7 +680,7 @@ const typename SHash<TRAITS>::element_t * SHash<TRAITS>::Lookup(PTR_element_t ta
         element_t& current = table[index];
 
         if (TRAITS::IsNull(current))
-            RETURN NULL;
+            return NULL;
 
         if (!TRAITS::IsDeleted(current))
         {
@@ -698,7 +690,7 @@ const typename SHash<TRAITS>::element_t * SHash<TRAITS>::Lookup(PTR_element_t ta
             }
             else if (TRAITS::Equals(key, TRAITS::GetKey(current)))
             {
-                RETURN &current;
+                return &current;
             }
         }
 
@@ -714,13 +706,12 @@ const typename SHash<TRAITS>::element_t * SHash<TRAITS>::Lookup(PTR_element_t ta
 template <typename TRAITS>
 BOOL SHash<TRAITS>::Add(element_t * table, count_t tableSize, const element_t & element)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*Lookup(table, tableSize, TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     key_t key = TRAITS::GetKey(element);
 
@@ -735,20 +726,20 @@ BOOL SHash<TRAITS>::Add(element_t * table, count_t tableSize, const element_t & 
         if (TRAITS::IsNull(current))
         {
             table[index] = element;
-            RETURN TRUE;
+            return TRUE;
         }
 
         if (TRAITS::IsDeleted(current))
         {
             table[index] = element;
-            RETURN FALSE;
+            return FALSE;
         }
 
         if (TRAITS::s_supports_autoremove && TRAITS::ShouldDelete(current))
         {
             RemoveElement(table, tableSize, &current);
             table[index] = element;
-            RETURN FALSE;
+            return FALSE;
         }
 
         if (increment == 0)
@@ -763,14 +754,13 @@ BOOL SHash<TRAITS>::Add(element_t * table, count_t tableSize, const element_t & 
 template <typename TRAITS>
 void SHash<TRAITS>::AddOrReplace(element_t *table, count_t tableSize, const element_t &element)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
         static_assert(!TRAITS::s_supports_remove, "SHash::AddOrReplace is not implemented for SHash with support for remove operations.");
-        POSTCONDITION(TRAITS::Equals(TRAITS::GetKey(element), TRAITS::GetKey(*Lookup(table, tableSize, TRAITS::GetKey(element)))));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     key_t key = TRAITS::GetKey(element);
 
@@ -788,7 +778,7 @@ void SHash<TRAITS>::AddOrReplace(element_t *table, count_t tableSize, const elem
             table[index] = element;
             m_tableCount++;
             m_tableOccupied++;
-            RETURN;
+            return;
         }
         else if (TRAITS::Equals(key, TRAITS::GetKey(current)))
         {
@@ -798,7 +788,7 @@ void SHash<TRAITS>::AddOrReplace(element_t *table, count_t tableSize, const elem
             }
 
             table[index] = element;
-            RETURN;
+            return;
         }
 
         if (increment == 0)
@@ -813,14 +803,14 @@ void SHash<TRAITS>::AddOrReplace(element_t *table, count_t tableSize, const elem
 template <typename TRAITS>
 void SHash<TRAITS>::Remove(element_t *table, count_t tableSize, key_t key)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW_UNLESS_TRAITS_THROWS;
         GC_NOTRIGGER;
         static_assert(TRAITS::s_supports_remove, "This SHash does not support remove operations.");
         PRECONDITION(Lookup(table, tableSize, key) != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     count_t hash = TRAITS::Hash(key);
     count_t index = hash % tableSize;
@@ -831,7 +821,7 @@ void SHash<TRAITS>::Remove(element_t *table, count_t tableSize, key_t key)
         element_t& current = table[index];
 
         if (TRAITS::IsNull(current))
-            RETURN;
+            return;
 
         if (!TRAITS::IsDeleted(current))
         {
@@ -854,7 +844,7 @@ void SHash<TRAITS>::Remove(element_t *table, count_t tableSize, key_t key)
 template <typename TRAITS>
 void SHash<TRAITS>::RemoveElement(element_t *table, count_t tableSize, element_t *element)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -862,7 +852,7 @@ void SHash<TRAITS>::RemoveElement(element_t *table, count_t tableSize, element_t
         PRECONDITION(table <= element && element < table + tableSize);
         PRECONDITION(!TRAITS::IsNull(*element) && !TRAITS::IsDeleted(*element));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (TRAITS::s_RemovePerEntryCleanupAction)
     {
@@ -871,35 +861,35 @@ void SHash<TRAITS>::RemoveElement(element_t *table, count_t tableSize, element_t
 
     *element = TRAITS::Deleted();
     m_tableCount--;
-    RETURN;
+    return;
 }
 
 template <typename TRAITS>
 BOOL SHash<TRAITS>::IsPrime(COUNT_T number)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This is a very low-tech check for primality, which doesn't scale very well.
     // There are more efficient tests if this proves to be burdensome for larger
     // tables.
 
     if ((number & 1) == 0)
-        RETURN FALSE;
+        return FALSE;
 
     COUNT_T factor = 3;
     while (factor * factor <= number)
     {
         if ((number % factor) == 0)
-            RETURN FALSE;
+            return FALSE;
         factor += 2;
     }
 
-    RETURN TRUE;
+    return TRUE;
 }
 
 // allow coexistence with simplerhash.inl
@@ -922,17 +912,19 @@ namespace
 template <typename TRAITS>
 COUNT_T SHash<TRAITS>::NextPrime(COUNT_T number)
 {
-    CONTRACT(COUNT_T)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(IsPrime(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     for (int i = 0; i < (int) (sizeof(g_shash_primes) / sizeof(g_shash_primes[0])); i++) {
         if (g_shash_primes[i] >= number)
-            RETURN g_shash_primes[i];
+            {
+            _ASSERTE(IsPrime(g_shash_primes[i]));
+                return g_shash_primes[i];
+            }
     }
 
     if ((number&1) == 0)
@@ -940,7 +932,10 @@ COUNT_T SHash<TRAITS>::NextPrime(COUNT_T number)
 
     while (number != 1) {
         if (IsPrime(number))
-            RETURN number;
+            {
+            _ASSERTE(IsPrime(number));
+                return number;
+            }
         number +=2;
     }
 

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -22,7 +22,6 @@
 #define SS_CONTRACT CONTRACT
 #define SS_CONTRACT_VOID CONTRACT_VOID
 #define SS_CONTRACT_END CONTRACT_END
-#define SS_RETURN RETURN
 #define SS_CONSTRUCTOR_CHECK CONSTRUCTOR_CHECK
 #define SS_PRECONDITION PRECONDITION
 #define SS_POSTCONDITION POSTCONDITION
@@ -32,7 +31,6 @@
 #define SS_CONTRACT(x) CONTRACTL
 #define SS_CONTRACT_VOID CONTRACTL
 #define SS_CONTRACT_END CONTRACTL_END
-#define SS_RETURN return
 #define SS_CONSTRUCTOR_CHECK
 #define SS_PRECONDITION(x)
 #define SS_POSTCONDITION(x)
@@ -52,16 +50,16 @@ inline SString::SString()
   : SBuffer(Immutable, s_EmptyBuffer, sizeof(s_EmptyBuffer))
 {
 #ifdef SSTRING_EXTRA_CHECKS
-    CONTRACT_VOID
+    CONTRACTL
     {
         CONSTRUCTOR_CHECK;
-        POSTCONDITION(IsEmpty());
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN;
+    _ASSERTE(IsEmpty());
+    return;
 #else
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -95,7 +93,7 @@ inline SString::SString(void *buffer, COUNT_T size)
         GetRawUnicode()[0] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s)
@@ -113,7 +111,7 @@ inline SString::SString(const SString &s)
 
     Set(s);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s1, const SString &s2)
@@ -131,7 +129,7 @@ inline SString::SString(const SString &s1, const SString &s2)
 
     Set(s1, s2);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s1, const SString &s2, const SString &s3)
@@ -150,7 +148,7 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3)
 
     Set(s1, s2, s3);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s1, const SString &s2, const SString &s3, const SString &s4)
@@ -169,7 +167,7 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3,
 
     Set(s1, s2, s3, s4);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
@@ -190,7 +188,7 @@ inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
 
     Set(s, i, count);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const SString &s, const CIterator &start, const CIterator &end)
@@ -214,7 +212,7 @@ inline SString::SString(const SString &s, const CIterator &start, const CIterato
 
     Set(s, start, end);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const WCHAR *string)
@@ -234,7 +232,7 @@ inline SString::SString(const WCHAR *string)
     _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
     SetNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(const WCHAR *string, COUNT_T count)
@@ -255,7 +253,7 @@ inline SString::SString(const WCHAR *string, COUNT_T count)
     _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
     SetNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(enum tagASCII, const ASCII *string)
@@ -273,7 +271,7 @@ inline SString::SString(enum tagASCII, const ASCII *string)
 
     SetASCII(string);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(enum tagASCII, const ASCII *string, COUNT_T count)
@@ -292,7 +290,7 @@ inline SString::SString(enum tagASCII, const ASCII *string, COUNT_T count)
 
     SetASCII(string, count);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagUTF8 dummytag, const UTF8 *string)
@@ -311,7 +309,7 @@ inline SString::SString(tagUTF8 dummytag, const UTF8 *string)
 
     SetUTF8(string);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagUTF8 dummytag, const UTF8 *string, COUNT_T count)
@@ -330,7 +328,7 @@ inline SString::SString(tagUTF8 dummytag, const UTF8 *string, COUNT_T count)
 
     SetUTF8(string, count);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(WCHAR character)
@@ -346,7 +344,7 @@ inline SString::SString(WCHAR character)
 
     Set(character);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagLiteral dummytag, const ASCII *literal)
@@ -365,7 +363,7 @@ inline SString::SString(tagLiteral dummytag, const ASCII *literal)
 
     SetRepresentation(REPRESENTATION_ASCII);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
@@ -382,7 +380,7 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 
     SetRepresentation(REPRESENTATION_UTF8);
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
@@ -400,7 +398,7 @@ inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
     SetRepresentation(REPRESENTATION_UNICODE);
     SetNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal, COUNT_T count)
@@ -418,7 +416,7 @@ inline SString::SString(tagLiteral dummytag, const WCHAR *literal, COUNT_T count
     SetRepresentation(REPRESENTATION_UNICODE);
     SetNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -442,7 +440,7 @@ inline void SString::Set(const SString &s)
     SetRepresentation(s.GetRepresentation());
     ClearNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -465,7 +463,7 @@ inline void SString::Set(const SString &s1, const SString &s2)
     Set(s1);
     Append(s2);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -490,7 +488,7 @@ inline void SString::Set(const SString &s1, const SString &s2, const SString &s3
     Append(s2);
     Append(s3);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -517,7 +515,7 @@ inline void SString::Set(const SString &s1, const SString &s2, const SString &s3
     Append(s3);
     Append(s4);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -546,7 +544,7 @@ inline void SString::Set(const SString &s, const CIterator &i, COUNT_T count)
     SBuffer::Copy(SBuffer::Begin(), i.m_ptr, count<<i.m_characterSizeShift);
     NullTerminate();
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -575,7 +573,7 @@ inline void SString::Set(const SString &s, const CIterator &start, const CIterat
 
     Set(s, start, end - start);
 
-    SS_RETURN;
+    return;
 }
 
 // Return a global empty string
@@ -619,7 +617,7 @@ inline const WCHAR *SString::GetUnicode() const
 
     ConvertToUnicode();
 
-    SS_RETURN GetRawUnicode();
+    return GetRawUnicode();
 }
 
 // Get a const pointer to the internal buffer as a UTF8 string.
@@ -638,7 +636,7 @@ inline const UTF8 *SString::GetUTF8() const
 
     ConvertToUTF8();
 
-    SS_RETURN GetRawUTF8();
+    return GetRawUTF8();
 }
 
 // Normalize the string to unicode.  This will make many operations nonfailing.
@@ -656,7 +654,7 @@ inline void SString::Normalize()
     ConvertToUnicode();
     SetNormalized();
 
-    SS_RETURN;
+    return;
 }
 
 // Get a const pointer to the internal buffer as a unicode string.
@@ -675,7 +673,7 @@ inline const WCHAR *SString::GetUnicode(const CIterator &i) const
 
     ConvertToUnicode(i);
 
-    SS_RETURN i.GetUnicode();
+    return i.GetUnicode();
 }
 
 // Append s to the end of this string.
@@ -693,7 +691,7 @@ inline void SString::Append(const SString &s)
 
     Insert(End(), s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::Append(const WCHAR *string)
@@ -713,7 +711,7 @@ inline void SString::Append(const WCHAR *string)
     s.ClearImmutable();
     Append(s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::AppendASCII(const CHAR *string)
@@ -730,7 +728,7 @@ inline void SString::AppendASCII(const CHAR *string)
     StackSString s(SString::Ascii, string);
     Append(s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::AppendUTF8(const CHAR *string)
@@ -747,7 +745,7 @@ inline void SString::AppendUTF8(const CHAR *string)
     StackSString s(SString::Utf8, string);
     Append(s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::Append(const WCHAR c)
@@ -763,7 +761,7 @@ inline void SString::Append(const WCHAR c)
     InlineSString<2 * sizeof(c)> s(c);
     Append(s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::AppendUTF8(const CHAR c)
@@ -780,7 +778,7 @@ inline void SString::AppendUTF8(const CHAR c)
     InlineSString<2 * sizeof(c)> s(SString::Utf8, c);
     Append(s);
 
-    SS_RETURN;
+    return;
 }
 
 // Turn this on to test that these if you are testing common scenarios dealing with
@@ -864,7 +862,7 @@ inline BOOL SString::Match(const CIterator &i, WCHAR c) const
 
     // End() will not throw here
     CONTRACT_VIOLATION(ThrowsViolation);
-    SS_RETURN (i < End() && i[0] == c);
+    return (i < End() && i[0] == c);
 }
 
 inline BOOL SString::Skip(CIterator &i, const SString &s) const
@@ -882,10 +880,10 @@ inline BOOL SString::Skip(CIterator &i, const SString &s) const
     if (Match(i, s))
     {
         i += s.GetRawCount();
-        SS_RETURN TRUE;
+        return TRUE;
     }
     else
-        SS_RETURN FALSE;
+        return FALSE;
 }
 
 inline BOOL SString::Skip(CIterator &i, WCHAR c) const
@@ -902,10 +900,10 @@ inline BOOL SString::Skip(CIterator &i, WCHAR c) const
     if (Match(i, c))
     {
         i++;
-        SS_RETURN TRUE;
+        return TRUE;
     }
     else
-        SS_RETURN FALSE;
+        return FALSE;
 }
 
 // Find string within this string. Return TRUE and update iterator if found
@@ -923,7 +921,7 @@ inline BOOL SString::Find(CIterator &i, const WCHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(string);
-    SS_RETURN Find(i, s);
+    return Find(i, s);
 }
 
 inline BOOL SString::FindASCII(CIterator &i, const CHAR *string) const
@@ -940,7 +938,7 @@ inline BOOL SString::FindASCII(CIterator &i, const CHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(SString::Ascii, string);
-    SS_RETURN Find(i, s);
+    return Find(i, s);
 }
 
 inline BOOL SString::FindUTF8(CIterator &i, const CHAR *string) const
@@ -957,7 +955,7 @@ inline BOOL SString::FindUTF8(CIterator &i, const CHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(SString::Utf8, string);
-    SS_RETURN Find(i, s);
+    return Find(i, s);
 }
 
 inline BOOL SString::FindBack(CIterator &i, const WCHAR *string) const
@@ -974,7 +972,7 @@ inline BOOL SString::FindBack(CIterator &i, const WCHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(string);
-    SS_RETURN FindBack(i, s);
+    return FindBack(i, s);
 }
 
 inline BOOL SString::FindBackASCII(CIterator &i, const CHAR *string) const
@@ -991,7 +989,7 @@ inline BOOL SString::FindBackASCII(CIterator &i, const CHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(SString::Ascii, string);
-    SS_RETURN FindBack(i, s);
+    return FindBack(i, s);
 }
 
 inline BOOL SString::FindBackUTF8(CIterator &i, const CHAR *string) const
@@ -1008,7 +1006,7 @@ inline BOOL SString::FindBackUTF8(CIterator &i, const CHAR *string) const
     SS_CONTRACT_END;
 
     StackSString s(SString::Utf8, string);
-    SS_RETURN FindBack(i, s);
+    return FindBack(i, s);
 }
 
 // Insert string at iterator position
@@ -1027,7 +1025,7 @@ inline void SString::Insert(const Iterator &i, const SString &s)
 
     Replace(i, 0, s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::Insert(const Iterator &i, const WCHAR *string)
@@ -1045,7 +1043,7 @@ inline void SString::Insert(const Iterator &i, const WCHAR *string)
     StackSString s(string);
     Replace(i, 0, s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::InsertASCII(const Iterator &i, const CHAR *string)
@@ -1063,7 +1061,7 @@ inline void SString::InsertASCII(const Iterator &i, const CHAR *string)
     StackSString s(SString::Ascii, string);
     Replace(i, 0, s);
 
-    SS_RETURN;
+    return;
 }
 
 inline void SString::InsertUTF8(const Iterator &i, const CHAR *string)
@@ -1081,7 +1079,7 @@ inline void SString::InsertUTF8(const Iterator &i, const CHAR *string)
     StackSString s(SString::Utf8, string);
     Replace(i, 0, s);
 
-    SS_RETURN;
+    return;
 }
 
 // Delete string at iterator position
@@ -1099,7 +1097,7 @@ inline void SString::Delete(const Iterator &i, COUNT_T length)
 
     Replace(i, length, Empty());
 
-    SS_RETURN;
+    return;
 }
 
 // Preallocate some space for the string buffer
@@ -1139,7 +1137,7 @@ inline BOOL SString::IsEmpty() const
     }
     SS_CONTRACT_END;
 
-    SS_RETURN (GetRawCount() == 0);
+    return (GetRawCount() == 0);
 }
 
 // RETURN true if the string rep is ASCII.
@@ -1153,7 +1151,7 @@ inline BOOL SString::IsASCII() const
     }
     SS_CONTRACT_END;
 
-    SS_RETURN IsRepresentation(REPRESENTATION_ASCII);
+    return IsRepresentation(REPRESENTATION_ASCII);
 }
 
 // Get the number of characters in the string (excluding the terminating NULL)
@@ -1171,7 +1169,7 @@ inline COUNT_T SString::GetCount() const
 
     ConvertToFixed();
 
-    SS_RETURN SizeToCount(GetSize());
+    return SizeToCount(GetSize());
 }
 
 // Private helpers:
@@ -1229,15 +1227,14 @@ inline SString::Representation SString::GetRepresentation() const
 inline void SString::SetRepresentation(SString::Representation representation)
 {
 #ifdef SSTRING_EXTRA_CHECKS
-    CONTRACT_VOID
+    CONTRACTL
     {
         GC_NOTRIGGER;
         NOTHROW;
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckRepresentation(representation));
-        POSTCONDITION(GetRepresentation() == representation);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 #else //SSTRING_EXTRA_CHECKS
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -1246,7 +1243,7 @@ inline void SString::SetRepresentation(SString::Representation representation)
 
     SBuffer::SetRepresentationField((int) representation);
 
-    SS_RETURN;
+    return;
 }
 
 // Private helper:
@@ -1269,13 +1266,12 @@ FORCEINLINE void SString::NullTerminate()
 {
     SUPPORTS_DAC_HOST_ONLY;
 #ifdef SSTRING_EXTRA_CHECKS
-    CONTRACT_VOID
+    CONTRACTL
     {
-        POSTCONDITION(CheckPointer(this));
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 #else //SSTRING_EXTRA_CHECKS
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -1292,7 +1288,7 @@ FORCEINLINE void SString::NullTerminate()
         ((WCHAR *)end)[-1] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1452,7 +1448,7 @@ inline COUNT_T SString::CountToSize(COUNT_T count) const
     }
     SS_CONTRACT_END;
 
-    SS_RETURN (count+1) << GetCharacterSizeShift();
+    return (count+1) << GetCharacterSizeShift();
 }
 
 //----------------------------------------------------------------------------
@@ -1473,7 +1469,7 @@ inline COUNT_T SString::SizeToCount(COUNT_T size) const
     }
     SS_CONTRACT_END;
 
-    SS_RETURN (size >> GetCharacterSizeShift()) - 1;
+    return (size >> GetCharacterSizeShift()) - 1;
 }
 
 //----------------------------------------------------------------------------
@@ -1629,7 +1625,7 @@ inline WCHAR *SString::OpenUnicodeBuffer(COUNT_T countChars)
     SS_CONTRACT_END;
 
     OpenBuffer(REPRESENTATION_UNICODE, countChars);
-    SS_RETURN GetRawUnicode();
+    return GetRawUnicode();
 }
 
 //----------------------------------------------------------------------------
@@ -1651,7 +1647,7 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
     buffer = new WCHAR[GetCount() +1];
     wcscpy_s(buffer, GetCount() + 1, GetUnicode());
 
-    SS_RETURN buffer.Extract();
+    return buffer.Extract();
 }
 
 //----------------------------------------------------------------------------
@@ -1673,7 +1669,7 @@ inline UTF8 *SString::GetCopyOfUTF8String()
     buffer = new UTF8[GetSize()];
     strncpy(buffer, GetUTF8(), GetSize());
 
-    SS_RETURN buffer.Extract();
+    return buffer.Extract();
 }
 
 //----------------------------------------------------------------------------
@@ -1698,7 +1694,7 @@ inline UTF8 *SString::OpenUTF8Buffer(COUNT_T countBytes)
     SS_CONTRACT_END;
 
     OpenBuffer(REPRESENTATION_UTF8, countBytes);
-    SS_RETURN GetRawUTF8();
+    return GetRawUTF8();
 }
 
 //----------------------------------------------------------------------------
@@ -1711,7 +1707,7 @@ inline UTF8 *SString::OpenUTF8Buffer(COUNT_T countBytes)
 inline void SString::OpenBuffer(SString::Representation representation, COUNT_T countChars)
 {
 #ifdef SSTRING_EXTRA_CHECKS
-    CONTRACT_VOID
+    CONTRACTL
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
@@ -1719,13 +1715,10 @@ inline void SString::OpenBuffer(SString::Representation representation, COUNT_T 
         PRECONDITION(CheckRepresentation(representation));
         PRECONDITION(CheckSize(countChars));
 #if _DEBUG
-        POSTCONDITION(IsBufferOpen());
 #endif
-        POSTCONDITION(GetRawCount() == countChars);
-        POSTCONDITION(GetRepresentation() == representation || countChars == 0);
         THROWS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 #else
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_THROWS;
@@ -1735,7 +1728,7 @@ inline void SString::OpenBuffer(SString::Representation representation, COUNT_T 
 
     SBuffer::OpenRawBuffer(CountToSize(countChars));
 
-    SS_RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1777,7 +1770,7 @@ inline void SString::CloseBuffer()
     SBuffer::CloseRawBuffer();
     NullTerminate();
 
-    SS_RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1804,7 +1797,7 @@ inline void SString::CloseBuffer(COUNT_T finalCount)
     SBuffer::CloseRawBuffer(CountToSize(finalCount));
     NullTerminate();
 
-    SS_RETURN;
+    return;
 }
 
 //----------------------------------------------------------------------------
@@ -1814,14 +1807,13 @@ inline void SString::CloseBuffer(COUNT_T finalCount)
 inline void SString::EnsureWritable() const
 {
 #ifdef SSTRING_EXTRA_CHECKS
-    CONTRACT_VOID
+    CONTRACTL
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        POSTCONDITION(!IsLiteral());
         THROWS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 #else //SSTRING_EXTRA_CHECKS
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_THROWS;
@@ -1830,7 +1822,7 @@ inline void SString::EnsureWritable() const
     if (IsLiteral())
         const_cast<SString *>(this)->Resize(GetRawCount(), GetRepresentation(), PRESERVE);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -1850,16 +1842,16 @@ inline void SString::ConvertToFixed() const
 
     // If we're already fixed size, great.
     if (IsFixedSize())
-        SS_RETURN;
+        return;
 
     // See if we can coerce it to ASCII.
     if (ScanASCII())
-        SS_RETURN;
+        return;
 
     // Convert to unicode then.
     ConvertToUnicode();
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -1880,16 +1872,16 @@ inline void SString::ConvertToIteratable() const
 
     // If we're already iteratable, great.
     if (IsIteratable())
-        SS_RETURN;
+        return;
 
     // See if we can coerce it to ASCII.
     if (ScanASCII())
-        SS_RETURN;
+        return;
 
     // Convert to unicode then.
     ConvertToUnicode();
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -1909,7 +1901,7 @@ FORCEINLINE SString::CIterator SString::Begin() const
 
     ConvertToIteratable();
 
-    SS_RETURN CIterator(this, 0);
+    return CIterator(this, 0);
 }
 
 FORCEINLINE SString::CIterator SString::End() const
@@ -1926,7 +1918,7 @@ FORCEINLINE SString::CIterator SString::End() const
     ConvertToIteratable();
     ConvertToIteratable();
 
-    SS_RETURN CIterator(this, GetCount());
+    return CIterator(this, GetCount());
 }
 
 //-----------------------------------------------------------------------------
@@ -1948,7 +1940,7 @@ FORCEINLINE SString::Iterator SString::Begin()
     ConvertToIteratable();
     EnsureMutable();
 
-    SS_RETURN Iterator(this, 0);
+    return Iterator(this, 0);
 }
 
 FORCEINLINE SString::Iterator SString::End()
@@ -1966,7 +1958,7 @@ FORCEINLINE SString::Iterator SString::End()
     ConvertToIteratable();
     EnsureMutable();
 
-    SS_RETURN Iterator(this, GetCount());
+    return Iterator(this, GetCount());
 }
 
 //-----------------------------------------------------------------------------
@@ -1997,7 +1989,7 @@ inline SString::Index::Index(SString *string, SCOUNT_T index)
 
     m_characterSizeShift = string->GetCharacterSizeShift();
 
-    SS_RETURN;
+    return;
 }
 
 inline BYTE &SString::Index::GetAt(SCOUNT_T delta) const

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -19,12 +19,11 @@
 
 //#define SSTRING_EXTRA_CHECKS
 #ifdef SSTRING_EXTRA_CHECKS
-#define SS_CONTRACT CONTRACT
-#define SS_CONTRACT_VOID CONTRACT_VOID
-#define SS_CONTRACT_END CONTRACT_END
+#define SS_CONTRACT(x) CONTRACTL
+#define SS_CONTRACT_VOID CONTRACTL
+#define SS_CONTRACT_END CONTRACTL_END
 #define SS_CONSTRUCTOR_CHECK CONSTRUCTOR_CHECK
 #define SS_PRECONDITION PRECONDITION
-#define SS_POSTCONDITION POSTCONDITION
 
 #else //SSTRING_EXTRA_CHECKS
 
@@ -33,8 +32,6 @@
 #define SS_CONTRACT_END CONTRACTL_END
 #define SS_CONSTRUCTOR_CHECK
 #define SS_PRECONDITION(x)
-#define SS_POSTCONDITION(x)
-//Do I need this instance check at all?
 
 #endif
 
@@ -75,7 +72,6 @@ inline SString::SString(void *buffer, COUNT_T size)
         SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
-        SS_POSTCONDITION(IsEmpty());
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
@@ -103,7 +99,6 @@ inline SString::SString(const SString &s)
     {
         SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s.Check());
-        SS_POSTCONDITION(Equals(s));
         THROWS;
         GC_NOTRIGGER;
     }
@@ -179,8 +174,6 @@ inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
         PRECONDITION(s.Check());
         PRECONDITION(i.Check());
         PRECONDITION(CheckCount(count));
-        SS_POSTCONDITION(s.Match(i, *this));
-        SS_POSTCONDITION(GetRawCount() == count);
         THROWS;
         GC_NOTRIGGER;
     }
@@ -203,8 +196,6 @@ inline SString::SString(const SString &s, const CIterator &start, const CIterato
         PRECONDITION(end.Check());
         PRECONDITION(s.CheckIteratorRange(end));
         PRECONDITION(start <= end);
-        SS_POSTCONDITION(s.Match(start, *this));
-        SS_POSTCONDITION(GetRawCount() == (COUNT_T) (end - start));
         THROWS;
         GC_NOTRIGGER;
     }
@@ -429,7 +420,6 @@ inline void SString::Set(const SString &s)
     {
         INSTANCE_CHECK;
         PRECONDITION(s.Check());
-        SS_POSTCONDITION(Equals(s));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
@@ -532,8 +522,6 @@ inline void SString::Set(const SString &s, const CIterator &i, COUNT_T count)
         PRECONDITION(s.Check());
         PRECONDITION(i.Check());
         PRECONDITION(CheckCount(count));
-        SS_POSTCONDITION(s.Match(i, *this));
-        SS_POSTCONDITION(GetRawCount() == count);
         THROWS;
         GC_NOTRIGGER;
     }
@@ -564,8 +552,6 @@ inline void SString::Set(const SString &s, const CIterator &start, const CIterat
         PRECONDITION(end.Check());
         PRECONDITION(s.CheckIteratorRange(end));
         PRECONDITION(end >= start);
-        SS_POSTCONDITION(s.Match(start, *this));
-        SS_POSTCONDITION(GetRawCount() == (COUNT_T) (end - start));
         THROWS;
         GC_NOTRIGGER;
     }
@@ -608,7 +594,6 @@ inline const WCHAR *SString::GetUnicode() const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         if (IsRepresentation(REPRESENTATION_UNICODE)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
@@ -627,7 +612,6 @@ inline const UTF8 *SString::GetUTF8() const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         if (IsRepresentation(REPRESENTATION_UTF8)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
@@ -645,7 +629,6 @@ inline void SString::Normalize()
     SS_CONTRACT_VOID
     {
         INSTANCE_CHECK;
-        SS_POSTCONDITION(IsNormalized());
         THROWS_UNLESS_NORMALIZED;
         GC_NOTRIGGER;
     }
@@ -915,7 +898,6 @@ inline BOOL SString::Find(CIterator &i, const WCHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -932,7 +914,6 @@ inline BOOL SString::FindASCII(CIterator &i, const CHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(SString::Ascii, string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -949,7 +930,6 @@ inline BOOL SString::FindUTF8(CIterator &i, const CHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(SString::Ascii, string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -966,7 +946,6 @@ inline BOOL SString::FindBack(CIterator &i, const WCHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -983,7 +962,6 @@ inline BOOL SString::FindBackASCII(CIterator &i, const CHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(SString::Ascii, string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1000,7 +978,6 @@ inline BOOL SString::FindBackUTF8(CIterator &i, const CHAR *string) const
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(CheckPointer(string));
-        SS_POSTCONDITION(RETVAL == Match(i, SString(SString::Ascii, string)));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1161,7 +1138,6 @@ inline COUNT_T SString::GetCount() const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckCount(RETVAL));
         THROWS_UNLESS_NORMALIZED;
         SUPPORTS_DAC;
     }
@@ -1442,7 +1418,6 @@ inline COUNT_T SString::CountToSize(COUNT_T count) const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckCount(count));
-        SS_POSTCONDITION(SizeToCount(RETVAL) == count);
         NOTHROW;
         SUPPORTS_DAC;
     }
@@ -1463,7 +1438,6 @@ inline COUNT_T SString::SizeToCount(COUNT_T size) const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckSize(size));
-        SS_POSTCONDITION(CountToSize(RETVAL) == size);
         NOTHROW;
         SUPPORTS_DAC;
     }
@@ -1615,11 +1589,7 @@ inline WCHAR *SString::OpenUnicodeBuffer(COUNT_T countChars)
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckCount(countChars));
 #if _DEBUG
-        SS_POSTCONDITION(IsBufferOpen());
 #endif
-        SS_POSTCONDITION(GetRawCount() == countChars);
-        SS_POSTCONDITION(GetRepresentation() == REPRESENTATION_UNICODE || countChars == 0);
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1638,7 +1608,6 @@ inline WCHAR *SString::GetCopyOfUnicodeString()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(buffer));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1660,7 +1629,6 @@ inline UTF8 *SString::GetCopyOfUTF8String()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(buffer));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1684,11 +1652,7 @@ inline UTF8 *SString::OpenUTF8Buffer(COUNT_T countBytes)
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckCount(countBytes));
 #if _DEBUG
-        SS_POSTCONDITION(IsBufferOpen());
 #endif
-        SS_POSTCONDITION(GetRawCount() == countBytes);
-        SS_POSTCONDITION(GetRepresentation() == REPRESENTATION_UTF8 || countBytes == 0);
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1762,7 +1726,6 @@ inline void SString::CloseBuffer()
 #if _DEBUG
         PRECONDITION_MSG(IsBufferOpen(), "Can only CloseBuffer() after a call to OpenBuffer()");
 #endif
-        SS_POSTCONDITION(CheckPointer(this));
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1788,8 +1751,6 @@ inline void SString::CloseBuffer(COUNT_T finalCount)
         PRECONDITION_MSG(IsBufferOpen(), "Can only CloseBuffer() after a call to OpenBuffer()");
 #endif
         PRECONDITION(CheckSize(finalCount));
-        SS_POSTCONDITION(CheckPointer(this));
-        SS_POSTCONDITION(GetRawCount() == finalCount);
         THROWS;
     }
     SS_CONTRACT_END;
@@ -1834,7 +1795,6 @@ inline void SString::ConvertToFixed() const
     {
         GC_NOTRIGGER;
         SS_PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(IsFixedSize());
         THROWS_UNLESS_NORMALIZED;
         SUPPORTS_DAC;
     }
@@ -1864,7 +1824,6 @@ inline void SString::ConvertToIteratable() const
     {
         GC_NOTRIGGER;
         SS_PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(IsIteratable());
         THROWS_UNLESS_NORMALIZED;
         SUPPORTS_DAC;
     }
@@ -1894,7 +1853,6 @@ FORCEINLINE SString::CIterator SString::Begin() const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
         THROWS_UNLESS_NORMALIZED;
     }
     SS_CONTRACT_END;
@@ -1910,7 +1868,6 @@ FORCEINLINE SString::CIterator SString::End() const
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
         THROWS_UNLESS_NORMALIZED;
     }
     SS_CONTRACT_END;
@@ -1931,7 +1888,6 @@ FORCEINLINE SString::Iterator SString::Begin()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
         THROWS; // EnsureMutable always throws
         SUPPORTS_DAC;
     }
@@ -1949,7 +1905,6 @@ FORCEINLINE SString::Iterator SString::End()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckValue(RETVAL));
         THROWS; // EnsureMutable always Throws
         SUPPORTS_DAC;
     }
@@ -1979,7 +1934,6 @@ inline SString::Index::Index(SString *string, SCOUNT_T index)
         PRECONDITION(CheckPointer(string));
         PRECONDITION(string->IsIteratable());
         PRECONDITION(DoCheck(0));
-        SS_POSTCONDITION(CheckPointer(this));
         // POSTCONDITION(Subtract(string->Begin()) == index); contract violation - fix later
         NOTHROW;
         CANNOT_TAKE_LOCK;

--- a/src/coreclr/inc/sstring.inl
+++ b/src/coreclr/inc/sstring.inl
@@ -22,7 +22,6 @@
 #define SS_CONTRACT(x) CONTRACTL
 #define SS_CONTRACT_VOID CONTRACTL
 #define SS_CONTRACT_END CONTRACTL_END
-#define SS_CONSTRUCTOR_CHECK CONSTRUCTOR_CHECK
 #define SS_PRECONDITION PRECONDITION
 
 #else //SSTRING_EXTRA_CHECKS
@@ -30,7 +29,6 @@
 #define SS_CONTRACT(x) CONTRACTL
 #define SS_CONTRACT_VOID CONTRACTL
 #define SS_CONTRACT_END CONTRACTL_END
-#define SS_CONSTRUCTOR_CHECK
 #define SS_PRECONDITION(x)
 
 #endif
@@ -49,14 +47,13 @@ inline SString::SString()
 #ifdef SSTRING_EXTRA_CHECKS
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
     CONTRACTL_END;
 
     _ASSERTE(IsEmpty());
-    return;
+    CONSISTENCY_CHECK(Check());
 #else
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -69,7 +66,6 @@ inline SString::SString(void *buffer, COUNT_T size)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(buffer));
         PRECONDITION(CheckSize(size));
         NOTHROW;
@@ -89,7 +85,7 @@ inline SString::SString(void *buffer, COUNT_T size)
         GetRawUnicode()[0] = 0;
     }
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s)
@@ -97,7 +93,6 @@ inline SString::SString(const SString &s)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s.Check());
         THROWS;
         GC_NOTRIGGER;
@@ -106,7 +101,7 @@ inline SString::SString(const SString &s)
 
     Set(s);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s1, const SString &s2)
@@ -114,7 +109,6 @@ inline SString::SString(const SString &s1, const SString &s2)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s1.Check());
         PRECONDITION(s2.Check());
         THROWS;
@@ -124,7 +118,7 @@ inline SString::SString(const SString &s1, const SString &s2)
 
     Set(s1, s2);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s1, const SString &s2, const SString &s3)
@@ -132,7 +126,6 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s1.Check());
         PRECONDITION(s2.Check());
         PRECONDITION(s3.Check());
@@ -143,7 +136,7 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3)
 
     Set(s1, s2, s3);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s1, const SString &s2, const SString &s3, const SString &s4)
@@ -151,7 +144,6 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3,
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s1.Check());
         PRECONDITION(s2.Check());
         PRECONDITION(s3.Check());
@@ -162,7 +154,7 @@ inline SString::SString(const SString &s1, const SString &s2, const SString &s3,
 
     Set(s1, s2, s3, s4);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
@@ -170,7 +162,6 @@ inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s.Check());
         PRECONDITION(i.Check());
         PRECONDITION(CheckCount(count));
@@ -181,7 +172,7 @@ inline SString::SString(const SString &s, const CIterator &i, COUNT_T count)
 
     Set(s, i, count);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const SString &s, const CIterator &start, const CIterator &end)
@@ -189,7 +180,6 @@ inline SString::SString(const SString &s, const CIterator &start, const CIterato
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(s.Check());
         PRECONDITION(start.Check());
         PRECONDITION(s.CheckIteratorRange(start));
@@ -203,7 +193,7 @@ inline SString::SString(const SString &s, const CIterator &start, const CIterato
 
     Set(s, start, end);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const WCHAR *string)
@@ -211,7 +201,6 @@ inline SString::SString(const WCHAR *string)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
         THROWS;
         GC_NOTRIGGER;
@@ -223,7 +212,7 @@ inline SString::SString(const WCHAR *string)
     _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
     SetNormalized();
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(const WCHAR *string, COUNT_T count)
@@ -231,7 +220,6 @@ inline SString::SString(const WCHAR *string, COUNT_T count)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
         PRECONDITION(CheckCount(count));
         THROWS;
@@ -244,7 +232,7 @@ inline SString::SString(const WCHAR *string, COUNT_T count)
     _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
     SetNormalized();
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(enum tagASCII, const ASCII *string)
@@ -252,7 +240,6 @@ inline SString::SString(enum tagASCII, const ASCII *string)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
         PRECONDITION(CheckASCIIString(string));
         THROWS;
@@ -262,7 +249,7 @@ inline SString::SString(enum tagASCII, const ASCII *string)
 
     SetASCII(string);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(enum tagASCII, const ASCII *string, COUNT_T count)
@@ -270,7 +257,6 @@ inline SString::SString(enum tagASCII, const ASCII *string, COUNT_T count)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
         PRECONDITION(CheckASCIIString(string, count));
         PRECONDITION(CheckCount(count));
@@ -281,7 +267,7 @@ inline SString::SString(enum tagASCII, const ASCII *string, COUNT_T count)
 
     SetASCII(string, count);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(tagUTF8 dummytag, const UTF8 *string)
@@ -289,7 +275,6 @@ inline SString::SString(tagUTF8 dummytag, const UTF8 *string)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         // !!! Check for illegal UTF8 encoding?
         PRECONDITION(CheckPointer(string, NULL_OK));
         THROWS;
@@ -308,7 +293,6 @@ inline SString::SString(tagUTF8 dummytag, const UTF8 *string, COUNT_T count)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         // !!! Check for illegal UTF8 encoding?
         PRECONDITION(CheckPointer(string, NULL_OK));
         PRECONDITION(CheckCount(count));
@@ -327,7 +311,6 @@ inline SString::SString(WCHAR character)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
@@ -335,7 +318,7 @@ inline SString::SString(WCHAR character)
 
     Set(character);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(tagLiteral dummytag, const ASCII *literal)
@@ -343,7 +326,6 @@ inline SString::SString(tagLiteral dummytag, const ASCII *literal)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(literal));
         PRECONDITION(CheckASCIIString(literal));
         NOTHROW;
@@ -354,7 +336,7 @@ inline SString::SString(tagLiteral dummytag, const ASCII *literal)
 
     SetRepresentation(REPRESENTATION_ASCII);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
@@ -362,7 +344,6 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(literal));
         NOTHROW;
         GC_NOTRIGGER;
@@ -371,7 +352,7 @@ inline SString::SString(tagUTF8Literal dummytag, const UTF8 *literal)
 
     SetRepresentation(REPRESENTATION_UTF8);
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
@@ -379,7 +360,6 @@ inline SString::SString(tagLiteral dummytag, const WCHAR *literal)
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(literal));
         NOTHROW;
         GC_NOTRIGGER;
@@ -397,7 +377,6 @@ inline SString::SString(tagLiteral dummytag, const WCHAR *literal, COUNT_T count
 {
     SS_CONTRACT_VOID
     {
-        SS_CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(literal));
         NOTHROW;
         GC_NOTRIGGER;
@@ -407,7 +386,7 @@ inline SString::SString(tagLiteral dummytag, const WCHAR *literal, COUNT_T count
     SetRepresentation(REPRESENTATION_UNICODE);
     SetNormalized();
 
-    return;
+    CONSISTENCY_CHECK(Check());
 }
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9753,7 +9753,7 @@ bool Lowering::CheckMultiRegLclVar(GenTreeLclVar* lclNode, int registerCount)
                 // matching reg and field counts"; for example, consider
                 //
                 // * STORE_LCL_VAR<struct{Vector3, int}>(CALL)
-                // * return(LCL_VAR<struct{Vector3, int}>)
+                // * RETURN(LCL_VAR<struct{Vector3, int}>)
                 //
                 // These return in two GPR registers, while the fields of the
                 // local are stored in SIMD and GPR register, so registerCount

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9753,7 +9753,7 @@ bool Lowering::CheckMultiRegLclVar(GenTreeLclVar* lclNode, int registerCount)
                 // matching reg and field counts"; for example, consider
                 //
                 // * STORE_LCL_VAR<struct{Vector3, int}>(CALL)
-                // * RETURN(LCL_VAR<struct{Vector3, int}>)
+                // * return(LCL_VAR<struct{Vector3, int}>)
                 //
                 // These return in two GPR registers, while the fields of the
                 // local are stored in SIMD and GPR register, so registerCount

--- a/src/coreclr/utilcode/clrconfig.cpp
+++ b/src/coreclr/utilcode/clrconfig.cpp
@@ -542,12 +542,11 @@ LPWSTR CLRConfig::GetConfigValue(const ConfigStringInfo & info)
 // static
 HRESULT CLRConfig::GetConfigValue(const ConfigStringInfo & info, _Outptr_result_z_ LPWSTR * outVal)
 {
-    CONTRACT(HRESULT) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
-        INJECT_FAULT (CONTRACT_RETURN E_OUTOFMEMORY);
-        POSTCONDITION(CheckPointer(outVal, NULL_OK)); // TODO: Should this check be *outVal instead of outVal?
-    } CONTRACT_END;
+        INJECT_FAULT (return E_OUTOFMEMORY);
+    } CONTRACTL_END;
 
     LPWSTR result = NULL;
 
@@ -568,7 +567,7 @@ HRESULT CLRConfig::GetConfigValue(const ConfigStringInfo & info, _Outptr_result_
     }
 
     *outVal = result;
-    RETURN S_OK;
+    return S_OK;
 }
 
 //

--- a/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
+++ b/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
@@ -54,7 +54,6 @@ ExplicitControlLoaderHeap::ExplicitControlLoaderHeap(bool fMakeExecutable) :
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         FORBID_FAULT;
     }

--- a/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
+++ b/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
@@ -293,15 +293,14 @@ BOOL ExplicitControlLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
 
 void *ExplicitControlLoaderHeap::AllocMemForCode_NoThrow(size_t dwHeaderSize, size_t dwCodeSize, DWORD dwCodeAlignment, size_t dwReserveForJumpStubs)
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
-        INJECT_FAULT(CONTRACT_RETURN NULL;);
+        INJECT_FAULT(return NULL;);
         PRECONDITION(0 == (dwCodeAlignment & (dwCodeAlignment - 1))); // require power of 2
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     INCONTRACT(_ASSERTE(!ARE_FAULTS_FORBIDDEN()));
 
@@ -314,14 +313,14 @@ void *ExplicitControlLoaderHeap::AllocMemForCode_NoThrow(size_t dwHeaderSize, si
     S_SIZE_T cbAllocSize = S_SIZE_T(dwHeaderSize) + S_SIZE_T(dwCodeSize) + S_SIZE_T(dwCodeAlignment - 1) + S_SIZE_T(dwReserveForJumpStubs);
     if( cbAllocSize.IsOverflow() )
     {
-        RETURN NULL;
+        return NULL;
     }
 
     if (cbAllocSize.Value() > GetBytesAvailCommittedRegion())
     {
         if (GetMoreCommittedPages(cbAllocSize.Value()) == FALSE)
         {
-            RETURN NULL;
+            return NULL;
         }
     }
 
@@ -329,7 +328,7 @@ void *ExplicitControlLoaderHeap::AllocMemForCode_NoThrow(size_t dwHeaderSize, si
     EtwAllocRequest(this, pResult, (pResult + dwCodeSize) - m_pAllocPtr);
     m_pAllocPtr = pResult + dwCodeSize;
 
-    RETURN pResult;
+    return pResult;
 }
 
 

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -43,7 +43,6 @@ UnlockedInterleavedLoaderHeap::UnlockedInterleavedLoaderHeap(
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         FORBID_FAULT;
     }

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -449,7 +449,7 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub_NoThrow(
                                                           INDEBUG(_In_ const char *szFile)
                                                           COMMA_INDEBUG(int  lineNum))
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         NOTHROW;
 
@@ -457,14 +457,14 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub_NoThrow(
         //INJECT_FAULT( do{ if (*pdwExtra) {*pdwExtra = 0} RETURN NULL; } while(0) );
 
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     size_t dwRequestedSize = m_dwGranularity;
     size_t alignment = 1;
 
     STATIC_CONTRACT_FAULT;
 
-    SHOULD_INJECT_FAULT(RETURN NULL);
+    SHOULD_INJECT_FAULT(return NULL);
 
     void *pResult;
 
@@ -486,7 +486,7 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub_NoThrow(
         {
             if (!GetMoreCommittedPages(dwRequestedSize))
             {
-                RETURN NULL;
+                return NULL;
             }
         }
 
@@ -523,7 +523,7 @@ void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub_NoThrow(
     EtwAllocRequest(this, pResult, dwRequestedSize);
 #endif //_DEBUG
 
-    RETURN pResult;
+    return pResult;
 }
 
 void *UnlockedInterleavedLoaderHeap::UnlockedAllocStub(

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -49,7 +49,6 @@ UnlockedLoaderHeap::UnlockedLoaderHeap(DWORD dwReserveBlockSize,
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         FORBID_FAULT;
     }

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -346,15 +346,14 @@ void *UnlockedLoaderHeap::UnlockedAllocMem(size_t dwSize
                                            COMMA_INDEBUG(_In_ const char *szFile)
                                            COMMA_INDEBUG(int  lineNum))
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
         INJECT_FAULT(ThrowOutOfMemory(););
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     void *pResult = UnlockedAllocMem_NoThrow(
         dwSize COMMA_INDEBUG(szFile) COMMA_INDEBUG(lineNum));
@@ -362,7 +361,7 @@ void *UnlockedLoaderHeap::UnlockedAllocMem(size_t dwSize
     if (pResult == NULL)
         ThrowOutOfMemory();
 
-    RETURN pResult;
+    return pResult;
 }
 
 #ifdef _DEBUG
@@ -398,18 +397,17 @@ void *UnlockedLoaderHeap::UnlockedAllocMem_NoThrow(size_t dwSize
                                                    COMMA_INDEBUG(_In_ const char *szFile)
                                                    COMMA_INDEBUG(int lineNum))
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
-        INJECT_FAULT(CONTRACT_RETURN NULL;);
+        INJECT_FAULT(return NULL;);
         PRECONDITION(dwSize != 0);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    SHOULD_INJECT_FAULT(RETURN NULL);
+    SHOULD_INJECT_FAULT(return NULL);
 
     INDEBUG(size_t dwRequestedSize = dwSize;)
 
@@ -480,7 +478,7 @@ again:
 #endif
 
             EtwAllocRequest(this, pData, dwSize);
-            RETURN pData;
+            return pData;
         }
     }
 
@@ -490,7 +488,7 @@ again:
         goto again;
 
     // We could not satisfy this allocation request
-    RETURN NULL;
+    return NULL;
 }
 
 void UnlockedLoaderHeap::UnlockedBackoutMem(void *pMem,
@@ -669,7 +667,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
                                                           COMMA_INDEBUG(_In_ const char *szFile)
                                                           COMMA_INDEBUG(int  lineNum))
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         NOTHROW;
 
@@ -678,12 +676,8 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
 
         PRECONDITION( alignment != 0 );
         PRECONDITION(0 == (alignment & (alignment - 1))); // require power of 2
-        POSTCONDITION( (RETVAL) ?
-                       (0 == ( ((UINT_PTR)(RETVAL)) & (alignment - 1))) : // If non-null, pointer must be aligned
-                       (pdwExtra == NULL || 0 == *pdwExtra)    //   or else *pdwExtra must be set to 0
-                     );
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     STATIC_CONTRACT_FAULT;
 
@@ -693,7 +687,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
         *pdwExtra = 0;
     }
 
-    SHOULD_INJECT_FAULT(RETURN NULL);
+    SHOULD_INJECT_FAULT(return NULL);
 
     void *pResult;
 
@@ -702,7 +696,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
     // Check for overflow if we align the allocation
     if (dwRequestedSize + alignment < dwRequestedSize)
     {
-        RETURN NULL;
+        return NULL;
     }
 
     // We don't know how much "extra" we need to satisfy the alignment until we know
@@ -715,7 +709,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
     {
         if (!GetMoreCommittedPages(dwRoomSize))
         {
-            RETURN NULL;
+            return NULL;
         }
     }
 
@@ -734,7 +728,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
     S_SIZE_T cbAllocSize = S_SIZE_T( dwRequestedSize ) + S_SIZE_T( extra );
     if( cbAllocSize.IsOverflow() )
     {
-        RETURN NULL;
+        return NULL;
     }
 
     size_t dwSize = AllocMem_TotalSize( cbAllocSize.Value());
@@ -791,7 +785,7 @@ void *UnlockedLoaderHeap::UnlockedAllocAlignedMem_NoThrow(size_t  dwRequestedSiz
         *pdwExtra = extra;
     }
 
-    RETURN pResult;
+    return pResult;
 
 }
 

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -118,7 +118,7 @@ CHECK PEDecoder::CheckILOnlyFormat() const
 
 BOOL PEDecoder::HasNTHeaders() const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
@@ -126,12 +126,12 @@ BOOL PEDecoder::HasNTHeaders() const
         SUPPORTS_DAC;
         PRECONDITION(HasContents());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Check for a valid DOS header
 
     if (m_size < sizeof(IMAGE_DOS_HEADER))
-        RETURN FALSE;
+        return FALSE;
 
     IMAGE_DOS_HEADER* pDOS = PTR_IMAGE_DOS_HEADER(m_base);
 
@@ -139,7 +139,7 @@ BOOL PEDecoder::HasNTHeaders() const
         if (pDOS->e_magic != VAL16(IMAGE_DOS_SIGNATURE)
             || (DWORD) pDOS->e_lfanew == VAL32(0))
         {
-            RETURN FALSE;
+            return FALSE;
         }
 
         // Check for integer overflow
@@ -147,31 +147,31 @@ BOOL PEDecoder::HasNTHeaders() const
                                S_SIZE_T(sizeof(IMAGE_NT_HEADERS)));
         if (cbNTHeaderEnd.IsOverflow())
         {
-            RETURN FALSE;
+            return FALSE;
         }
 
         // Now check for a valid NT header
         if (m_size < cbNTHeaderEnd.Value())
         {
-            RETURN FALSE;
+            return FALSE;
         }
     }
 
     IMAGE_NT_HEADERS *pNT = PTR_IMAGE_NT_HEADERS(m_base + VAL32(pDOS->e_lfanew));
 
     if (pNT->Signature != VAL32(IMAGE_NT_SIGNATURE))
-        RETURN FALSE;
+        return FALSE;
 
     if (pNT->OptionalHeader.Magic == VAL16(IMAGE_NT_OPTIONAL_HDR32_MAGIC))
     {
         if (pNT->FileHeader.SizeOfOptionalHeader != VAL16(sizeof(IMAGE_OPTIONAL_HEADER32)))
-            RETURN FALSE;
+            return FALSE;
     }
     else if (pNT->OptionalHeader.Magic == VAL16(IMAGE_NT_OPTIONAL_HDR64_MAGIC))
     {
         // on 64 bit we can promote this
         if (pNT->FileHeader.SizeOfOptionalHeader != VAL16(sizeof(IMAGE_OPTIONAL_HEADER64)))
-            RETURN FALSE;
+            return FALSE;
 
         // Check for integer overflow
         S_SIZE_T cbNTHeaderEnd(S_SIZE_T(static_cast<SIZE_T>(VAL32(pDOS->e_lfanew))) +
@@ -179,23 +179,23 @@ BOOL PEDecoder::HasNTHeaders() const
 
         if (cbNTHeaderEnd.IsOverflow())
         {
-            RETURN FALSE;
+            return FALSE;
     }
 
         // Now check for a valid NT header
         if (m_size < cbNTHeaderEnd.Value())
         {
-            RETURN FALSE;
+            return FALSE;
         }
 
     }
     else
-        RETURN FALSE;
+        return FALSE;
 
     // Go ahead and cache NT header since we already found it.
     const_cast<PEDecoder *>(this)->m_pNTHeaders = dac_cast<PTR_IMAGE_NT_HEADERS>(pNT);
 
-    RETURN TRUE;
+    return TRUE;
 }
 
 CHECK PEDecoder::CheckNTHeaders() const
@@ -683,25 +683,25 @@ CHECK PEDecoder::CheckInternalAddress(SIZE_T address, COUNT_T size, IsNullOK ok)
 
 RVA PEDecoder::InternalAddressToRva(SIZE_T address) const
 {
-    CONTRACT(RVA)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckRva(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_flags & FLAG_RELOCATED)
     {
         // Address has been fixed up
-        RETURN (RVA) ((BYTE *) address - (BYTE *) m_base);
+        _ASSERTE(CheckRva((RVA) ((BYTE *) address - (BYTE *) m_base)));
+        return (RVA) ((BYTE *) address - (BYTE *) m_base);
     }
     else
     {
         // Address has not been fixed up
-        RETURN (RVA) (address - (SIZE_T) GetPreferredBase());
+        return (RVA) (address - (SIZE_T) GetPreferredBase());
     }
 }
 
@@ -709,7 +709,7 @@ RVA PEDecoder::InternalAddressToRva(SIZE_T address) const
 // The name should include the starting "." as well.
 IMAGE_SECTION_HEADER *PEDecoder::FindSection(LPCSTR sectionName) const
 {
-    CONTRACT(IMAGE_SECTION_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -717,16 +717,15 @@ IMAGE_SECTION_HEADER *PEDecoder::FindSection(LPCSTR sectionName) const
         NOTHROW;
         GC_NOTRIGGER;
         CANNOT_TAKE_LOCK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Ensure that the section name length is valid
     SIZE_T iSectionNameLength = strlen(sectionName);
     if ((iSectionNameLength < 1) || (iSectionNameLength > IMAGE_SIZEOF_SHORT_NAME))
     {
         _ASSERTE(!"Invalid section name!");
-        RETURN NULL;
+        return NULL;
     }
 
     // Get the start and ends of the sections
@@ -753,23 +752,22 @@ IMAGE_SECTION_HEADER *PEDecoder::FindSection(LPCSTR sectionName) const
      }
 
     if (TRUE == fFoundSection)
-        RETURN pSection;
+        return pSection;
     else
-        RETURN NULL;
+        return NULL;
 }
 
 IMAGE_SECTION_HEADER *PEDecoder::RvaToSection(RVA rva) const
 {
-    CONTRACT(IMAGE_SECTION_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         CANNOT_TAKE_LOCK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PTR_IMAGE_SECTION_HEADER section = dac_cast<PTR_IMAGE_SECTION_HEADER>(FindFirstSection(FindNTHeaders()));
     PTR_IMAGE_SECTION_HEADER sectionEnd = section + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
@@ -788,31 +786,30 @@ IMAGE_SECTION_HEADER *PEDecoder::RvaToSection(RVA rva) const
                 }
             }
             if (rva < VAL32(section->VirtualAddress))
-                RETURN NULL;
+                return NULL;
             else
             {
-                RETURN section;
+                return section;
             }
         }
 
         section++;
     }
 
-    RETURN NULL;
+    return NULL;
 }
 
 IMAGE_SECTION_HEADER *PEDecoder::OffsetToSection(COUNT_T fileOffset) const
 {
-    CONTRACT(IMAGE_SECTION_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PTR_IMAGE_SECTION_HEADER section = dac_cast<PTR_IMAGE_SECTION_HEADER>(FindFirstSection(FindNTHeaders()));
     PTR_IMAGE_SECTION_HEADER sectionEnd = section + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
@@ -822,20 +819,22 @@ IMAGE_SECTION_HEADER *PEDecoder::OffsetToSection(COUNT_T fileOffset) const
         if (fileOffset < section->PointerToRawData + section->SizeOfRawData)
         {
             if (fileOffset < section->PointerToRawData)
-                RETURN NULL;
+                return NULL;
             else
-                RETURN section;
+                {
+                    return section;
+                }
         }
 
         section++;
     }
 
-    RETURN NULL;
+    return NULL;
 }
 
 TADDR PEDecoder::GetRvaData(RVA rva, IsNullOK ok /*= NULL_NOT_OK*/) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -845,10 +844,10 @@ TADDR PEDecoder::GetRvaData(RVA rva, IsNullOK ok /*= NULL_NOT_OK*/) const
         CANNOT_TAKE_LOCK;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if ((rva == 0)&&(ok == NULL_NOT_OK))
-        RETURN (TADDR)NULL;
+        return (TADDR)NULL;
 
     RVA offset;
     if (IsMapped())
@@ -858,12 +857,12 @@ TADDR PEDecoder::GetRvaData(RVA rva, IsNullOK ok /*= NULL_NOT_OK*/) const
         offset = RvaToOffset(rva);
     }
 
-    RETURN( m_base + offset );
+    return( m_base + offset );
 }
 
 RVA PEDecoder::GetDataRva(const TADDR data) const
 {
-    CONTRACT(RVA)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -872,16 +871,16 @@ RVA PEDecoder::GetDataRva(const TADDR data) const
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (data == (TADDR)NULL)
-        RETURN 0;
+        return 0;
 
     COUNT_T offset = (COUNT_T) (data - m_base);
     if (IsMapped())
-        RETURN offset;
+        return offset;
     else
-        RETURN OffsetToRva(offset);
+        return OffsetToRva(offset);
 }
 
 BOOL PEDecoder::PointerInPE(PTR_CVOID data) const
@@ -911,7 +910,7 @@ BOOL PEDecoder::PointerInPE(PTR_CVOID data) const
 
 TADDR PEDecoder::GetOffsetData(COUNT_T fileOffset, IsNullOK ok /*= NULL_NOT_OK*/) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckNTHeaders());
@@ -919,12 +918,12 @@ TADDR PEDecoder::GetOffsetData(COUNT_T fileOffset, IsNullOK ok /*= NULL_NOT_OK*/
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if ((fileOffset == 0)&&(ok == NULL_NOT_OK))
-        RETURN (TADDR)NULL;
+        return (TADDR)NULL;
 
-    RETURN GetRvaData(OffsetToRva(fileOffset));
+    return GetRvaData(OffsetToRva(fileOffset));
 }
 
 //-------------------------------------------------------------------------------
@@ -1210,20 +1209,20 @@ ULONG PEDecoder::GetEntryPointToken() const
 
 IMAGE_COR_VTABLEFIXUP *PEDecoder::GetVTableFixups(COUNT_T *pCount) const
 {
-    CONTRACT(IMAGE_COR_VTABLEFIXUP *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckCorHeader());
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     IMAGE_DATA_DIRECTORY *pDir = &GetCorHeader()->VTableFixups;
 
     if (pCount != NULL)
         *pCount = VAL32(pDir->Size)/sizeof(IMAGE_COR_VTABLEFIXUP);
 
-    RETURN PTR_IMAGE_COR_VTABLEFIXUP(GetDirectoryData(pDir));
+    return PTR_IMAGE_COR_VTABLEFIXUP(GetDirectoryData(pDir));
 }
 
 CHECK PEDecoder::CheckILOnly() const
@@ -2138,15 +2137,14 @@ PTR_IMAGE_DEBUG_DIRECTORY PEDecoder::GetDebugDirectoryEntry(UINT index) const
 
 PTR_CVOID PEDecoder::GetNativeManifestMetadata(COUNT_T *pSize) const
 {
-    CONTRACT(PTR_CVOID)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(HasReadyToRunHeader());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK)); // TBD - may not store metadata for IJW
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMAGE_DATA_DIRECTORY *pDir = NULL;
     {
@@ -2175,14 +2173,14 @@ PTR_CVOID PEDecoder::GetNativeManifestMetadata(COUNT_T *pSize) const
                 *pSize = 0;
             }
 
-            RETURN NULL;
+            return NULL;
         }
     }
 
     if (pSize != NULL)
         *pSize = VAL32(pDir->Size);
 
-    RETURN dac_cast<PTR_VOID>(GetDirectoryData(pDir));
+    return dac_cast<PTR_VOID>(GetDirectoryData(pDir));
 }
 
 BOOL PEDecoder::HasNativeEntryPoint() const
@@ -2201,16 +2199,15 @@ BOOL PEDecoder::HasNativeEntryPoint() const
 
 void *PEDecoder::GetNativeEntryPoint() const
 {
-    CONTRACT (void *) {
+    CONTRACTL {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckCorHeader());
         PRECONDITION(HasNativeEntryPoint());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
-    RETURN ((void *) GetRvaData((RVA)VAL32(IMAGE_COR20_HEADER_FIELD(*GetCorHeader(), EntryPointToken))));
+    return ((void *) GetRvaData((RVA)VAL32(IMAGE_COR20_HEADER_FIELD(*GetCorHeader(), EntryPointToken))));
 }
 
 #ifdef DACCESS_COMPILE

--- a/src/coreclr/utilcode/sbuffer.cpp
+++ b/src/coreclr/utilcode/sbuffer.cpp
@@ -31,18 +31,17 @@ const DWORD g_garbageFillBuffer[GARBAGE_FILL_BUFFER_ITEMS] =
 //----------------------------------------------------------------------------
 void SBuffer::ReallocateBuffer(COUNT_T allocation, Preserve preserve)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(this));
         PRECONDITION(CheckBufferClosed());
         PRECONDITION(CheckAllocation(allocation));
         PRECONDITION(allocation >= m_size);
-        POSTCONDITION(m_allocation == allocation);
         if (allocation > 0) THROWS; else NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     BYTE *newBuffer = NULL;
     if (allocation > 0)
@@ -69,12 +68,13 @@ void SBuffer::ReallocateBuffer(COUNT_T allocation, Preserve preserve)
 
     ClearImmutable();
 
-    RETURN;
+    _ASSERTE(m_allocation == allocation);
+    return;
 }
 
 void SBuffer::Replace(const Iterator &i, COUNT_T deleteSize, COUNT_T insertSize)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
@@ -82,7 +82,7 @@ void SBuffer::Replace(const Iterator &i, COUNT_T deleteSize, COUNT_T insertSize)
         PRECONDITION(CheckIteratorRange(i, deleteSize));
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     COUNT_T startRange = (COUNT_T) (i.m_ptr - m_buffer);
     // The PRECONDITION(CheckIterationRange(i, deleteSize)) should check this in
@@ -139,7 +139,7 @@ void SBuffer::Replace(const Iterator &i, COUNT_T deleteSize, COUNT_T insertSize)
 
     DebugConstructBuffer(i.m_ptr, insertSize);
 
-    RETURN;
+    return;
 }
 
 

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -282,7 +282,6 @@ void SString::SetPreallocated(const WCHAR *string, COUNT_T count)
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
         PRECONDITION(CheckCount(count));
-        SS_POSTCONDITION(IsEmpty());
         GC_NOTRIGGER;
         NOTHROW;
         SUPPORTS_DAC_HOST_ONLY;
@@ -588,7 +587,6 @@ void SString::Truncate(const Iterator &i)
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
-        SS_POSTCONDITION(GetRawCount() == i - Begin());
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
@@ -1646,7 +1644,6 @@ void SString::LowerCase()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         if (IsRepresentation(REPRESENTATION_UNICODE)) NOTHROW; else THROWS;
         SUPPORTS_DAC;
     }
@@ -1696,7 +1693,6 @@ void SString::UpperCase()
     {
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(this));
-        SS_POSTCONDITION(CheckPointer(RETVAL));
         if (IsRepresentation(REPRESENTATION_UNICODE)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC;

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -983,6 +983,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, s));
                     return TRUE;
                 }
                 start++;
@@ -1000,6 +1001,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, s));
                     return TRUE;
                 }
                 start++;
@@ -1011,6 +1013,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         {
             if (source.GetRawCount() == 0)
                 {
+                _ASSERTE(Match(i, s));
                     return TRUE;
                 }
         }
@@ -1021,6 +1024,7 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
+    _ASSERTE(!Match(i, s));
     return FALSE;
 }
 
@@ -1053,6 +1057,7 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, c));
                     return TRUE;
                 }
                 start++;
@@ -1069,6 +1074,7 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, c));
                     return TRUE;
                 }
                 start++;
@@ -1084,6 +1090,7 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
+    _ASSERTE(!Match(i, c));
     return FALSE;
 }
 
@@ -1122,6 +1129,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, s));
                     return TRUE;
                 }
                 start--;
@@ -1142,6 +1150,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, s));
                     return TRUE;
                 }
                 start--;
@@ -1153,6 +1162,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         {
             if (source.GetRawCount() == 0)
                 {
+                _ASSERTE(Match(i, s));
                     return TRUE;
                 }
         }
@@ -1163,6 +1173,7 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
+    _ASSERTE(!Match(i, s));
     return FALSE;
 }
 
@@ -1199,6 +1210,7 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, c));
                     return TRUE;
                 }
                 start--;
@@ -1218,6 +1230,7 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
+                    _ASSERTE(Match(i, c));
                     return TRUE;
                 }
                 start--;
@@ -1233,6 +1246,7 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
+    _ASSERTE(!Match(i, c));
     return FALSE;
 }
 

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -222,7 +222,7 @@ static int CaseHashHelperA(const CHAR *buffer, COUNT_T count)
 //-----------------------------------------------------------------------------
 void SString::Set(const WCHAR *string)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(string, NULL_OK));
@@ -230,7 +230,7 @@ void SString::Set(const WCHAR *string)
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (string == NULL || *string == 0)
         Clear();
@@ -240,7 +240,7 @@ void SString::Set(const WCHAR *string)
         wcscpy_s(GetRawUnicode(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 
-    RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -268,7 +268,7 @@ void SString::Set(const WCHAR *string, COUNT_T count)
         GetRawUnicode()[count] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -294,7 +294,7 @@ void SString::SetPreallocated(const WCHAR *string, COUNT_T count)
     ClearAllocated();
     SetRepresentation(REPRESENTATION_UNICODE);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -320,7 +320,7 @@ void SString::SetASCII(const ASCII *string)
         strcpy_s(GetRawUTF8(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -349,7 +349,7 @@ void SString::SetASCII(const ASCII *string, COUNT_T count)
         GetRawASCII()[count] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -376,7 +376,7 @@ void SString::SetUTF8(const UTF8 *string)
         strcpy_s(GetRawUTF8(), GetBufferSizeInCharIncludeNullChar(), string);
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -405,7 +405,7 @@ void SString::SetUTF8(const UTF8 *string, COUNT_T count)
         GetRawUTF8()[count] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -428,7 +428,7 @@ void SString::SetAndConvertToUTF8(const WCHAR *string)
 
     utf16Str.ConvertToUTF8(*this);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -454,7 +454,7 @@ void SString::Set(WCHAR character)
         GetRawUnicode()[1] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -479,7 +479,7 @@ void SString::SetUTF8(CHAR character)
         GetRawUTF8()[1] = 0;
     }
 
-    SS_RETURN;
+    return;
 }
 
 
@@ -502,7 +502,7 @@ void SString::SetLiteral(const ASCII *literal)
     SString s(Literal, literal);
     Set(s);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -523,7 +523,7 @@ void SString::SetLiteral(const WCHAR *literal)
     SString s(Literal, literal);
     Set(s);
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -541,7 +541,7 @@ ULONG SString::Hash() const
 
     ConvertToUnicode();
 
-    SS_RETURN HashString(GetRawUnicode());
+    return HashString(GetRawUnicode());
 }
 
 //-----------------------------------------------------------------------------
@@ -576,7 +576,7 @@ ULONG SString::HashCaseInsensitive() const
         UNREACHABLE();
     }
 
-    SS_RETURN result;
+    return result;
 }
 
 //-----------------------------------------------------------------------------
@@ -603,7 +603,7 @@ void SString::Truncate(const Iterator &i)
 
     i.Resync(this, (BYTE *) (GetRawUnicode() + size));
 
-    SS_RETURN;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -612,21 +612,21 @@ void SString::Truncate(const Iterator &i)
 //-----------------------------------------------------------------------------
 void SString::ConvertASCIIToUnicode(SString &dest) const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(IsRepresentation(REPRESENTATION_ASCII));
-        POSTCONDITION(dest.IsRepresentation(REPRESENTATION_UNICODE));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Handle the empty case.
     if (IsEmpty())
     {
         dest.Clear();
-        RETURN;
+        _ASSERTE(dest.IsRepresentation(REPRESENTATION_UNICODE));
+        return;
     }
 
     CONSISTENCY_CHECK(CheckPointer(GetRawASCII()));
@@ -655,7 +655,8 @@ void SString::ConvertASCIIToUnicode(SString &dest) const
         inBuf--;
     }
 
-    RETURN;
+    _ASSERTE(dest.IsRepresentation(REPRESENTATION_UNICODE));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -663,14 +664,13 @@ void SString::ConvertASCIIToUnicode(SString &dest) const
 //-----------------------------------------------------------------------------
 void SString::ConvertToUnicode() const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
-        POSTCONDITION(IsRepresentation(REPRESENTATION_UNICODE));
         if (IsRepresentation(REPRESENTATION_UNICODE)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsRepresentation(REPRESENTATION_UNICODE))
     {
@@ -687,7 +687,8 @@ void SString::ConvertToUnicode() const
         }
     }
 
-    RETURN;
+    _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -696,15 +697,14 @@ void SString::ConvertToUnicode() const
 //-----------------------------------------------------------------------------
 void SString::ConvertToUnicode(const CIterator &i) const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(i.Check());
-        POSTCONDITION(IsRepresentation(REPRESENTATION_UNICODE));
         if (IsRepresentation(REPRESENTATION_UNICODE)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsRepresentation(REPRESENTATION_UNICODE))
     {
@@ -736,7 +736,8 @@ void SString::ConvertToUnicode(const CIterator &i) const
         }
     }
 
-    RETURN;
+    _ASSERTE(IsRepresentation(REPRESENTATION_UNICODE));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -744,14 +745,13 @@ void SString::ConvertToUnicode(const CIterator &i) const
 //-----------------------------------------------------------------------------
 void SString::ConvertToUTF8() const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
-        POSTCONDITION(IsRepresentation(REPRESENTATION_UTF8));
         if (IsRepresentation(REPRESENTATION_UTF8)) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsRepresentation(REPRESENTATION_UTF8))
     {
@@ -769,7 +769,8 @@ void SString::ConvertToUTF8() const
         }
     }
 
-    RETURN;
+    _ASSERTE(IsRepresentation(REPRESENTATION_UTF8));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -777,15 +778,14 @@ void SString::ConvertToUTF8() const
 //-----------------------------------------------------------------------------
 void SString::ConvertToUnicode(SString &s) const
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(s.Check());
-        POSTCONDITION(s.IsRepresentation(REPRESENTATION_UNICODE));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     int page = 0;
 
@@ -793,11 +793,13 @@ void SString::ConvertToUnicode(SString &s) const
     {
     case REPRESENTATION_EMPTY:
         s.Clear();
-        RETURN;
+        _ASSERTE(s.IsRepresentation(REPRESENTATION_UNICODE));
+        return;
 
     case REPRESENTATION_UNICODE:
         s.Set(*this);
-        RETURN;
+        _ASSERTE(s.IsRepresentation(REPRESENTATION_UNICODE));
+        return;
 
     case REPRESENTATION_UTF8:
         page = CP_UTF8;
@@ -805,7 +807,8 @@ void SString::ConvertToUnicode(SString &s) const
 
     case REPRESENTATION_ASCII:
         ConvertASCIIToUnicode(s);
-        RETURN;
+        _ASSERTE(s.IsRepresentation(REPRESENTATION_UNICODE));
+        return;
 
     default:
         UNREACHABLE();
@@ -821,7 +824,8 @@ void SString::ConvertToUnicode(SString &s) const
     if (length == 0)
         ThrowLastError();
 
-    RETURN;
+    _ASSERTE(s.IsRepresentation(REPRESENTATION_UNICODE));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -829,25 +833,26 @@ void SString::ConvertToUnicode(SString &s) const
 //-----------------------------------------------------------------------------
 COUNT_T SString::ConvertToUTF8(SString &s) const
 {
-    CONTRACT(COUNT_T)
+    CONTRACTL
     {
         PRECONDITION(s.Check());
-        POSTCONDITION(s.IsRepresentation(REPRESENTATION_UTF8));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     switch (GetRepresentation())
     {
     case REPRESENTATION_EMPTY:
         s.Clear();
-        RETURN 1;
+        _ASSERTE(s.IsRepresentation(REPRESENTATION_UTF8));
+        return 1;
 
     case REPRESENTATION_ASCII:
     case REPRESENTATION_UTF8:
         s.Set(*this);
-        RETURN s.GetRawCount()+1;
+        _ASSERTE(s.IsRepresentation(REPRESENTATION_UTF8));
+        return s.GetRawCount()+1;
 
     case REPRESENTATION_UNICODE:
         break;
@@ -876,7 +881,8 @@ COUNT_T SString::ConvertToUTF8(SString &s) const
 
     IfFailThrow(hr);
 
-    RETURN length + 1;
+    _ASSERTE(s.IsRepresentation(REPRESENTATION_UTF8));
+    return length + 1;
 }
 
 //-----------------------------------------------------------------------------
@@ -884,15 +890,14 @@ COUNT_T SString::ConvertToUTF8(SString &s) const
 //-----------------------------------------------------------------------------
 void SString::Replace(const Iterator &i, WCHAR c)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, 1));
-        POSTCONDITION(Match(i, c));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsRepresentation(REPRESENTATION_ASCII) && ((c&~0x7f) == 0))
     {
@@ -905,7 +910,8 @@ void SString::Replace(const Iterator &i, WCHAR c)
         *(USHORT*)i.m_ptr = c;
     }
 
-    RETURN;
+    _ASSERTE(Match(i, c));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -913,17 +919,16 @@ void SString::Replace(const Iterator &i, WCHAR c)
 //-----------------------------------------------------------------------------
 void SString::Replace(const Iterator &i, COUNT_T length, const SString &s)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i, length));
         PRECONDITION(s.Check());
-        POSTCONDITION(Match(i, s));
         THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Representation representation = GetRepresentation();
     if (representation == REPRESENTATION_EMPTY)
@@ -945,7 +950,8 @@ void SString::Replace(const Iterator &i, COUNT_T length, const SString &s)
         SBuffer::Copy(i, source.m_buffer, insertSize);
     }
 
-    RETURN;
+    _ASSERTE(Match(i, s));
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -953,16 +959,15 @@ void SString::Replace(const Iterator &i, COUNT_T length, const SString &s)
 //-----------------------------------------------------------------------------
 BOOL SString::Find(CIterator &i, const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(s.Check());
-        POSTCONDITION(RETVAL == Match(i, s));
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Get a compatible string from s
     StackSString temp;
@@ -980,7 +985,8 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
                 }
                 start++;
             }
@@ -997,7 +1003,8 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
                 }
                 start++;
             }
@@ -1007,7 +1014,10 @@ BOOL SString::Find(CIterator &i, const SString &s) const
     case REPRESENTATION_EMPTY:
         {
             if (source.GetRawCount() == 0)
-                RETURN TRUE;
+                {
+                _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
+                }
         }
         break;
 
@@ -1016,7 +1026,8 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    _ASSERTE(FALSE == Match(i, s));
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1024,15 +1035,14 @@ BOOL SString::Find(CIterator &i, const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::Find(CIterator &i, WCHAR c) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
-        POSTCONDITION(RETVAL == Match(i, c));
         THROWS_UNLESS_NORMALIZED;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Get a compatible string
     if (c & ~0x7f)
@@ -1049,7 +1059,8 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, c));
+                    return TRUE;
                 }
                 start++;
             }
@@ -1065,7 +1076,8 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, c));
+                    return TRUE;
                 }
                 start++;
             }
@@ -1080,7 +1092,8 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    _ASSERTE(FALSE == Match(i, c));
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1089,16 +1102,15 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
 //-----------------------------------------------------------------------------
 BOOL SString::FindBack(CIterator &i, const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
         PRECONDITION(s.Check());
-        POSTCONDITION(RETVAL == Match(i, s));
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Get a compatible string from s
     StackSString temp;
@@ -1119,7 +1131,8 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
                 }
                 start--;
             }
@@ -1139,7 +1152,8 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
                 }
                 start--;
             }
@@ -1149,7 +1163,10 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
     case REPRESENTATION_EMPTY:
         {
             if (source.GetRawCount() == 0)
-                RETURN TRUE;
+                {
+                _ASSERTE(TRUE == Match(i, s));
+                    return TRUE;
+                }
         }
         break;
 
@@ -1158,7 +1175,8 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    _ASSERTE(FALSE == Match(i, s));
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1167,15 +1185,14 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::FindBack(CIterator &i, WCHAR c) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
-        POSTCONDITION(RETVAL == Match(i, c));
         THROWS_UNLESS_NORMALIZED;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Get a compatible string from s
     if (c & ~0x7f)
@@ -1195,7 +1212,8 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, c));
+                    return TRUE;
                 }
                 start--;
             }
@@ -1214,7 +1232,8 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    RETURN TRUE;
+                    _ASSERTE(TRUE == Match(i, c));
+                    return TRUE;
                 }
                 start--;
             }
@@ -1229,7 +1248,8 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    _ASSERTE(FALSE == Match(i, c));
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1291,14 +1311,14 @@ BOOL SString::EndsWithCaseInsensitive(const SString &s) const
 //-----------------------------------------------------------------------------
 int SString::Compare(const SString &s) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(s.Check());
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp);
@@ -1343,9 +1363,9 @@ int SString::Compare(const SString &s) const
     }
 
     if (result == 0)
-        RETURN equals;
+        return equals;
     else
-        RETURN result;
+        return result;
 }
 
 //-----------------------------------------------------------------------------
@@ -1355,14 +1375,14 @@ int SString::Compare(const SString &s) const
 
 int SString::CompareCaseInsensitive(const SString &s) const
 {
-    CONTRACT(int)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(s.Check());
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp);
@@ -1407,9 +1427,9 @@ int SString::CompareCaseInsensitive(const SString &s) const
     }
 
     if (result == 0)
-        RETURN equals;
+        return equals;
     else
-        RETURN result;
+        return result;
 }
 
 //-----------------------------------------------------------------------------
@@ -1419,7 +1439,7 @@ int SString::CompareCaseInsensitive(const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::Equals(const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(s.Check());
@@ -1427,7 +1447,7 @@ BOOL SString::Equals(const SString &s) const
         FAULTS_UNLESS_BOTH_NORMALIZED(s, ThrowOutOfMemory());
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp);
@@ -1435,25 +1455,25 @@ BOOL SString::Equals(const SString &s) const
     COUNT_T count = GetRawCount();
 
     if (count != source.GetRawCount())
-        RETURN FALSE;
+        return FALSE;
 
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (u16_strncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
+        return (u16_strncmp(GetRawUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
-        RETURN (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
+        return (strncmp(GetRawASCII(), source.GetRawASCII(), count) == 0);
 
     case REPRESENTATION_EMPTY:
-        RETURN TRUE;
+        return TRUE;
 
     default:
     case REPRESENTATION_UTF8:
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1462,7 +1482,7 @@ BOOL SString::Equals(const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::EqualsCaseInsensitive(const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(s.Check());
@@ -1470,7 +1490,7 @@ BOOL SString::EqualsCaseInsensitive(const SString &s) const
         FAULTS_UNLESS_BOTH_NORMALIZED(s, ThrowOutOfMemory());
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp);
@@ -1478,25 +1498,25 @@ BOOL SString::EqualsCaseInsensitive(const SString &s) const
     COUNT_T count = GetRawCount();
 
     if (count != source.GetRawCount())
-        RETURN FALSE;
+        return FALSE;
 
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (CaseCompareHelper(GetRawUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
+        return (CaseCompareHelper(GetRawUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_ASCII:
-        RETURN (CaseCompareHelperA(GetRawASCII(), source.GetRawASCII(), count, FALSE, TRUE) == 0);
+        return (CaseCompareHelperA(GetRawASCII(), source.GetRawASCII(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_EMPTY:
-        RETURN TRUE;
+        return TRUE;
 
     default:
     case REPRESENTATION_UTF8:
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1506,7 +1526,7 @@ BOOL SString::EqualsCaseInsensitive(const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::Match(const CIterator &i, const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
@@ -1514,7 +1534,7 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp, i);
@@ -1523,25 +1543,25 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
     COUNT_T count = source.GetRawCount();
 
     if (remaining < count)
-        RETURN FALSE;
+        return FALSE;
 
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (u16_strncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
+        return (u16_strncmp(i.GetUnicode(), source.GetRawUnicode(), count) == 0);
 
     case REPRESENTATION_ASCII:
-        RETURN (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);
+        return (strncmp(i.GetASCII(), source.GetRawASCII(), count) == 0);
 
     case REPRESENTATION_EMPTY:
-        RETURN TRUE;
+        return TRUE;
 
     default:
     case REPRESENTATION_UTF8:
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1550,7 +1570,7 @@ BOOL SString::Match(const CIterator &i, const SString &s) const
 //-----------------------------------------------------------------------------
 BOOL SString::MatchCaseInsensitive(const CIterator &i, const SString &s) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckIteratorRange(i));
@@ -1558,7 +1578,7 @@ BOOL SString::MatchCaseInsensitive(const CIterator &i, const SString &s) const
         THROWS_UNLESS_BOTH_NORMALIZED(s);
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString temp;
     const SString &source = GetCompatibleString(s, temp, i);
@@ -1567,25 +1587,25 @@ BOOL SString::MatchCaseInsensitive(const CIterator &i, const SString &s) const
     COUNT_T count = source.GetRawCount();
 
     if (remaining < count)
-        RETURN FALSE;
+        return FALSE;
 
     switch (GetRepresentation())
     {
     case REPRESENTATION_UNICODE:
-        RETURN (CaseCompareHelper(i.GetUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
+        return (CaseCompareHelper(i.GetUnicode(), source.GetRawUnicode(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_ASCII:
-        RETURN (CaseCompareHelperA(i.GetASCII(), source.GetRawASCII(), count, FALSE, TRUE) == 0);
+        return (CaseCompareHelperA(i.GetASCII(), source.GetRawASCII(), count, FALSE, TRUE) == 0);
 
     case REPRESENTATION_EMPTY:
-        RETURN TRUE;
+        return TRUE;
 
     default:
     case REPRESENTATION_UTF8:
         UNREACHABLE();
     }
 
-    RETURN FALSE;
+    return FALSE;
 }
 
 //-----------------------------------------------------------------------------
@@ -1606,11 +1626,11 @@ BOOL SString::MatchCaseInsensitive(const CIterator &i, WCHAR c) const
     // End() will not throw here
     CONTRACT_VIOLATION(ThrowsViolation);
     if (i >= End())
-        SS_RETURN FALSE;
+        return FALSE;
 
     WCHAR test = i[0];
 
-    SS_RETURN (test == c
+    return (test == c
                || ((CAN_SIMPLE_UPCASE(test) ? SIMPLE_UPCASE(test) : MapChar(test, LCMAP_UPPERCASE))
                    == (CAN_SIMPLE_UPCASE(c) ? SIMPLE_UPCASE(c) : MapChar(c, LCMAP_UPPERCASE))));
 }
@@ -1712,14 +1732,14 @@ void SString::Printf(const CHAR *format, ...)
 
 void SString::VPrintf(const CHAR *format, va_list args)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(format));
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This method overrides the content of the SString, so it can come in with any format.
     // We're going to change the representation here.
@@ -1739,7 +1759,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
         {
             // Succeeded in writing. Now resize -
             Resize(result, REPRESENTATION_UTF8, PRESERVE);
-            RETURN;
+            return;
         }
     }
 
@@ -1768,7 +1788,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
         {
             // Succeed in writing. Shrink the buffer to fit exactly.
             Resize(result, REPRESENTATION_UTF8, PRESERVE);
-            RETURN;
+            return;
         }
 
         if (errno==ENOMEM)
@@ -1782,7 +1802,7 @@ void SString::VPrintf(const CHAR *format, va_list args)
             ThrowHR(HRESULT_FROM_WIN32(ERROR_NO_UNICODE_TRANSLATION));
         }
     }
-    RETURN;
+    return;
 }
 
 void SString::AppendPrintf(const CHAR *format, ...)
@@ -1819,13 +1839,13 @@ BOOL SString::FormatMessage(DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, 
                             const SString &arg7, const SString &arg8,
                             const SString &arg9, const SString &arg10)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     const WCHAR *args[] = {arg1.GetUnicode(), arg2.GetUnicode(), arg3.GetUnicode(), arg4.GetUnicode(),
                            arg5.GetUnicode(), arg6.GetUnicode(), arg7.GetUnicode(), arg8.GetUnicode(),
@@ -1851,7 +1871,7 @@ BOOL SString::FormatMessage(DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, 
                 result -= 1;
             }
             Resize(result, REPRESENTATION_UNICODE, PRESERVE);
-            RETURN TRUE;
+            return TRUE;
         }
     }
 
@@ -1863,7 +1883,7 @@ BOOL SString::FormatMessage(DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, 
                                       (LPWSTR)(LPWSTR*)&string, 0, (va_list*)args);
 
     if (result == 0)
-        RETURN FALSE;
+        return FALSE;
 
     LPWSTR stringRaw = string;
     _ASSERTE(stringRaw != NULL);
@@ -1871,7 +1891,7 @@ BOOL SString::FormatMessage(DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, 
         stringRaw[result-1] = W('\0');
 
     Set(stringRaw);
-    RETURN TRUE;
+    return TRUE;
 }
 
 #if 1
@@ -1882,13 +1902,13 @@ BOOL SString::FormatMessage(DWORD dwFlags, LPCVOID lpSource, DWORD dwMessageId, 
 // @todo -this should be removed and placed outside of SString
 void SString::MakeFullNamespacePath(const SString &nameSpace, const SString &name)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (nameSpace.GetRepresentation() == REPRESENTATION_UTF8
         && name.GetRepresentation() == REPRESENTATION_UTF8)
@@ -1910,7 +1930,7 @@ void SString::MakeFullNamespacePath(const SString &nameSpace, const SString &nam
             ns::MakePath(GetRawUnicode(), count+1, ns, n);
     }
 
-    RETURN;
+    return;
 }
 #endif
 
@@ -1922,24 +1942,24 @@ void SString::MakeFullNamespacePath(const SString &nameSpace, const SString &nam
 //----------------------------------------------------------------------------
 BOOL SString::IsRepresentation(Representation representation) const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         PRECONDITION(CheckRepresentation(representation));
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Representation currentRepresentation = GetRepresentation();
 
     // If representations are the same, cool.
     if (currentRepresentation == representation)
-        RETURN TRUE;
+        return TRUE;
 
     // If we have an empty representation, we match everything
     if (currentRepresentation == REPRESENTATION_EMPTY)
-        RETURN TRUE;
+        return TRUE;
 
     // If we're a 1 byte charset, there are some more chances to match
     if (currentRepresentation != REPRESENTATION_UNICODE
@@ -1947,15 +1967,15 @@ BOOL SString::IsRepresentation(Representation representation) const
     {
         // If we're ASCII, we can be any 1 byte rep
         if (currentRepresentation == REPRESENTATION_ASCII)
-            RETURN TRUE;
+            return TRUE;
 
         // We really want to be ASCII - scan to see if we qualify
         if (ScanASCII())
-            RETURN TRUE;
+            return TRUE;
     }
 
     // Sorry, must convert.
-    RETURN FALSE;
+    return FALSE;
 }
 
 //----------------------------------------------------------------------------
@@ -2067,14 +2087,13 @@ const SString &SString::GetCompatibleString(const SString &s, SString &scratch) 
 //----------------------------------------------------------------------------
 BOOL SString::ScanASCII() const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
-        POSTCONDITION(IsRepresentation(REPRESENTATION_ASCII) || IsASCIIScanned());
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!IsASCIIScanned())
     {
@@ -2089,12 +2108,14 @@ BOOL SString::ScanASCII() const
         if (c == cEnd)
         {
             const_cast<SString *>(this)->SetRepresentation(REPRESENTATION_ASCII);
-            RETURN TRUE;
+            _ASSERTE(IsRepresentation(REPRESENTATION_ASCII) || IsASCIIScanned());
+            return TRUE;
         }
         else
             const_cast<SString *>(this)->SetASCIIScanned();
     }
-    RETURN FALSE;
+    _ASSERTE(IsRepresentation(REPRESENTATION_ASCII) || IsASCIIScanned());
+    return FALSE;
 }
 
 //----------------------------------------------------------------------------
@@ -2107,16 +2128,14 @@ BOOL SString::ScanASCII() const
 
 void SString::Resize(COUNT_T count, SString::Representation representation, Preserve preserve)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(CountToSize(count) >= count);
-        POSTCONDITION(IsRepresentation(representation));
-        POSTCONDITION(GetRawCount() == count);
         if (count == 0) NOTHROW; else THROWS;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // If we are resizing to zero, Clear is more efficient
     if (count == 0)
@@ -2143,7 +2162,9 @@ void SString::Resize(COUNT_T count, SString::Representation representation, Pres
         NullTerminate();
     }
 
-    RETURN;
+    _ASSERTE(IsRepresentation(representation));
+    _ASSERTE(GetRawCount() == count);
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -2151,15 +2172,14 @@ void SString::Resize(COUNT_T count, SString::Representation representation, Pres
 //-----------------------------------------------------------------------------
 void SString::Clear()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(IsEmpty());
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC_HOST_ONLY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SetRepresentation(REPRESENTATION_EMPTY);
 
@@ -2175,7 +2195,8 @@ void SString::Clear()
         GetRawUnicode()[0] = 0;
     }
 
-    RETURN;
+    _ASSERTE(IsEmpty());
+    return;
 }
 
 

--- a/src/coreclr/utilcode/sstring.cpp
+++ b/src/coreclr/utilcode/sstring.cpp
@@ -983,7 +983,6 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
                 start++;
@@ -1001,7 +1000,6 @@ BOOL SString::Find(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
                 start++;
@@ -1013,7 +1011,6 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         {
             if (source.GetRawCount() == 0)
                 {
-                _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
         }
@@ -1024,7 +1021,6 @@ BOOL SString::Find(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
-    _ASSERTE(FALSE == Match(i, s));
     return FALSE;
 }
 
@@ -1057,7 +1053,6 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, c));
                     return TRUE;
                 }
                 start++;
@@ -1074,7 +1069,6 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, c));
                     return TRUE;
                 }
                 start++;
@@ -1090,7 +1084,6 @@ BOOL SString::Find(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
-    _ASSERTE(FALSE == Match(i, c));
     return FALSE;
 }
 
@@ -1129,7 +1122,6 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (u16_strncmp(start, source.GetRawUnicode(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
                 start--;
@@ -1150,7 +1142,6 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
                 if (strncmp(start, source.GetRawASCII(), count) == 0)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
                 start--;
@@ -1162,7 +1153,6 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         {
             if (source.GetRawCount() == 0)
                 {
-                _ASSERTE(TRUE == Match(i, s));
                     return TRUE;
                 }
         }
@@ -1173,7 +1163,6 @@ BOOL SString::FindBack(CIterator &i, const SString &s) const
         UNREACHABLE();
     }
 
-    _ASSERTE(FALSE == Match(i, s));
     return FALSE;
 }
 
@@ -1210,7 +1199,6 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, c));
                     return TRUE;
                 }
                 start--;
@@ -1230,7 +1218,6 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
                 if (*start == c)
                 {
                     i.Resync(this, (BYTE*) start);
-                    _ASSERTE(TRUE == Match(i, c));
                     return TRUE;
                 }
                 start--;
@@ -1246,7 +1233,6 @@ BOOL SString::FindBack(CIterator &i, WCHAR c) const
         UNREACHABLE();
     }
 
-    _ASSERTE(FALSE == Match(i, c));
     return FALSE;
 }
 

--- a/src/coreclr/utilcode/sstring_com.cpp
+++ b/src/coreclr/utilcode/sstring_com.cpp
@@ -22,12 +22,12 @@ BOOL SString::LoadResource(int resourceID)
 
 HRESULT SString::LoadResourceAndReturnHR(int resourceID)
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hr = E_FAIL;
 
@@ -82,5 +82,5 @@ HRESULT SString::LoadResourceAndReturnHR(int resourceID)
     EX_END_CATCH
 #endif //!FEATURE_UTILCODE_NO_DEPENDENCIES
 
-    RETURN hr;
+    return hr;
 } // SString::LoadResourceAndReturnHR

--- a/src/coreclr/utilcode/webcildecoder.cpp
+++ b/src/coreclr/utilcode/webcildecoder.cpp
@@ -99,17 +99,17 @@ BOOL WebcilDecoder::HasContents() const
 
 BOOL WebcilDecoder::HasWebcilHeaders() const
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(HasContents());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_size < sizeof(WebcilHeader))
-        RETURN FALSE;
+        return FALSE;
 
     const WebcilHeader *pHeader = (const WebcilHeader *)(m_base);
     if (pHeader->Id[0] != WEBCIL_MAGIC_W ||
@@ -117,23 +117,23 @@ BOOL WebcilDecoder::HasWebcilHeaders() const
         pHeader->Id[2] != WEBCIL_MAGIC_I ||
         pHeader->Id[3] != WEBCIL_MAGIC_L)
     {
-        RETURN FALSE;
+        return FALSE;
     }
 
     if (pHeader->VersionMajor != WEBCIL_VERSION_MAJOR ||
         pHeader->VersionMinor != WEBCIL_VERSION_MINOR)
     {
-        RETURN FALSE;
+        return FALSE;
     }
 
     if (pHeader->CoffSections == 0 || pHeader->CoffSections > WEBCIL_MAX_SECTIONS)
-        RETURN FALSE;
+        return FALSE;
 
     COUNT_T headerEnd = sizeof(WebcilHeader) + (COUNT_T)pHeader->CoffSections * sizeof(WebcilSectionHeader);
     if (m_size < headerEnd)
-        RETURN FALSE;
+        return FALSE;
 
-    RETURN TRUE;
+    return TRUE;
 }
 
 BOOL WebcilDecoder::HasBaseRelocations() const
@@ -361,18 +361,17 @@ CHECK WebcilDecoder::CheckCorHeader() const
 
 IMAGE_COR20_HEADER *WebcilDecoder::GetCorHeader() const
 {
-    CONTRACT(IMAGE_COR20_HEADER *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(HasCorHeader());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     FindCorHeader();
-    RETURN m_pCorHeader;
+    return m_pCorHeader;
 }
 
 // ------------------------------------------------------------
@@ -554,38 +553,38 @@ CHECK WebcilDecoder::CheckRva(RVA rva, COUNT_T size, int forbiddenFlags, IsNullO
 
 TADDR WebcilDecoder::GetRvaData(RVA rva, IsNullOK ok) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if ((rva == 0) && (ok == NULL_NOT_OK))
-        RETURN (TADDR)NULL;
+        return (TADDR)NULL;
 
     // Webcil is always flat — translate RVA via section table to file offset
     COUNT_T offset = RvaToOffset(rva);
-    RETURN (m_base + offset);
+    return (m_base + offset);
 }
 
 RVA WebcilDecoder::GetDataRva(const TADDR data) const
 {
-    CONTRACT(RVA)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (data == (TADDR)NULL)
-        RETURN 0;
+        return 0;
 
     // Webcil is always flat — convert file offset to RVA
     COUNT_T offset = (COUNT_T)(data - m_base);
-    RETURN OffsetToRva(offset);
+    return OffsetToRva(offset);
 }
 
 BOOL WebcilDecoder::PointerInPE(PTR_CVOID data) const
@@ -650,56 +649,56 @@ CHECK WebcilDecoder::CheckOffset(COUNT_T fileOffset, COUNT_T size, IsNullOK ok) 
 
 TADDR WebcilDecoder::GetOffsetData(COUNT_T fileOffset, IsNullOK ok) const
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if ((fileOffset == 0) && (ok == NULL_NOT_OK))
-        RETURN (TADDR)NULL;
+        return (TADDR)NULL;
 
-    RETURN GetRvaData(OffsetToRva(fileOffset));
+    return GetRvaData(OffsetToRva(fileOffset));
 }
 
 COUNT_T WebcilDecoder::RvaToOffset(RVA rva) const
 {
-    CONTRACT(COUNT_T)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (rva == 0)
-        RETURN 0;
+        return 0;
 
     const WebcilSectionHeader *section = RvaToSection(rva);
     _ASSERTE(section != NULL);
 
-    RETURN rva - section->VirtualAddress + section->PointerToRawData;
+    return rva - section->VirtualAddress + section->PointerToRawData;
 }
 
 RVA WebcilDecoder::OffsetToRva(COUNT_T fileOffset) const
 {
-    CONTRACT(RVA)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (fileOffset == 0)
-        RETURN 0;
+        return 0;
 
     const WebcilSectionHeader *section = OffsetToSection(fileOffset);
     _ASSERTE(section != NULL);
 
-    RETURN fileOffset - section->PointerToRawData + section->VirtualAddress;
+    return fileOffset - section->PointerToRawData + section->VirtualAddress;
 }
 
 // ------------------------------------------------------------

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -276,14 +276,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl()
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(CONTEXT));
     // Clear the CONTEXT_XSTATE, since the REGDISPLAY contains just plain CONTEXT structure
@@ -312,7 +312,7 @@ void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFlo
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.
 
-    RETURN;
+    return;
 }
 
 // The HijackFrame has to know the registers that are pushed by OnHijackTripThread

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2365,21 +2365,20 @@ Assembly *AppDomain::LoadAssembly(AssemblySpec* pSpec,
                                   PEAssembly * pPEAssembly,
                                   FileLoadLevel targetLevel)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         GC_TRIGGERS;
         THROWS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pPEAssembly));
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (pSpec == nullptr)
     {
         // skip caching, since we don't have anything to base it on
-        RETURN LoadAssemblyInternal(pSpec, pPEAssembly, targetLevel);
+        return LoadAssemblyInternal(pSpec, pPEAssembly, targetLevel);
     }
 
     Assembly* pRetVal = NULL;
@@ -2425,7 +2424,7 @@ Assembly *AppDomain::LoadAssembly(AssemblySpec* pSpec,
     }
     EX_END_HOOK;
 
-    RETURN pRetVal;
+    return pRetVal;
 }
 
 
@@ -2433,20 +2432,16 @@ Assembly *AppDomain::LoadAssemblyInternal(AssemblySpec* pIdentity,
                                               PEAssembly * pPEAssembly,
                                               FileLoadLevel targetLevel)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         GC_TRIGGERS;
         THROWS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pPEAssembly));
         PRECONDITION(::GetAppDomain()==this);
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL->GetLoadLevel() >= GetCurrentFileLoadLevel()
-                      || RETVAL->GetLoadLevel() >= targetLevel);
-        POSTCONDITION(RETVAL->CheckNoError(targetLevel));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 
     Assembly * result;
@@ -2520,22 +2515,20 @@ Assembly *AppDomain::LoadAssemblyInternal(AssemblySpec* pIdentity,
         GetAppDomain()->AddAssemblyToCache(pIdentity, result);
     }
 
-    RETURN result;
+    _ASSERTE(result->CheckNoError(targetLevel));
+    return result;
 } // AppDomain::LoadAssembly
 
 Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pLock));
         PRECONDITION(AppDomain::GetCurrentDomain() == this);
         PRECONDITION(targetLevel >= FILE_LOAD_ALLOCATE);
-        POSTCONDITION(RETVAL->GetLoadLevel() >= GetCurrentFileLoadLevel()
-                      || RETVAL->GetLoadLevel() >= targetLevel);
-        POSTCONDITION(RETVAL->CheckNoError(targetLevel));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Make sure we release the lock on exit
     FileLoadLockRefHolder lockRef(pLock);
@@ -2548,7 +2541,8 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
 
         pAssembly->ThrowIfError(targetLevel);
 
-        RETURN pAssembly;
+        _ASSERTE(pAssembly->CheckNoError(targetLevel));
+        return pAssembly;
     }
 
     // Initialize a loading queue.  This will hold any loads which are triggered recursively but
@@ -2639,7 +2633,8 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
     // specify the minimum load level acceptable and throw if not reached.)
 
     pAssembly->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
-    RETURN pAssembly;
+    _ASSERTE(pAssembly->CheckNoError(targetLevel));
+    return pAssembly;
 }
 
 void AppDomain::TryIncrementalLoad(FileLoadLevel workLevel, FileLoadLockHolder& lockHolder)
@@ -2860,20 +2855,22 @@ void AppDomain::SetFriendlyName(LPCWSTR pwzFriendlyName)
 
 LPCWSTR AppDomain::GetFriendlyName()
 {
-    CONTRACT (LPCWSTR)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_friendlyName == NULL)
-        RETURN DEFAULT_DOMAIN_FRIENDLY_NAME;
+        {
+            return DEFAULT_DOMAIN_FRIENDLY_NAME;
+        }
 
-    RETURN (LPCWSTR)m_friendlyName;
+    _ASSERTE(CheckPointer((LPCWSTR)m_friendlyName, NULL_OK));
+    return (LPCWSTR)m_friendlyName;
 }
 
 #ifndef DACCESS_COMPILE
@@ -2971,24 +2968,23 @@ void AppDomain::AddUnmanagedImageToCache(LPCWSTR libraryName, NATIVE_LIBRARY_HAN
 
 NATIVE_LIBRARY_HANDLE AppDomain::FindUnmanagedImageInCache(LPCWSTR libraryName)
 {
-    CONTRACT(NATIVE_LIBRARY_HANDLE)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(libraryName));
-        POSTCONDITION(CheckPointer(RETVAL,NULL_OK));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DomainCacheCrstHolderForGCPreemp lock(this);
 
     const UnmanagedImageCacheEntry *existingEntry = m_unmanagedCache.LookupPtr(libraryName);
     if (existingEntry == NULL)
-        RETURN NULL;
+        return NULL;
 
-    RETURN existingEntry->Handle;
+    return existingEntry->Handle;
 }
 
 BOOL AppDomain::RemoveFileFromCache(PEAssembly * pPEAssembly)
@@ -3425,15 +3421,14 @@ void AppDomain::RaiseExitProcessEvent()
 
 DefaultAssemblyBinder *AppDomain::CreateDefaultBinder()
 {
-    CONTRACT(DefaultAssemblyBinder *)
+    CONTRACTL
     {
         GC_TRIGGERS;
         THROWS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!m_pDefaultBinder)
     {
@@ -3445,7 +3440,7 @@ DefaultAssemblyBinder *AppDomain::CreateDefaultBinder()
         IfFailThrow(BINDER_SPACE::AssemblyBinderCommon::CreateDefaultBinder(&m_pDefaultBinder));
     }
 
-    RETURN m_pDefaultBinder;
+    return m_pDefaultBinder;
 }
 
 
@@ -3532,14 +3527,13 @@ void AppDomain::NotifyDebuggerUnload()
 
 RCWRefCache *AppDomain::GetRCWRefCache()
 {
-    CONTRACT(RCWRefCache*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!m_pRCWRefCache) {
         NewHolder<RCWRefCache> pRCWRefCache = new RCWRefCache(this);
@@ -3548,7 +3542,7 @@ RCWRefCache *AppDomain::GetRCWRefCache()
             pRCWRefCache.SuppressRelease();
         }
     }
-    RETURN m_pRCWRefCache;
+    return m_pRCWRefCache;
 }
 #endif // FEATURE_COMWRAPPERS
 
@@ -3556,15 +3550,14 @@ RCWRefCache *AppDomain::GetRCWRefCache()
 
 RCWCache *AppDomain::CreateRCWCache()
 {
-    CONTRACT(RCWCache*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Initialize the global RCW cleanup list here as well. This is so that it
     // it guaranteed to exist if any RCW's are created, but it is not created
@@ -3587,7 +3580,7 @@ RCWCache *AppDomain::CreateRCWCache()
         }
     }
 
-    RETURN m_pRCWCache;
+    return m_pRCWCache;
 }
 
 void AppDomain::ReleaseRCWs(LPVOID pCtxCookie)
@@ -3667,15 +3660,14 @@ Assembly* AppDomain::RaiseTypeResolveEventThrowing(Assembly* pAssembly, LPCSTR s
 
 Assembly* AppDomain::RaiseResourceResolveEvent(Assembly* pAssembly, LPCSTR szName)
 {
-    CONTRACT(Assembly*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Assembly* pResolvedAssembly = NULL;
 
@@ -3707,7 +3699,7 @@ Assembly* AppDomain::RaiseResourceResolveEvent(Assembly* pAssembly, LPCSTR szNam
     }
     GCPROTECT_END();
 
-    RETURN pResolvedAssembly;
+    return pResolvedAssembly;
 }
 
 
@@ -3715,15 +3707,14 @@ Assembly *
 AppDomain::RaiseAssemblyResolveEvent(
     AssemblySpec * pSpec)
 {
-    CONTRACT(Assembly*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString ssName;
     pSpec->GetDisplayName(0, ssName);
@@ -3769,7 +3760,7 @@ AppDomain::RaiseAssemblyResolveEvent(
     }
     GCPROTECT_END();
 
-    RETURN pAssembly;
+    return pAssembly;
 } // AppDomain::RaiseAssemblyResolveEvent
 
 void SystemDomain::ProcessDelayedUnloadLoaderAllocators()
@@ -3822,12 +3813,12 @@ void SystemDomain::ProcessDelayedUnloadLoaderAllocators()
 
 void AppDomain::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(GCHeapUtilities::IsGCInProgress() &&
              GCHeapUtilities::IsServerHeap()   &&
@@ -3838,7 +3829,7 @@ void AppDomain::EnumStaticGCRefs(promote_func* fn, ScanContext* sc)
         m_pPinnedHeapHandleTable->EnumStaticGCRefs(fn, sc);
     }
 
-    RETURN;
+    return;
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2544,6 +2544,8 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
         pAssembly->ThrowIfError(targetLevel);
 
         _ASSERTE(pAssembly->CheckNoError(targetLevel));
+        _ASSERTE(pAssembly->GetLoadLevel() >= GetCurrentFileLoadLevel()
+            || pAssembly->GetLoadLevel() >= targetLevel);
         return pAssembly;
     }
 
@@ -2635,8 +2637,8 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
     // specify the minimum load level acceptable and throw if not reached.)
 
     pAssembly->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
-    _ASSERTE(result->GetLoadLevel() >= GetCurrentFileLoadLevel()
-        || result->GetLoadLevel() >= targetLevel);
+    _ASSERTE(pAssembly->GetLoadLevel() >= GetCurrentFileLoadLevel()
+        || pAssembly->GetLoadLevel() >= targetLevel);
     _ASSERTE(pAssembly->CheckNoError(targetLevel));
     return pAssembly;
 }

--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2515,6 +2515,8 @@ Assembly *AppDomain::LoadAssemblyInternal(AssemblySpec* pIdentity,
         GetAppDomain()->AddAssemblyToCache(pIdentity, result);
     }
 
+    _ASSERTE(result->GetLoadLevel() >= GetCurrentFileLoadLevel()
+        || result->GetLoadLevel() >= targetLevel);
     _ASSERTE(result->CheckNoError(targetLevel));
     return result;
 } // AppDomain::LoadAssembly
@@ -2633,6 +2635,8 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
     // specify the minimum load level acceptable and throw if not reached.)
 
     pAssembly->RequireLoadLevel((FileLoadLevel)(immediateTargetLevel-1));
+    _ASSERTE(result->GetLoadLevel() >= GetCurrentFileLoadLevel()
+        || result->GetLoadLevel() >= targetLevel);
     _ASSERTE(pAssembly->CheckNoError(targetLevel));
     return pAssembly;
 }
@@ -2865,11 +2869,10 @@ LPCWSTR AppDomain::GetFriendlyName()
     CONTRACTL_END;
 
     if (m_friendlyName == NULL)
-        {
-            return DEFAULT_DOMAIN_FRIENDLY_NAME;
-        }
+    {
+        return DEFAULT_DOMAIN_FRIENDLY_NAME;
+    }
 
-    _ASSERTE(CheckPointer((LPCWSTR)m_friendlyName, NULL_OK));
     return (LPCWSTR)m_friendlyName;
 }
 

--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -1334,7 +1334,7 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -1347,7 +1347,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // @TODO: Remove this after the debugger is fixed to avoid stack-walks from bad places
     // @TODO: This may be still needed for sampling profilers
@@ -1386,7 +1386,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
     pRD->pCurrentContext->R9 = (DWORD) dac_cast<TADDR>(m_pSPAfterProlog);
     pRD->pCurrentContextPointers->R9 = (DWORD *)&m_pSPAfterProlog;
 
-    RETURN;
+    return;
 }
 
 #ifdef FEATURE_HIJACK
@@ -1398,14 +1398,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl(void)
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(T_CONTEXT));
 

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -350,7 +350,7 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -360,7 +360,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!InlinedCallFrame::FrameHasActiveCall(this))
     {
@@ -415,7 +415,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 #ifdef FEATURE_HIJACK
@@ -427,14 +427,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl(void)
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(T_CONTEXT));
     // Clear the CONTEXT_XSTATE, since the REGDISPLAY contains just plain CONTEXT structure
@@ -464,7 +464,7 @@ void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFlo
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    ResumableFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 void HijackFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)

--- a/src/coreclr/vm/arraynative.cpp
+++ b/src/coreclr/vm/arraynative.cpp
@@ -72,8 +72,6 @@ void memmoveGCRefs(void *dest, const void *src, size_t len)
     _ASSERTE(IS_ALIGNED(src, sizeof(SIZE_T)));
     _ASSERTE(IS_ALIGNED(len, sizeof(SIZE_T)));
 
-    _ASSERTE(CheckPointer(dest));
-    _ASSERTE(CheckPointer(src));
 
     if (len != 0 && dest != src)
     {

--- a/src/coreclr/vm/arraynative.inl
+++ b/src/coreclr/vm/arraynative.inl
@@ -36,8 +36,6 @@ FORCEINLINE void InlinedForwardGCSafeCopyHelper(void *dest, const void *src, siz
     _ASSERTE(IS_ALIGNED(src, sizeof(SIZE_T)));
     _ASSERTE(IS_ALIGNED(len, sizeof(SIZE_T)));
 
-    _ASSERTE(CheckPointer(dest));
-    _ASSERTE(CheckPointer(src));
 
     SIZE_T *dptr = (SIZE_T *)dest;
     SIZE_T *sptr = (SIZE_T *)src;
@@ -170,8 +168,6 @@ FORCEINLINE void InlinedBackwardGCSafeCopyHelper(void *dest, const void *src, si
     _ASSERTE(IS_ALIGNED(src, sizeof(SIZE_T)));
     _ASSERTE(IS_ALIGNED(len, sizeof(SIZE_T)));
 
-    _ASSERTE(CheckPointer(dest));
-    _ASSERTE(CheckPointer(src));
 
     SIZE_T *dptr = (SIZE_T *)((BYTE *)dest + len);
     SIZE_T *sptr = (SIZE_T *)((BYTE *)src + len);
@@ -304,8 +300,6 @@ FORCEINLINE void InlinedMemmoveGCRefsHelper(void *dest, const void *src, size_t 
     _ASSERTE(IS_ALIGNED(src, sizeof(SIZE_T)));
     _ASSERTE(IS_ALIGNED(len, sizeof(SIZE_T)));
 
-    _ASSERTE(CheckPointer(dest));
-    _ASSERTE(CheckPointer(src));
 
     const bool notInHeap = ((BYTE*)dest < g_lowest_address || (BYTE*)dest >= g_highest_address);
 

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -62,16 +62,15 @@ namespace
 {
     void DefineEmitScope(GUID iid, void** ppEmit)
     {
-        CONTRACT_VOID
+        CONTRACTL
         {
             PRECONDITION(CheckPointer(ppEmit));
-            POSTCONDITION(CheckPointer(*ppEmit));
             THROWS;
             GC_TRIGGERS;
             MODE_ANY;
             INJECT_FAULT(COMPlusThrowOM(););
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         SafeComHolder<IMetaDataDispenserEx> pDispenser;
 
@@ -99,7 +98,7 @@ namespace
 
         IfFailThrow(pDispenser->DefineScope(CLSID_CorMetaDataRuntime, 0, iid, (IUnknown**)ppEmit));
 
-        RETURN;
+        return;
     }
 }
 
@@ -372,14 +371,14 @@ Assembly * Assembly::Create(
 Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNameParts* pAssemblyNameParts, INT32 hashAlgorithm, INT32 access, LOADERALLOCATORREF* pKeepAlive)
 {
     // WARNING: not backout clean
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         MODE_COOPERATIVE;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This must be before creation of the AllocMemTracker so that the destructor for the AllocMemTracker happens before the destructor for pLoaderAllocator.
     // That is necessary as the allocation of Assembly objects and other related details is done on top of heaps located in
@@ -541,7 +540,7 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         pRetVal = pAssem;
     }
 
-    RETURN pRetVal;
+    return pRetVal;
 } // Assembly::CreateDynamic
 
 void Assembly::SetDomainAssembly(DomainAssembly *pDomainAssembly)
@@ -591,16 +590,15 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
                                            mdTypeDef mdNested,
                                            mdTypeDef* pCL)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
         if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT; else INJECT_FAULT(COMPlusThrowOM(););
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, loadFlag==Loader::Load ? NULL_NOT_OK : NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     mdToken mdLinkRef;
     mdToken mdBinding;
@@ -620,7 +618,7 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
     {
         if (loadFlag != Loader::Load)
         {
-            RETURN NULL;
+            return NULL;
         }
         else
         {
@@ -659,9 +657,9 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
             }
 
             if (pAssembly)
-                RETURN pAssembly->GetModule();
+                return pAssembly->GetModule();
             else
-                RETURN NULL;
+                return NULL;
 
         }
 
@@ -681,7 +679,9 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
             return pModule;
 #else
             if (pModule != NULL)
-                RETURN pModule;
+                {
+                    return pModule;
+                }
 
             if(loadFlag==Loader::SafeLookup)
                 return NULL;
@@ -701,7 +701,7 @@ Module *Assembly::FindModuleByExportedType(mdExportedType mdType,
         if (mdNested != mdTypeDefNil)
             mdBinding = mdNested;
 
-        RETURN FindModuleByExportedType(mdLinkRef, loadFlag, mdBinding, pCL);
+        return FindModuleByExportedType(mdLinkRef, loadFlag, mdBinding, pCL);
 
     default:
         ThrowHR(COR_E_BADIMAGEFORMAT, BFA_INVALID_TOKEN_TYPE);
@@ -717,7 +717,7 @@ Module * Assembly::FindModuleByTypeRef(
     Loader::LoadFlag loadFlag,
     BOOL *           pfNoResolutionScope)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -728,10 +728,9 @@ Module * Assembly::FindModuleByTypeRef(
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(TypeFromToken(tkType) == mdtTypeRef);
         PRECONDITION(CheckPointer(pfNoResolutionScope));
-        POSTCONDITION( CheckPointer(RETVAL, loadFlag==Loader::Load ? NULL_NOT_OK : NULL_OK) );
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     // WARNING! Correctness of the type forwarder detection algorithm in code:ClassLoader::ResolveTokenToTypeDefThrowing
     // relies on this function not performing any form of type forwarding itself.
@@ -774,7 +773,7 @@ Module * Assembly::FindModuleByTypeRef(
                     // The ModuleBase scenarios should never need this
                     COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
                 }
-                RETURN(static_cast<Module*>(pModule));
+                return(static_cast<Module*>(pModule));
             }
             iter++;
         }
@@ -803,7 +802,7 @@ Module * Assembly::FindModuleByTypeRef(
             // Type is in the referencing module.
             GCX_NOTRIGGER();
             CANNOTTHROWCOMPLUSEXCEPTION();
-            RETURN( static_cast<Module*>(pModule) );
+            return( static_cast<Module*>(pModule) );
         }
 
         case mdtModuleRef:
@@ -813,24 +812,24 @@ Module * Assembly::FindModuleByTypeRef(
                 // Either we're not supposed to load, or we're doing a GC or stackwalk
                 // in which case we shouldn't need to load.  So just look up the module
                 // and return what we find.
-                RETURN(pModule->LookupModule(tkType));
+                return(pModule->LookupModule(tkType));
             }
 
 #ifndef DACCESS_COMPILE
             if (loadFlag == Loader::Load)
             {
                 Module* pActualModule = pModule->LoadModule(tkType);
-                RETURN(pActualModule);
+                return(pActualModule);
             }
             else
             {
-                RETURN NULL;
+                return NULL;
             }
 
 #else //DACCESS_COMPILE
             _ASSERTE(loadFlag!=Loader::Load);
             DacNotImpl();
-            RETURN NULL;
+            return NULL;
 #endif //DACCESS_COMPILE
         }
         break;
@@ -856,25 +855,25 @@ Module * Assembly::FindModuleByTypeRef(
 
             if (pAssembly != NULL)
             {
-                RETURN pAssembly->m_pModule;
+                return pAssembly->m_pModule;
             }
 
 #ifdef DACCESS_COMPILE
-            RETURN NULL;
+            return NULL;
 #else
             if (loadFlag != Loader::Load)
             {
-                RETURN NULL;
+                return NULL;
             }
 
             pAssembly = pModule->LoadAssembly(tkType);
             if (pAssembly == NULL)
             {
-                RETURN NULL;
+                return NULL;
             }
             else
             {
-                RETURN pAssembly->m_pModule;
+                return pAssembly->m_pModule;
             }
 #endif //!DACCESS_COMPILE
         }
@@ -1427,23 +1426,24 @@ INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs, bool captureException
 
 MethodDesc* Assembly::GetEntryPoint()
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         INJECT_FAULT(COMPlusThrowOM(););
         MODE_ANY;
 
         // Can return NULL if no entry point.
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pEntryPoint)
-        RETURN m_pEntryPoint;
+        {
+            return m_pEntryPoint;
+        }
 
     mdToken mdEntry = m_pPEAssembly->GetEntryPointToken();
     if (IsNilToken(mdEntry))
-        RETURN NULL;
+        return NULL;
 
     Module *pModule = NULL;
     switch(TypeFromToken(mdEntry)) {
@@ -1464,7 +1464,7 @@ MethodDesc* Assembly::GetEntryPoint()
 
     // May be unmanaged entrypoint
     if (!pModule)
-        RETURN NULL;
+        return NULL;
 
     // We need to get its properties and the class token for this MethodDef token.
     mdToken mdParent;
@@ -1512,7 +1512,7 @@ MethodDesc* Assembly::GetEntryPoint()
     {
         m_pEntryPoint = pModule->FindMethod(mdEntry);
     }
-    RETURN m_pEntryPoint;
+    return m_pEntryPoint;
 }
 
 //---------------------------------------------------------------------------------------
@@ -1522,14 +1522,14 @@ MethodDesc* Assembly::GetEntryPoint()
 //
 OBJECTREF Assembly::GetExposedObject()
 {
-    CONTRACT(OBJECTREF)
+    CONTRACTL
     {
         GC_TRIGGERS;
         THROWS;
         INJECT_FAULT(COMPlusThrowOM(););
         MODE_COOPERATIVE;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LoaderAllocator * pLoaderAllocator = GetLoaderAllocator();
 
@@ -1586,7 +1586,7 @@ OBJECTREF Assembly::GetExposedObject()
             return NULL;
     }
 
-    RETURN pLoaderAllocator->GetHandleValue(m_hExposedObject);
+    return pLoaderAllocator->GetHandleValue(m_hExposedObject);
 }
 
 OBJECTREF Assembly::GetExposedObjectIfExists()
@@ -1683,17 +1683,15 @@ bool Assembly::TrySetTypeLib(_In_ ITypeLib *pNew)
 //***********************************************************
 mdAssemblyRef Assembly::AddAssemblyRef(Assembly *refedAssembly, IMetaDataAssemblyEmit *pAssemEmitter)
 {
-    CONTRACT(mdAssemblyRef)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(CheckPointer(refedAssembly));
         PRECONDITION(CheckPointer(pAssemEmitter, NULL_NOT_OK));
-        POSTCONDITION(!IsNilToken(RETVAL));
-        POSTCONDITION(TypeFromToken(RETVAL) == mdtAssemblyRef);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SafeComHolder<IMetaDataAssemblyEmit> emitHolder;
 
@@ -1711,7 +1709,9 @@ mdAssemblyRef Assembly::AddAssemblyRef(Assembly *refedAssembly, IMetaDataAssembl
     mdAssemblyRef ar;
     IfFailThrow(spec.EmitToken(pAssemEmitter, &ar));
 
-    RETURN ar;
+    _ASSERTE(!IsNilToken(ar));
+    _ASSERTE(TypeFromToken(ar) == mdtAssemblyRef);
+    return ar;
 }   // Assembly::AddAssemblyRef
 
 //***********************************************************
@@ -1927,13 +1927,13 @@ Assembly::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 #include <optsmallperfcritical.h>
 void Assembly::EnsureLoadLevel(FileLoadLevel targetLevel)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     TRIGGERSGC ();
     if (IsLoading())
@@ -1954,7 +1954,7 @@ void Assembly::EnsureLoadLevel(FileLoadLevel targetLevel)
     else
         ThrowIfError(targetLevel);
 
-    RETURN;
+    return;
 }
 
 #include <optdefault.h>
@@ -1988,13 +1988,13 @@ CHECK Assembly::CheckLoadLevel(FileLoadLevel requiredLevel, BOOL deadlockOK)
 
 void Assembly::RequireLoadLevel(FileLoadLevel targetLevel)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (GetLoadLevel() < targetLevel)
     {
@@ -2002,21 +2002,20 @@ void Assembly::RequireLoadLevel(FileLoadLevel targetLevel)
         ThrowHR(MSEE_E_ASSEMBLYLOADINPROGRESS); // @todo: better exception
     }
 
-    RETURN;
+    return;
 }
 
 void Assembly::SetError(Exception *ex)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(!IsError());
         PRECONDITION(ex != NULL);
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
-        POSTCONDITION(IsError());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     m_pError = ex->DomainBoundClone();
 
@@ -2036,26 +2035,27 @@ void Assembly::SetError(Exception *ex)
         }
     }
 
-    RETURN;
+    _ASSERTE(IsError());
+    return;
 }
 
 void Assembly::ThrowIfError(FileLoadLevel targetLevel)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         MODE_ANY;
         THROWS;
         GC_TRIGGERS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_level < targetLevel && m_pError != NULL)
     {
         PAL_CPP_THROW(Exception*, m_pError->DomainBoundClone());
     }
 
-    RETURN;
+    return;
 }
 
 CHECK Assembly::CheckNoError(FileLoadLevel targetLevel)
@@ -2231,13 +2231,13 @@ void Assembly::FinishLoad()
 
 void Assembly::Activate()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(IsLoaded());
         STANDARD_VM_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // We cannot execute any code in this assembly until we know what exception plan it is on.
     // At the point of an exception's stack-crawl it is too late because we cannot tolerate a GC.
@@ -2272,7 +2272,7 @@ void Assembly::Activate()
     }
 #endif
 
-    RETURN;
+    return;
 }
 
 void Assembly::Begin()

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -122,14 +122,13 @@ extern "C" void QCALLTYPE AssemblyNative_InternalLoad(NativeAssemblyNameParts* p
 /* static */
 Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage, bool excludeAppPaths)
 {
-    CONTRACT(Assembly*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pBinder));
         PRECONDITION(pImage != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Assembly *pLoadedAssembly = NULL;
     ReleaseHolder<BINDER_SPACE::Assembly> pAssembly;
@@ -171,7 +170,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
     PEAssemblyHolder pPEAssembly(PEAssembly::Open(pAssembly->GetPEImage(), pAssembly));
     bindOperation.SetResult(pPEAssembly.GetValue());
 
-    RETURN pCurDomain->LoadAssembly(&spec, pPEAssembly, FILE_LOADED);
+    return pCurDomain->LoadAssembly(&spec, pPEAssembly, FILE_LOADED);
 }
 
 extern "C" void QCALLTYPE AssemblyNative_LoadFromPath(INT_PTR ptrNativeAssemblyBinder, LPCWSTR pwzILPath, LPCWSTR pwzNIPath, QCall::ObjectHandleOnStack retLoadedAssembly)

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -860,7 +860,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
         abHolder.SuppressRelease();
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p\n",entry,pAssembly->GetPEAssembly());
-        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+        _ASSERTE(UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly));
         return TRUE;
     }
     else
@@ -872,7 +872,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                 // OK if this is a duplicate
                 if (entry->GetAssembly() == pAssembly)
                     {
-                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+                        _ASSERTE(UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly));
                         return TRUE;
                     }
             }
@@ -883,14 +883,13 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                     && pAssembly->GetPEAssembly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
-                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+                    _ASSERTE(UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly));
                     return TRUE;
                 }
             }
         }
 
         // Invalid cache transition (see above note about state transitions)
-        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         return FALSE;
     }
 }
@@ -950,7 +949,7 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly: Add cached entry (%p) with PEAssembly %p\n", entry, pPEAssembly);
 
-        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
+        _ASSERTE(UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly));
         return TRUE;
     }
     else
@@ -960,7 +959,7 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
             // OK if this is a duplicate
             if (entry->GetFile() != NULL
                 && pPEAssembly->Equals(entry->GetFile()))
-                _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
+                _ASSERTE(UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly));
                 return TRUE;
         }
         else
@@ -972,7 +971,6 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
         }
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEAssembly %p\n", entry, pPEAssembly);
         // Invalid cache transition (see above note about state transitions)
-        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         return FALSE;
     }
 }

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -376,7 +376,10 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel,
 
     PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound));
     if (pFile == NULL)
+    {
+        _ASSERTE(!fThrowOnFileNotFound);
         return NULL;
+    }
 
     return pDomain->LoadAssembly(this, pFile, targetLevel);
 }

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -351,17 +351,15 @@ AssemblyBinder* AssemblySpec::GetBinderFromParentAssembly(AppDomain *pDomain)
 Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel,
                                      BOOL fThrowOnFileNotFound)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION((!fThrowOnFileNotFound && CheckPointer(RETVAL, NULL_OK))
-                      || CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ETWOnStartup (LoaderCatchCall_V1, LoaderCatchCallEnd_V1);
     AppDomain* pDomain = GetAppDomain();
@@ -373,14 +371,14 @@ Assembly *AssemblySpec::LoadAssembly(FileLoadLevel targetLevel,
         bindOperation.SetResult(assembly->GetPEAssembly(), true /*cached*/);
 
         pDomain->LoadAssembly(assembly, targetLevel);
-        RETURN assembly;
+        return assembly;
     }
 
     PEAssemblyHolder pFile(pDomain->BindAssemblySpec(this, fThrowOnFileNotFound));
     if (pFile == NULL)
-        RETURN NULL;
+        return NULL;
 
-    RETURN pDomain->LoadAssembly(this, pFile, targetLevel);
+    return pDomain->LoadAssembly(this, pFile, targetLevel);
 }
 
 /* static */
@@ -390,36 +388,34 @@ Assembly *AssemblySpec::LoadAssembly(LPCSTR pSimpleName,
                                      DWORD cbPublicKeyOrToken,
                                      DWORD dwFlags)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pSimpleName));
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AssemblySpec spec;
     spec.Init(pSimpleName, pContext, pbPublicKeyOrToken, cbPublicKeyOrToken, dwFlags);
 
-    RETURN spec.LoadAssembly(FILE_LOADED);
+    return spec.LoadAssembly(FILE_LOADED);
 }
 
 /* static */
 Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pFilePath));
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     GCX_PREEMP();
 
@@ -433,7 +429,7 @@ Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
     if (!pILImage->CheckILFormat())
         THROW_BAD_FORMAT(BFA_BAD_IL, pILImage.GetValue());
 
-    RETURN AssemblyNative::LoadFromPEImage(AppDomain::GetCurrentDomain()->GetDefaultBinder(), pILImage, true /* excludeAppPaths */);
+    return AssemblyNative::LoadFromPEImage(AppDomain::GetCurrentDomain()->GetDefaultBinder(), pILImage, true /* excludeAppPaths */);
 }
 
 HRESULT AssemblySpec::CheckFriendAssemblyName()
@@ -658,7 +654,7 @@ BOOL AssemblySpecBindingCache::Contains(AssemblySpec *pSpec)
 Assembly *AssemblySpecBindingCache::LookupAssembly(AssemblySpec *pSpec,
                                                          BOOL fThrow /*=TRUE*/)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (fThrow) {
@@ -672,16 +668,15 @@ Assembly *AssemblySpecBindingCache::LookupAssembly(AssemblySpec *pSpec,
             FORBID_FAULT;
         }
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AssemblyBinding *entry = (AssemblyBinding *) INVALIDENTRY;
 
     entry = LookupInternal(pSpec, fThrow);
 
     if (entry == (AssemblyBinding *) INVALIDENTRY)
-        RETURN NULL;
+        return NULL;
     else
     {
         if ((entry->GetAssembly() == NULL) && fThrow)
@@ -690,13 +685,13 @@ Assembly *AssemblySpecBindingCache::LookupAssembly(AssemblySpec *pSpec,
             entry->ThrowIfError();
         }
 
-        RETURN entry->GetAssembly();
+        return entry->GetAssembly();
     }
 }
 
 PEAssembly *AssemblySpecBindingCache::LookupFile(AssemblySpec *pSpec, BOOL fThrow /*=TRUE*/)
 {
-    CONTRACT(PEAssembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (fThrow) {
@@ -710,15 +705,14 @@ PEAssembly *AssemblySpecBindingCache::LookupFile(AssemblySpec *pSpec, BOOL fThro
             FORBID_FAULT;
         }
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AssemblyBinding *entry = (AssemblyBinding *) INVALIDENTRY;
     entry = LookupInternal(pSpec, fThrow);
 
     if (entry == (AssemblyBinding *) INVALIDENTRY)
-        RETURN NULL;
+        return NULL;
     else
     {
         if (fThrow && (entry->GetFile() == NULL))
@@ -727,7 +721,7 @@ PEAssembly *AssemblySpecBindingCache::LookupFile(AssemblySpec *pSpec, BOOL fThro
             entry->ThrowIfError();
         }
 
-        RETURN entry->GetFile();
+        return entry->GetFile();
     }
 }
 
@@ -826,16 +820,15 @@ private:
 
 BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAssembly)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UPTR key = (UPTR)pSpec->Hash();
 
@@ -867,7 +860,8 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
         abHolder.SuppressRelease();
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p\n",entry,pAssembly->GetPEAssembly());
-        RETURN TRUE;
+        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+        return TRUE;
     }
     else
     {
@@ -877,7 +871,10 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
             {
                 // OK if this is a duplicate
                 if (entry->GetAssembly() == pAssembly)
-                    RETURN TRUE;
+                    {
+                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+                        return TRUE;
+                    }
             }
             else
             {
@@ -886,13 +883,15 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                     && pAssembly->GetPEAssembly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
-                    RETURN TRUE;
+                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+                    return TRUE;
                 }
             }
         }
 
         // Invalid cache transition (see above note about state transitions)
-        RETURN FALSE;
+        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
+        return FALSE;
     }
 }
 
@@ -902,16 +901,15 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
 
 BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *pPEAssembly)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION((!RETVAL) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UPTR key = (UPTR)pSpec->Hash();
 
@@ -952,7 +950,8 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly: Add cached entry (%p) with PEAssembly %p\n", entry, pPEAssembly);
 
-        RETURN TRUE;
+        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
+        return TRUE;
     }
     else
     {
@@ -961,7 +960,8 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
             // OK if this is a duplicate
             if (entry->GetFile() != NULL
                 && pPEAssembly->Equals(entry->GetFile()))
-                RETURN TRUE;
+                _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
+                return TRUE;
         }
         else
         if (entry->IsPostBindError())
@@ -972,22 +972,22 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
         }
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEAssembly %p\n", entry, pPEAssembly);
         // Invalid cache transition (see above note about state transitions)
-        RETURN FALSE;
+        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
+        return FALSE;
     }
 }
 
 BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pEx)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        DISABLED(POSTCONDITION(UnsafeContains(this, pSpec))); //<TODO>@todo: Getting violations here - StoreExceptions could happen anywhere so this is possibly too aggressive.</TODO>
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UPTR key = (UPTR)pSpec->Hash();
 
@@ -1017,7 +1017,7 @@ BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pE
         abHolder.SuppressRelease();
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreException): Add cached entry (%p) with exception %p\n",entry,pEx);
-        RETURN TRUE;
+        return TRUE;
     }
     else
     {
@@ -1025,7 +1025,7 @@ BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pE
         if (entry->IsError())
         {
             if (entry->GetHR() == pEx->GetHR())
-                RETURN TRUE;
+                return TRUE;
         }
         else
         {
@@ -1033,18 +1033,18 @@ BOOL AssemblySpecBindingCache::StoreException(AssemblySpec *pSpec, Exception* pE
             if (entry->GetAssembly() == NULL)
             {
                 entry->InitException(pEx);
-                RETURN TRUE;
+                return TRUE;
             }
         }
 
         // Invalid cache transition (see above note about state transitions)
-        RETURN FALSE;
+        return FALSE;
     }
 }
 
 BOOL AssemblySpecBindingCache::RemoveAssembly(Assembly* pAssembly)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
@@ -1052,7 +1052,7 @@ BOOL AssemblySpecBindingCache::RemoveAssembly(Assembly* pAssembly)
         MODE_ANY;
         PRECONDITION(pAssembly != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     BOOL result = FALSE;
     PtrHashMap::PtrIterator i = m_map.begin();
     while (!i.end())
@@ -1073,7 +1073,7 @@ BOOL AssemblySpecBindingCache::RemoveAssembly(Assembly* pAssembly)
         ++i;
     }
 
-    RETURN result;
+    return result;
 }
 
 /* static */

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -860,7 +860,6 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
         abHolder.SuppressRelease();
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p\n",entry,pAssembly->GetPEAssembly());
-        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         return TRUE;
     }
     else
@@ -872,7 +871,6 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                 // OK if this is a duplicate
                 if (entry->GetAssembly() == pAssembly)
                     {
-                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
                         return TRUE;
                     }
             }
@@ -883,14 +881,12 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                     && pAssembly->GetPEAssembly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
-                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
                     return TRUE;
                 }
             }
         }
 
         // Invalid cache transition (see above note about state transitions)
-        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         return FALSE;
     }
 }
@@ -950,7 +946,6 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly: Add cached entry (%p) with PEAssembly %p\n", entry, pPEAssembly);
 
-        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         return TRUE;
     }
     else
@@ -960,7 +955,6 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
             // OK if this is a duplicate
             if (entry->GetFile() != NULL
                 && pPEAssembly->Equals(entry->GetFile()))
-                _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
                 return TRUE;
         }
         else
@@ -972,7 +966,6 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
         }
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEAssembly %p\n", entry, pPEAssembly);
         // Invalid cache transition (see above note about state transitions)
-        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         return FALSE;
     }
 }

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -860,6 +860,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
         abHolder.SuppressRelease();
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly (StoreAssembly): Add cached entry (%p) with PEAssembly %p\n",entry,pAssembly->GetPEAssembly());
+        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         return TRUE;
     }
     else
@@ -871,6 +872,7 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                 // OK if this is a duplicate
                 if (entry->GetAssembly() == pAssembly)
                     {
+                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
                         return TRUE;
                     }
             }
@@ -881,12 +883,14 @@ BOOL AssemblySpecBindingCache::StoreAssembly(AssemblySpec *pSpec, Assembly *pAss
                     && pAssembly->GetPEAssembly()->Equals(entry->GetFile()))
                 {
                     entry->SetAssembly(pAssembly);
+                    _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
                     return TRUE;
                 }
             }
         }
 
         // Invalid cache transition (see above note about state transitions)
+        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupAssembly(this, pSpec, pAssembly)));
         return FALSE;
     }
 }
@@ -946,6 +950,7 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
 
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"StorePEAssembly: Add cached entry (%p) with PEAssembly %p\n", entry, pPEAssembly);
 
+        _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         return TRUE;
     }
     else
@@ -955,6 +960,7 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
             // OK if this is a duplicate
             if (entry->GetFile() != NULL
                 && pPEAssembly->Equals(entry->GetFile()))
+                _ASSERTE((!TRUE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
                 return TRUE;
         }
         else
@@ -966,6 +972,7 @@ BOOL AssemblySpecBindingCache::StorePEAssembly(AssemblySpec *pSpec, PEAssembly *
         }
         STRESS_LOG2(LF_CLASSLOADER,LL_INFO10,"Incompatible cached entry found (%p) when adding PEAssembly %p\n", entry, pPEAssembly);
         // Invalid cache transition (see above note about state transitions)
+        _ASSERTE((!FALSE) || (UnsafeContains(this, pSpec) && UnsafeVerifyLookupFile(this, pSpec, pPEAssembly)));
         return FALSE;
     }
 }

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -256,7 +256,6 @@ class AssemblySpecHash
     {
         CONTRACTL
         {
-            CONSTRUCTOR_CHECK;
             THROWS;
             GC_NOTRIGGER;
             MODE_ANY;

--- a/src/coreclr/vm/cachelinealloc.cpp
+++ b/src/coreclr/vm/cachelinealloc.cpp
@@ -85,15 +85,14 @@ CCacheLineAllocator::~CCacheLineAllocator()
 
 void *CCacheLineAllocator::VAlloc(ULONG cbSize)
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
+        INJECT_FAULT(return NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // helper to call virtual free to release memory
 
@@ -112,7 +111,7 @@ void *CCacheLineAllocator::VAlloc(ULONG cbSize)
             if(tempPtr->m_pAddr[i] == NULL)
             {
                 tempPtr->m_pAddr[i] = pv;
-                RETURN pv;
+                return pv;
             }
         }
 
@@ -128,10 +127,10 @@ LNew:
         {
             // couldn't find space to register this page
             ClrVirtualFree(pv, 0, MEM_RELEASE);
-            RETURN NULL;
+            return NULL;
         }
     }
-    RETURN pv;
+    return pv;
 }
 
 ///////////////////////////////////////////////////////
@@ -144,21 +143,20 @@ void CCacheLineAllocator::VFree(void* pv)
 {
     BOOL bRes = FALSE;
 
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pv));
-        POSTCONDITION(bRes);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // helper to call virtual free to release memory
 
     bRes = ClrVirtualFree (pv, 0, MEM_RELEASE);
 
-    RETURN_VOID;
+    return;
 }
 
 ///////////////////////////////////////////////////////
@@ -169,15 +167,14 @@ void CCacheLineAllocator::VFree(void* pv)
 //WARNING: must have a lock when calling this function
 void *CCacheLineAllocator::GetCacheLine64()
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
+        INJECT_FAULT(return NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LPCacheLine tempPtr = m_freeList64.RemoveHead();
     if (tempPtr == NULL)
@@ -187,7 +184,7 @@ void *CCacheLineAllocator::GetCacheLine64()
         // Virtual Allocation for some more cache lines
         BYTE* ptr = (BYTE*)VAlloc(AllocSize);
         if(!ptr)
-            RETURN NULL;
+            return NULL;
 
         tempPtr = (LPCacheLine)ptr;
         // Link all the buckets
@@ -206,7 +203,7 @@ void *CCacheLineAllocator::GetCacheLine64()
 
     // initialize cacheline, 64 bytes
     memset((void*)tempPtr,0,64);
-    RETURN tempPtr;
+    return tempPtr;
 }
 
 
@@ -218,22 +215,21 @@ void *CCacheLineAllocator::GetCacheLine64()
 //WARNING: must have a lock when calling this function
 void *CCacheLineAllocator::GetCacheLine32()
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
+        INJECT_FAULT(return NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LPCacheLine tempPtr = m_freeList32.RemoveHead();
     if (tempPtr != NULL)
     {
         // initialize cacheline, 32 bytes
         memset((void*)tempPtr,0,32);
-        RETURN tempPtr;
+        return tempPtr;
     }
     tempPtr = (LPCacheLine)GetCacheLine64();
     if (tempPtr != NULL)
@@ -241,7 +237,7 @@ void *CCacheLineAllocator::GetCacheLine32()
         m_freeList32.InsertHead(tempPtr);
         tempPtr = (LPCacheLine)((BYTE *)tempPtr+32);
     }
-    RETURN tempPtr;
+    return tempPtr;
 }
 ///////////////////////////////////////////////////////
 //    void CCacheLineAllocator::FreeCacheLine64(void * tempPtr)

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -586,16 +586,13 @@ static BOOL IsEditAndContinueCapable(Assembly *pAssembly, PEAssembly *pPEAssembl
 /* static */
 Module *Module::Create(Assembly *pAssembly, PEAssembly *pPEAssembly, AllocMemTracker *pamTracker)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pAssembly));
         PRECONDITION(CheckPointer(pPEAssembly));
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL->GetAssembly() == pAssembly);
-        POSTCONDITION(RETVAL->GetPEAssembly() == pPEAssembly);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Hoist CONTRACT into separate routine because of EX incompatibility
 
@@ -623,7 +620,7 @@ Module *Module::Create(Assembly *pAssembly, PEAssembly *pPEAssembly, AllocMemTra
     ModuleHolder pModuleSafe(pModule);
     pModuleSafe->DoInit(pamTracker, NULL);
 
-    RETURN pModuleSafe.Extract();
+    return pModuleSafe.Extract();
 }
 
 void Module::ApplyMetaData()
@@ -819,16 +816,15 @@ bool Module::NeedsGlobalMethodTable()
 
 MethodTable *Module::GetGlobalMethodTable()
 {
-    CONTRACT (MethodTable *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN NULL;);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
+        INJECT_FAULT(return NULL;);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 
     if ((m_dwPersistedFlags & COMPUTED_GLOBAL_CLASS) == 0)
@@ -843,11 +839,11 @@ MethodTable *Module::GetGlobalMethodTable()
         }
 
         InterlockedOr((LONG*)&m_dwPersistedFlags, COMPUTED_GLOBAL_CLASS);
-        RETURN pMT;
+        return pMT;
     }
     else
     {
-        RETURN LookupTypeDef(COR_GLOBAL_PARENT_TOKEN).AsMethodTable();
+        return LookupTypeDef(COR_GLOBAL_PARENT_TOKEN).AsMethodTable();
     }
 }
 
@@ -1236,15 +1232,14 @@ void Module::SetDomainAssembly(DomainAssembly *pDomainAssembly)
 //
 OBJECTREF Module::GetExposedObject()
 {
-    CONTRACT(OBJECTREF)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(RETVAL != NULL);
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
         LoaderAllocator * pLoaderAllocator = GetLoaderAllocator();
 
@@ -1292,7 +1287,7 @@ OBJECTREF Module::GetExposedObject()
         }
     }
 
-    RETURN pLoaderAllocator->GetHandleValue(m_hExposedObject);
+    return pLoaderAllocator->GetHandleValue(m_hExposedObject);
 }
 
 OBJECTREF Module::GetExposedObjectIfExists()
@@ -1667,15 +1662,14 @@ static ISymUnmanagedReader* const k_pInvalidSymReader = (ISymUnmanagedReader*)0x
 #if defined(FEATURE_ISYM_READER)
 ISymUnmanagedReader *Module::GetISymUnmanagedReaderNoThrow(void)
 {
-    CONTRACT(ISymUnmanagedReader *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         NOTHROW;
         WRAPPER(GC_TRIGGERS);
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ISymUnmanagedReader *ret = NULL;
 
@@ -1686,7 +1680,8 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReaderNoThrow(void)
     EX_SWALLOW_NONTERMINAL
     // We swallow any exception and say that we simply couldn't get a reader by returning NULL.
     // The only type of error that should be possible here is OOM.
-    RETURN (ret);
+    _ASSERTE(CheckPointer((ret), NULL_OK));
+    return (ret);
 }
 
 #if defined(HOST_AMD64)
@@ -1701,18 +1696,17 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReaderNoThrow(void)
 
 ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
 {
-    CONTRACT(ISymUnmanagedReader *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         THROWS;
         WRAPPER(GC_TRIGGERS);
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (g_fEEShutDown)
-        RETURN NULL;
+        return NULL;
 
     // Verify that symbol reading is permitted for this module.
     // If we know we've already created a symbol reader, don't bother checking.  There is
@@ -1723,7 +1717,7 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
     // race on m_pISymUnmanagedReader here is OK.  The perf cost is minor because the only real
     // work is done by the security system which caches the result.
     if( m_pISymUnmanagedReader == NULL && !IsSymbolReadingEnabled() )
-        RETURN NULL;
+        return NULL;
 
     // Take the lock for the m_pISymUnmanagedReader
     // This ensures that we'll only ever attempt to create one reader at a time, and we won't
@@ -1751,7 +1745,8 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         {
             // Case 3.  We don't have a module path or an in memory symbol stream,
             // so there is no-where to try and get symbols from.
-            RETURN (NULL);
+            _ASSERTE(CheckPointer((NULL), NULL_OK));
+            return (NULL);
         }
 
         // Create a binder to find the reader.
@@ -1774,13 +1769,15 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         hr = GetClrModuleDirectory(symbolReaderPath);
         if (FAILED(hr))
         {
-            RETURN (NULL);
+            _ASSERTE(CheckPointer((NULL), NULL_OK));
+            return (NULL);
         }
         symbolReaderPath.Append(NATIVE_SYMBOL_READER_DLL);
         hr = FakeCoCreateInstanceEx(CLSID_CorSymBinder_SxS, symbolReaderPath.GetUnicode(), IID_ISymUnmanagedBinder, (void**)&pBinder, NULL);
         if (FAILED(hr))
         {
-            RETURN (NULL);
+            _ASSERTE(CheckPointer((NULL), NULL_OK));
+            return (NULL);
         }
 
         LOG((LF_CORDB, LL_INFO10, "M::GISUR: Created binder\n"));
@@ -1851,12 +1848,14 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
     // If we previously failed to create the reader, return NULL
     if (m_pISymUnmanagedReader == k_pInvalidSymReader)
     {
-        RETURN (NULL);
+        _ASSERTE(CheckPointer((NULL), NULL_OK));
+        return (NULL);
     }
 
     // Success - return an AddRef'd copy of the reader
     m_pISymUnmanagedReader->AddRef();
-    RETURN (m_pISymUnmanagedReader);
+    _ASSERTE(CheckPointer((m_pISymUnmanagedReader), NULL_OK));
+    return (m_pISymUnmanagedReader);
 }
 #endif // FEATURE_ISYM_READER
 
@@ -2309,25 +2308,25 @@ mdToken Module::GetEntryPointToken()
 
 BYTE *Module::GetProfilerBase()
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         CANNOT_TAKE_LOCK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pPEAssembly == NULL)  // I'd rather assert this is not the case...
     {
-        RETURN NULL;
+        return NULL;
     }
     else if (m_pPEAssembly->HasLoadedPEImage())
     {
-        RETURN  (BYTE*)(m_pPEAssembly->GetLoadedLayout()->GetBase());
+        return (BYTE*)(m_pPEAssembly->GetLoadedLayout()->GetBase());
     }
     else
     {
-        RETURN NULL;
+        return NULL;
     }
 }
 
@@ -2340,17 +2339,16 @@ Module::GetAssemblyIfLoaded(
     AssemblyBinder      *pBinderForLoadedAssembly // = NULL
 )
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         FORBID_FAULT;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Assembly * pAssembly = NULL;
     BOOL fCanUseRidMap = pMDImportOverride == NULL;
@@ -2428,7 +2426,7 @@ Module::GetAssemblyIfLoaded(
 
 #endif //DACCESS_COMPILE
 
-    RETURN pAssembly;
+    return pAssembly;
 } // Module::GetAssemblyIfLoaded
 
 DWORD
@@ -2466,16 +2464,15 @@ ModuleBase::GetAssemblyRefFlags(
 #ifndef DACCESS_COMPILE
 Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
 {
-    CONTRACT(Assembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
         if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT; else { INJECT_FAULT(COMPlusThrowOM();); }
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_NOT_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ETWOnStartup (LoaderCatchCall_V1, LoaderCatchCallEnd_V1);
 
@@ -2486,7 +2483,7 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
     if (pAssembly != NULL)
     {
         ::GetAppDomain()->LoadAssembly(pAssembly, FILE_LOADED);
-        RETURN pAssembly;
+        return pAssembly;
     }
 
     {
@@ -2511,7 +2508,7 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
 
     StoreAssemblyRef(kAssemblyRef, pAssembly);
 
-    RETURN pAssembly;
+    return pAssembly;
 }
 #else
 Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
@@ -2523,7 +2520,7 @@ Assembly * Module::LoadAssemblyImpl(mdAssemblyRef kAssemblyRef)
 
 Module *Module::GetModuleIfLoaded(mdFile kFile)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
@@ -2531,11 +2528,10 @@ Module *Module::GetModuleIfLoaded(mdFile kFile)
         MODE_ANY;
         PRECONDITION(TypeFromToken(kFile) == mdtFile
                      || TypeFromToken(kFile) == mdtModuleRef);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         FORBID_FAULT;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
 
@@ -2548,20 +2544,20 @@ Module *Module::GetModuleIfLoaded(mdFile kFile)
         LPCSTR moduleName;
         if (FAILED(GetMDImport()->GetModuleRefProps(kFile, &moduleName)))
         {
-            RETURN NULL;
+            return NULL;
         }
 
-        RETURN GetAssembly()->GetModule()->GetModuleIfLoaded(mdFileNil);
+        return GetAssembly()->GetModule()->GetModuleIfLoaded(mdFileNil);
     }
 
-    RETURN NULL;
+    return NULL;
 }
 
 #ifndef DACCESS_COMPILE
 
 Module *ModuleBase::LoadModule(mdFile kFile)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
@@ -2570,7 +2566,7 @@ Module *ModuleBase::LoadModule(mdFile kFile)
         PRECONDITION(TypeFromToken(kFile) == mdtFile
                      || TypeFromToken(kFile) == mdtModuleRef);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LPCSTR psModuleName=NULL;
     if (TypeFromToken(kFile) == mdtModuleRef)
@@ -2590,13 +2586,13 @@ Module *ModuleBase::LoadModule(mdFile kFile)
 
     SString name(SString::Utf8, psModuleName);
     EEFileLoadException::Throw(name, COR_E_MULTIMODULEASSEMBLIESDIALLOWED, NULL);
-    RETURN NULL;
+    return NULL;
 }
 #endif // !DACCESS_COMPILE
 
 PTR_Module Module::LookupModule(mdToken kFile)
 {
-    CONTRACT(PTR_Module)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
@@ -2606,21 +2602,20 @@ PTR_Module Module::LookupModule(mdToken kFile)
         MODE_ANY;
         PRECONDITION(TypeFromToken(kFile) == mdtFile
                      || TypeFromToken(kFile) == mdtModuleRef);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (TypeFromToken(kFile) == mdtModuleRef)
     {
         LPCSTR moduleName;
         IfFailThrow(GetMDImport()->GetModuleRefProps(kFile, &moduleName));
 
-        RETURN GetAssembly()->GetModule()->LookupModule(mdFileNil);
+        return GetAssembly()->GetModule()->LookupModule(mdFileNil);
     }
 
     PTR_Module pModule = LookupFile(kFile);
-    RETURN pModule;
+    return pModule;
 }
 
 
@@ -2651,16 +2646,15 @@ TypeHandle ModuleBase::LookupTypeRef(mdTypeRef token)
 //
 PTR_TADDR LookupMapBase::GrowMap(ModuleBase * pModule, DWORD rid)
 {
-    CONTRACT(PTR_TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(ThrowOutOfMemory(););
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LookupMapBase *pMap = this;
     LookupMapBase *pPrev = NULL;
@@ -2678,7 +2672,7 @@ PTR_TADDR LookupMapBase::GrowMap(ModuleBase * pModule, DWORD rid)
             if (dwIndex < pMap->dwCount)
             {
                 // Already there - some other thread must have added it
-                RETURN pMap->GetIndexPtr(dwIndex);
+                return pMap->GetIndexPtr(dwIndex);
             }
 
             dwBlockSize *= 2;
@@ -2707,7 +2701,7 @@ PTR_TADDR LookupMapBase::GrowMap(ModuleBase * pModule, DWORD rid)
         VolatileStore<LookupMapBase*>(&(pPrev->pNext), pNewMap);
     }
 
-    RETURN pNewMap->GetIndexPtr(dwIndex);
+    return pNewMap->GetIndexPtr(dwIndex);
 }
 
 #endif // DACCESS_COMPILE
@@ -2838,18 +2832,17 @@ void Module::DebugLogRidMapOccupancy()
 
 MethodDesc *Module::FindMethodThrowing(mdToken pMethod)
 {
-    CONTRACT (MethodDesc *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     SigTypeContext typeContext;  /* empty type context: methods will not be generic */
-    RETURN MemberLoader::GetMethodDescFromMemberDefOrRefOrSpec(this, pMethod,
+    return MemberLoader::GetMethodDescFromMemberDefOrRefOrSpec(this, pMethod,
                                                                &typeContext,
                                                                TRUE, /* strictMetadataChecks */
                                                                FALSE /* dont get code shared between generic instantiations */);
@@ -2861,13 +2854,12 @@ MethodDesc *Module::FindMethodThrowing(mdToken pMethod)
 
 MethodDesc *Module::FindMethod(mdToken pMethod)
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         INSTANCE_CHECK;
         NOTHROW;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     MethodDesc *pMDRet = NULL;
 
@@ -2887,7 +2879,7 @@ MethodDesc *Module::FindMethod(mdToken pMethod)
     }
     EX_END_CATCH
 
-    RETURN pMDRet;
+    return pMDRet;
 }
 
 // Return true if this module has any live (jitted) JMC functions.
@@ -3448,19 +3440,18 @@ void Module::FixupVTables()
 
 ModuleBase *Module::GetModuleFromIndex(DWORD ix)
 {
-    CONTRACT(ModuleBase*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsReadyToRun())
     {
-        RETURN ZapSig::DecodeModuleFromIndex(this, ix);
+        return ZapSig::DecodeModuleFromIndex(this, ix);
     }
     else
     {
@@ -3468,12 +3459,12 @@ ModuleBase *Module::GetModuleFromIndex(DWORD ix)
         Assembly *pAssembly = this->LookupAssemblyRef(mdAssemblyRefToken);
         if (pAssembly)
         {
-            RETURN pAssembly->GetModule();
+            return pAssembly->GetModule();
         }
         else
         {
             // GetModuleFromIndex failed
-            RETURN NULL;
+            return NULL;
         }
     }
 }
@@ -3482,29 +3473,28 @@ ModuleBase *Module::GetModuleFromIndex(DWORD ix)
 
 ModuleBase *Module::GetModuleFromIndexIfLoaded(DWORD ix)
 {
-    CONTRACT(ModuleBase*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(IsReadyToRun());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifndef DACCESS_COMPILE
-    RETURN ZapSig::DecodeModuleFromIndexIfLoaded(this, ix);
+    return ZapSig::DecodeModuleFromIndexIfLoaded(this, ix);
 #else // DACCESS_COMPILE
     DacNotImpl();
-    RETURN NULL;
+    return NULL;
 #endif // DACCESS_COMPILE
 }
 
 #ifndef DACCESS_COMPILE
 IMDInternalImport* Module::GetNativeAssemblyImport(BOOL loadAllowed)
 {
-    CONTRACT(IMDInternalImport*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (loadAllowed) GC_TRIGGERS;                    else GC_NOTRIGGER;
@@ -3512,28 +3502,24 @@ IMDInternalImport* Module::GetNativeAssemblyImport(BOOL loadAllowed)
         if (loadAllowed) INJECT_FAULT(COMPlusThrowOM()); else FORBID_FAULT;
         MODE_ANY;
         PRECONDITION(IsReadyToRun());
-        POSTCONDITION(loadAllowed ?
-            CheckPointer(RETVAL) :
-            CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetReadyToRunInfo()->GetNativeManifestModule()->GetMDImport();
+    return GetReadyToRunInfo()->GetNativeManifestModule()->GetMDImport();
 }
 
 BYTE* Module::GetNativeFixupBlobData(RVA rva)
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN(BYTE*) GetReadyToRunImage()->GetRvaData(rva);
+    return (BYTE*) GetReadyToRunImage()->GetRvaData(rva);
 }
 #endif // DACCESS_COMPILE
 
@@ -3803,15 +3789,14 @@ void Module::SetBeingUnloaded()
 /* static */
 ReflectionModule *ReflectionModule::Create(Assembly *pAssembly, PEAssembly *pPEAssembly, AllocMemTracker *pamTracker, LPCWSTR szName)
 {
-    CONTRACT(ReflectionModule *)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pAssembly));
         PRECONDITION(CheckPointer(pPEAssembly));
         PRECONDITION(pPEAssembly->IsReflectionEmit());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Hoist CONTRACT into separate routine because of EX incompatibility
 
@@ -3824,7 +3809,7 @@ ReflectionModule *ReflectionModule::Create(Assembly *pAssembly, PEAssembly *pPEA
     pModule->DoInit(pamTracker, szName);
     pModule->SetIsRuntimeWrapExceptionsCached_ForReflectionEmitModules();
 
-    RETURN pModule.Extract();
+    return pModule.Extract();
 }
 
 
@@ -4238,14 +4223,13 @@ static bool MethodSignatureContainsGenericVariables(SigParser& sp)
 //==========================================================================
 VASigCookie *Module::GetVASigCookie(Signature vaSignature, const SigTypeContext* typeContext)
 {
-    CONTRACT(VASigCookie*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SigTypeContext emptyContext;
 
@@ -4276,18 +4260,17 @@ VASigCookie *Module::GetVASigCookie(Signature vaSignature, const SigTypeContext*
 
     VASigCookie *pCookie = GetVASigCookieWorker(this, pLoaderModule, vaSignature, typeContext);
 
-    RETURN pCookie;
+    return pCookie;
 }
 
 VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoaderModule, Signature vaSignature, const SigTypeContext* typeContext)
 {
-    CONTRACT(VASigCookie*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     VASigCookie *pCookie = NULL;
 
@@ -4422,7 +4405,7 @@ VASigCookie *Module::GetVASigCookieWorker(Module* pDefiningModule, Module* pLoad
         }
     }
 
-    RETURN pCookie;
+    return pCookie;
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -1745,7 +1745,6 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         {
             // Case 3.  We don't have a module path or an in memory symbol stream,
             // so there is no-where to try and get symbols from.
-            _ASSERTE(CheckPointer((NULL), NULL_OK));
             return (NULL);
         }
 
@@ -1769,14 +1768,12 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
         hr = GetClrModuleDirectory(symbolReaderPath);
         if (FAILED(hr))
         {
-            _ASSERTE(CheckPointer((NULL), NULL_OK));
             return (NULL);
         }
         symbolReaderPath.Append(NATIVE_SYMBOL_READER_DLL);
         hr = FakeCoCreateInstanceEx(CLSID_CorSymBinder_SxS, symbolReaderPath.GetUnicode(), IID_ISymUnmanagedBinder, (void**)&pBinder, NULL);
         if (FAILED(hr))
         {
-            _ASSERTE(CheckPointer((NULL), NULL_OK));
             return (NULL);
         }
 
@@ -1848,7 +1845,6 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReader(void)
     // If we previously failed to create the reader, return NULL
     if (m_pISymUnmanagedReader == k_pInvalidSymReader)
     {
-        _ASSERTE(CheckPointer((NULL), NULL_OK));
         return (NULL);
     }
 

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -620,6 +620,8 @@ Module *Module::Create(Assembly *pAssembly, PEAssembly *pPEAssembly, AllocMemTra
     ModuleHolder pModuleSafe(pModule);
     pModuleSafe->DoInit(pamTracker, NULL);
 
+    _ASSERTE(pModuleSafe->GetAssembly() == pAssembly);
+    _ASSERTE(pModuleSafe->GetPEAssembly() == pPEAssembly);
     return pModuleSafe.Extract();
 }
 
@@ -1680,7 +1682,6 @@ ISymUnmanagedReader *Module::GetISymUnmanagedReaderNoThrow(void)
     EX_SWALLOW_NONTERMINAL
     // We swallow any exception and say that we simply couldn't get a reader by returning NULL.
     // The only type of error that should be possible here is OOM.
-    _ASSERTE(CheckPointer((ret), NULL_OK));
     return (ret);
 }
 

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -1120,13 +1120,12 @@ namespace
 /*static*/
 void ClassLoader::LoadExactParents(MethodTable* pMT)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pMT));
-        POSTCONDITION(pMT->CheckLoadLevel(CLASS_LOAD_EXACTPARENTS));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!pMT->IsCanonicalMethodTable())
     {
@@ -1177,7 +1176,8 @@ void ClassLoader::LoadExactParents(MethodTable* pMT)
     // We can now mark this type as having exact parents
     pMT->SetHasExactParent();
 
-    RETURN;
+    _ASSERTE(pMT->CheckLoadLevel(CLASS_LOAD_EXACTPARENTS));
+    return;
 }
 
 // Get CorElementType of the reduced type of a type.
@@ -1590,17 +1590,16 @@ void TypeHandle::NotifyDebuggerUnload() const
 // This is needed when creating a delegate to an instance method in a value type
 MethodDesc* MethodTable::GetBoxedEntryPointMD(MethodDesc *pMD)
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(IsValueType());
         PRECONDITION(!pMD->ContainsGenericVariables());
         PRECONDITION(!pMD->IsUnboxingStub());
-        POSTCONDITION(RETVAL->IsUnboxingStub());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
-    RETURN MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
+    return MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
                                                         pMD->GetMethodTable(),
                                                         TRUE /* get unboxing entry point */,
                                                         pMD->GetMethodInstantiation(),
@@ -1613,7 +1612,7 @@ MethodDesc* MethodTable::GetBoxedEntryPointMD(MethodDesc *pMD)
 // This is used when generating the code for an BoxedEntryPointStub.
 MethodDesc* MethodTable::GetUnboxedEntryPointMD(MethodDesc *pMD)
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
@@ -1622,11 +1621,10 @@ MethodDesc* MethodTable::GetUnboxedEntryPointMD(MethodDesc *pMD)
         // so move the assert to the caller when needed
         //PRECONDITION(!pMD->ContainsGenericVariables());
         PRECONDITION(pMD->IsUnboxingStub());
-        POSTCONDITION(!RETVAL->IsUnboxingStub());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     BOOL allowInstParam = (pMD->GetNumGenericMethodArgs() == 0);
-    RETURN MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
+    return MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
                                                         this,
                                                         FALSE /* don't get unboxing entry point */,
                                                         pMD->GetMethodInstantiation(),
@@ -1639,7 +1637,7 @@ MethodDesc* MethodTable::GetUnboxedEntryPointMD(MethodDesc *pMD)
 // This is used when generating the code for an BoxedEntryPointStub.
 MethodDesc* MethodTable::GetExistingUnboxedEntryPointMD(MethodDesc *pMD)
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
         INJECT_FAULT(COMPlusThrowOM(););
@@ -1648,11 +1646,10 @@ MethodDesc* MethodTable::GetExistingUnboxedEntryPointMD(MethodDesc *pMD)
         // so move the assert to the caller when needed
         //PRECONDITION(!pMD->ContainsGenericVariables());
         PRECONDITION(pMD->IsUnboxingStub());
-        POSTCONDITION(!RETVAL->IsUnboxingStub());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     BOOL allowInstParam = (pMD->GetNumGenericMethodArgs() == 0);
-    RETURN MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
+    return MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
                                                         this,
                                                         FALSE /* don't get unboxing entry point */,
                                                         pMD->GetMethodInstantiation(),

--- a/src/coreclr/vm/classhash.cpp
+++ b/src/coreclr/vm/classhash.cpp
@@ -138,7 +138,7 @@ bool EEClassHashTable::UncompressModuleAndClassDef(HashDatum Data, Loader::LoadF
                                                    Module **ppModule, mdTypeDef *pCL,
                                                    mdExportedType *pmdFoundExportedType)
 {
-    CONTRACT(bool)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
@@ -148,10 +148,9 @@ bool EEClassHashTable::UncompressModuleAndClassDef(HashDatum Data, Loader::LoadF
 
         PRECONDITION(CheckPointer(pCL));
         PRECONDITION(CheckPointer(ppModule));
-        POSTCONDITION(*ppModule != nullptr || loadFlag != Loader::Load);
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     DWORD dwData = (DWORD)dac_cast<TADDR>(Data);
     _ASSERTE((dwData & EECLASSHASH_TYPEHANDLE_DISCR) == EECLASSHASH_TYPEHANDLE_DISCR);
@@ -166,7 +165,8 @@ bool EEClassHashTable::UncompressModuleAndClassDef(HashDatum Data, Loader::LoadF
         _ASSERTE(*ppModule != nullptr); // Should never fail.
     }
 
-    RETURN (*ppModule != nullptr);
+    _ASSERTE(*ppModule != nullptr || loadFlag != Loader::Load);
+    return (*ppModule != nullptr);
 }
 
 /* static */

--- a/src/coreclr/vm/clrex.h
+++ b/src/coreclr/vm/clrex.h
@@ -329,7 +329,6 @@ class EEMessageException : public EEException
         CONTRACTL_END;
 
         EEMessageException boilerplate(E_FAIL);
-        _ASSERTE(CheckPointer((PVOID&)boilerplate));
         return (PVOID&)boilerplate;
     }
 

--- a/src/coreclr/vm/clrex.h
+++ b/src/coreclr/vm/clrex.h
@@ -320,17 +320,17 @@ class EEMessageException : public EEException
 
     static PVOID GetEEMessageExceptionVPtr()
     {
-        CONTRACT (PVOID)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         EEMessageException boilerplate(E_FAIL);
-        RETURN (PVOID&)boilerplate;
+        _ASSERTE(CheckPointer((PVOID&)boilerplate));
+        return (PVOID&)boilerplate;
     }
 
     BOOL GetResourceMessage(UINT iResourceID, SString &result);

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -348,10 +348,12 @@ TypeHandle ClassLoader::LoadTypeByNameThrowing(Assembly *pAssembly,
         _ASSERTE(!result.IsNull());
     }
 
+#ifndef DACCESS_COMPILE
     if (!result.IsNull())
     {
         _ASSERTE(result.CheckLoadLevel(level));
     }
+#endif
 
     return result;
 }
@@ -420,7 +422,7 @@ TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoad
     }
     else
     {
-        _ASSERTE(typeHnd.CheckLoadLevel(level));
+        _ASSERTE(!typeHnd.IsNull());
     }
 
     return(typeHnd);
@@ -1697,7 +1699,6 @@ ClassLoader::ClassLoader(Assembly *pAssembly)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -101,21 +101,20 @@ PTR_Module ClassLoader::ComputeLoaderModuleWorker(
     Instantiation classInst,         // the type arguments to the type (if any)
     Instantiation methodInst)        // the type arguments to the method (if any)
 {
-    CONTRACT(Module*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         FORBID_FAULT;
         MODE_ANY;
         PRECONDITION(CheckPointer(pDefinitionModule, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     // No generic instantiation, return the definition module
     if (classInst.IsEmpty() && methodInst.IsEmpty())
-        RETURN PTR_Module(pDefinitionModule);
+        return PTR_Module(pDefinitionModule);
 
     // Use the definition module as the loader module by default
     Module *pLoaderModule = pDefinitionModule;
@@ -192,7 +191,7 @@ ComputeCollectibleLoaderModule:
         if (pLatestLoaderModule != NULL)
             pLoaderModule = pLatestLoaderModule;
     }
-    RETURN PTR_Module(pLoaderModule);
+    return PTR_Module(pLoaderModule);
 }
 
 /*static*/
@@ -314,7 +313,7 @@ TypeHandle ClassLoader::LoadTypeByNameThrowing(Assembly *pAssembly,
                                                ClassLoader::LoadTypesFlag fLoadTypes,
                                                ClassLoadLevel level)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -326,24 +325,21 @@ TypeHandle ClassLoader::LoadTypeByNameThrowing(Assembly *pAssembly,
         PRECONDITION(CheckPointer(pAssembly));
         PRECONDITION(pNameHandle != NULL);
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL,
-                     (fNotFound == ThrowIfNotFound && fLoadTypes == LoadTypes )? NULL_NOT_OK : NULL_OK));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.CheckLoadLevel(level));
         SUPPORTS_DAC;
 #ifdef DACCESS_COMPILE
         PRECONDITION((fNotFound == ClassLoader::ReturnNullIfNotFound) && (fLoadTypes == DontLoadTypes));
 #endif
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     if (fLoadTypes == ClassLoader::DontLoadTypes)
         pNameHandle->SetTokenNotToLoad(tdAllTypes);
 
     ClassLoader* classLoader = pAssembly->GetLoader();
     if (fNotFound == ClassLoader::ThrowIfNotFound)
-        RETURN classLoader->LoadTypeHandleThrowIfFailed(pNameHandle, level);
+        return classLoader->LoadTypeHandleThrowIfFailed(pNameHandle, level);
     else
-        RETURN classLoader->LoadTypeHandleThrowing(pNameHandle, level);
+        return classLoader->LoadTypeHandleThrowing(pNameHandle, level);
 }
 
 #ifndef DACCESS_COMPILE
@@ -363,7 +359,7 @@ TypeHandle ClassLoader::LoadTypeByNameThrowing(Assembly *pAssembly,
 TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoadLevel level,
                                                     Module* pLookInThisModuleOnly/*=NULL*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
@@ -373,11 +369,9 @@ TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoad
         MODE_ANY;
         PRECONDITION(CheckPointer(pName));
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL, pName->OKToLoad() ? NULL_NOT_OK : NULL_OK));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.CheckLoadLevel(level));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Lookup in the classes that this class loader knows about
     TypeHandle typeHnd = LoadTypeHandleThrowing(pName, level, pLookInThisModuleOnly);
@@ -406,7 +400,7 @@ TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoad
         }
     }
 
-    RETURN(typeHnd);
+    return(typeHnd);
 }
 
 #ifndef DACCESS_COMPILE
@@ -747,7 +741,7 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
                                                     ClassLoadLevel level /*=CLASS_LOADED*/,
                                                     const InstantiationContext *pInstContext /*=NULL*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -756,12 +750,10 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
         PRECONDITION(CheckPointer(pKey));
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
         PRECONDITION(CheckPointer(pInstContext, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, fLoadTypes==DontLoadTypes ? NULL_OK : NULL_NOT_OK));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.GetLoadLevel() >= level);
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     // Lookup in the classes that this class loader knows about
     TypeHandle typeHnd = LookupTypeHandleForTypeKey(pKey);
@@ -770,7 +762,8 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
         if (typeHnd.GetLoadLevel() >= level)
         {
             // If something has been published in the tables, and it's at the right level, just return it
-            RETURN typeHnd;
+            _ASSERTE(typeHnd.IsNull() || typeHnd.GetLoadLevel() >= level);
+            return typeHnd;
         }
     }
 
@@ -786,7 +779,7 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
     // instantiations either because we're in FORBIDGC_LOADER_USE mode, so
     // we should bail out here.
     if (fLoadTypes == DontLoadTypes)
-        RETURN TypeHandle();
+        return TypeHandle();
 
 #ifndef DACCESS_COMPILE
     // If we got here, we now have to allocate a new parameterized type.
@@ -794,10 +787,10 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
     CONSISTENCY_CHECK(!FORBIDGC_LOADER_USE_ENABLED());
 
     Module *pLoaderModule = ComputeLoaderModule(pKey);
-    RETURN(pLoaderModule->GetClassLoader()->LoadTypeHandleForTypeKey(pKey, typeHnd, level, pInstContext));
+    return(pLoaderModule->GetClassLoader()->LoadTypeHandleForTypeKey(pKey, typeHnd, level, pInstContext));
 #else
     DacNotImpl();
-    RETURN(typeHnd);
+    return(typeHnd);
 #endif
 }
 
@@ -1148,7 +1141,7 @@ ClassLoader::LoadTypeHandleThrowing(
     ClassLoadLevel level,
     Module *       pLookInThisModuleOnly /*=NULL*/)
 {
-    CONTRACT(TypeHandle) {
+    CONTRACTL {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1156,10 +1149,9 @@ ClassLoader::LoadTypeHandleThrowing(
         DAC_LOADS_TYPE(level, !pName->OKToLoad());
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
         PRECONDITION(CheckPointer(pName));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.GetLoadLevel() >= level);
         MODE_ANY;
         SUPPORTS_DAC;
-    } CONTRACT_END
+    } CONTRACTL_END
 
     TypeHandle typeHnd;
     Module * pFoundModule = NULL;
@@ -1314,7 +1306,8 @@ ClassLoader::LoadTypeHandleThrowing(
     }
 #endif // !DACCESS_COMPILE
 
-    RETURN typeHnd;
+    _ASSERTE(typeHnd.IsNull() || typeHnd.GetLoadLevel() >= level);
+    return typeHnd;
 } // ClassLoader::LoadTypeHandleThrowing
 
 /* static */
@@ -1323,7 +1316,7 @@ TypeHandle ClassLoader::LoadPointerOrByrefTypeThrowing(CorElementType typ,
                                                        LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                        ClassLoadLevel level/*=CLASS_LOADED*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1333,13 +1326,12 @@ TypeHandle ClassLoader::LoadPointerOrByrefTypeThrowing(CorElementType typ,
         PRECONDITION(CheckPointer(baseType));
         PRECONDITION(typ == ELEMENT_TYPE_BYREF || typ == ELEMENT_TYPE_PTR);
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     TypeKey key(typ, baseType);
-    RETURN(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
+    return(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
 }
 
 /* static */
@@ -1347,7 +1339,7 @@ TypeHandle ClassLoader::LoadNativeValueTypeThrowing(TypeHandle baseType,
                                                     LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                     ClassLoadLevel level/*=CLASS_LOADED*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1356,12 +1348,11 @@ TypeHandle ClassLoader::LoadNativeValueTypeThrowing(TypeHandle baseType,
         PRECONDITION(CheckPointer(baseType));
         PRECONDITION(baseType.AsMethodTable()->IsValueType());
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     TypeKey key(ELEMENT_TYPE_VALUETYPE, baseType);
-    RETURN(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
+    return(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
 }
 
 /* static */
@@ -1371,21 +1362,20 @@ TypeHandle ClassLoader::LoadFnptrTypeThrowing(BYTE callConv,
                                               LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                               ClassLoadLevel level/*=CLASS_LOADED*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
         if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT; else { INJECT_FAULT(COMPlusThrowOM()); }
         if (FORBIDGC_LOADER_USE_ENABLED() || fLoadTypes != LoadTypes) { LOADS_TYPE(CLASS_LOAD_BEGIN); } else { LOADS_TYPE(level); }
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     TypeKey key(callConv, ntypars, inst);
-    RETURN(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
+    return(LoadConstructedTypeThrowing(&key, fLoadTypes, level));
 }
 
 // Find an instantiation of a generic type if it has already been created.
@@ -1403,7 +1393,7 @@ TypeHandle ClassLoader::LoadGenericInstantiationThrowing(Module *pModule,
 {
     // This can be called in FORBIDGC_LOADER_USE mode by the debugger to find
     // a particular generic type instance that is already loaded.
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1412,10 +1402,9 @@ TypeHandle ClassLoader::LoadGenericInstantiationThrowing(Module *pModule,
         MODE_ANY;
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
         PRECONDITION(CheckPointer(pInstContext, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     // Essentially all checks to determine if a generic instantiation of a type
     // is well-formed go in this method, i.e. this is the
@@ -1432,7 +1421,8 @@ TypeHandle ClassLoader::LoadGenericInstantiationThrowing(Module *pModule,
                                             level,
                                             fFromNativeImage ? NULL : &inst);
         _ASSERTE(th.GetNumGenericArgs() == inst.GetNumArgs());
-        RETURN th;
+        _ASSERTE(CheckPointer(th, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
+        return th;
     }
 
     if (!fFromNativeImage)
@@ -1455,11 +1445,11 @@ TypeHandle ClassLoader::LoadGenericInstantiationThrowing(Module *pModule,
     // for DACCESS_COMPILE.
     if (TypeHandle::IsCanonicalSubtypeInstantiation(inst) && !IsCanonicalGenericInstantiation(inst))
     {
-        RETURN(ClassLoader::LoadCanonicalGenericInstantiation(&key, fLoadTypes, level));
+        return(ClassLoader::LoadCanonicalGenericInstantiation(&key, fLoadTypes, level));
     }
 #endif
 
-    RETURN(LoadConstructedTypeThrowing(&key, fLoadTypes, level, pInstContext));
+    return(LoadConstructedTypeThrowing(&key, fLoadTypes, level, pInstContext));
 }
 
 //   For non-nested classes, gets the ExportedType name and finds the corresponding
@@ -1560,17 +1550,16 @@ VOID ClassLoader::CreateCanonicallyCasedKey(LPCUTF8 pszNameSpace, LPCUTF8 pszNam
 /*static*/
 TypeHandle ClassLoader::LookupTypeDefOrRefInModule(ModuleBase *pModule, mdToken cl, ClassLoadLevel *pLoadLevel)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         FORBID_FAULT;
         MODE_ANY;
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     BAD_FORMAT_NOTHROW_ASSERT((TypeFromToken(cl) == mdtTypeRef ||
                        TypeFromToken(cl) == mdtTypeDef ||
@@ -1590,7 +1579,7 @@ TypeHandle ClassLoader::LookupTypeDefOrRefInModule(ModuleBase *pModule, mdToken 
         }
     }
 
-    RETURN(typeHandle);
+    return(typeHandle);
 }
 
 #ifndef DACCESS_COMPILE
@@ -1757,7 +1746,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
                                                        const Substitution *pSubst,
                                                        MethodTable *pMTInterfaceMapOwner)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1767,9 +1756,8 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
         PRECONDITION(FORBIDGC_LOADER_USE_ENABLED() || GetAppDomain()->CheckCanLoadTypes(pModule->GetAssembly()));
-        POSTCONDITION(CheckPointer(RETVAL, (fNotFoundAction == ThrowIfNotFound)? NULL_NOT_OK : NULL_OK));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     if (TypeFromToken(typeDefOrRefOrSpec) == mdtTypeSpec)
     {
@@ -1785,7 +1773,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
                 pModule->GetAssembly()->ThrowTypeLoadException(pInternalImport, typeDefOrRefOrSpec, IDS_CLASSLOAD_BADFORMAT);
             }
 #endif //!DACCESS_COMPILE
-            RETURN (TypeHandle());
+            return (TypeHandle());
         }
         SigPointer sigptr(pSig, cSig);
         TypeHandle typeHnd = sigptr.GetTypeHandleThrowing(pModule, pTypeContext, fLoadTypes,
@@ -1795,11 +1783,12 @@ TypeHandle ClassLoader::LoadTypeDefOrRefOrSpecThrowing(Module *pModule,
             pModule->GetAssembly()->ThrowTypeLoadException(pInternalImport, typeDefOrRefOrSpec,
                                                            IDS_CLASSLOAD_GENERAL);
 #endif
-        RETURN (typeHnd);
+        _ASSERTE(CheckPointer((typeHnd), (fNotFoundAction == ThrowIfNotFound)? NULL_NOT_OK : NULL_OK));
+        return (typeHnd);
     }
     else
     {
-        RETURN (LoadTypeDefOrRefThrowing(pModule, typeDefOrRefOrSpec,
+        return (LoadTypeDefOrRefThrowing(pModule, typeDefOrRefOrSpec,
                                          fNotFoundAction,
                                          fUninstantiated,
                                          ((fLoadTypes == LoadTypes) ? tdNoTypes : tdAllTypes),
@@ -1821,7 +1810,7 @@ TypeHandle ClassLoader::LoadTypeDefThrowing(Module *pModule,
                                             Instantiation * pTargetInstantiation)
 {
 
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -1833,11 +1822,9 @@ TypeHandle ClassLoader::LoadTypeDefThrowing(Module *pModule,
         PRECONDITION(FORBIDGC_LOADER_USE_ENABLED()
                      || GetAppDomain()->CheckCanLoadTypes(pModule->GetAssembly()));
 
-        POSTCONDITION(CheckPointer(RETVAL, NameHandle::OKToLoad(typeDef, tokenNotToLoad) && (fNotFoundAction == ThrowIfNotFound) ? NULL_NOT_OK : NULL_OK));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.GetCl() == typeDef);
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     TypeHandle typeHnd;
 
@@ -1853,7 +1840,7 @@ TypeHandle ClassLoader::LoadTypeDefThrowing(Module *pModule,
 #endif
 
         if (existingLoadLevel >= level)
-            RETURN(typeHnd);
+            return(typeHnd);
     }
 
     IMDInternalImport *pInternalImport = pModule->GetMDImport();
@@ -1988,7 +1975,7 @@ TypeHandle ClassLoader::LoadTypeDefThrowing(Module *pModule,
 #endif
     ;
 
-    RETURN(typeHnd);
+    return(typeHnd);
 }
 
 // Given a token specifying a typeDef or typeRef, and a module in
@@ -2004,7 +1991,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefThrowing(ModuleBase *pModule,
                                                  ClassLoadLevel level)
 {
 
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -2013,10 +2000,9 @@ TypeHandle ClassLoader::LoadTypeDefOrRefThrowing(ModuleBase *pModule,
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
 
-        POSTCONDITION(CheckPointer(RETVAL, NameHandle::OKToLoad(typeDefOrRef, tokenNotToLoad) && (fNotFoundAction == ThrowIfNotFound) ? NULL_NOT_OK : NULL_OK));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // NotFoundAction could be the bizarre 'ThrowButNullV11McppWorkaround',
     //  which means ThrowIfNotFound EXCEPT if this might be the Everett MCPP
@@ -2050,7 +2036,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefThrowing(ModuleBase *pModule,
         // being used inappropriately.
         if (!((fUninstantiated == FailIfUninstDefOrRef) && !typeHnd.IsNull() && typeHnd.IsGenericTypeDefinition()))
         {
-            RETURN(typeHnd);
+            return(typeHnd);
         }
     }
     else
@@ -2111,7 +2097,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefThrowing(ModuleBase *pModule,
                         if(typeHnd.IsNull() && bReturnNullOkWhenNoResolutionScope)
                         {
                             fNotFoundAction = ReturnNullIfNotFound;
-                            RETURN(typeHnd);
+                            return(typeHnd);
                         }
                     }
                     else
@@ -2160,7 +2146,7 @@ TypeHandle ClassLoader::LoadTypeDefOrRefThrowing(ModuleBase *pModule,
 #endif
     }
 
-    RETURN(thRes);
+    return(thRes);
 }
 
 /*static*/
@@ -2173,7 +2159,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
     Loader::LoadFlag loadFlag,
     BOOL *           pfUsesTypeForwarder) // The semantic of this parameter: TRUE if a type forwarder is found. It is never set to FALSE.
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -2182,7 +2168,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
         PRECONDITION(CheckPointer(pTypeRefModule));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // It's a TypeDef already
     if (TypeFromToken(typeRefToken) == mdtTypeDef)
@@ -2194,7 +2180,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
             *ppTypeDefModule = static_cast<Module*>(pTypeRefModule);
         if (pTypeDefToken != NULL)
             *pTypeDefToken = typeRefToken;
-        RETURN TRUE;
+        return TRUE;
     }
 
     TypeHandle typeHnd = pTypeRefModule->LookupTypeRef(typeRefToken);
@@ -2207,7 +2193,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
             *ppTypeDefModule = typeHnd.GetModule();
         if (pTypeDefToken != NULL)
             *pTypeDefToken = typeHnd.GetCl();
-        RETURN TRUE;
+        return TRUE;
     }
 
     BOOL fNoResolutionScope; //not used
@@ -2219,7 +2205,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
 
     if (pFoundRefModule == NULL)
     {   // We didn't find the TypeRef anywhere
-        RETURN FALSE;
+        return FALSE;
     }
 
     // If checking for type forwarders, then we can see if a type forwarder was used based on the output of
@@ -2235,7 +2221,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
             *ppTypeDefModule = typeHnd.GetModule();
         if (pTypeDefToken != NULL)
             *pTypeDefToken = typeHnd.GetCl();
-        RETURN TRUE;
+        return TRUE;
     }
 
     // Not in my module, have to look it up by name
@@ -2243,7 +2229,7 @@ ClassLoader::ResolveTokenToTypeDefThrowing(
     LPCUTF8 pszClassName;
     if (FAILED(pTypeRefModule->GetMDImport()->GetNameOfTypeRef(typeRefToken, &pszNameSpace, &pszClassName)))
     {
-        RETURN FALSE;
+        return FALSE;
     }
     NameHandle nameHandle(pTypeRefModule, typeRefToken);
     nameHandle.SetName(pszNameSpace, pszClassName);
@@ -2265,7 +2251,7 @@ ClassLoader::ResolveNameToTypeDefThrowing(
     Loader::LoadFlag loadFlag,
     BOOL *           pfUsesTypeForwarder) // The semantic of this parameter: TRUE if a type forwarder is found. It is never set to FALSE.
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -2275,7 +2261,7 @@ ClassLoader::ResolveNameToTypeDefThrowing(
         PRECONDITION(CheckPointer(pName));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     TypeHandle typeHnd;
     mdToken  foundTypeDef;
@@ -2299,7 +2285,7 @@ ClassLoader::ResolveNameToTypeDefThrowing(
             pSourceModule->IsReflectionEmit() ? NULL : pSourceModule,
             loadFlag))
         {
-            RETURN FALSE;
+            return FALSE;
         }
 
         // Type is already loaded and cached in the loader's by-name table
@@ -2313,12 +2299,12 @@ ClassLoader::ResolveNameToTypeDefThrowing(
                 *ppTypeDefModule = typeHnd.GetModule();
             if (pTypeDefToken != NULL)
                 *pTypeDefToken = typeHnd.GetCl();
-            RETURN TRUE;
+            return TRUE;
         }
 
         if (pFoundModule == NULL)
         {   // Module was probably not loaded
-            RETURN FALSE;
+            return FALSE;
         }
 
         if (TypeFromToken(foundExportedType) != mdtExportedType)
@@ -2333,7 +2319,7 @@ ClassLoader::ResolveNameToTypeDefThrowing(
                 *pTypeDefToken = foundTypeDef;
             if (ppTypeDefModule != NULL)
                 *ppTypeDefModule = pFoundModule;
-            RETURN TRUE;
+            return TRUE;
         }
         // It's exported type
 
@@ -2341,7 +2327,7 @@ ClassLoader::ResolveNameToTypeDefThrowing(
         pSourceModule = pFoundModule;
     }
     // Type forwarding chain is too long
-    RETURN FALSE;
+    return FALSE;
 } // ClassLoader::ResolveTokenToTypeDefThrowing
 
 #ifndef DACCESS_COMPILE
@@ -2401,7 +2387,7 @@ ClassLoader::LoadApproxTypeThrowing(
     SigPointer *           pSigInst,
     const SigTypeContext * pClassTypeContext)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2409,9 +2395,8 @@ ClassLoader::LoadApproxTypeThrowing(
         MODE_ANY;
         PRECONDITION(CheckPointer(pSigInst, NULL_OK));
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMDInternalImport * pInternalImport = pModule->GetMDImport();
 
@@ -2463,12 +2448,12 @@ ClassLoader::LoadApproxTypeThrowing(
         // of setting up the method table.
         if (genericTypeTH.IsInterface())
         {
-            RETURN genericTypeTH;
+            return genericTypeTH;
         }
         else
         {
             // approxTypes, i.e. approximate reference types by Object, i.e. load the canonical type
-            RETURN SigPointer(pSig, cSig).GetTypeHandleThrowing(
+            return SigPointer(pSig, cSig).GetTypeHandleThrowing(
                 pModule,
                 pClassTypeContext,
                 ClassLoader::LoadTypes,
@@ -2480,7 +2465,7 @@ ClassLoader::LoadApproxTypeThrowing(
     {
         if (pSigInst != NULL)
             *pSigInst = SigPointer();
-        RETURN LoadTypeDefOrRefThrowing(
+        return LoadTypeDefOrRefThrowing(
             pModule,
             tok,
             ClassLoader::ThrowIfNotFound,
@@ -2627,15 +2612,14 @@ TypeHandle ClassLoader::DoIncrementalLoad(const TypeKey *pTypeKey, TypeHandle ty
 // For all other types, create a method table
 TypeHandle ClassLoader::CreateTypeHandleForTypeKey(const TypeKey* pKey, AllocMemTracker* pamTracker)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pKey));
 
-        POSTCONDITION(RETVAL.CheckMatchesKey(pKey));
         MODE_ANY;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     TypeHandle typeHnd = TypeHandle();
 
@@ -2732,7 +2716,8 @@ TypeHandle ClassLoader::CreateTypeHandleForTypeKey(const TypeKey* pKey, AllocMem
         }
     }
 
-    RETURN typeHnd;
+    _ASSERTE(typeHnd.CheckMatchesKey(pKey));
+    return typeHnd;
 }
 
 // Publish a type (and possibly member information) in the loader's
@@ -3150,12 +3135,11 @@ ClassLoader::LoadTypeHandleForTypeKey_Body(
     TypeHandle                        typeHnd,
     ClassLoadLevel                    targetLevel)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     if (!pTypeKey->IsConstructed())
     {
@@ -3209,7 +3193,10 @@ retry:
             if (!typeHnd.IsNull())
             {
                 if (typeHnd.GetLoadLevel() >= targetLevel)
-                    RETURN typeHnd;
+                    {
+                    _ASSERTE(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
+                        return typeHnd;
+                    }
             }
         }
 
@@ -3249,7 +3236,10 @@ retry:
                 if (!typeHnd.IsNull())
                 {
                     if (typeHnd.GetLoadLevel() >= targetLevel)
-                        RETURN typeHnd;
+                        {
+                        _ASSERTE(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
+                            return typeHnd;
+                        }
                 }
             }
 
@@ -3271,7 +3261,10 @@ retry:
         {
             // If the type load on the other thread loaded the type to the needed level, return it here.
             if (typeHnd.GetLoadLevel() >= targetLevel)
-                RETURN typeHnd;
+                {
+                _ASSERTE(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
+                    return typeHnd;
+                }
         }
 
         // The type load on the other thread did not load the type "enough". Begin the type load
@@ -3291,7 +3284,10 @@ retry:
     {
         currentLevel = typeHnd.GetLoadLevel();
         if (currentLevel >= targetLevel)
-            RETURN typeHnd;
+            {
+            _ASSERTE(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
+                return typeHnd;
+            }
     }
 
     // It was not loaded, and it is not being loaded, so we must load it.  Create a new LoadingEntry
@@ -3361,7 +3357,8 @@ retry:
     if (currentLevel < targetLevel)
         goto retry;
 
-    RETURN typeHnd;
+    _ASSERTE(!typeHnd.IsNull() && typeHnd.GetLoadLevel() >= targetLevel);
+    return typeHnd;
 } // ClassLoader::LoadTypeHandleForTypeKey_Body
 
 #endif //!DACCESS_COMPILE
@@ -3377,7 +3374,7 @@ ClassLoader::LoadArrayTypeThrowing(
     LoadTypesFlag  fLoadTypes,  //=LoadTypes
     ClassLoadLevel level)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
@@ -3385,9 +3382,8 @@ ClassLoader::LoadArrayTypeThrowing(
         if (FORBIDGC_LOADER_USE_ENABLED() || fLoadTypes != LoadTypes) { LOADS_TYPE(CLASS_LOAD_BEGIN); } else { LOADS_TYPE(level); }
         MODE_ANY;
         SUPPORTS_DAC;
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     CorElementType predefinedElementType = ELEMENT_TYPE_END;
 
@@ -3397,7 +3393,7 @@ ClassLoader::LoadArrayTypeThrowing(
         if (predefinedElementType <= ELEMENT_TYPE_R8) {
             TypeHandle th = g_pPredefinedArrayTypes[predefinedElementType];
             if (th != 0)
-                RETURN(th);
+                return(th);
         }
         // This call to AsPtr is somewhat bogus and only used
         // as an optimization.  If the TypeHandle is really a TypeDesc
@@ -3407,14 +3403,14 @@ ClassLoader::LoadArrayTypeThrowing(
             // Code duplicated because Object[]'s SigCorElementType is E_T_CLASS, not OBJECT
             TypeHandle th = g_pPredefinedArrayTypes[ELEMENT_TYPE_OBJECT];
             if (th != 0)
-                RETURN(th);
+                return(th);
             predefinedElementType = ELEMENT_TYPE_OBJECT;
         }
         else if (elemType.AsPtr() == PTR_VOID(g_pStringClass)) {
             // Code duplicated because String[]'s SigCorElementType is E_T_CLASS, not STRING
             TypeHandle th = g_pPredefinedArrayTypes[ELEMENT_TYPE_STRING];
             if (th != 0)
-                RETURN(th);
+                return(th);
             predefinedElementType = ELEMENT_TYPE_STRING;
         }
         else {
@@ -3442,7 +3438,7 @@ ClassLoader::LoadArrayTypeThrowing(
         g_pPredefinedArrayTypes[predefinedElementType] = th;
     }
 
-    RETURN(th);
+    return(th);
 } // ClassLoader::LoadArrayTypeThrowing
 
 #ifndef DACCESS_COMPILE
@@ -3669,18 +3665,17 @@ VOID ClassLoader::AddExportedTypeHaveLock(Module *pManifestModule,
 
 static MethodTable* GetEnclosingMethodTable(MethodTable *pMT)
 {
-    CONTRACT(MethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         MODE_ANY;
         PRECONDITION(CheckPointer(pMT));
-        POSTCONDITION(RETVAL == NULL || RETVAL->IsTypicalTypeDefinition());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN pMT->LoadEnclosingMethodTable();
+    return pMT->LoadEnclosingMethodTable();
 }
 
 AccessCheckContext::AccessCheckContext(MethodDesc* pCallerMethod)
@@ -4306,7 +4301,7 @@ BOOL ClassLoader::CanAccess(                            // TRUE if access is all
                                                         // there is no need to check the method's instantiation.
     const AccessCheckOptions & accessCheckOptions)      // = s_NormalAccessChecks
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -4314,7 +4309,7 @@ BOOL ClassLoader::CanAccess(                            // TRUE if access is all
         PRECONDITION(CheckPointer(pContext));
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AccessCheckOptions accessCheckOptionsNoThrow(accessCheckOptions, FALSE);
 
@@ -4361,11 +4356,11 @@ BOOL ClassLoader::CanAccess(                            // TRUE if access is all
         if (!canAccess)
         {
             BOOL fail = accessCheckOptions.FailOrThrow(pContext);
-            RETURN(fail);
+            return(fail);
         }
     }
 
-    RETURN(TRUE);
+    return(TRUE);
 } // BOOL ClassLoader::CanAccess()
 
 //******************************************************************************

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -336,10 +336,24 @@ TypeHandle ClassLoader::LoadTypeByNameThrowing(Assembly *pAssembly,
         pNameHandle->SetTokenNotToLoad(tdAllTypes);
 
     ClassLoader* classLoader = pAssembly->GetLoader();
+
+    TypeHandle result;
     if (fNotFound == ClassLoader::ThrowIfNotFound)
-        return classLoader->LoadTypeHandleThrowIfFailed(pNameHandle, level);
+        result = classLoader->LoadTypeHandleThrowIfFailed(pNameHandle, level);
     else
-        return classLoader->LoadTypeHandleThrowing(pNameHandle, level);
+        result = classLoader->LoadTypeHandleThrowing(pNameHandle, level);
+
+    if (fNotFound == ClassLoader::ThrowIfNotFound && fLoadTypes == LoadTypes)
+    {
+        _ASSERTE(!result.IsNull());
+    }
+
+    if (!result.IsNull())
+    {
+        _ASSERTE(result.CheckLoadLevel(level));
+    }
+
+    return result;
 }
 
 #ifndef DACCESS_COMPILE
@@ -398,6 +412,15 @@ TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoad
             DacNotImpl();
 #endif
         }
+    }
+
+    if (typeHnd.IsNull())
+    {
+        _ASSERTE(!pName->OKToLoad());
+    }
+    else
+    {
+        _ASSERTE(typeHnd.CheckLoadLevel(level));
     }
 
     return(typeHnd);
@@ -787,7 +810,9 @@ TypeHandle ClassLoader::LoadConstructedTypeThrowing(const TypeKey *pKey,
     CONSISTENCY_CHECK(!FORBIDGC_LOADER_USE_ENABLED());
 
     Module *pLoaderModule = ComputeLoaderModule(pKey);
-    return(pLoaderModule->GetClassLoader()->LoadTypeHandleForTypeKey(pKey, typeHnd, level, pInstContext));
+    typeHnd = (pLoaderModule->GetClassLoader()->LoadTypeHandleForTypeKey(pKey, typeHnd, level, pInstContext));
+    _ASSERTE(typeHnd.IsNull() || typeHnd.GetLoadLevel() >= level);
+    return typeHnd;
 #else
     DacNotImpl();
     return(typeHnd);

--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -422,7 +422,9 @@ TypeHandle ClassLoader::LoadTypeHandleThrowIfFailed(NameHandle* pName, ClassLoad
     }
     else
     {
-        _ASSERTE(!typeHnd.IsNull());
+#ifndef DACCESS_COMPILE
+        _ASSERTE(typeHnd.CheckLoadLevel(level));
+#endif
     }
 
     return(typeHnd);

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2493,7 +2493,6 @@ HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap 
             // Always exercise the fallback path in the caller when forced relocs are turned on
             if (!pInfo->GetThrowOnOutOfMemoryWithinRange() && PEDecoder::GetForceRelocs())
                 {
-                _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
                     return NULL;
                 }
 #endif
@@ -2504,7 +2503,6 @@ HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap 
                 // Conserve emergency jump stub reserve until when it is really needed
                 if (!pInfo->GetThrowOnOutOfMemoryWithinRange())
                     {
-                    _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
                         return NULL;
                     }
 #ifdef TARGET_AMD64

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2435,11 +2435,10 @@ static size_t GetDefaultReserveForJumpStubs(size_t codeHeapSize)
 
 HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap *pJitMetaHeap)
 {
-    CONTRACT(HeapList *) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
-        POSTCONDITION((RETVAL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     size_t   reserveSize        = pInfo->GetReserveSize();
     size_t   initialRequestSize = pInfo->GetRequestSize();
@@ -2493,7 +2492,10 @@ HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap 
 #ifdef _DEBUG
             // Always exercise the fallback path in the caller when forced relocs are turned on
             if (!pInfo->GetThrowOnOutOfMemoryWithinRange() && PEDecoder::GetForceRelocs())
-                RETURN NULL;
+                {
+                _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
+                    return NULL;
+                }
 #endif
             pBaseAddr = (BYTE*)ExecutableAllocator::Instance()->ReserveWithinRange(reserveSize, loAddr, hiAddr);
 
@@ -2501,7 +2503,10 @@ HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap 
             {
                 // Conserve emergency jump stub reserve until when it is really needed
                 if (!pInfo->GetThrowOnOutOfMemoryWithinRange())
-                    RETURN NULL;
+                    {
+                    _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
+                        return NULL;
+                    }
 #ifdef TARGET_AMD64
                 pBaseAddr = ExecutionManager::GetEEJitManager()->AllocateFromEmergencyJumpStubReserve(loAddr, hiAddr, &reserveSize);
                 if (!pBaseAddr)
@@ -2583,7 +2588,8 @@ HeapList* LoaderCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, LoaderHeap 
          ));
 
     pCodeHeap.SuppressRelease();
-    RETURN pHp;
+    _ASSERTE((pHp != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
+    return pHp;
 }
 
 void * LoaderCodeHeap::AllocMemForCode_NoThrow(size_t header, size_t size, DWORD alignment, size_t reserveForJumpStubs)
@@ -2690,12 +2696,11 @@ extern "C" PT_RUNTIME_FUNCTION GetRuntimeFunctionCallback(IN ULONG     ControlPc
 
 HeapList* EECodeGenManager::NewCodeHeap(CodeHeapRequestInfo *pInfo, DomainCodeHeapList *pADHeapList)
 {
-    CONTRACT(HeapList *) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(m_CodeHeapLock.OwnedByCurrentThread());
-        POSTCONDITION((RETVAL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     size_t initialRequestSize = pInfo->GetRequestSize();
     size_t minReserveSize = VIRTUAL_ALLOC_RESERVE_GRANULARITY; //     ( 64 KB)
@@ -2758,7 +2763,7 @@ HeapList* EECodeGenManager::NewCodeHeap(CodeHeapRequestInfo *pInfo, DomainCodeHe
     if (pHp == NULL)
     {
         _ASSERTE(!pInfo->GetThrowOnOutOfMemoryWithinRange());
-        RETURN(NULL);
+        return(NULL);
     }
 
     _ASSERTE (pHp != NULL);
@@ -2813,19 +2818,18 @@ HeapList* EECodeGenManager::NewCodeHeap(CodeHeapRequestInfo *pInfo, DomainCodeHe
     HeapList **ppHeapList = pADHeapList->m_CodeHeapList.AppendThrowing();
     *ppHeapList = pHp;
 
-    RETURN(pHp);
+    return(pHp);
 }
 
 void* EECodeGenManager::AllocCodeWorker(CodeHeapRequestInfo *pInfo,
                                      size_t header, size_t blockSize, unsigned align,
                                      HeapList ** ppCodeHeap)
 {
-    CONTRACT(void *) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(m_CodeHeapLock.OwnedByCurrentThread());
-        POSTCONDITION((RETVAL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     pInfo->SetRequestSize(header+blockSize+(align-1)+pInfo->GetReserveForJumpStubs());
 
@@ -2905,7 +2909,7 @@ void* EECodeGenManager::AllocCodeWorker(CodeHeapRequestInfo *pInfo,
             if (pCodeHeap == NULL)
             {
                 _ASSERTE(!pInfo->GetThrowOnOutOfMemoryWithinRange());
-                RETURN(NULL);
+                return(NULL);
             }
 
             mem = (pCodeHeap->pHeap)->AllocMemForCode_NoThrow(header, blockSize, align, pInfo->GetReserveForJumpStubs());
@@ -2953,7 +2957,7 @@ void* EECodeGenManager::AllocCodeWorker(CodeHeapRequestInfo *pInfo,
         pCodeHeap->endAddress = (TADDR)mem+blockSize;
     }
 
-    RETURN(mem);
+    return(mem);
 }
 
 template<typename TCodeHeader>
@@ -3288,15 +3292,14 @@ JumpStubBlockHeader *  EEJitManager::AllocJumpStubBlock(MethodDesc* pMD, DWORD n
                                                         LoaderAllocator *pLoaderAllocator,
                                                         bool throwOnOutOfMemoryWithinRange)
 {
-    CONTRACT(JumpStubBlockHeader *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(loAddr < hiAddr);
         PRECONDITION(pLoaderAllocator != NULL);
-        POSTCONDITION((RETVAL != NULL) || !throwOnOutOfMemoryWithinRange);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE((sizeof(JumpStubBlockHeader) % CODE_SIZE_ALIGN) == 0);
 
@@ -3317,7 +3320,7 @@ JumpStubBlockHeader *  EEJitManager::AllocJumpStubBlock(MethodDesc* pMD, DWORD n
         if (mem == (TADDR)0)
         {
             _ASSERTE(!throwOnOutOfMemoryWithinRange);
-            RETURN(NULL);
+            return(NULL);
         }
 
         // CodeHeader comes immediately before the block
@@ -3345,19 +3348,18 @@ JumpStubBlockHeader *  EEJitManager::AllocJumpStubBlock(MethodDesc* pMD, DWORD n
     LOG((LF_JIT, LL_INFO1000, "Allocated new JumpStubBlockHeader for %d stubs at" FMT_ADDR " in loader allocator " FMT_ADDR "\n",
          numJumps, DBG_ADDR(mem) , DBG_ADDR(pLoaderAllocator) ));
 
-    RETURN((JumpStubBlockHeader*)mem);
+    return((JumpStubBlockHeader*)mem);
 }
 
 void * EEJitManager::AllocCodeFragmentBlock(size_t blockSize, unsigned alignment, LoaderAllocator *pLoaderAllocator, StubCodeBlockKind kind)
 {
-    CONTRACT(void *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(pLoaderAllocator != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HeapList *pCodeHeap = NULL;
     CodeHeapRequestInfo requestInfo(pLoaderAllocator);
@@ -3387,7 +3389,7 @@ void * EEJitManager::AllocCodeFragmentBlock(size_t blockSize, unsigned alignment
         pCodeHeap->reserveForJumpStubs += requestInfo.GetReserveForJumpStubs();
     }
 
-    RETURN((void *)mem);
+    return((void *)mem);
 }
 
 BYTE* EECodeGenManager::AllocFromJitMetaHeap(MethodDesc* pMD, size_t blockSize)
@@ -5840,14 +5842,13 @@ PCODE ExecutionManager::jumpStub(MethodDesc* pMD, PCODE target,
                                  LoaderAllocator *pLoaderAllocator,
                                  bool throwOnOutOfMemoryWithinRange)
 {
-    CONTRACT(PCODE) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(pLoaderAllocator != NULL || pMD != NULL);
         PRECONDITION(loAddr < hiAddr);
-        POSTCONDITION((RETVAL != NULL) || !throwOnOutOfMemoryWithinRange);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     PCODE jumpStub = (PCODE)NULL;
 
@@ -5904,7 +5905,7 @@ PCODE ExecutionManager::jumpStub(MethodDesc* pMD, PCODE target,
         // Is the matching entry with the requested range?
         if (((TADDR)loAddr <= jumpStub) && (jumpStub <= (TADDR)hiAddr))
         {
-            RETURN(jumpStub);
+            return(jumpStub);
         }
     }
 
@@ -5914,7 +5915,7 @@ PCODE ExecutionManager::jumpStub(MethodDesc* pMD, PCODE target,
     if (jumpStub == (PCODE)NULL)
     {
         _ASSERTE(!throwOnOutOfMemoryWithinRange);
-        RETURN((PCODE)NULL);
+        return((PCODE)NULL);
     }
 
     _ASSERTE(((TADDR)loAddr <= jumpStub) && (jumpStub <= (TADDR)hiAddr));
@@ -5922,7 +5923,7 @@ PCODE ExecutionManager::jumpStub(MethodDesc* pMD, PCODE target,
     LOG((LF_JIT, LL_INFO10000, "Add JumpStub to" FMT_ADDR "at" FMT_ADDR "\n",
             DBG_ADDR(target), DBG_ADDR(jumpStub) ));
 
-    RETURN(jumpStub);
+    return(jumpStub);
 }
 
 PCODE ExecutionManager::getNextJumpStub(MethodDesc* pMD, PCODE target,
@@ -5930,13 +5931,12 @@ PCODE ExecutionManager::getNextJumpStub(MethodDesc* pMD, PCODE target,
                                         LoaderAllocator *pLoaderAllocator,
                                         bool throwOnOutOfMemoryWithinRange)
 {
-    CONTRACT(PCODE) {
+    CONTRACTL {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(pLoaderAllocator != NULL);
         PRECONDITION(m_JumpStubCrst.OwnedByCurrentThread());
-        POSTCONDITION((RETVAL != NULL) || !throwOnOutOfMemoryWithinRange);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     BYTE *           jumpStub       = NULL;
     BYTE *           jumpStubRW     = NULL;
@@ -6014,7 +6014,7 @@ PCODE ExecutionManager::getNextJumpStub(MethodDesc* pMD, PCODE target,
     if (curBlock == NULL)
     {
         _ASSERTE(!throwOnOutOfMemoryWithinRange);
-        RETURN((PCODE)NULL);
+        return((PCODE)NULL);
     }
 
     curBlockWriterHolder.AssignExecutableWriterHolder(curBlock, sizeof(JumpStubBlockHeader) + ((size_t) (curBlock->m_used + 1) * BACK_TO_BACK_JUMP_ALLOCATE_SIZE));
@@ -6101,7 +6101,7 @@ DONE:
         }
     }
 
-    RETURN((PCODE)jumpStub);
+    return((PCODE)jumpStub);
 }
 #endif // HOST_64BIT
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/comcache.cpp
+++ b/src/coreclr/vm/comcache.cpp
@@ -120,17 +120,16 @@ static void CheckForFuncEvalAbort(HRESULT hr)
 //
 STDAPI_(LPSTREAM) CreateMemStm(DWORD cb, BYTE** ppBuf)
 {
-    CONTRACT(LPSTREAM)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        INJECT_FAULT(CONTRACT_RETURN NULL);
+        INJECT_FAULT(return NULL);
         PRECONDITION(CheckPointer(ppBuf, NULL_OK));
         PRECONDITION(CheckPointer(ppBuf, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LPSTREAM        pstm = NULL;
 
@@ -144,7 +143,7 @@ STDAPI_(LPSTREAM) CreateMemStm(DWORD cb, BYTE** ppBuf)
     if(ppBuf)
         *ppBuf = pMem;
 
-    RETURN pstm;
+    return pstm;
 }
 
 //=====================================================================
@@ -338,18 +337,15 @@ CtxEntry* CtxEntryCache::FindCtxEntry(LPVOID pCtxCookie, Thread *pThread)
     CtxEntry *pCtxEntry = NULL;
     Thread *pSTAThread = NULL;
 
-    CONTRACT (CtxEntry*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pCtxCookie));
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(pCtxCookie == pCtxEntry->GetCtxCookie());
-        POSTCONDITION(pSTAThread == pCtxEntry->GetSTAThread());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Find our STA (if any)
     if (pThread->GetApartment() == Thread::AS_InSTA)
@@ -393,7 +389,9 @@ CtxEntry* CtxEntryCache::FindCtxEntry(LPVOID pCtxCookie, Thread *pThread)
     }
 
     // Returned the found or allocated entry.
-    RETURN pCtxEntry;
+    _ASSERTE(pCtxCookie == pCtxEntry->GetCtxCookie());
+    _ASSERTE(pSTAThread == pCtxEntry->GetSTAThread());
+    return pCtxEntry;
 }
 
 
@@ -570,14 +568,13 @@ VOID IUnkEntry::Free()
 // Get IUnknown for the current context from IUnkEntry
 IUnknown* IUnkEntry::GetIUnknownForCurrContext(bool fNoAddRef)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, (fNoAddRef ? NULL_OK : NULL_NOT_OK)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IUnknown* pUnk = NULL;
     LPVOID pCtxCookie = GetCurrentCtxCookie();
@@ -600,22 +597,22 @@ IUnknown* IUnkEntry::GetIUnknownForCurrContext(bool fNoAddRef)
     if (pUnk == NULL && !fNoAddRef)
         pUnk = UnmarshalIUnknownForCurrContext();
 
-    RETURN pUnk;
+    _ASSERTE(CheckPointer(pUnk, (fNoAddRef ? NULL_OK : NULL_NOT_OK)));
+    return pUnk;
 }
 
 //================================================================
 // Unmarshal IUnknown for the current context from IUnkEntry
 IUnknown* IUnkEntry::UnmarshalIUnknownForCurrContext()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(!IsFreeThreaded());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT     hrCDH               = S_OK;
     IUnknown*   pUnk                = NULL;
@@ -759,7 +756,7 @@ IUnknown* IUnkEntry::UnmarshalIUnknownForCurrContext()
         pUnk = UnmarshalIUnknownForCurrContextHelper();
     }
 
-    RETURN pUnk;
+    return pUnk;
 }
 
 //================================================================
@@ -887,15 +884,14 @@ HRESULT IUnkEntry::MarshalIUnknownToStreamCallback2(LPVOID pData)
 // Unmarshal IUnknown for the current context if the lock is held
 IUnknown* IUnkEntry::UnmarshalIUnknownForCurrContextHelper()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(!IsFreeThreaded());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hrCDH = S_OK;
     IUnknown * pUnk = NULL;
@@ -954,7 +950,7 @@ IUnknown* IUnkEntry::UnmarshalIUnknownForCurrContextHelper()
         }
     }
 
-    RETURN pUnk;
+    return pUnk;
 }
 
 //================================================================

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -268,13 +268,13 @@ static void FillInComVtableSlot(SLOT* pComVtable,
 
 ComCallMethodDesc* ComMethodTable::ComCallMethodDescFromSlot(unsigned i)
 {
-    CONTRACT(ComCallMethodDesc*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SLOT* rgVtable = (SLOT*)((ComMethodTable *)this+1);
 
@@ -283,7 +283,7 @@ ComCallMethodDesc* ComMethodTable::ComCallMethodDescFromSlot(unsigned i)
 
     ComCallUMThunkMarshInfo* pMarshInfo = (ComCallUMThunkMarshInfo*)pUMEntryThunk->GetData()->GetUMThunkMarshInfo();
 
-    RETURN pMarshInfo->GetComCallMethodDesc();
+    return pMarshInfo->GetComCallMethodDesc();
 }
 
 #ifdef FEATURE_INTERPRETER
@@ -850,29 +850,28 @@ void SimpleComCallWrapper::SetUpCPListHelper(MethodTable **apSrcItfMTs, int cSrc
 
 ConnectionPoint *SimpleComCallWrapper::TryCreateConnectionPoint(ComCallWrapper *pWrap, MethodTable *pEventMT)
 {
-    CONTRACT (ConnectionPoint*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pWrap));
         PRECONDITION(CheckPointer(pEventMT));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     EX_TRY
     {
-        RETURN CreateConnectionPoint(pWrap, pEventMT);
+        return CreateConnectionPoint(pWrap, pEventMT);
     }
     EX_SWALLOW_NONTERMINAL
 
-    RETURN nullptr;
+    return nullptr;
 }
 
 ConnectionPoint *SimpleComCallWrapper::CreateConnectionPoint(ComCallWrapper *pWrap, MethodTable *pEventMT)
 {
-    CONTRACT (ConnectionPoint*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -880,26 +879,25 @@ ConnectionPoint *SimpleComCallWrapper::CreateConnectionPoint(ComCallWrapper *pWr
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pWrap));
         PRECONDITION(CheckPointer(pEventMT));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN (new ConnectionPoint(pWrap, pEventMT));
+    return (new ConnectionPoint(pWrap, pEventMT));
 }
 
 CQuickArray<ConnectionPoint*> *SimpleComCallWrapper::CreateCPArray()
 {
-    CONTRACT (CQuickArray<ConnectionPoint*>*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN (new CQuickArray<ConnectionPoint*>());
+    _ASSERTE(CheckPointer((new CQuickArray<ConnectionPoint*>())));
+    return (new CQuickArray<ConnectionPoint*>());
 }
 
 //--------------------------------------------------------------------------
@@ -1015,7 +1013,7 @@ NOINLINE BOOL SimpleComCallWrapper::ShouldUseManagedIProvideClassInfo()
 // The returned interface is AddRef'd.
 IUnknown* SimpleComCallWrapper::QIStandardInterface(Enum_StdInterfaces index)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -1024,9 +1022,8 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(Enum_StdInterfaces index)
         // assert for valid index
         PRECONDITION(index < enum_LastStdVtable);
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IUnknown* pIntf = NULL;
 
@@ -1078,7 +1075,7 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(Enum_StdInterfaces index)
             this->AddRefWithAggregationCheck();
     }
 
-    RETURN pIntf;
+    return pIntf;
 }
 
 #include <optsmallperfcritical.h>   // improves CCW QI perf by ~10%
@@ -1097,7 +1094,7 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(Enum_StdInterfaces index)
 #define HANDLE_IID_INLINE(itfEnum,data1,data2,data3, data4,data5,data6,data7,data8,data9,data10,data11)     \
     CASE_IID_INLINE(itfEnum,data1,data2,data3, data4,data5,data6,data7,data8,data9,data10,data11)           \
     {                                                                                                       \
-        RETURN QIStandardInterface(itfEnum);                                                                \
+        return QIStandardInterface(itfEnum);                                                                \
     }                                                                                                       \
     break;                                                                                                  \
 
@@ -1106,48 +1103,46 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(Enum_StdInterfaces index)
         if (IS_EQUAL_GUID_LOW_12_BYTES(riid,data1,data2,data3, data4,data5,data6,data7,data8,data9,data10,data11))  \
 
 #define IS_KNOWN_INTERFACE_CONTRACT(iid) \
-    CONTRACT(bool)                                          \
+    CONTRACTL \
     {                                                       \
         MODE_ANY;                                           \
         NOTHROW;                                            \
         GC_NOTRIGGER;                                       \
-        POSTCONDITION(RETVAL == !!IsEqualGUID(iid, riid));  \
     }                                                       \
-    CONTRACT_END;                                           \
+    CONTRACTL_END;                                           \
 
 inline bool IsIUnknown(REFIID riid)
 {
     IS_KNOWN_INTERFACE_CONTRACT(IID_IUnknown);
-    RETURN IS_EQUAL_GUID(riid, 0x00000000,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46);
+    return IS_EQUAL_GUID(riid, 0x00000000,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46);
 }
 inline bool IsIDispatch(REFIID riid)
 {
     IS_KNOWN_INTERFACE_CONTRACT(IID_IDispatch);
-    RETURN IS_EQUAL_GUID(riid, 0x00020400,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46);
+    return IS_EQUAL_GUID(riid, 0x00020400,0x0000,0x0000,0xC0,0x00,0x00,0x00,0x00,0x00,0x00,0x46);
 }
 inline bool IsGUID_NULL(REFIID riid)
 {
     IS_KNOWN_INTERFACE_CONTRACT(GUID_NULL);
-    RETURN IS_EQUAL_GUID(riid, 0x00000000,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00);
+    return IS_EQUAL_GUID(riid, 0x00000000,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00);
 }
 inline bool IsIErrorInfo(REFIID riid)
 {
     IS_KNOWN_INTERFACE_CONTRACT(IID_IErrorInfo);
-    RETURN IS_EQUAL_GUID(riid, 0x1CF2B120,0x547D,0x101B,0x8E,0x65,0x08,0x00,0x2B,0x2B,0xD1,0x19);
+    return IS_EQUAL_GUID(riid, 0x1CF2B120,0x547D,0x101B,0x8E,0x65,0x08,0x00,0x2B,0x2B,0xD1,0x19);
 }
 
 // QI for well known interfaces from within the runtime based on an IID.
 IUnknown* SimpleComCallWrapper::QIStandardInterface(REFIID riid)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // IID_IMarshal                    00000003-0000-0000-C000-000000000046
     // IID_IErrorInfo                  1CF2B120-547D-101B-8E65-08002B2BD119
@@ -1178,7 +1173,7 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(REFIID riid)
                 {
                     if (!pTemplate->SupportsICustomQueryInterface() || !CustomQIRespondsToIMarshal())
                     {
-                        RETURN QIStandardInterface(enum_IAgileObject);
+                        return QIStandardInterface(enum_IAgileObject);
                     }
                 }
             }
@@ -1186,7 +1181,7 @@ IUnknown* SimpleComCallWrapper::QIStandardInterface(REFIID riid)
         break;
     }
 
-    RETURN NULL;
+    return NULL;
 }
 #include <optdefault.h>
 
@@ -1235,16 +1230,15 @@ void SimpleComCallWrapper::ResetOuter()
 //--------------------------------------------------------------------------
 IUnknown* SimpleComCallWrapper::GetOuter()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN m_pOuter;
+    return m_pOuter;
 }
 
 BOOL SimpleComCallWrapper::FindConnectionPoint(REFIID riid, IConnectionPoint **ppCP)
@@ -1508,16 +1502,15 @@ HRESULT ComCallWrapper::GetInnerUnknown(void **ppv)
 //--------------------------------------------------------------------------
 IUnknown* ComCallWrapper::GetOuter()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetSimpleWrapper()->GetOuter();
+    return GetSimpleWrapper()->GetOuter();
 }
 
 //--------------------------------------------------------------------------
@@ -1525,16 +1518,15 @@ IUnknown* ComCallWrapper::GetOuter()
 //--------------------------------------------------------------------------
 SyncBlock* ComCallWrapper::GetSyncBlock()
 {
-    CONTRACT (SyncBlock*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetSimpleWrapper()->GetSyncBlock();
+    return GetSimpleWrapper()->GetSyncBlock();
 }
 
 //--------------------------------------------------------------------------
@@ -1546,7 +1538,7 @@ ComCallWrapper* ComCallWrapper::CopyFromTemplate(ComCallWrapperTemplate* pTempla
                                                  ComCallWrapperCache *pWrapperCache,
                                                  OBJECTHANDLE oh)
 {
-    CONTRACT (ComCallWrapper*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -1555,9 +1547,8 @@ ComCallWrapper* ComCallWrapper::CopyFromTemplate(ComCallWrapperTemplate* pTempla
         PRECONDITION(CheckPointer(pTemplate));
         PRECONDITION(CheckPointer(pWrapperCache));
         PRECONDITION(oh != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // num interfaces on the object
     size_t numInterfaces = pTemplate->GetNumInterfaces();
@@ -1623,7 +1614,7 @@ ComCallWrapper* ComCallWrapper::CopyFromTemplate(ComCallWrapperTemplate* pTempla
             blockIndex = 0; // reset block index
             if (pNewWrapper == NULL)
             {
-                RETURN NULL;
+                return NULL;
             }
 
             pWrapper = pNewWrapper;
@@ -1641,7 +1632,7 @@ ComCallWrapper* ComCallWrapper::CopyFromTemplate(ComCallWrapperTemplate* pTempla
 
     pStartWrapper.SuppressRelease();
 
-    RETURN pStartWrapper;
+    return pStartWrapper;
 }
 
 //--------------------------------------------------------------------------
@@ -1650,16 +1641,15 @@ ComCallWrapper* ComCallWrapper::CopyFromTemplate(ComCallWrapperTemplate* pTempla
 //--------------------------------------------------------------------------
 SLOT** ComCallWrapper::GetComIPLocInWrapper(ComCallWrapper* pWrap, unsigned int iIndex)
 {
-    CONTRACT (SLOT**)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pWrap));
         PRECONDITION(iIndex > 1);  // We should never attempt to get the basic or IClassX interface here.
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SLOT** pTearOff = NULL;
     while (iIndex >= NumVtablePtrs)
@@ -1672,7 +1662,7 @@ SLOT** ComCallWrapper::GetComIPLocInWrapper(ComCallWrapper* pWrap, unsigned int 
     _ASSERTE(pWrap != NULL);
     pTearOff = (SLOT **)&pWrap->m_rgpIPtr[iIndex];
 
-    RETURN pTearOff;
+    return pTearOff;
 }
 
 //--------------------------------------------------------------------------
@@ -1825,17 +1815,16 @@ void ComCallWrapper::ClearHandle()
 
 SLOT** ComCallWrapper::GetFirstInterfaceSlot()
 {
-    CONTRACT(SLOT**)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SLOT** firstInterface = GetComIPLocInWrapper(this, Slot_FirstInterface);
-    RETURN firstInterface;
+    return firstInterface;
 }
 
 //--------------------------------------------------------------------------
@@ -1887,15 +1876,14 @@ void ComCallWrapper::FreeWrapper(ComCallWrapperCache *pWrapperCache)
 //--------------------------------------------------------------------------
 ComCallWrapper* ComCallWrapper::CreateWrapper(OBJECTREF* ppObj)
 {
-    CONTRACT(ComCallWrapper *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(ppObj != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ComCallWrapper* pStartWrapper = NULL;
     OBJECTREF pServer = NULL;
@@ -1996,7 +1984,7 @@ ComCallWrapper* ComCallWrapper::CreateWrapper(OBJECTREF* ppObj)
     }
     GCPROTECT_END();
 
-    RETURN pStartWrapper;
+    return pStartWrapper;
 }
 
 //--------------------------------------------------------------------------
@@ -2006,14 +1994,13 @@ ComCallWrapper* ComCallWrapper::CreateWrapper(OBJECTREF* ppObj)
 //--------------------------------------------------------------------------
 IUnknown* ComCallWrapper::GetIClassXIP(bool inspectionOnly)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ComCallWrapper *pWrap = this;
     IUnknown *pIntf = NULL;
@@ -2027,7 +2014,7 @@ IUnknown* ComCallWrapper::GetIClassXIP(bool inspectionOnly)
     if (NULL == slot)
     {
         if (inspectionOnly)
-            RETURN NULL;
+            return NULL;
 
         // Get the IClassX ComMethodTable (create if it doesn't exist),
         //  and set it into the vtable map.
@@ -2045,7 +2032,7 @@ IUnknown* ComCallWrapper::GetIClassXIP(bool inspectionOnly)
         // We won't attempt to lay out the class if we are only trying to
         // passively inspect the interface.
         if (inspectionOnly)
-            RETURN NULL;
+            return NULL;
         else
             pIClassXComMT->LayOutClassMethodTable();
     }
@@ -2055,7 +2042,9 @@ IUnknown* ComCallWrapper::GetIClassXIP(bool inspectionOnly)
 
     // If we are only inspecting, don't addref.
     if (inspectionOnly)
-        RETURN pIntf;
+        {
+            return pIntf;
+        }
 
     // AddRef the wrapper.
     // Note that we don't do SafeAddRef(pIntf) because it's overkill to
@@ -2063,26 +2052,26 @@ IUnknown* ComCallWrapper::GetIClassXIP(bool inspectionOnly)
     ULONG cbRef = pWrap->AddRefWithAggregationCheck();
 
     // 0xbadF00d implies the AddRef didn't go through
-    RETURN ((cbRef != 0xbadf00d) ? pIntf : NULL);
+    _ASSERTE(CheckPointer(((cbRef != 0xbadf00d) ? pIntf : NULL), NULL_OK));
+    return ((cbRef != 0xbadf00d) ? pIntf : NULL);
 }
 
 IUnknown* ComCallWrapper::GetBasicIP(bool inspectionOnly)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // If the legacy switch is set, we'll always return the IClassX IP
     //  when QIing for IUnknown or IDispatch.
     // Whidbey Tactics has decided to make this opt-in rather than
     // opt-out for now.  Remove the check for the legacy switch.
     if (GetComCallWrapperTemplate()->SupportsIClassX())
-        RETURN GetIClassXIP(inspectionOnly);
+        return GetIClassXIP(inspectionOnly);
 
     ComCallWrapper *pWrap = this;
     IUnknown *pIntf = NULL;
@@ -2098,7 +2087,7 @@ IUnknown* ComCallWrapper::GetBasicIP(bool inspectionOnly)
     if (!pIBasicComMT->IsLayoutComplete())
     {
         if (inspectionOnly)
-            RETURN NULL;
+            return NULL;
         else
             pIBasicComMT->LayOutBasicMethodTable();
     }
@@ -2108,7 +2097,9 @@ IUnknown* ComCallWrapper::GetBasicIP(bool inspectionOnly)
 
     // If we are not addref'ing the IUnknown (for passive inspection like ETW), return it now.
     if (inspectionOnly)
-        RETURN pIntf;
+        {
+            return pIntf;
+        }
 
     // AddRef the wrapper.
     // Note that we don't do SafeAddRef(pIntf) because it's overkill to
@@ -2116,7 +2107,8 @@ IUnknown* ComCallWrapper::GetBasicIP(bool inspectionOnly)
     ULONG cbRef = pWrap->AddRefWithAggregationCheck();
 
     // 0xbadF00d implies the AddRef didn't go through
-    RETURN ((cbRef != 0xbadf00d) ? pIntf : NULL);
+    _ASSERTE(CheckPointer(((cbRef != 0xbadf00d) ? pIntf : NULL), NULL_OK));
+    return ((cbRef != 0xbadf00d) ? pIntf : NULL);
 }
 
 //--------------------------------------------------------------------------
@@ -2151,7 +2143,7 @@ static IUnknown *GetComIPFromCCW_VisibilityCheck(
     ComMethodTable *pIntfComMT,
     GetComIPFromCCW::flags flags)
 {
-    CONTRACT(IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2159,16 +2151,16 @@ static IUnknown *GetComIPFromCCW_VisibilityCheck(
         PRECONDITION(CheckPointer(pIntf));
         PRECONDITION(CheckPointer(pIntfComMT));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (// Do a visibility check if needed.
         ((flags & GetComIPFromCCW::CheckVisibility) && (!pIntfComMT->IsComVisible())))
     {
         //  If not, fail to return the interface.
         SafeRelease(pIntf);
-        RETURN NULL;
+        return NULL;
     }
-    RETURN pIntf;
+    return pIntf;
 }
 
 static IUnknown * GetComIPFromCCW_HandleExtendsCOMObject(
@@ -2247,15 +2239,14 @@ static IUnknown * GetComIPFromCCW_ForIID_Worker(
     GetComIPFromCCW::flags flags,
     ComCallWrapperTemplate * pTemplate)
 {
-    CONTRACT(IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pWrap));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ComMethodTable * pIntfComMT = NULL;
     MethodTable * pMT = pWrap->GetMethodTableOfObjectRef();
@@ -2277,24 +2268,23 @@ static IUnknown * GetComIPFromCCW_ForIID_Worker(
             // Giveout IClassX of this class because the IID matches one of the IClassX in the hierarchy
             // This assumes any IClassX implementation must be derived from base class IClassX's implementation
             IUnknown * pIntf = pWrap->GetIClassXIP();
-            RETURN GetComIPFromCCW_VisibilityCheck(pIntf, pIntfMT, pIntfComMT, flags);
+            return GetComIPFromCCW_VisibilityCheck(pIntf, pIntfMT, pIntfComMT, flags);
         }
     }
 
-    RETURN NULL;
+    return NULL;
 }
 
 static IUnknown *GetComIPFromCCW_ForIntfMT_Worker(ComCallWrapper *pWrap, MethodTable *pIntfMT, GetComIPFromCCW::flags flags)
 {
-    CONTRACT(IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pWrap));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable * pMT = pWrap->GetMethodTableOfObjectRef();
 
@@ -2324,11 +2314,11 @@ static IUnknown *GetComIPFromCCW_ForIntfMT_Worker(ComCallWrapper *pWrap, MethodT
 
                 // Giveout IClassX
                 IUnknown * pIntf = pWrap->GetIClassXIP();
-                RETURN GetComIPFromCCW_VisibilityCheck(pIntf, pIntfMT, pIntfComMT, flags);
+                return GetComIPFromCCW_VisibilityCheck(pIntf, pIntfMT, pIntfComMT, flags);
             }
         }
     }
-    RETURN NULL;
+    return NULL;
 }
 
 static bool GetComIPFromCCW_HandleCustomQI(
@@ -2412,15 +2402,14 @@ MethodTable * ComCallWrapper::GetMethodTableOfObjectRef()
 IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, MethodTable* pIntfMT,
                                           GetComIPFromCCW::flags flags)
 {
-    CONTRACT(IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pWrap));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // scan the wrapper
     if (pWrap->IsLinked())
@@ -2435,7 +2424,7 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
     if (IsIUnknown(riid))
     {
         // We don't do visibility checks on IUnknown.
-        RETURN pWrap->GetBasicIP();
+        return pWrap->GetBasicIP();
     }
 
     if (!(flags & GetComIPFromCCW::SuppressCustomizedQueryInterface)
@@ -2445,20 +2434,22 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
         //               GetInterface implemented by user to do the customized QI work.
         IUnknown * pUnkCustomQIResult = NULL;
         if (GetComIPFromCCW_HandleCustomQI(pWrap, riid, pIntfMT, &pUnkCustomQIResult))
-            RETURN pUnkCustomQIResult;
+            {
+                return pUnkCustomQIResult;
+            }
     }
 
     if (IsIDispatch(riid))
     {
         // We don't do visibility checks on IUnknown.
-        RETURN pWrap->GetIDispatchIP();
+        return pWrap->GetIDispatchIP();
     }
 
     signed imapIndex = -1;
     if (pIntfMT == NULL)
     {
         if (IsGUID_NULL(riid))  // there's no interface with GUID_NULL IID so we can bail out right away
-            RETURN NULL;
+            return NULL;
 
         // Go through all the implemented methods except the COM imported class interfaces
         // and compare the IID's to find the requested one.
@@ -2482,11 +2473,15 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
             SimpleComCallWrapper* pSimpleWrap = pWrap->GetSimpleWrapper();
             IUnknown * pIntf = pSimpleWrap->QIStandardInterface(riid);
             if (pIntf)
-                RETURN pIntf;
+                {
+                    return pIntf;
+                }
 
             pIntf = GetComIPFromCCW_ForIID_Worker(pWrap, riid, pIntfMT, flags, pTemplate);
             if (pIntf)
-                RETURN pIntf;
+                {
+                    return pIntf;
+                }
         }
     }
     else
@@ -2497,7 +2492,9 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
         {
             IUnknown * pIntf = GetComIPFromCCW_ForIntfMT_Worker(pWrap, pIntfMT, flags);
             if (pIntf)
-                RETURN pIntf;
+                {
+                    return pIntf;
+                }
         }
     }
 
@@ -2531,12 +2528,14 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
         IUnknown * pIntf = GetComIPFromCCW_HandleExtendsCOMObject(pWrap, riid, pIntfMT,
                                 pTemplate, imapIndex, intfIndex);
         if (pIntf)
-            RETURN pIntf;
+            {
+                return pIntf;
+            }
     }
 
     // check if interface is supported
     if (imapIndex == -1)
-        RETURN NULL;
+        return NULL;
 
     // interface method table != NULL
     _ASSERTE(pIntfMT != NULL);
@@ -2551,7 +2550,7 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
     {
         MethodTable *pClassMT = pTemplate->GetClassType().GetMethodTable();
         if (!pItfComMT->LayOutInterfaceMethodTable(pClassMT))
-            RETURN NULL;
+            return NULL;
     }
 
     // AddRef the wrapper.
@@ -2561,7 +2560,7 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
 
     // 0xbadF00d implies the AddRef didn't go through
     if (cbRef == 0xbadf00d)
-        RETURN NULL;
+        return NULL;
 
     // The interface pointer is the pointer to the vtable.
     IUnknown * pIntf = (IUnknown*)ppVtable;
@@ -2576,7 +2575,7 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
         SafeRelease(pIntf);
         pIntf = NULL;
     }
-    RETURN pIntf;
+    return pIntf;
 }
 
 //--------------------------------------------------------------------------
@@ -2585,14 +2584,13 @@ IUnknown* ComCallWrapper::GetComIPFromCCW(ComCallWrapper *pWrap, REFIID riid, Me
 //--------------------------------------------------------------------------
 IDispatch* ComCallWrapper::GetIDispatchIP()
 {
-    CONTRACT (IDispatch*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SimpleComCallWrapper* pSimpleWrap = GetSimpleWrapper();
     MethodTable*          pMT         = pSimpleWrap->GetMethodTable();
@@ -2614,7 +2612,7 @@ IDispatch* ComCallWrapper::GetIDispatchIP()
     {
         // The class implements IReflect so lets let it handle IDispatch calls.
         // We will do this by exposing the IDispatchEx implementation of IDispatch.
-        RETURN (IDispatch *)pSimpleWrap->QIStandardInterface(IID_IDispatchEx);
+        return (IDispatch *)pSimpleWrap->QIStandardInterface(IID_IDispatchEx);
     }
 
     // Get the correct default interface
@@ -2628,23 +2626,23 @@ IDispatch* ComCallWrapper::GetIDispatchIP()
             CorIfaceAttr ifaceType = hndDefItfClass.GetMethodTable()->GetComInterfaceType();
             if (IsDispatchBasedItf(ifaceType))
             {
-                RETURN (IDispatch*)GetComIPFromCCW(this, GUID_NULL, hndDefItfClass.GetMethodTable());
+                return (IDispatch*)GetComIPFromCCW(this, GUID_NULL, hndDefItfClass.GetMethodTable());
             }
             else
             {
-                RETURN NULL;
+                return NULL;
             }
         }
 
         case DefaultInterfaceType_IUnknown:
         {
-            RETURN NULL;
+            return NULL;
         }
 
         case DefaultInterfaceType_AutoDual:
         case DefaultInterfaceType_AutoDispatch:
         {
-            RETURN (IDispatch*)GetBasicIP();
+            return (IDispatch*)GetBasicIP();
         }
 
         case DefaultInterfaceType_BaseComClass:
@@ -2660,13 +2658,13 @@ IDispatch* ComCallWrapper::GetIDispatchIP()
             pDisp = pRCW->GetIDispatch();
 
             RCWPROTECT_END(pRCW);
-            RETURN pDisp.Extract();
+            return pDisp.Extract();
         }
 
         default:
         {
             _ASSERTE(!"Invalid default interface type!");
-            RETURN NULL;
+            return NULL;
         }
     }
 }
@@ -2723,16 +2721,15 @@ ComCallWrapperCache::~ComCallWrapperCache()
 //-------------------------------------------------------------------
 ComCallWrapperCache *ComCallWrapperCache::Create(LoaderAllocator *pLoaderAllocator)
 {
-    CONTRACT (ComCallWrapperCache*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pLoaderAllocator));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     NewHolder<ComCallWrapperCache> pWrapperCache = new ComCallWrapperCache();
 
@@ -2748,7 +2745,7 @@ ComCallWrapperCache *ComCallWrapperCache::Create(LoaderAllocator *pLoaderAllocat
 
     line.SuppressRelease();
     pWrapperCache.SuppressRelease();
-    RETURN pWrapperCache;
+    return pWrapperCache;
 }
 
 //-------------------------------------------------------------------
@@ -3463,15 +3460,14 @@ void ComMethodTable::LayOutBasicMethodTable()
 //--------------------------------------------------------------------------
 DispatchInfo *ComMethodTable::GetDispatchInfo()
 {
-    CONTRACT (DispatchInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!m_pDispatchInfo)
     {
@@ -3487,7 +3483,7 @@ DispatchInfo *ComMethodTable::GetDispatchInfo()
 
     }
 
-    RETURN m_pDispatchInfo;
+    return m_pDispatchInfo;
 }
 
 //--------------------------------------------------------------------------
@@ -3515,25 +3511,24 @@ void ComMethodTable::SetITypeInfo(ITypeInfo *pNew)
 //--------------------------------------------------------------------------
 ComMethodTable *ComMethodTable::GetParentClassComMT()
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(IsIClassX());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable *pParentComPlusMT = m_pMT->GetComPlusParentMethodTable();
     if (!pParentComPlusMT)
-        RETURN NULL;
+        return NULL;
 
     ComCallWrapperTemplate *pTemplate = pParentComPlusMT->GetComCallWrapperTemplate();
     if (!pTemplate)
-        RETURN NULL;
+        return NULL;
 
-    RETURN pTemplate->GetClassComMT();
+    return pTemplate->GetClassComMT();
 }
 
 //---------------------------------------------------------
@@ -3667,19 +3662,20 @@ LONG ComCallWrapperTemplate::Release()
 
 ComMethodTable* ComCallWrapperTemplate::GetClassComMT()
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(SupportsIClassX());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // First check the cache
     if (m_pClassComMT)
-        RETURN m_pClassComMT;
+        {
+            return m_pClassComMT;
+        }
 
     MethodTable *pMT = m_thClass.GetMethodTable();
 
@@ -3693,21 +3689,20 @@ ComMethodTable* ComCallWrapperTemplate::GetClassComMT()
         pClassComMT->Release();
     }
 
-    RETURN m_pClassComMT;
+    return m_pClassComMT;
 }
 
 ComMethodTable* ComCallWrapperTemplate::GetComMTForItf(MethodTable *pItfMT)
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pItfMT));
         PRECONDITION(pItfMT->IsInterface());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Look through all the implemented interfaces to see if the specified
     // one is present yet.
@@ -3715,25 +3710,26 @@ ComMethodTable* ComCallWrapperTemplate::GetComMTForItf(MethodTable *pItfMT)
     {
         ComMethodTable* pItfComMT = (ComMethodTable *)m_rgpIPtr[iItf] - 1;
         if (pItfComMT && (pItfComMT->m_pMT == pItfMT))
-            RETURN pItfComMT;
+            {
+                return pItfComMT;
+            }
     }
 
     // The class does not implement the specified interface.
-    RETURN NULL;
+    return NULL;
 }
 
 ComMethodTable* ComCallWrapperTemplate::GetBasicComMT()
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN m_pBasicComMT;
+    return m_pBasicComMT;
 }
 
 
@@ -3745,17 +3741,16 @@ ULONG ComCallWrapperTemplate::GetNumInterfaces()
 
 SLOT* ComCallWrapperTemplate::GetVTableSlot(ULONG index)
 {
-    CONTRACT (SLOT*)
+    CONTRACTL
     {
         WRAPPER(THROWS);
         WRAPPER(GC_TRIGGERS);
         MODE_ANY;
         PRECONDITION(index >= 0 && index < m_cbInterfaces);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN m_rgpIPtr[index];
+    return m_rgpIPtr[index];
 }
 
 // Determines whether the template is for a type that cannot be safely marshalled to
@@ -3885,7 +3880,7 @@ DefaultInterfaceType ComCallWrapperTemplate::GetDefaultInterface(MethodTable **p
 //--------------------------------------------------------------------------
 ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForClass(MethodTable *pClassMT)
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -3895,9 +3890,8 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForClass(MethodTable
         PRECONDITION(!pClassMT->IsInterface());
         PRECONDITION(!pClassMT->GetComPlusParentMethodTable() || pClassMT->GetComPlusParentMethodTable()->GetComCallWrapperTemplate());
         PRECONDITION(SupportsIClassX());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     unsigned cbNewPublicFields = 0;
     unsigned cbNewPublicMethods = 0;
@@ -4095,7 +4089,7 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForClass(MethodTable
     LOG((LF_INTEROP, LL_INFO1000, "---------- end of CreateComMethodTableForClass %s -----------\n", pClassMT->GetClass()->GetDebugClassName()));
 
     pComMT.SuppressRelease();
-    RETURN pComMT;
+    return pComMT;
 }
 
 //--------------------------------------------------------------------------
@@ -4103,7 +4097,7 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForClass(MethodTable
 //--------------------------------------------------------------------------
 ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForInterface(MethodTable* pInterfaceMT)
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -4111,9 +4105,8 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForInterface(MethodT
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pInterfaceMT));
         PRECONDITION(pInterfaceMT->IsInterface());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable *pItfClass = pInterfaceMT;
     CorIfaceAttr ItfType = pInterfaceMT->GetComInterfaceType();
@@ -4176,20 +4169,19 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForInterface(MethodT
     LOG((LF_INTEROP, LL_INFO1000, "---------- end of CreateComMethodTableForInterface %s -----------\n", pItfClass->GetDebugClassName()));
 
     pComMT.SuppressRelease();
-    RETURN pComMT;
+    return pComMT;
 }
 
 ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForBasic(MethodTable* pMT)
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     const unsigned cbExtraSlots = ComMethodTable::GetNumExtraSlots(ifDispatch);
     CorClassIfaceAttr ClassItfType = pMT->GetComClassInterfaceType();
@@ -4238,7 +4230,7 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForBasic(MethodTable
     LOG((LF_INTEROP, LL_INFO1000, "---------- end of CreateComMethodTableForBasic %s -----------\n", pMT->GetDebugClassName()));
 
     pComMT.SuppressRelease();
-    RETURN pComMT;
+    return pComMT;
 }
 
 //--------------------------------------------------------------------------
@@ -4302,16 +4294,15 @@ ComMethodTable *ComCallWrapperTemplate::InitializeForInterface(MethodTable *pPar
 //--------------------------------------------------------------------------
 ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClass)
 {
-    CONTRACT (ComCallWrapperTemplate*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(!thClass.IsNull());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     GCX_PREEMP();
 
@@ -4350,7 +4341,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
         if (pTemplate)
         {
             pTemplate.SuppressRelease();
-            RETURN pTemplate;
+            return pTemplate;
         }
 
         // Allocate the template.
@@ -4402,7 +4393,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
             _ASSERTE(pTemplate != NULL);
 
             pTemplate.SuppressRelease();
-            RETURN pTemplate;
+            return pTemplate;
         }
         pTemplate.SuppressRelease();
 
@@ -4439,7 +4430,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
             END_PROFILER_CALLBACK();
         }
 #endif // PROFILING_SUPPORTED
-        RETURN pTemplate;
+        return pTemplate;
     }
 }
 
@@ -4448,7 +4439,7 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::CreateTemplate(TypeHandle thClas
 //--------------------------------------------------------------------------
 ComCallWrapperTemplate *ComCallWrapperTemplate::CreateTemplateForInterface(MethodTable *pItfMT)
 {
-    CONTRACT (ComCallWrapperTemplate*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -4456,9 +4447,8 @@ ComCallWrapperTemplate *ComCallWrapperTemplate::CreateTemplateForInterface(Metho
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pItfMT));
         PRECONDITION(pItfMT->IsInterface());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     GCX_PREEMP();
 
@@ -4470,7 +4460,7 @@ ComCallWrapperTemplate *ComCallWrapperTemplate::CreateTemplateForInterface(Metho
     if (pTemplate)
     {
         pTemplate.SuppressRelease();
-        RETURN pTemplate;
+        return pTemplate;
     }
 
     pTemplate = (ComCallWrapperTemplate *)new BYTE[sizeof(ComCallWrapperTemplate) + numInterfaces * sizeof(SLOT)];
@@ -4502,7 +4492,7 @@ ComCallWrapperTemplate *ComCallWrapperTemplate::CreateTemplateForInterface(Metho
     }
 
     pTemplate.SuppressRelease();
-    RETURN pTemplate;
+    return pTemplate;
 }
 
 void ComCallWrapperTemplate::DetermineComVisibility()
@@ -4555,29 +4545,30 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::FindInvisibleParent()
 //--------------------------------------------------------------------------
 ComCallWrapperTemplate* ComCallWrapperTemplate::GetTemplate(TypeHandle thType)
 {
-    CONTRACT (ComCallWrapperTemplate*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 
     // Check to see if the specified class already has a template set up.
     ComCallWrapperTemplate* pTemplate = thType.GetComCallWrapperTemplate();
     if (pTemplate)
-        RETURN pTemplate;
+        {
+            return pTemplate;
+        }
 
     // Create the template and return it. CreateTemplate will take care of synchronization.
     if (thType.IsInterface())
     {
-        RETURN CreateTemplateForInterface(thType.AsMethodTable());
+        return CreateTemplateForInterface(thType.AsMethodTable());
     }
     else
     {
-        RETURN CreateTemplate(thType);
+        return CreateTemplate(thType);
     }
 }
 
@@ -4590,15 +4581,14 @@ ComCallWrapperTemplate* ComCallWrapperTemplate::GetTemplate(TypeHandle thType)
 //--------------------------------------------------------------------------
 ComMethodTable *ComCallWrapperTemplate::SetupComMethodTableForClass(MethodTable *pMT, BOOL bLayOutComMT)
 {
-    CONTRACT (ComMethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(!pMT->IsInterface());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Retrieve the COM call wrapper template for the class.
     ComCallWrapperTemplate *pTemplate = GetTemplate(pMT);
@@ -4615,7 +4605,7 @@ ComMethodTable *ComCallWrapperTemplate::SetupComMethodTableForClass(MethodTable 
         _ASSERTE(pIClassXComMT->IsLayoutComplete());
     }
 
-    RETURN pIClassXComMT;
+    return pIClassXComMT;
 }
 
 //--------------------------------------------------------------------------
@@ -4624,18 +4614,17 @@ ComMethodTable *ComCallWrapperTemplate::SetupComMethodTableForClass(MethodTable 
 //--------------------------------------------------------------------------
 Module* ComCallMethodDesc::GetModule()
 {
-    CONTRACT (Module*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION( IsFieldCall() ? (m_pFD != NULL) : (m_pMD != NULL) );
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable* pClass = (IsFieldCall()) ? m_pFD->GetEnclosingMethodTable() : m_pMD->GetMethodTable();
     _ASSERTE(pClass != NULL);
 
-    RETURN pClass->GetModule();
+    return pClass->GetModule();
 }

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -896,7 +896,6 @@ CQuickArray<ConnectionPoint*> *SimpleComCallWrapper::CreateCPArray()
     }
     CONTRACTL_END;
 
-    _ASSERTE(CheckPointer((new CQuickArray<ConnectionPoint*>())));
     return (new CQuickArray<ConnectionPoint*>());
 }
 

--- a/src/coreclr/vm/comcallablewrapper.h
+++ b/src/coreclr/vm/comcallablewrapper.h
@@ -62,30 +62,28 @@ public:
 
     CCacheLineAllocator* GetCacheLineAllocator()
     {
-        CONTRACT (CCacheLineAllocator*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pCacheLineAllocator;
+        return m_pCacheLineAllocator;
     }
 
     LoaderAllocator* GetLoaderAllocator()
     {
-        CONTRACT (LoaderAllocator*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pLoaderAllocator;
+        return m_pLoaderAllocator;
     }
 
 private:
@@ -537,7 +535,7 @@ struct ComMethodTable
 
     MethodDesc* GetMethodDescForSlot(unsigned i)
     {
-        CONTRACT (MethodDesc*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
@@ -545,9 +543,8 @@ struct ComMethodTable
             PRECONDITION(IsLayoutComplete());
             PRECONDITION(i < m_cbSlots);
             PRECONDITION(!IsSlotAField(i));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         i += GetNumExtraSlots(GetInterfaceType());
 
@@ -556,12 +553,12 @@ struct ComMethodTable
         pCMD = ComCallMethodDescFromSlot(i);
         _ASSERTE(pCMD->IsMethodCall());
 
-        RETURN pCMD->GetMethodDesc();
+        return pCMD->GetMethodDesc();
     }
 
     ComCallMethodDesc* GetFieldCallMethodDescForSlot(unsigned i)
     {
-        CONTRACT (ComCallMethodDesc*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
@@ -569,15 +566,15 @@ struct ComMethodTable
             PRECONDITION(IsLayoutComplete());
             PRECONDITION(i < m_cbSlots);
             PRECONDITION(IsSlotAField(i));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         i += GetNumExtraSlots(GetInterfaceType());
         ComCallMethodDesc* pCMD = ComCallMethodDescFromSlot(i);
 
         _ASSERTE(pCMD->IsFieldCall());
-        RETURN (ComCallMethodDesc *)pCMD;
+        _ASSERTE(CheckPointer((ComCallMethodDesc *)pCMD));
+        return (ComCallMethodDesc *)pCMD;
     }
 
     BOOL OwnedbyThisMT(unsigned slotIndex)
@@ -616,23 +613,22 @@ struct ComMethodTable
 
     static inline PTR_ComMethodTable ComMethodTableFromIP(PTR_IUnknown pUnk)
     {
-        CONTRACT (PTR_ComMethodTable)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
             SUPPORTS_DAC;
             PRECONDITION(CheckPointer(pUnk));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         PTR_ComMethodTable pMT = dac_cast<PTR_ComMethodTable>(*PTR_TADDR(pUnk) - sizeof(ComMethodTable));
 
         // validate the object
         _ASSERTE((SLOT)(size_t)0xDEADC0FF == pMT->m_ptReserved );
 
-        RETURN pMT;
+        return pMT;
     }
 
     ULONG GetNumSlots()
@@ -791,18 +787,17 @@ protected:
 
     static PTR_ComCallWrapper GetNext(PTR_ComCallWrapper pWrap)
     {
-        CONTRACT (PTR_ComCallWrapper)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
             SUPPORTS_DAC;
             PRECONDITION(CheckPointer(pWrap));
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (LinkedWrapperTerminator == pWrap->m_pNext ? NULL : pWrap->m_pNext);
+        return (LinkedWrapperTerminator == pWrap->m_pNext ? NULL : pWrap->m_pNext);
     }
 
     // Helper to create a wrapper
@@ -845,23 +840,22 @@ public:
     // accessor to wrapper object in the sync block
     inline static PTR_ComCallWrapper GetWrapperForObject(OBJECTREF pObj, ComCallWrapperTemplate *pTemplate = NULL)
     {
-        CONTRACT (PTR_ComCallWrapper)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
             SUPPORTS_DAC;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         PTR_SyncBlock pSync = pObj->PassiveGetSyncBlock();
         if (!pSync)
-            RETURN NULL;
+            return NULL;
 
         PTR_InteropSyncBlockInfo pInteropInfo = pSync->GetInteropInfoNoCreate();
         if (!pInteropInfo)
-            RETURN NULL;
+            return NULL;
 
         PTR_ComCallWrapper pCCW = pInteropInfo->GetCCW();
 
@@ -875,7 +869,7 @@ public:
             }
         }
 
-        RETURN pCCW;
+        return pCCW;
     }
 
     // get inner unknown
@@ -919,14 +913,14 @@ public:
     // GetObjectRef which will cause a little bit of nasty infinite recursion.
     inline OBJECTREF GetObjectRef()
     {
-        CONTRACT (OBJECTREF)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_COOPERATIVE;
             PRECONDITION(CheckPointer(m_ppThis));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         if (m_ppThis == NULL)
         {
@@ -934,7 +928,7 @@ public:
             AccessNeuteredCCW_FailFast();
         }
 
-        RETURN ObjectFromHandle(m_ppThis);
+        return ObjectFromHandle(m_ppThis);
     }
 
     //
@@ -986,18 +980,17 @@ public:
     //Get Simple wrapper, for std interfaces such as IProvideClassInfo
     PTR_SimpleComCallWrapper GetSimpleWrapper()
     {
-        CONTRACT (PTR_SimpleComCallWrapper)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             INSTANCE_CHECK;
-            POSTCONDITION(CheckPointer(RETVAL));
             SUPPORTS_DAC;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pSimpleWrapper;
+        return m_pSimpleWrapper;
     }
 
 
@@ -1007,21 +1000,20 @@ public:
 #if !defined(DACCESS_COMPILE)
     inline static ComCallWrapper* GetStartWrapperFromIP(IUnknown* pUnk)
     {
-        CONTRACT (ComCallWrapper*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
             PRECONDITION(CheckPointer(pUnk));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         ComCallWrapper* pWrap = GetWrapperFromIP(pUnk);
         if (pWrap->IsLinked())
             pWrap = GetStartWrapper(pWrap);
 
-        RETURN pWrap;
+        return pWrap;
     }
 #endif // DACCESS_COMPILE
 
@@ -1176,15 +1168,15 @@ public:
 
     SyncBlock* GetSyncBlock()
     {
-        CONTRACT (SyncBlock*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pSyncBlock;
+        return m_pSyncBlock;
     }
 
     // Init pointer to the vtable of the interface
@@ -1223,29 +1215,28 @@ public:
 
     OBJECTREF GetObjectRef()
     {
-        CONTRACT (OBJECTREF)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_COOPERATIVE;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (GetMainWrapper()->GetObjectRef());
+        return (GetMainWrapper()->GetObjectRef());
     }
 
     ComCallWrapperCache* GetWrapperCache()
     {
-        CONTRACT (ComCallWrapperCache*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pWrapperCache;
+        return m_pWrapperCache;
     }
 
     // Connection point helper methods.
@@ -1329,37 +1320,35 @@ public:
     //--------------------------------------------------------------------------
     static PTR_SimpleComCallWrapper GetWrapperFromIP(PTR_IUnknown pUnk)
     {
-        CONTRACT (SimpleComCallWrapper*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(CheckPointer(pUnk));
-            POSTCONDITION(CheckPointer(RETVAL));
             SUPPORTS_DAC;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         int i = GetStdInterfaceKind(pUnk);
         PTR_SimpleComCallWrapper pSimpleWrapper = dac_cast<PTR_SimpleComCallWrapper>(dac_cast<TADDR>(pUnk) - sizeof(LPBYTE) * i - offsetof(SimpleComCallWrapper,m_rgpVtable));
-        RETURN pSimpleWrapper;
+        return pSimpleWrapper;
     }
 
     // get the main wrapper
     PTR_ComCallWrapper GetMainWrapper()
     {
-        CONTRACT (PTR_ComCallWrapper)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             SUPPORTS_DAC;
             INSTANCE_CHECK;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pWrap;
+        return m_pWrap;
     }
 
     inline ULONG GetRefCount()
@@ -1514,32 +1503,31 @@ public:
 
     MethodTable* GetMethodTable()
     {
-        CONTRACT (MethodTable*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pMT;
+        return m_pMT;
     }
 
     DispatchExInfo* GetDispatchExInfo()
     {
-        CONTRACT (DispatchExInfo*)
+        CONTRACTL
         {
             WRAPPER(THROWS);
             WRAPPER(GC_TRIGGERS);
             MODE_ANY;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         if (m_pAuxData.Load() == NULL)
-            RETURN NULL;
+            return NULL;
         else
-            RETURN m_pAuxData->m_pDispatchExInfo;
+            return m_pAuxData->m_pDispatchExInfo;
     }
 
     BOOL SupportsICustomQueryInterface()
@@ -1641,15 +1629,14 @@ struct cdac_data<SimpleComCallWrapper>
 //--------------------------------------------------------------------------------
 inline ComCallWrapper* __stdcall ComCallWrapper::InlineGetWrapper(OBJECTREF* ppObj)
 {
-    CONTRACT (ComCallWrapper*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(ppObj));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // get the wrapper for this CLR object
     ComCallWrapper* pWrap = GetWrapperForObject(*ppObj);
@@ -1661,7 +1648,7 @@ inline ComCallWrapper* __stdcall ComCallWrapper::InlineGetWrapper(OBJECTREF* ppO
 
     pWrap->AddRef();
 
-    RETURN pWrap;
+    return pWrap;
 }
 
 inline ULONG ComCallWrapper::GetRefCount()
@@ -1758,16 +1745,15 @@ inline void ComCallWrapper::ClearSimpleWrapper(ComCallWrapper* pWrap)
 
 inline PTR_ComCallWrapper ComCallWrapper::GetWrapperFromIP(PTR_IUnknown pUnk)
 {
-    CONTRACT (PTR_ComCallWrapper)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pUnk));
-        POSTCONDITION(CheckPointer(RETVAL));
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // This code path may be exercised from out-of-process.  Unfortunately, we need to manipulate the
     // target address here, and so we need to do some non-trivial casting.  First, cast the PTR type
@@ -1775,7 +1761,7 @@ inline PTR_ComCallWrapper ComCallWrapper::GetWrapperFromIP(PTR_IUnknown pUnk)
     // result as a target address to instantiate a ComCallWrapper.  The line below is equivalent to:
     // ComCallWrapper* pWrap = (ComCallWrapper*)((size_t)pUnk & enum_ThisMask);
     PTR_ComCallWrapper pWrap = dac_cast<PTR_ComCallWrapper>(dac_cast<TADDR>(pUnk) & enum_ThisMask);
-    RETURN pWrap;
+    return pWrap;
 }
 
 //--------------------------------------------------------------------------
@@ -1785,7 +1771,7 @@ inline PTR_ComCallWrapper ComCallWrapper::GetWrapperFromIP(PTR_IUnknown pUnk)
 //--------------------------------------------------------------------------
 inline PTR_ComCallWrapper ComCallWrapper::GetStartWrapper(PTR_ComCallWrapper pWrap)
 {
-    CONTRACT (PTR_ComCallWrapper)
+    CONTRACTL
     {
         NOTHROW;
         GC_TRIGGERS;
@@ -1793,12 +1779,11 @@ inline PTR_ComCallWrapper ComCallWrapper::GetStartWrapper(PTR_ComCallWrapper pWr
         SUPPORTS_DAC;
         PRECONDITION(CheckPointer(pWrap));
         PRECONDITION(pWrap->IsLinked());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PTR_SimpleComCallWrapper pSimpleWrap = pWrap->GetSimpleWrapper();
-    RETURN (pSimpleWrap->GetMainWrapper());
+    return (pSimpleWrap->GetMainWrapper());
 }
 
 //--------------------------------------------------------------------------

--- a/src/coreclr/vm/comconnectionpoints.cpp
+++ b/src/coreclr/vm/comconnectionpoints.cpp
@@ -287,17 +287,16 @@ HRESULT __stdcall ConnectionPoint::EnumConnections(IEnumConnections **ppEnum)
 
 IConnectionPointContainer *ConnectionPoint::GetConnectionPointContainerWorker()
 {
-    CONTRACT(IConnectionPointContainer*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Retrieve the IConnectionPointContainer from the owner wrapper.
-    RETURN (IConnectionPointContainer*)
+    return (IConnectionPointContainer*)
         ComCallWrapper::GetComIPFromCCW(m_pOwnerWrap, IID_IConnectionPointContainer, NULL);
 }
 
@@ -469,32 +468,31 @@ void ConnectionPoint::SetupEventMethods()
 
 MethodDesc *ConnectionPoint::FindProviderMethodDesc( MethodDesc *pEventMethodDesc, EnumEventMethods Method )
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pEventMethodDesc));
         PRECONDITION(Method == EventAdd || Method == EventRemove);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     // Retrieve the event method.
     MethodDesc *pProvMethodDesc =
         MemberLoader::FindEventMethod(m_pTCEProviderMT, pEventMethodDesc->GetName(), Method, MemberLoader::FM_IgnoreCase);
     if (!pProvMethodDesc)
-        RETURN NULL;
+        return NULL;
 
     // Validate that the signature of the delegate is the expected signature.
     MetaSig Sig(pProvMethodDesc);
     if (Sig.NextArg() != ELEMENT_TYPE_CLASS)
-        RETURN NULL;
+        return NULL;
 
     // <TODO>@TODO: this ignores the type of failure - try GetLastTypeHandleThrowing()</TODO>
     TypeHandle DelegateType = Sig.GetLastTypeHandleNT();
     if (DelegateType.IsNull())
-        RETURN NULL;
+        return NULL;
 
     PCCOR_SIGNATURE pEventMethSig;
     DWORD cEventMethSig;
@@ -506,10 +504,10 @@ MethodDesc *ConnectionPoint::FindProviderMethodDesc( MethodDesc *pEventMethodDes
         pEventMethodDesc->GetModule());
 
     if (!pInvokeMD)
-        RETURN NULL;
+        return NULL;
 
     // The requested method exists and has the appropriate signature.
-    RETURN pProvMethodDesc;
+    return pProvMethodDesc;
 }
 
 void ConnectionPoint::InvokeProviderMethod( OBJECTREF pProvider, OBJECTREF pSubscriber, MethodDesc *pProvMethodDesc, MethodDesc *pEventMethodDesc )

--- a/src/coreclr/vm/comconnectionpoints.h
+++ b/src/coreclr/vm/comconnectionpoints.h
@@ -56,7 +56,7 @@ struct ConnectionCookie
     // Currently called only from Cooperative mode.
     static ConnectionCookie* CreateConnectionCookie(OBJECTHANDLE hndEventProvObj)
     {
-        CONTRACT (ConnectionCookie*)
+        CONTRACTL
         {
             THROWS;
             GC_NOTRIGGER;
@@ -64,9 +64,9 @@ struct ConnectionCookie
             INJECT_FAULT(COMPlusThrowOM());
             PRECONDITION(NULL != hndEventProvObj);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (new ConnectionCookie(hndEventProvObj));
+        return (new ConnectionCookie(hndEventProvObj));
     }
 
     SLink           m_Link;

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -1552,20 +1552,19 @@ void COMDelegate::ValidateDelegatePInvoke(MethodDesc* pMD)
 // static
 PCODE COMDelegate::GetStubForILStub(EEImplMethodDesc* pDelegateMD, MethodDesc** ppStubMD, DWORD dwStubFlags)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pDelegateMD));
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ValidateDelegatePInvoke(pDelegateMD);
 
     dwStubFlags |= PINVOKESTUB_FL_DELEGATE;
 
-    RETURN PInvoke::GetStubForILStub(pDelegateMD, ppStubMD, dwStubFlags);
+    return PInvoke::GetStubForILStub(pDelegateMD, ppStubMD, dwStubFlags);
 }
 
 

--- a/src/coreclr/vm/commtmemberinfomap.cpp
+++ b/src/coreclr/vm/commtmemberinfomap.cpp
@@ -97,28 +97,27 @@ public:
 // ============================================================================
 EEHashEntry_t * EEModuleTokenHashTableHelper::AllocateEntry(EEModuleTokenPair *pKey, BOOL bDeepCopy, void *pHeap)
 {
-    CONTRACT (EEHashEntry_t*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN NULL);
+        INJECT_FAULT(return NULL);
         PRECONDITION(CheckPointer(pKey));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(!bDeepCopy && "Deep copy is not supported by the EEModuleTokenHashTableHelper");
 
     EEHashEntry_t *pEntry = (EEHashEntry_t *) new (nothrow) BYTE[SIZEOF_EEHASH_ENTRY + sizeof(EEModuleTokenPair)];
     if (!pEntry)
-        RETURN NULL;
+        return NULL;
 
     EEModuleTokenPair *pEntryKey = (EEModuleTokenPair *) pEntry->Key;
     pEntryKey->m_tk = pKey->m_tk;
     pEntryKey->m_pModule = pKey->m_pModule;
 
-    RETURN pEntry;
+    return pEntry;
 } // EEHashEntry_t * EEModuleTokenHashTableHelper::AllocateEntry()
 
 
@@ -259,23 +258,25 @@ void ComMTMemberInfoMap::Init(size_t sizeOfPtr)
 
 ComMTMethodProps *ComMTMemberInfoMap::GetMethodProps(mdToken tk, Module *pModule)
 {
-    CONTRACT (ComMTMethodProps*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     EEModuleTokenPair TokenModulePair(tk, pModule);
     HashDatum Data;
 
     if (m_TokenToComMTMethodPropsMap.GetValue(&TokenModulePair, &Data))
-        RETURN (ComMTMethodProps *)Data;
+        {
+        _ASSERTE(CheckPointer((ComMTMethodProps *)Data, NULL_OK));
+            return (ComMTMethodProps *)Data;
+        }
 
-    RETURN NULL;
+    return NULL;
 } // ComMTMethodProps *ComMTMemberInfoMap::GetMethodProps()
 
 
@@ -1389,13 +1390,13 @@ public:
 
     BOOL IsVbRefType()
     {
-        CONTRACT(BOOL)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         // Get the arg, and skip decorations.
         SigPointer pt = GetArgProps();
@@ -1412,15 +1413,15 @@ public:
 
         // Is it just Object?
         if (mt == ELEMENT_TYPE_OBJECT)
-            RETURN TRUE;
+            return TRUE;
 
         // A particular class?
         if (mt == ELEMENT_TYPE_CLASS)
         {
             // Exclude "string".
             if (pt.IsStringType(m_pModule, GetSigTypeContext()))
-                RETURN FALSE;
-            RETURN TRUE;
+                return FALSE;
+            return TRUE;
         }
 
         // A particular valuetype?
@@ -1428,12 +1429,12 @@ public:
         {
             // Include "variant".
             if (pt.IsClass(m_pModule, g_VariantClassName, GetSigTypeContext()))
-                RETURN TRUE;
-            RETURN FALSE;
+                return TRUE;
+            return FALSE;
         }
 
         // An array, a string, or POD.
-        RETURN FALSE;
+        return FALSE;
     }
 }; // class MetaSigExport : public MetaSig
 

--- a/src/coreclr/vm/commtmemberinfomap.h
+++ b/src/coreclr/vm/commtmemberinfomap.h
@@ -91,14 +91,13 @@ public:
     // Allocate some bytes from the pool.
     BYTE* Alloc(size_t nBytes)
     {
-        CONTRACT (BYTE*)
+        CONTRACTL
         {
             THROWS;
             GC_NOTRIGGER;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         nBytes = ALIGN_UP(nBytes, sizeof(void*));
 
@@ -118,7 +117,7 @@ public:
 
         BYTE* pResult = m_pCurrent->data + m_cbUsed;
         m_cbUsed += nBytes;
-        RETURN pResult;
+        return pResult;
     }
 }; // class CDescPool
 

--- a/src/coreclr/vm/comtoclrcall.cpp
+++ b/src/coreclr/vm/comtoclrcall.cpp
@@ -85,12 +85,12 @@ void ComCallMethodDesc::InitField(FieldDesc* pFD, BOOL isGetter)
 // too late to make this computation - the metadata is no longer available.
 void ComCallMethodDesc::InitNativeInfo()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(!IsNativeInfoInitialized());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     m_StackBytes = (UINT16)-1;
 
@@ -355,7 +355,7 @@ Done:
         m_flags |= enum_NativeInfoInitialized;
     }
     EX_SWALLOW_NONTRANSIENT
-    RETURN;
+    return;
 }
 
 namespace
@@ -455,14 +455,12 @@ namespace
 
 PCODE ComCallMethodDesc::CreateCOMToCLRStub(DWORD dwStubFlags, MethodDesc **ppStubMD)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(ppStubMD));
-        POSTCONDITION(CheckPointer(*ppStubMD));
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodDesc * pStubMD;
 
@@ -498,7 +496,7 @@ PCODE ComCallMethodDesc::CreateCOMToCLRStub(DWORD dwStubFlags, MethodDesc **ppSt
     }
 #endif // TARGET_X86
 
-    RETURN JitILStub(pStubMD);
+    return JitILStub(pStubMD);
 }
 
 PLATFORM_THREAD_LOCAL HRESULT t_ComPreStubLastHResult;

--- a/src/coreclr/vm/comtoclrcall.h
+++ b/src/coreclr/vm/comtoclrcall.h
@@ -68,16 +68,16 @@ public:
     // is field getter
     BOOL IsFieldGetter()
     {
-        CONTRACT (BOOL)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(IsFieldCall());
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (m_flags & enum_IsGetter);
+        return (m_flags & enum_IsGetter);
     }
 
     BOOL IsNativeR4RetVal()
@@ -137,35 +137,33 @@ public:
     // get method desc
     MethodDesc* GetMethodDesc()
     {
-        CONTRACT (MethodDesc*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(!IsFieldCall());
             PRECONDITION(CheckPointer(m_pMD));
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pMD;
+        return m_pMD;
     }
 
     // get interface method desc
     MethodDesc* GetInterfaceMethodDesc()
     {
-        CONTRACT (MethodDesc *)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(!IsFieldCall());
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
             SUPPORTS_DAC;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pInterfaceMD;
+        return m_pInterfaceMD;
     }
 
     // get interface method desc if non-NULL, class method desc otherwise
@@ -184,18 +182,17 @@ public:
     // get field desc
     FieldDesc* GetFieldDesc()
     {
-        CONTRACT (FieldDesc*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(IsFieldCall());
             PRECONDITION(CheckPointer(m_pFD));
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pFD;
+        return m_pFD;
     }
 
     // get module
@@ -216,7 +213,7 @@ public:
     // get slot number for the method
     unsigned GetSlot()
     {
-        CONTRACT (unsigned)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
@@ -224,9 +221,9 @@ public:
             PRECONDITION(IsMethodCall());
             PRECONDITION(CheckPointer(m_pMD));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pMD->GetSlot();
+        return m_pMD->GetSlot();
     }
 
     // get num stack bytes to pop
@@ -248,7 +245,7 @@ public:
     //get call sig
     PCCOR_SIGNATURE GetSig(DWORD *pcbSigSize = NULL)
     {
-        CONTRACT (PCCOR_SIGNATURE)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
@@ -256,7 +253,7 @@ public:
             PRECONDITION(IsMethodCall());
             PRECONDITION(CheckPointer(m_pMD));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         PCCOR_SIGNATURE pSig;
         DWORD cbSigSize;
@@ -268,7 +265,7 @@ public:
             *pcbSigSize = cbSigSize;
         }
 
-        RETURN pSig;
+        return pSig;
     }
 
     PCODE CreateCOMToCLRStub(DWORD dwStubFlags, MethodDesc **ppStubMD);

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -386,23 +386,22 @@ void DispatchMemberInfo::MarshalReturnValueManagedToNative(OBJECTREF *pSrcObj, V
 
 ComMTMethodProps * DispatchMemberInfo::GetMemberProps(OBJECTREF MemberInfoObj, ComMTMemberInfoMap *pMemberMap)
 {
-    CONTRACT (ComMTMethodProps*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(MemberInfoObj != NULL);
         PRECONDITION(CheckPointer(pMemberMap, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DISPID DispId = DISPID_UNKNOWN;
     ComMTMethodProps *pMemberProps = NULL;
 
     // If we don't have a member map then we cannot retrieve properties for the member.
     if (!pMemberMap)
-        RETURN NULL;
+        return NULL;
 
     // Get the member's properties.
     struct { OBJECTREF MemberInfoObj; REFLECTMODULEBASEREF module; } gc;
@@ -420,7 +419,7 @@ ComMTMethodProps * DispatchMemberInfo::GetMemberProps(OBJECTREF MemberInfoObj, C
             {
                 // We don't expose runtime-async methods via IDispatch.
                 if (pMeth->IsAsyncMethod())
-                    RETURN NULL;
+                    return NULL;
 
                 pMemberProps = pMemberMap->GetMethodProps(pMeth->GetMemberDef(), pMeth->GetModule());
             }
@@ -444,7 +443,7 @@ ComMTMethodProps * DispatchMemberInfo::GetMemberProps(OBJECTREF MemberInfoObj, C
     }
     GCPROTECT_END();
 
-    RETURN pMemberProps;
+    return pMemberProps;
 }
 
 DISPID DispatchMemberInfo::GetMemberDispId(OBJECTREF MemberInfoObj, ComMTMemberInfoMap *pMemberMap)
@@ -474,7 +473,7 @@ DISPID DispatchMemberInfo::GetMemberDispId(OBJECTREF MemberInfoObj, ComMTMemberI
 
 LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInfoMap *pMemberMap)
 {
-    CONTRACT (LPWSTR)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -482,9 +481,8 @@ LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInf
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(MemberInfoObj != NULL);
         PRECONDITION(CheckPointer(pMemberMap, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     NewArrayHolder<WCHAR> strMemberName = NULL;
     ComMTMethodProps *pMemberProps = NULL;
@@ -521,7 +519,7 @@ LPWSTR DispatchMemberInfo::GetMemberName(OBJECTREF MemberInfoObj, ComMTMemberInf
     GCPROTECT_END();
 
     strMemberName.SuppressRelease();
-    RETURN strMemberName;
+    return strMemberName;
 }
 
 void DispatchMemberInfo::DetermineMemberType()
@@ -952,19 +950,18 @@ DispatchInfo::~DispatchInfo()
 
 DispatchMemberInfo* DispatchInfo::FindMember(DISPID DispID)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // We need to special case DISPID_UNKNOWN and -2 because the hashtable cannot handle them.
     // This is OK since these are invalid DISPID's.
     if ((DispID == DISPID_UNKNOWN) || (DispID == -2))
-        RETURN NULL;
+        return NULL;
 
     // Lookup in the hashtable to find member with the specified DISPID. Note: this hash is unsynchronized, but Gethash
     // doesn't require synchronization.
@@ -976,24 +973,23 @@ DispatchMemberInfo* DispatchInfo::FindMember(DISPID DispID)
 
         pMemberInfo->EnsureInitialized();
 
-        RETURN pMemberInfo;
+        return pMemberInfo;
     }
     else
     {
-        RETURN NULL;
+        return NULL;
     }
 }
 
 DispatchMemberInfo* DispatchInfo::FindMember(SString& strName, BOOL bCaseSensitive)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     BOOL fFound = FALSE;
 
@@ -1013,7 +1009,7 @@ DispatchMemberInfo* DispatchInfo::FindMember(SString& strName, BOOL bCaseSensiti
                 // We have found the member, so ensure it is initialized and return it.
                 pCurrMemberInfo->EnsureInitialized();
 
-                RETURN pCurrMemberInfo;
+                return pCurrMemberInfo;
             }
         }
 
@@ -1022,27 +1018,26 @@ DispatchMemberInfo* DispatchInfo::FindMember(SString& strName, BOOL bCaseSensiti
     }
 
     // No member has been found with the corresponding name.
-    RETURN NULL;
+    return NULL;
 }
 
 // Helper method used to create DispatchMemberInfo's. This is only here because
 // we can't call new inside a method that has a EX_TRY statement.
 DispatchMemberInfo* DispatchInfo::CreateDispatchMemberInfoInstance(DISPID dispID, SString& strMemberName, OBJECTREF memberInfoObj)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DispatchMemberInfo* pInfo = new DispatchMemberInfo(this, dispID, strMemberName);
     pInfo->SetHandle(AllocateHandle(memberInfoObj));
 
-    RETURN pInfo;
+    return pInfo;
 }
 
 // Used for cleanup of managed objects via custom marshalers. This class is stack-allocated
@@ -2303,15 +2298,14 @@ void DispatchInfo::SetUpNamedParamArray(DispatchMemberInfo *pMemberInfo, DISPID 
 
 VARIANT *DispatchInfo::RetrieveSrcVariant(VARIANT *pDispParamsVariant)
 {
-    CONTRACT (VARIANT*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pDispParamsVariant));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // For VB6 compatibility reasons, if the VARIANT is a VT_BYREF | VT_VARIANT that
     // contains another VARIANT with VT_BYREF | VT_VARIANT, then we need to extract the
@@ -2320,11 +2314,11 @@ VARIANT *DispatchInfo::RetrieveSrcVariant(VARIANT *pDispParamsVariant)
     if (V_VT(pDispParamsVariant) == (VT_VARIANT | VT_BYREF) &&
         (V_VT(V_VARIANTREF(pDispParamsVariant)) & (VT_TYPEMASK | VT_BYREF)) == (VT_VARIANT | VT_BYREF))
     {
-        RETURN (V_VARIANTREF(pDispParamsVariant));
+        return (V_VARIANTREF(pDispParamsVariant));
     }
     else
     {
-        RETURN pDispParamsVariant;
+        return pDispParamsVariant;
     }
 }
 
@@ -2380,14 +2374,13 @@ bool DispatchInfo::IsPropertyAccessorVisible(bool fIsSetter, OBJECTREF* pMemberI
 
 MethodDesc* DispatchInfo::GetFieldInfoMD(BinderMethodID Method, TypeHandle hndFieldInfoType)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     MethodDesc *pMD;
 
@@ -2404,19 +2397,18 @@ MethodDesc* DispatchInfo::GetFieldInfoMD(BinderMethodID Method, TypeHandle hndFi
     _ASSERTE(pMD && "Unable to find specified FieldInfo method");
 
     // Return the specified method desc.
-    RETURN pMD;
+    return pMD;
 }
 
 MethodDesc* DispatchInfo::GetPropertyInfoMD(BinderMethodID Method, TypeHandle hndPropInfoType)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     MethodDesc *pMD;
 
@@ -2433,19 +2425,18 @@ MethodDesc* DispatchInfo::GetPropertyInfoMD(BinderMethodID Method, TypeHandle hn
     _ASSERTE(pMD && "Unable to find specified PropertyInfo method");
 
     // Return the specified method desc.
-    RETURN pMD;
+    return pMD;
 }
 
 MethodDesc* DispatchInfo::GetMethodInfoMD(BinderMethodID Method, TypeHandle hndMethodInfoType)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     MethodDesc *pMD;
 
@@ -2462,25 +2453,24 @@ MethodDesc* DispatchInfo::GetMethodInfoMD(BinderMethodID Method, TypeHandle hndM
     _ASSERTE(pMD && "Unable to find specified MethodInfo method");
 
     // Return the specified method desc.
-    RETURN pMD;
+    return pMD;
 }
 
 MethodDesc* DispatchInfo::GetCustomAttrProviderMD(TypeHandle hndCustomAttrProvider)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable *pMT = hndCustomAttrProvider.AsMethodTable();
     MethodDesc *pMD = pMT->GetMethodDescForInterfaceMethod(CoreLibBinder::GetMethod(METHOD__ICUSTOM_ATTR_PROVIDER__GET_CUSTOM_ATTRIBUTES), TRUE /* throwOnConflict */);
 
     // Return the specified method desc.
-    RETURN pMD;
+    return pMD;
 }
 
 // This method synchronizes the DispatchInfo's members with the ones in the method tables type.
@@ -2800,16 +2790,15 @@ PTRARRAYREF DispatchInfo::RetrieveMethList()
 // Virtual method to retrieve the InvokeMember method desc.
 MethodDesc* DispatchInfo::GetInvokeMemberMD()
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN CoreLibBinder::GetMethod(METHOD__CLASS__INVOKE_MEMBER);
+    return CoreLibBinder::GetMethod(METHOD__CLASS__INVOKE_MEMBER);
 }
 
 // Virtual method to retrieve the object associated with this DispatchInfo that
@@ -2830,15 +2819,14 @@ OBJECTREF DispatchInfo::GetReflectionObject()
 // Virtual method to retrieve the member info map.
 ComMTMemberInfoMap *DispatchInfo::GetMemberInfoMap()
 {
-    CONTRACT (ComMTMemberInfoMap*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 
     // Create the member info map.
@@ -2848,7 +2836,7 @@ ComMTMemberInfoMap *DispatchInfo::GetMemberInfoMap()
     pMemberInfoMap->Init(sizeof(void*));
 
     pMemberInfoMap.SuppressRelease();
-    RETURN pMemberInfoMap;
+    return pMemberInfoMap;
 }
 
 // Helper function to fill in an EXCEPINFO for an InvocationException.
@@ -3001,40 +2989,38 @@ DispatchExInfo::~DispatchExInfo()
 // find the method.
 DispatchMemberInfo* DispatchExInfo::SynchFindMember(DISPID DispID)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DispatchMemberInfo *pMemberInfo = FindMember(DispID);
 
     if (!pMemberInfo && SynchWithManagedView())
         pMemberInfo = FindMember(DispID);
 
-    RETURN pMemberInfo;
+    return pMemberInfo;
 }
 
 DispatchMemberInfo* DispatchExInfo::SynchFindMember(SString& strName, BOOL bCaseSensitive)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DispatchMemberInfo *pMemberInfo = FindMember(strName, bCaseSensitive);
 
     if (!pMemberInfo && SynchWithManagedView())
         pMemberInfo = FindMember(strName, bCaseSensitive);
 
-    RETURN pMemberInfo;
+    return pMemberInfo;
 }
 
 // Helper method that invokes the member with the specified DISPID. These methods synch
@@ -3061,14 +3047,13 @@ HRESULT DispatchExInfo::SynchInvokeMember(SimpleComCallWrapper *pSimpleWrap, DIS
 
 DispatchMemberInfo* DispatchExInfo::GetFirstMember()
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Start with the first member.
     DispatchMemberInfo **ppNextMemberInfo = &m_pFirstMemberInfo;
@@ -3091,24 +3076,23 @@ DispatchMemberInfo* DispatchExInfo::GetFirstMember()
     while ((*ppNextMemberInfo) && !(*ppNextMemberInfo)->GetMemberInfoObject())
         ppNextMemberInfo = (*ppNextMemberInfo)->GetNextPtr();
 
-    RETURN *ppNextMemberInfo;
+    return *ppNextMemberInfo;
 }
 
 DispatchMemberInfo* DispatchExInfo::GetNextMember(DISPID CurrMemberDispID)
 {
-    CONTRACT (DispatchMemberInfo*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Do a lookup in the hashtable to find the DispatchMemberInfo for the DISPID.
     DispatchMemberInfo *pDispMemberInfo = FindMember(CurrMemberDispID);
     if (!pDispMemberInfo)
-        RETURN NULL;
+        return NULL;
 
     // Start from the next member.
     DispatchMemberInfo **ppNextMemberInfo = pDispMemberInfo->GetNextPtr();
@@ -3131,25 +3115,24 @@ DispatchMemberInfo* DispatchExInfo::GetNextMember(DISPID CurrMemberDispID)
     while ((*ppNextMemberInfo) && !(*ppNextMemberInfo)->GetMemberInfoObject())
         ppNextMemberInfo = (*ppNextMemberInfo)->GetNextPtr();
 
-    RETURN *ppNextMemberInfo;
+    return *ppNextMemberInfo;
 }
 
 MethodDesc* DispatchExInfo::GetIReflectMD(BinderMethodID Method)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable *pMT = m_pSimpleWrapperOwner->GetMethodTable();
     MethodDesc *pMD = pMT->GetMethodDescForInterfaceMethod(CoreLibBinder::GetMethod(Method), TRUE /* throwOnConflict */);
 
     // Return the specified method desc.
-    RETURN pMD;
+    return pMD;
 }
 
 PTRARRAYREF DispatchExInfo::RetrievePropList()
@@ -3224,16 +3207,15 @@ PTRARRAYREF DispatchExInfo::RetrieveMethList()
 // Virtual method to retrieve the InvokeMember method desc.
 MethodDesc* DispatchExInfo::GetInvokeMemberMD()
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN GetIReflectMD(METHOD__IREFLECT__INVOKE_MEMBER);
+    return GetIReflectMD(METHOD__IREFLECT__INVOKE_MEMBER);
 }
 
 // Virtual method to retrieve the object associated with this DispatchInfo that

--- a/src/coreclr/vm/dispatchinfo.h
+++ b/src/coreclr/vm/dispatchinfo.h
@@ -120,44 +120,44 @@ public:
     // Inline accessors.
     BOOL IsCultureAware()
     {
-        CONTRACT (BOOL)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(Unknown != m_CultureAwareState);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (Aware == m_CultureAwareState);
+        return (Aware == m_CultureAwareState);
     }
 
     EnumMemberTypes GetMemberType()
     {
-        CONTRACT (EnumMemberTypes)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(Uninitted != m_enumType);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_enumType;
+        return m_enumType;
     }
 
     int GetNumParameters()
     {
-        CONTRACT (int)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(m_iNumParams != -1);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_iNumParams;
+        return m_iNumParams;
     }
 
     BOOL IsLastParamOleVarArg()

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -1199,12 +1199,11 @@ public:
 
     PCCOR_SIGNATURE GetStubTargetMethodSig()
     {
-        CONTRACT(PCCOR_SIGNATURE)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_NOT_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         BYTE *pb;
 
@@ -1220,7 +1219,7 @@ public:
             pb = (BYTE*)m_qbNativeFnSigBuffer.Ptr();
         }
 
-        RETURN pb;
+        return pb;
     }
 
     DWORD
@@ -2965,14 +2964,13 @@ void PInvokeStaticSigInfo::DllImportInit(
 #if !defined (TARGET_UNIX)
 static LPBYTE FollowIndirect(LPBYTE pTarget)
 {
-    CONTRACT(LPBYTE)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LPBYTE pRet = NULL;
 
@@ -2999,7 +2997,7 @@ static LPBYTE FollowIndirect(LPBYTE pTarget)
     }
     EX_END_CATCH
 
-    RETURN pRet;
+    return pRet;
 }
 #endif // !TARGET_UNIX
 
@@ -4472,7 +4470,7 @@ namespace
         bool& bILStubCreator,
         MethodDesc* pLastMD)
     {
-        CONTRACT(MethodDesc*)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
 
@@ -4480,9 +4478,8 @@ namespace
             PRECONDITION(!pParams->m_sig.IsEmpty());
             PRECONDITION(CheckPointer(pParams->m_pModule));
             PRECONDITION(CheckPointer(pTargetMD, NULL_OK));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         MethodDesc*     pMD;
 
@@ -4500,7 +4497,7 @@ namespace
                                         bILStubCreator,
                                         pLastMD);
 
-        RETURN pMD;
+        return pMD;
     }
 
     void RemoveILStubCacheEntry(PInvokeStubParameters* pParams, ILStubHashBlob* pHashParams)
@@ -4760,7 +4757,7 @@ void PInvoke::InitializeSigInfoAndPopulatePInvokeMethodDesc(_Inout_ PInvokeMetho
 // of the stub method
 HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, MethodDesc **ppRetStubMD)
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -4769,7 +4766,7 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
         PRECONDITION(CheckPointer(ppRetStubMD));
         PRECONDITION(*ppRetStubMD == NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hr;
 
@@ -4806,11 +4803,11 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
                 &cbBytes);
 
             if (FAILED(hr))
-                RETURN hr;
+                return hr;
             // GetCustomAttribute returns S_FALSE when it cannot find the attribute but nothing fails...
             // Translate that to E_FAIL
             else if (hr == S_FALSE)
-                RETURN E_FAIL;
+                return E_FAIL;
         }
         else
         {
@@ -4822,14 +4819,14 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
             if (pInterfaceMD)
             {
                 hr = FindPredefinedILStubMethod(pInterfaceMD, dwStubFlags, ppRetStubMD);
-                RETURN hr;
+                return hr;
             }
             else
-                RETURN E_FAIL;
+                return E_FAIL;
         }
     }
     else
-        RETURN E_FAIL;
+        return E_FAIL;
 
     //
     // Parse the attribute
@@ -5024,7 +5021,7 @@ HRESULT FindPredefinedILStubMethod(MethodDesc *pTargetMD, DWORD dwStubFlags, Met
 
     *ppRetStubMD = pStubMD;
 
-    RETURN S_OK;
+    return S_OK;
 }
 #endif // FEATURE_COMINTEROP
 
@@ -5128,14 +5125,13 @@ namespace
                             bool*                    pGeneratedNewStub = nullptr
                             )
     {
-        CONTRACT(MethodDesc*)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
 
             PRECONDITION(CheckPointer(pSigDesc));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
 
         ///////////////////////////////
@@ -5174,7 +5170,7 @@ namespace
             // This cannot be done during NGEN/PEVerify (in PASSIVE_DOMAIN) so I've moved it here
             pStubMD->EnsureActive();
 
-            RETURN pStubMD;
+            return pStubMD;
         }
 #endif // FEATURE_COMINTEROP
 
@@ -5426,7 +5422,7 @@ namespace
         }
 #endif // defined(TARGET_X86)
 
-        RETURN pStubMD;
+        return pStubMD;
     }
 }
 
@@ -5437,14 +5433,13 @@ MethodDesc* PInvoke::CreateCLRToNativeILStub(
                 CorInfoCallConvExtension unmgdCallConv,
                 DWORD                    dwStubFlags) // PInvokeStubFlags
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pSigDesc));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     int         iLCIDArg = 0;
     int         numArgs = 0;
@@ -5499,7 +5494,7 @@ MethodDesc* PInvoke::CreateCLRToNativeILStub(
                 pParamTokenArray,
                 iLCIDArg);
 
-    RETURN pStubMD;
+    return pStubMD;
 }
 
 #ifdef FEATURE_COMINTEROP
@@ -5511,7 +5506,7 @@ MethodDesc* PInvoke::CreateFieldAccessILStub(
                 DWORD              dwStubFlags, // PInvokeStubFlags
                 FieldDesc*         pFD)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
@@ -5519,9 +5514,8 @@ MethodDesc* PInvoke::CreateFieldAccessILStub(
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(CheckPointer(pFD, NULL_OK));
         PRECONDITION(SF_IsFieldGetterStub(dwStubFlags) || SF_IsFieldSetterStub(dwStubFlags));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     int numArgs = (SF_IsFieldSetterStub(dwStubFlags) ? 1 : 0);
     int numParamTokens = numArgs + 1;
@@ -5572,7 +5566,7 @@ MethodDesc* PInvoke::CreateFieldAccessILStub(
                 pParamTokenArray,
                 -1);
 
-    RETURN pStubMD;
+    return pStubMD;
 }
 #endif // FEATURE_COMINTEROP
 
@@ -5580,15 +5574,14 @@ MethodDesc* PInvoke::CreateFieldAccessILStub(
 
 MethodDesc* PInvoke::CreateLayoutClassMarshalILStub(MethodTable* pMT, MarshalOperation operation)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pMT));
         PRECONDITION(!pMT->IsValueType());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // void (ref byte managedData, byte* nativeData, ref CleanupWorkListElement cwl)
     FunctionSigBuilder sigBuilder;
@@ -5642,7 +5635,7 @@ MethodDesc* PInvoke::CreateLayoutClassMarshalILStub(MethodTable* pMT, MarshalOpe
 
     szMetaSig.SuppressRelease();
 
-    RETURN pStubMD;
+    return pStubMD;
 }
 
 #endif // DACCESS_COMPILE
@@ -5695,15 +5688,14 @@ namespace
     {
         // GetProcAddress cannot be called while preemptive GC is disabled.
         // It requires the OS to take the loader lock.
-        CONTRACT(LPVOID)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
             PRECONDITION(CheckPointer(pMD));
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN pMD->FindEntryPoint(hMod);
+        return pMD->FindEntryPoint(hMod);
     }
 
     //---------------------------------------------------------
@@ -5779,21 +5771,20 @@ namespace
 
 PCODE PInvoke::GetStubForILStub(MethodDesc* pManagedMD, MethodDesc** ppStubMD, DWORD dwStubFlags)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pManagedMD));
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CONSISTENCY_CHECK(*ppStubMD == NULL);
 
     PInvokeStaticSigInfo sigInfo(pManagedMD);
     *ppStubMD = PInvoke::CreateCLRToNativeILStub(&sigInfo, dwStubFlags, pManagedMD);
 
-    RETURN JitILStub(*ppStubMD);
+    return JitILStub(*ppStubMD);
 }
 
 PCODE PInvoke::GetStubForILStub(PInvokeMethodDesc* pNMD, MethodDesc** ppStubMD, DWORD dwStubFlags)
@@ -5911,14 +5902,14 @@ PCODE JitILStub(MethodDesc* pStubMD)
 
 PCODE GetStubForInteropMethod(MethodDesc* pMD, DWORD dwStubFlags)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
 
         PRECONDITION(CheckPointer(pMD));
         PRECONDITION(pMD->IsPInvoke() || pMD->IsCLRToCOMCall() || pMD->IsEEImpl() || pMD->IsIL());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PCODE                   pStub = (PCODE)NULL;
     MethodDesc*             pStubMD = NULL;
@@ -5961,7 +5952,7 @@ PCODE GetStubForInteropMethod(MethodDesc* pMD, DWORD dwStubFlags)
         EnsureComStarted();
     }
 
-    RETURN pStub;
+    return pStub;
 }
 
 VOID PInvokeMethodDesc::SetPInvokeTarget(LPVOID pTarget)

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -118,15 +118,14 @@ UMEntryThunkCache::~UMEntryThunkCache()
 
 UMEntryThunkData *UMEntryThunkCache::GetUMEntryThunk(MethodDesc *pMD)
 {
-    CONTRACT (UMEntryThunkData *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pMD));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CrstHolder ch(&m_crst);
 
@@ -153,7 +152,7 @@ UMEntryThunkData *UMEntryThunkCache::GetUMEntryThunk(MethodDesc *pMD)
         umHolder.SuppressRelease();
     }
 
-    RETURN pThunk;
+    return pThunk;
 }
 
 //-------------------------------------------------------------------------
@@ -262,15 +261,14 @@ PCODE TheUMEntryPrestubWorker(UMEntryThunkData* pUMEntryThunkData)
 
 UMEntryThunkData* UMEntryThunkData::CreateUMEntryThunk()
 {
-    CONTRACT (UMEntryThunkData*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UMEntryThunkData * pData = s_thunkFreeList.GetUMEntryThunk();
 
@@ -297,12 +295,12 @@ UMEntryThunkData* UMEntryThunkData::CreateUMEntryThunk()
         pamTracker->SuppressRelease();
     }
 
-    RETURN pData;
+    return pData;
 }
 
 UMEntryThunkData* UMEntryThunkData::CreateUMEntryThunk(LoaderAllocator* pLoaderAllocator, AllocMemTracker* pamTracker)
 {
-    CONTRACT (UMEntryThunkData*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
@@ -310,16 +308,15 @@ UMEntryThunkData* UMEntryThunkData::CreateUMEntryThunk(LoaderAllocator* pLoaderA
         PRECONDITION(CheckPointer(pLoaderAllocator));
         PRECONDITION(CheckPointer(pamTracker));
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UMEntryThunkData* pData = (UMEntryThunkData*)pamTracker->Track(pLoaderAllocator->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(UMEntryThunkData))));
     UMEntryThunk* pThunk = (UMEntryThunk*)pamTracker->Track(pLoaderAllocator->GetNewStubPrecodeHeap()->AllocStub());
     pData->m_pUMEntryThunk = pThunk;
     pThunk->Init(pThunk, dac_cast<TADDR>(pData), NULL, dac_cast<TADDR>(PRECODE_UMENTRY_THUNK));
 
-    RETURN pData;
+    return pData;
 }
 
 void UMEntryThunkData::Terminate()

--- a/src/coreclr/vm/dllimportcallback.h
+++ b/src/coreclr/vm/dllimportcallback.h
@@ -287,14 +287,14 @@ public:
 
     PCODE GetManagedTarget() const
     {
-        CONTRACT (PCODE)
+        CONTRACTL
         {
             THROWS;
             GC_TRIGGERS;
             MODE_ANY;
             PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         OBJECTHANDLE hndDelegate = GetObjectHandle();
         if (hndDelegate != NULL)
@@ -308,26 +308,26 @@ public:
             // We have optimizations that skip the Invoke method and call directly the
             // delegate's target method. We need to return the target in that case,
             // otherwise debugger would fail to step in.
-            RETURN orDelegate->GetMethodPtr();
+            return orDelegate->GetMethodPtr();
         }
         else if (m_pManagedTarget != (PCODE)NULL)
         {
-            RETURN m_pManagedTarget;
+            return m_pManagedTarget;
         }
         else if (m_pMD != NULL)
         {
-            RETURN m_pMD->GetMultiCallableAddrOfCode();
+            return m_pMD->GetMultiCallableAddrOfCode();
         }
         else
         {
-            RETURN (PCODE)NULL;
+            return (PCODE)NULL;
         }
     }
 #endif // !DACCESS_COMPILE
 
     OBJECTHANDLE GetObjectHandle() const
     {
-        CONTRACT (OBJECTHANDLE)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
@@ -339,9 +339,9 @@ public:
                          m_state == kLoadTimeInited ||
                          m_pObjectHandle == NULL);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pObjectHandle;
+        return m_pObjectHandle;
     }
 
     bool IsCollectedDelegate() const
@@ -353,48 +353,45 @@ public:
 
     UMThunkMarshInfo* GetUMThunkMarshInfo() const
     {
-        CONTRACT (UMThunkMarshInfo*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             SUPPORTS_DAC;
             PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pUMThunkMarshInfo;
+        return m_pUMThunkMarshInfo;
     }
 
     PCODE GetCode() const
     {
-        CONTRACT (PCODE)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
-            POSTCONDITION(CheckPointer(dac_cast<BYTE*>(RETVAL), NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN PINSTRToPCODE(dac_cast<TADDR>(m_pUMEntryThunk));
+        return PINSTRToPCODE(dac_cast<TADDR>(m_pUMEntryThunk));
     }
 
     MethodDesc* GetMethod() const
     {
-        CONTRACT (MethodDesc*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(m_state == kRunTimeInited || m_state == kLoadTimeInited);
-            POSTCONDITION(CheckPointer(RETVAL,NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pMD;
+        return m_pMD;
     }
 };
 

--- a/src/coreclr/vm/domainassembly.cpp
+++ b/src/coreclr/vm/domainassembly.cpp
@@ -22,7 +22,6 @@ DomainAssembly::DomainAssembly(PEAssembly* pPEAssembly, LoaderAllocator* pLoader
     CONTRACTL
     {
         STANDARD_VM_CHECK;
-        CONSTRUCTOR_CHECK;
     }
     CONTRACTL_END;
 

--- a/src/coreclr/vm/dynamicinterfacecastable.cpp
+++ b/src/coreclr/vm/dynamicinterfacecastable.cpp
@@ -9,14 +9,13 @@ namespace
 {
     BOOL CallIsInterfaceImplemented(OBJECTREF *objPROTECTED, const TypeHandle &interfaceTypeHandle, BOOL throwIfNotImplemented)
     {
-        CONTRACT(BOOL) {
+        CONTRACTL {
             THROWS;
             GC_TRIGGERS;
             MODE_COOPERATIVE;
             PRECONDITION(objPROTECTED != NULL);
             PRECONDITION(interfaceTypeHandle.IsInterface());
-            POSTCONDITION(!throwIfNotImplemented || RETVAL);
-        } CONTRACT_END;
+        } CONTRACTL_END;
 
         struct
         {
@@ -31,19 +30,19 @@ namespace
         isInterfaceImplemented.InvokeThrowing(objPROTECTED, &gc.managedType, CLR_BOOL_ARG(throwIfNotImplemented), &isImplemented);
         GCPROTECT_END();
 
-        RETURN isImplemented;
+        _ASSERTE(!throwIfNotImplemented || isImplemented);
+        return isImplemented;
     }
 
     OBJECTREF CallGetInterfaceImplementation(OBJECTREF *objPROTECTED, const TypeHandle &interfaceTypeHandle)
     {
-        CONTRACT(OBJECTREF) {
+        CONTRACTL {
             THROWS;
             GC_TRIGGERS;
             MODE_COOPERATIVE;
             PRECONDITION(objPROTECTED != NULL);
             PRECONDITION(interfaceTypeHandle.IsInterface());
-            POSTCONDITION(RETVAL != NULL);
-        } CONTRACT_END;
+        } CONTRACTL_END;
 
         struct
         {
@@ -59,33 +58,33 @@ namespace
         getInterfaceImplementation.InvokeThrowing(objPROTECTED, &gc.managedType, &gc.result);
         GCPROTECT_END();
 
-        RETURN gc.result;
+        _ASSERTE(gc.result != NULL);
+        return gc.result;
     }
 }
 
 BOOL DynamicInterfaceCastable::IsInstanceOf(OBJECTREF *objPROTECTED, const TypeHandle &typeHandle, BOOL throwIfNotImplemented)
 {
-    CONTRACT(BOOL) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(objPROTECTED != NULL);
         PRECONDITION(typeHandle.IsInterface());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
-    RETURN CallIsInterfaceImplemented(objPROTECTED, typeHandle, throwIfNotImplemented);
+    return CallIsInterfaceImplemented(objPROTECTED, typeHandle, throwIfNotImplemented);
 }
 
 OBJECTREF DynamicInterfaceCastable::GetInterfaceImplementation(OBJECTREF *objPROTECTED, const TypeHandle &typeHandle)
 {
-    CONTRACT(OBJECTREF) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(objPROTECTED != NULL);
         PRECONDITION(typeHandle.IsInterface());
-        POSTCONDITION(RETVAL != NULL);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
-    RETURN CallGetInterfaceImplementation(objPROTECTED, typeHandle);
+    return CallGetInterfaceImplementation(objPROTECTED, typeHandle);
 }

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -20,22 +20,21 @@
 // get the method table for dynamic methods
 DynamicMethodTable* Module::GetDynamicMethodTable()
 {
-    CONTRACT (DynamicMethodTable*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(m_pDynamicMethodTable));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!m_pDynamicMethodTable)
         DynamicMethodTable::CreateDynamicMethodTable(&m_pDynamicMethodTable, this, AppDomain::GetCurrentDomain());
 
 
-    RETURN m_pDynamicMethodTable;
+    return m_pDynamicMethodTable;
 }
 
 void ReleaseDynamicMethodTable(DynamicMethodTable *pDynMT)
@@ -49,7 +48,7 @@ void ReleaseDynamicMethodTable(DynamicMethodTable *pDynMT)
 
 void DynamicMethodTable::CreateDynamicMethodTable(DynamicMethodTable **ppLocation, Module *pModule, AppDomain *pDomain)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -57,16 +56,15 @@ void DynamicMethodTable::CreateDynamicMethodTable(DynamicMethodTable **ppLocatio
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(ppLocation));
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(*ppLocation));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AllocMemTracker amt;
 
     LoaderHeap* pHeap = pDomain->GetHighFrequencyHeap();
     _ASSERTE(pHeap);
 
-    if (*ppLocation) RETURN;
+    if (*ppLocation) return;
 
     DynamicMethodTable* pDynMT = (DynamicMethodTable*)
             amt.Track(pHeap->AllocMem(S_SIZE_T(sizeof(DynamicMethodTable))));
@@ -74,7 +72,7 @@ void DynamicMethodTable::CreateDynamicMethodTable(DynamicMethodTable **ppLocatio
     // Note: Memory allocated on loader heap is zero filled
     // memset((void*)pDynMT, 0, sizeof(DynamicMethodTable));
 
-    if (*ppLocation) RETURN;
+    if (*ppLocation) return;
 
     LOG((LF_BCL, LL_INFO100, "Level2 - Creating DynamicMethodTable {0x%p}...\n", pDynMT));
 
@@ -84,19 +82,19 @@ void DynamicMethodTable::CreateDynamicMethodTable(DynamicMethodTable **ppLocatio
     pDynMT->m_pDomain = pDomain;
     pDynMT->MakeMethodTable(&amt);
 
-    if (*ppLocation) RETURN;
+    if (*ppLocation) return;
 
     if (InterlockedCompareExchangeT(ppLocation, pDynMT, NULL) != NULL)
     {
         LOG((LF_BCL, LL_INFO100, "Level2 - Another thread got here first - deleting DynamicMethodTable {0x%p}...\n", pDynMT));
-        RETURN;
+        return;
     }
 
     dynMTHolder.SuppressRelease();
 
     amt.SuppressRelease();
     LOG((LF_BCL, LL_INFO10, "Level1 - DynamicMethodTable created {0x%p}...\n", pDynMT));
-    RETURN;
+    return;
 }
 
 void DynamicMethodTable::MakeMethodTable(AllocMemTracker *pamTracker)
@@ -142,14 +140,14 @@ void DynamicMethodTable::Destroy()
 
 void DynamicMethodTable::AddMethodsToList()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AllocMemTracker amt;
 
@@ -161,12 +159,12 @@ void DynamicMethodTable::AddMethodsToList()
     //
     MethodDescChunk* pChunk = MethodDescChunk::CreateChunk(pHeap, 0 /* one chunk of maximum size */,
         mcDynamic, TRUE /* fNonVtableSlot */, TRUE /* fNativeCodeSlot */, FALSE /* HasAsyncMethodData */, m_pMethodTable, &amt);
-    if (m_DynamicMethodList) RETURN;
+    if (m_DynamicMethodList) return;
 
     int methodCount = pChunk->GetCount();
 
     BYTE* pResolvers = (BYTE*)amt.Track(pHeap->AllocMem(S_SIZE_T(sizeof(LCGMethodResolver)) * S_SIZE_T(methodCount)));
-    if (m_DynamicMethodList) RETURN;
+    if (m_DynamicMethodList) return;
 
     DynamicMethodDesc *pNewMD = (DynamicMethodDesc *)pChunk->GetFirstMethodDesc();
     DynamicMethodDesc *pPrevMD = NULL;
@@ -200,12 +198,12 @@ void DynamicMethodTable::AddMethodsToList()
         pResolvers += sizeof(LCGMethodResolver);
     }
 
-    if (m_DynamicMethodList) RETURN;
+    if (m_DynamicMethodList) return;
 
     {
         // publish method list and method table
         LockHolder lh(this);
-        if (m_DynamicMethodList) RETURN;
+        if (m_DynamicMethodList) return;
 
         // publish the new method descs on the method table
         m_pMethodTable->GetClass()->AddChunk(pChunk);
@@ -217,7 +215,7 @@ void DynamicMethodTable::AddMethodsToList()
 
 DynamicMethodDesc* DynamicMethodTable::GetDynamicMethod(BYTE *psig, DWORD sigSize, PTR_CUTF8 name)
 {
-    CONTRACT (DynamicMethodDesc*)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
@@ -226,9 +224,8 @@ DynamicMethodDesc* DynamicMethodTable::GetDynamicMethod(BYTE *psig, DWORD sigSiz
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(psig));
         PRECONDITION(sigSize > 0);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LOG((LF_BCL, LL_INFO10000, "Level4 - Getting DynamicMethod\n"));
 
@@ -285,7 +282,7 @@ DynamicMethodDesc* DynamicMethodTable::GetDynamicMethod(BYTE *psig, DWORD sigSiz
     pNewMD->SetNotInline(TRUE);
     pNewMD->GetLCGMethodResolver()->Reset();
 
-    RETURN pNewMD;
+    return pNewMD;
 }
 
 void DynamicMethodTable::AddToFreeList(DynamicMethodDesc *pMethod)
@@ -316,15 +313,14 @@ void DynamicMethodTable::AddToFreeList(DynamicMethodDesc *pMethod)
 //
 HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EECodeGenManager *pJitManager)
 {
-    CONTRACT (HeapList*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION((RETVAL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     NewHolder<HostCodeHeap> pCodeHeap(new HostCodeHeap(pJitManager, !pInfo->IsInterpreted()));
 
@@ -332,7 +328,8 @@ HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EECodeGenMana
     if (pHp == NULL)
     {
         _ASSERTE(!pInfo->GetThrowOnOutOfMemoryWithinRange());
-        RETURN NULL;
+        _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
+        return NULL;
     }
 
     LOG((LF_BCL, LL_INFO100, "Level2 - CodeHeap creation {0x%p} - base addr 0x%p, size available 0x%p, nibble map ptr 0x%p\n",
@@ -341,7 +338,8 @@ HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EECodeGenMana
     pCodeHeap.SuppressRelease();
 
     LOG((LF_BCL, LL_INFO10, "Level1 - CodeHeap created {0x%p}\n", (HostCodeHeap*)pCodeHeap));
-    RETURN pHp;
+    _ASSERTE((pHp != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
+    return pHp;
 }
 
 HostCodeHeap::HostCodeHeap(EECodeGenManager *pJitManager, bool isExecutable)

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -328,7 +328,6 @@ HeapList* HostCodeHeap::CreateCodeHeap(CodeHeapRequestInfo *pInfo, EECodeGenMana
     if (pHp == NULL)
     {
         _ASSERTE(!pInfo->GetThrowOnOutOfMemoryWithinRange());
-        _ASSERTE((NULL != NULL) || !pInfo->GetThrowOnOutOfMemoryWithinRange());
         return NULL;
     }
 

--- a/src/coreclr/vm/eeconfig.cpp
+++ b/src/coreclr/vm/eeconfig.cpp
@@ -31,14 +31,13 @@ int GCStressPolicy::InhibitHolder::s_nGcStressDisabled = 0;
 // Poor mans narrow
 LPUTF8 NarrowWideChar(__inout_z LPCWSTR str)
 {
-    CONTRACT (LPUTF8)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(str, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     if (str != 0) {
         LPCWSTR fromPtr = str;
@@ -47,9 +46,9 @@ LPUTF8 NarrowWideChar(__inout_z LPCWSTR str)
         while(*fromPtr != 0)
             *toPtr++ = (char) *fromPtr++;
         *toPtr = 0;
-        RETURN result;
+        return result;
     }
-    RETURN NULL;
+    return NULL;
 }
 
 /**************************************************************/

--- a/src/coreclr/vm/eecontract.h
+++ b/src/coreclr/vm/eecontract.h
@@ -64,13 +64,7 @@ class EEContract : public BaseContract
 
 #define EE_THREAD_NOT_REQUIRED
 
-// Replace the CONTRACT macro with the EE version
-#undef CONTRACT
-#define CONTRACT(_returntype)  CUSTOM_CONTRACT(EEContract, _returntype)
-
-#undef CONTRACT_VOID
-#define CONTRACT_VOID  CUSTOM_CONTRACT_VOID(EEContract)
-
+// Replace the CONTRACTL macro with the EE version
 #undef CONTRACTL
 #define CONTRACTL  CUSTOM_CONTRACTL(EEContract)
 

--- a/src/coreclr/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/vm/eedbginterfaceimpl.cpp
@@ -42,13 +42,12 @@ Thread* EEDbgInterfaceImpl::GetThread(void)
 // Since this may be called from a Debugger Interop Hijack, the EEThread may be bogus.
 // Thus we can't use contracts. If we do fix that, then the contract below would be nice...
 #if 0
-    CONTRACT(Thread *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 #endif
 
     return ::GetThreadNULLOk();
@@ -76,16 +75,15 @@ StackWalkAction EEDbgInterfaceImpl::StackWalkFramesEx(Thread* pThread,
 
 Frame *EEDbgInterfaceImpl::GetFrame(CrawlFrame *pCF)
 {
-    CONTRACT(Frame *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pCF));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN pCF->GetFrame();
+    return pCF->GetFrame();
 }
 
 bool EEDbgInterfaceImpl::InitRegDisplay(Thread* pThread,
@@ -373,16 +371,15 @@ void EEDbgInterfaceImpl::SetThreadFilterContext(Thread *thread,
 
 CONTEXT *EEDbgInterfaceImpl::GetThreadFilterContext(Thread *thread)
 {
-    CONTRACT(CONTEXT *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(thread));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN thread->GetFilterContext();
+    return thread->GetFilterContext();
 }
 
 #ifdef FEATURE_INTEROP_DEBUGGING
@@ -415,16 +412,15 @@ PCODE EEDbgInterfaceImpl::GetNativeCodeStartAddress(PCODE address)
 
 MethodDesc *EEDbgInterfaceImpl::GetNativeCodeMethodDesc(const PCODE address)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(address != NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN ExecutionManager::GetCodeMethodDesc(address);
+    return ExecutionManager::GetCodeMethodDesc(address);
 }
 
 #ifndef USE_GC_INFO_DECODER
@@ -679,50 +675,47 @@ DWORD EEDbgInterfaceImpl::MethodDescIsStatic(MethodDesc *pFD)
 
 Module *EEDbgInterfaceImpl::MethodDescGetModule(MethodDesc *pFD)
 {
-    CONTRACT(Module *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pFD));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN pFD->GetModule();
+    return pFD->GetModule();
 }
 
 #ifndef DACCESS_COMPILE
 
 COR_ILMETHOD* EEDbgInterfaceImpl::MethodDescGetILHeader(MethodDesc *pFD)
 {
-    CONTRACT(COR_ILMETHOD *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pFD));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (pFD->IsIL())
     {
-        RETURN pFD->GetILHeader();
+        return pFD->GetILHeader();
     }
 
-    RETURN NULL;
+    return NULL;
 }
 
 MethodDesc *EEDbgInterfaceImpl::FindLoadedMethodRefOrDef(Module* pModule,
                                                           mdToken memberRef)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Must have a MemberRef or a MethodDef
     mdToken tkType = TypeFromToken(memberRef);
@@ -730,10 +723,10 @@ MethodDesc *EEDbgInterfaceImpl::FindLoadedMethodRefOrDef(Module* pModule,
 
     if (tkType == mdtMemberRef)
     {
-        RETURN pModule->LookupMemberRefAsMethod(memberRef);
+        return pModule->LookupMemberRefAsMethod(memberRef);
     }
 
-    RETURN pModule->LookupMethodDef(memberRef);
+    return pModule->LookupMethodDef(memberRef);
 }
 
 MethodDesc *EEDbgInterfaceImpl::LoadMethodDef(Module* pModule,
@@ -742,14 +735,13 @@ MethodDesc *EEDbgInterfaceImpl::LoadMethodDef(Module* pModule,
                                               TypeHandle *pGenericArgs,
                                               TypeHandle *pOwnerType)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(TypeFromToken(methodDef) == mdtMethodDef);
 
@@ -817,7 +809,8 @@ MethodDesc *EEDbgInterfaceImpl::LoadMethodDef(Module* pModule,
             *pOwnerType = TypeHandle(pRes->GetMethodTable());
         }
     }
-    RETURN (pRes);
+    _ASSERTE(CheckPointer((pRes)));
+    return (pRes);
 
 }
 
@@ -825,15 +818,15 @@ MethodDesc *EEDbgInterfaceImpl::LoadMethodDef(Module* pModule,
 TypeHandle EEDbgInterfaceImpl::FindLoadedClass(Module *pModule,
                                              mdTypeDef classToken)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pModule));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN ClassLoader::LookupTypeDefOrRefInModule(pModule, classToken);
+    return ClassLoader::LookupTypeDefOrRefInModule(pModule, classToken);
 
 }
 
@@ -915,15 +908,15 @@ TypeHandle EEDbgInterfaceImpl::FindLoadedElementType(CorElementType et)
 TypeHandle EEDbgInterfaceImpl::LoadClass(Module *pModule,
                                        mdTypeDef classToken)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pModule));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN ClassLoader::LoadTypeDefOrRefThrowing(pModule, classToken,
+    return ClassLoader::LoadTypeDefOrRefThrowing(pModule, classToken,
                                                           ClassLoader::ThrowIfNotFound,
                                                           ClassLoader::PermitUninstDefOrRef);
 
@@ -934,32 +927,32 @@ TypeHandle EEDbgInterfaceImpl::LoadInstantiation(Module *pModule,
                                                  DWORD ntypars,
                                                  TypeHandle *inst)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pModule));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN ClassLoader::LoadGenericInstantiationThrowing(pModule, typeDef, Instantiation(inst, ntypars));
+    return ClassLoader::LoadGenericInstantiationThrowing(pModule, typeDef, Instantiation(inst, ntypars));
 }
 
 TypeHandle EEDbgInterfaceImpl::LoadArrayType(CorElementType et,
                                              TypeHandle elemtype,
                                              unsigned rank)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (elemtype.IsNull())
-        RETURN TypeHandle();
+        return TypeHandle();
     else
-        RETURN ClassLoader::LoadArrayTypeThrowing(elemtype, et, rank);
+        return ClassLoader::LoadArrayTypeThrowing(elemtype, et, rank);
 }
 
 TypeHandle EEDbgInterfaceImpl::LoadPointerOrByrefType(CorElementType et,

--- a/src/coreclr/vm/field.cpp
+++ b/src/coreclr/vm/field.cpp
@@ -752,20 +752,19 @@ Instantiation FieldDesc::GetExactClassInstantiation(TypeHandle possibleObjType)
 
 TypeHandle FieldDesc::GetExactFieldType(TypeHandle owner)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(owner, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     if (GetApproxEnclosingMethodTable() == owner.AsMethodTable())
     {
         //Yes, this is exactly the type I was looking for.
-        RETURN(GetFieldTypeHandleThrowing());
+        return(GetFieldTypeHandleThrowing());
     }
     else
     {
@@ -786,7 +785,7 @@ TypeHandle FieldDesc::GetExactFieldType(TypeHandle owner)
         SigTypeContext sigTypeContext(GetExactClassInstantiation(owner), Instantiation());
 
         // Load the exact type
-        RETURN (sig.GetTypeHandleThrowing(GetModule(), &sigTypeContext));
+        return (sig.GetTypeHandleThrowing(GetModule(), &sigTypeContext));
     }
 }
 

--- a/src/coreclr/vm/fieldmarshaler.cpp
+++ b/src/coreclr/vm/fieldmarshaler.cpp
@@ -414,14 +414,13 @@ UINT32 NativeFieldDescriptor::AlignmentRequirement() const
 
 PTR_FieldDesc NativeFieldDescriptor::GetFieldDesc() const
 {
-    CONTRACT(PTR_FieldDesc)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN m_pFD;
+    return m_pFD;
 }

--- a/src/coreclr/vm/fieldmarshaler.h
+++ b/src/coreclr/vm/fieldmarshaler.h
@@ -94,17 +94,16 @@ public:
 
     PTR_MethodTable GetNestedNativeMethodTable() const
     {
-        CONTRACT(PTR_MethodTable)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(IsNestedType());
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN nestedTypeAndCount.m_pNestedType;
+        return nestedTypeAndCount.m_pNestedType;
     }
 
     ULONG GetNumElements() const

--- a/src/coreclr/vm/genericdict.cpp
+++ b/src/coreclr/vm/genericdict.cpp
@@ -40,16 +40,15 @@ DictionaryLayout* DictionaryLayout::Allocate(WORD              numSlots,
                                              LoaderAllocator * pAllocator,
                                              AllocMemTracker * pamTracker)
 {
-    CONTRACT(DictionaryLayout*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(CheckPointer(pAllocator));
         PRECONDITION(numSlots > 0);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     S_SIZE_T bytes = S_SIZE_T(sizeof(DictionaryLayout)) + S_SIZE_T(sizeof(DictionaryEntryLayout)) * S_SIZE_T(numSlots-1);
 
@@ -64,7 +63,7 @@ DictionaryLayout* DictionaryLayout::Allocate(WORD              numSlots,
     pD->m_numSlots = numSlots;
     pD->m_numInitialSlots = numSlots;
 
-    RETURN pD;
+    return pD;
 }
 
 #endif //!DACCESS_COMPILE
@@ -482,13 +481,12 @@ DictionaryEntryLayout::GetKind()
 #ifndef DACCESS_COMPILE
 Dictionary* Dictionary::GetMethodDictionaryWithSizeCheck(MethodDesc* pMD, ULONG slotIndex)
 {
-    CONTRACT(Dictionary*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DWORD numGenericArgs = pMD->GetNumGenericMethodArgs();
 
@@ -535,18 +533,17 @@ Dictionary* Dictionary::GetMethodDictionaryWithSizeCheck(MethodDesc* pMD, ULONG 
         }
     }
 
-    RETURN pDictionary;
+    return pDictionary;
 }
 
 Dictionary* Dictionary::GetTypeDictionaryWithSizeCheck(MethodTable* pMT, ULONG slotIndex)
 {
-    CONTRACT(Dictionary*)
+    CONTRACTL
     {
        THROWS;
        GC_TRIGGERS;
-       POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DWORD numGenericArgs = pMT->GetNumGenericArgs();
 
@@ -595,7 +592,7 @@ Dictionary* Dictionary::GetTypeDictionaryWithSizeCheck(MethodTable* pMT, ULONG s
         }
     }
 
-    RETURN pDictionary;
+    return pDictionary;
 }
 
 struct StaticVirtualDispatchHashBlob : public ILStubHashBlobBase

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -26,13 +26,12 @@
 /* static */
 TypeHandle ClassLoader::CanonicalizeGenericArg(TypeHandle thGenericArg)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
 #if defined(FEATURE_SHARE_GENERIC_CODE)
     CorElementType et = thGenericArg.GetSignatureCorElementType();
@@ -40,19 +39,20 @@ TypeHandle ClassLoader::CanonicalizeGenericArg(TypeHandle thGenericArg)
     // Note that generic variables do not share
 
     if (CorTypeInfo::IsObjRef_NoThrow(et))
-        RETURN(TypeHandle(g_pCanonMethodTableClass));
+        return(TypeHandle(g_pCanonMethodTableClass));
 
     if (et == ELEMENT_TYPE_VALUETYPE)
     {
         // Don't share structs. But sharability must be propagated through
         // them (i.e. struct<object> * shares with struct<string> *)
-        RETURN(TypeHandle(thGenericArg.GetCanonicalMethodTable()));
+        return(TypeHandle(thGenericArg.GetCanonicalMethodTable()));
     }
 
     _ASSERTE(et != ELEMENT_TYPE_PTR && et != ELEMENT_TYPE_FNPTR);
-    RETURN(thGenericArg);
+    return(thGenericArg);
 #else
-    RETURN (thGenericArg);
+    _ASSERTE(CheckPointer((thGenericArg)));
+    return (thGenericArg);
 #endif // FEATURE_SHARE_GENERIC_CODE
 }
 
@@ -118,15 +118,13 @@ TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(const TypeKey *pTypeKe
                                                           LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                           ClassLoadLevel level/*=CLASS_LOADED*/)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
         if (FORBIDGC_LOADER_USE_ENABLED() || fLoadTypes != LoadTypes) { LOADS_TYPE(CLASS_LOAD_BEGIN); } else { LOADS_TYPE(level); }
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == LoadTypes) ? NULL_NOT_OK : NULL_OK)));
-        POSTCONDITION(RETVAL.IsNull() || RETVAL.CheckLoadLevel(level));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     Instantiation inst = pTypeKey->GetInstantiation();
     DWORD ntypars = inst.GetNumArgs();
@@ -148,7 +146,7 @@ TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(const TypeKey *pTypeKe
     TypeKey canonKey(pTypeKey->GetModule(), pTypeKey->GetTypeToken(), Instantiation(repInst, ntypars));
     ret = ClassLoader::LoadConstructedTypeThrowing(&canonKey, fLoadTypes, level);
 
-    RETURN(ret);
+    return(ret);
 }
 
 // Create a non-canonical instantiation of a generic type, by
@@ -160,7 +158,7 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     const TypeKey         *pTypeKey,
     AllocMemTracker *pamTracker)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pTypeKey));
@@ -168,10 +166,8 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
         PRECONDITION(pTypeKey->HasInstantiation());
         PRECONDITION(ClassLoader::IsSharableInstantiation(pTypeKey->GetInstantiation()));
         PRECONDITION(!TypeHandle::IsCanonicalSubtypeInstantiation(pTypeKey->GetInstantiation()));
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL.CheckMatchesKey(pTypeKey));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     Module *pLoaderModule = ClassLoader::ComputeLoaderModule(pTypeKey);
     LoaderAllocator* pAllocator=pLoaderModule->GetLoaderAllocator();
@@ -491,7 +487,7 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // We never have non-virtual slots in this method table (set SetNumVtableSlots and SetNumVirtuals above)
     _ASSERTE(!pMT->HasNonVirtualSlots());
 
-    RETURN(TypeHandle(pMT));
+    return(TypeHandle(pMT));
 } // ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation
 
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -487,6 +487,8 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     // We never have non-virtual slots in this method table (set SetNumVtableSlots and SetNumVirtuals above)
     _ASSERTE(!pMT->HasNonVirtualSlots());
 
+    _ASSERTE(TypeHandle(pMT).CheckMatchesKey(pTypeKey));
+
     return(TypeHandle(pMT));
 } // ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation
 

--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -607,12 +607,6 @@ InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(MethodTable *pExactOrRe
         // canonical and exhibit some kind of code sharing.
         PRECONDITION(!getWrappedCode || pExactOrRepMT->IsCanonicalMethodTable());
         PRECONDITION(!getWrappedCode || pExactOrRepMT->IsSharedByGenericInstantiations() || ClassLoader::IsSharableInstantiation(methodInst));
-
-        // Unboxing stubs are dealt with separately in FindOrCreateAssociatedMethodDesc.  This should
-        // probably be streamlined...
-
-        // All wrapped method descriptors (except BoxedEntryPointStubs, which don't use this path) take an inst arg.
-        // The only ones that don't should have been found in the type's meth table.
     }
     CONTRACTL_END
 
@@ -630,7 +624,18 @@ InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(MethodTable *pExactOrRe
                                                   asyncThunk);
 
     if (resultMD != NULL)
-       return((InstantiatedMethodDesc*) resultMD);
+    {
+        InstantiatedMethodDesc *pInstMD = (InstantiatedMethodDesc*)resultMD;
+
+        // Unboxing stubs are dealt with separately in FindOrCreateAssociatedMethodDesc.  This should
+        // probably be streamlined...
+        _ASSERTE(!pInstMD->IsUnboxingStub());
+
+        // All wrapped method descriptors (except BoxedEntryPointStubs, which don't use this path) take an inst arg.
+        // The only ones that don't should have been found in the type's meth table.
+        _ASSERTE(!getWrappedCode || pInstMD->RequiresInstArg());
+        return pInstMD;
+    }
 
     return(NULL);
 }
@@ -788,9 +793,6 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
         // if we took the fast path.
         _ASSERTE(pDefMD->IsArray() || pDefMD->GetExactDeclaringType(pExactMT) != NULL);
 
-        _ASSERTE(((pDefMD == NULL) && !allowCreate) || CheckPointer(pDefMD));
-        _ASSERTE(((pDefMD == NULL) && !allowCreate) || forceBoxedEntryPoint || !pDefMD->IsUnboxingStub());
-        _ASSERTE(((pDefMD == NULL) && !allowCreate) || allowInstParam || !pDefMD->RequiresInstArg());
         return pDefMD;
     }
 
@@ -1250,6 +1252,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 
         pInstMD->CheckRestore(level);
 
+        _ASSERTE(allowInstParam || !pInstMD->RequiresInstArg());
+
         return(pInstMD);
     }
 }
@@ -1397,13 +1401,18 @@ MethodDesc * MethodDesc::FindOrCreateTypicalSharedInstantiation(BOOL allowCreate
             genericMethodArgs[i] = TypeHandle(g_pCanonMethodTableClass);
     }
 
-    return(MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
-                                                        pMT,
-                                                        FALSE, /* don't get unboxing entry point */
-                                                        Instantiation(genericMethodArgs, nGenericMethodArgs),
-                                                        TRUE,
-                                                        FALSE,
-                                                        allowCreate));
+    MethodDesc* result = MethodDesc::FindOrCreateAssociatedMethodDesc(
+        pMD,
+        pMT,
+        FALSE, /* don't get unboxing entry point */
+        Instantiation(genericMethodArgs, nGenericMethodArgs),
+        TRUE,
+        FALSE,
+        allowCreate);
+
+    _ASSERTE(result == NULL || result->IsSharedByGenericInstantiations());
+    return result;
+
 }
 
 //@GENERICSVER: Set up the typical instance (i.e., non-instantiated)

--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -324,7 +324,7 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
                                                   Instantiation methodInst,
                                                   BOOL getWrappedCode)
 {
-    CONTRACT(InstantiatedMethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -333,11 +333,8 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
         PRECONDITION(CheckPointer(pGenericMDescInRepMT));
         PRECONDITION(methodInst.IsEmpty() || pGenericMDescInRepMT->IsGenericMethodDefinition());
         PRECONDITION(methodInst.GetNumArgs() == pGenericMDescInRepMT->GetNumGenericMethodArgs());
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(getWrappedCode == RETVAL->IsSharedByGenericInstantiations());
-        POSTCONDITION(methodInst.IsEmpty() || RETVAL->HasMethodInstantiation());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // All instantiated method descs live off the RepMT for the
     // instantiated class they live in.
@@ -543,7 +540,9 @@ InstantiatedMethodDesc::NewInstantiatedMethodDesc(MethodTable *pExactMT,
 
     }
 
-    RETURN pNewMD;
+    _ASSERTE(getWrappedCode == pNewMD->IsSharedByGenericInstantiations());
+    _ASSERTE(methodInst.IsEmpty() || pNewMD->HasMethodInstantiation());
+    return pNewMD;
 }
 
 // Calling this method is equivalent to
@@ -596,7 +595,7 @@ InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(MethodTable *pExactOrRe
                                                          BOOL getWrappedCode,
                                                          BOOL asyncThunk)
 {
-    CONTRACT(InstantiatedMethodDesc *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
@@ -611,13 +610,11 @@ InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(MethodTable *pExactOrRe
 
         // Unboxing stubs are dealt with separately in FindOrCreateAssociatedMethodDesc.  This should
         // probably be streamlined...
-        POSTCONDITION(!RETVAL || !RETVAL->IsUnboxingStub());
 
         // All wrapped method descriptors (except BoxedEntryPointStubs, which don't use this path) take an inst arg.
         // The only ones that don't should have been found in the type's meth table.
-        POSTCONDITION(!getWrappedCode || !RETVAL || RETVAL->RequiresInstArg());
     }
-    CONTRACT_END
+    CONTRACTL_END
 
 
     // First look in the table for the runtime loader module in case someone created it before any
@@ -633,9 +630,9 @@ InstantiatedMethodDesc::FindLoadedInstantiatedMethodDesc(MethodTable *pExactOrRe
                                                   asyncThunk);
 
     if (resultMD != NULL)
-       RETURN((InstantiatedMethodDesc*) resultMD);
+       return((InstantiatedMethodDesc*) resultMD);
 
-    RETURN(NULL);
+    return(NULL);
 }
 
 
@@ -753,7 +750,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                                              AsyncVariantLookup asyncVariantLookup,
                                              ClassLoadLevel level)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         if (allowCreate) { GC_TRIGGERS; } else { GC_NOTRIGGER; }
@@ -777,11 +774,8 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
         // For remotable methods we better not be allowing instantiation parameters.
         PRECONDITION(!forceRemotableMethod || !allowInstParam);
 
-        POSTCONDITION(((RETVAL == NULL) && !allowCreate) || CheckPointer(RETVAL));
-        POSTCONDITION(((RETVAL == NULL) && !allowCreate) || forceBoxedEntryPoint || !RETVAL->IsUnboxingStub());
-        POSTCONDITION(((RETVAL == NULL) && !allowCreate) || allowInstParam || !RETVAL->RequiresInstArg());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Quick exit for the common cases where the result is the same as the primary MD we are given
     if (!pDefMD->HasClassOrMethodInstantiation() &&
@@ -794,7 +788,10 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
         // if we took the fast path.
         _ASSERTE(pDefMD->IsArray() || pDefMD->GetExactDeclaringType(pExactMT) != NULL);
 
-        RETURN pDefMD;
+        _ASSERTE(((pDefMD == NULL) && !allowCreate) || CheckPointer(pDefMD));
+        _ASSERTE(((pDefMD == NULL) && !allowCreate) || forceBoxedEntryPoint || !pDefMD->IsUnboxingStub());
+        _ASSERTE(((pDefMD == NULL) && !allowCreate) || allowInstParam || !pDefMD->RequiresInstArg());
+        return pDefMD;
     }
 
     // Get the version of the method desc. for the instantiated shared class, e.g.
@@ -831,7 +828,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 
         if (!allowCreate && !pMDescInCanonMT->GetMethodTable()->IsFullyLoaded())
         {
-            RETURN(NULL);
+            return(NULL);
         }
 
         pMDescInCanonMT->CheckRestore(level);
@@ -848,7 +845,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
         && (!forceRemotableMethod || !pMDescInCanonMT->IsInterface()
                 || !pMDescInCanonMT->GetMethodTable()->IsSharedByGenericInstantiations()) )
     {
-        RETURN(pMDescInCanonMT);
+        return(pMDescInCanonMT);
     }
 
     // Unboxing stubs
@@ -890,7 +887,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
             if (pResultMD != NULL)
             {
                 _ASSERTE(pResultMD->GetMethodTable()->IsFullyLoaded());
-                RETURN(pResultMD);
+                return(pResultMD);
             }
 
             MethodTable *pRepMT = pMDescInCanonMT->GetMethodTable();
@@ -914,7 +911,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                 // !allowCreate ==> GC_NOTRIGGER ==> no entering Crst
                 if (!allowCreate)
                 {
-                    RETURN(NULL);
+                    return(NULL);
                 }
 
 #ifndef DACCESS_COMPILE
@@ -981,7 +978,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                 // !allowCreate ==> GC_NOTRIGGER ==> no entering Crst
                 if (!allowCreate)
                 {
-                    RETURN(NULL);
+                    return(NULL);
                 }
 
 #ifndef DACCESS_COMPILE
@@ -1049,13 +1046,13 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 
         if (!allowCreate && !pResultMD->GetMethodTable()->IsFullyLoaded())
         {
-            RETURN(NULL);
+            return(NULL);
         }
 
         pResultMD->CheckRestore(level);
         _ASSERTE(pResultMD->IsUnboxingStub());
         _ASSERTE(!pResultMD->IsInstantiatingStub());
-        RETURN(pResultMD);
+        return(pResultMD);
     }
 
 
@@ -1101,7 +1098,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
                 _ASSERTE(pResultMD->GetMethodTable()->IsFullyLoaded());
                 if (allowInstParam || !pResultMD->RequiresInstArg())
                 {
-                    RETURN(pResultMD);
+                    return(pResultMD);
                 }
             }
         }
@@ -1117,7 +1114,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
             ClassLoader::IsTypicalInstantiation(pModule, methodDef, methodInst))
         {
             _ASSERTE(!pMDescInCanonMT->IsUnboxingStub());
-            RETURN(pMDescInCanonMT);
+            return(pMDescInCanonMT);
         }
 
         // OK, so we now know the thing we're looking for can only be found in the MethodDesc table.
@@ -1162,7 +1159,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
             {
                 if (!allowCreate)
                 {
-                    RETURN(NULL);
+                    return(NULL);
                 }
 
 #ifndef DACCESS_COMPILE
@@ -1189,7 +1186,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
             {
                 if (!allowCreate)
                 {
-                    RETURN(NULL);
+                    return(NULL);
                 }
 
 #ifndef DACCESS_COMPILE
@@ -1232,7 +1229,7 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
             {
                 if (!allowCreate)
                 {
-                    RETURN(NULL);
+                    return(NULL);
                 }
 
 #ifndef DACCESS_COMPILE
@@ -1248,12 +1245,12 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 
         if (!allowCreate && !pInstMD->GetMethodTable()->IsFullyLoaded())
         {
-            RETURN(NULL);
+            return(NULL);
         }
 
         pInstMD->CheckRestore(level);
 
-        RETURN(pInstMD);
+        return(pInstMD);
     }
 }
 
@@ -1343,15 +1340,13 @@ MethodDesc::FindOrCreateAssociatedMethodDesc(MethodDesc* pDefMD,
 //
 MethodDesc * MethodDesc::FindOrCreateTypicalSharedInstantiation(BOOL allowCreate /* = TRUE */)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         PRECONDITION(IsTypicalMethodDefinition());
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL->IsTypicalSharedInstantiation());
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     MethodDesc *pMD = this;
     MethodTable *pMT = pMD->GetMethodTable();
@@ -1402,7 +1397,7 @@ MethodDesc * MethodDesc::FindOrCreateTypicalSharedInstantiation(BOOL allowCreate
             genericMethodArgs[i] = TypeHandle(g_pCanonMethodTableClass);
     }
 
-    RETURN(MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
+    return(MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
                                                         pMT,
                                                         FALSE, /* don't get unboxing entry point */
                                                         Instantiation(genericMethodArgs, nGenericMethodArgs),

--- a/src/coreclr/vm/i386/cgenx86.cpp
+++ b/src/coreclr/vm/i386/cgenx86.cpp
@@ -67,14 +67,14 @@ void ClearRegDisplayArgumentAndScratchRegisters(REGDISPLAY * pRD)
 
 void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
 
@@ -85,19 +85,19 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStackPop)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CalleeSavedRegisters* regs = GetCalleeSavedRegisters();
 
@@ -115,38 +115,38 @@ void TransitionFrame::UpdateRegDisplayHelper(const PREGDISPLAY pRD, UINT cbStack
 
     SyncRegDisplayToCurrentContext(pRD);
 
-    RETURN;
+    return;
 }
 
 void ExternalMethodFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     UpdateRegDisplayHelper(pRD, CbStackPopUsingGCRefMap(GetGCRefMap()));
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    ExternalMethodFrane::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 
 void StubDispatchFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PTR_BYTE pGCRefMap = GetGCRefMap();
     if (pGCRefMap != NULL)
@@ -177,7 +177,7 @@ void StubDispatchFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool update
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    StubDispatchFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 PCODE StubDispatchFrame::GetReturnAddress_Impl()
@@ -200,14 +200,14 @@ PCODE StubDispatchFrame::GetReturnAddress_Impl()
 
 void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SetRegdisplayPCTAddr(pRD, GetReturnAddressPtr());
 
@@ -242,12 +242,12 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    FaultingExceptionFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -260,7 +260,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // @TODO: Remove this after the debugger is fixed to avoid stack-walks from bad places
     // @TODO: This may be still needed for sampling profilers
@@ -312,7 +312,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 #ifdef FEATURE_HIJACK
@@ -327,14 +327,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl()
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SetRegdisplayPCTAddr(pRD, dac_cast<TADDR>(m_Regs) + offsetof(CONTEXT, Eip));
 
@@ -355,7 +355,7 @@ void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFlo
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    ResumableFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 // The HijackFrame has to know the registers that are pushed by OnHijackTripThread
@@ -395,34 +395,34 @@ void HijackFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats
 
 void PInvokeCalliFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     VASigCookie *pVASigCookie = GetVASigCookie();
     UpdateRegDisplayHelper(pRD, pVASigCookie->sizeOfArgs);
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    PInvokeCalliFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 #ifndef UNIX_X86_ABI
 void TailCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SetRegdisplayPCTAddr(pRD, GetReturnAddressPtr());
 
@@ -438,7 +438,7 @@ void TailCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloa
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TailCallFrame::UpdateRegDisplay_Impl(ip:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 #endif // !UNIX_X86_ABI
 
@@ -456,12 +456,12 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 #ifndef TARGET_X86
 #error Make sure this works before porting to platforms other than x86.
 #endif
-    CONTRACT(WORD) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         PRECONDITION(CORDebuggerAttached());
         PRECONDITION(CheckPointer(pAddr));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     // Ordering is because x86 is little-endien.
     BYTE bLow  = pAddr[0];
@@ -484,7 +484,7 @@ WORD GetUnpatchedCodeData(LPCBYTE pAddr)
 #endif
 
     WORD w = bLow + (bHigh << 8);
-    RETURN w;
+    return w;
 }
 
 

--- a/src/coreclr/vm/i386/stublinkerx86.cpp
+++ b/src/coreclr/vm/i386/stublinkerx86.cpp
@@ -821,20 +821,20 @@ VOID StubLinkerCPU::X86EmitEspOffset(BYTE opcode,
 // Get X86Reg indexes of argument registers based on offset into ArgumentRegister
 X86Reg GetX86ArgumentRegisterFromOffset(size_t ofs)
 {
-    CONTRACT(X86Reg)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
 
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    #define ARGUMENT_REGISTER(reg) if (ofs == offsetof(ArgumentRegisters, reg)) RETURN  k##reg ;
+    #define ARGUMENT_REGISTER(reg) if (ofs == offsetof(ArgumentRegisters, reg)) return  k##reg ;
     ENUM_ARGUMENT_REGISTERS();
     #undef ARGUMENT_REGISTER
 
     _ASSERTE(0);//Can't get here.
-    RETURN kEBP;
+    return kEBP;
 }
 
 

--- a/src/coreclr/vm/ilmarshalers.cpp
+++ b/src/coreclr/vm/ilmarshalers.cpp
@@ -1054,15 +1054,14 @@ namespace
 {
     MethodDesc* GetStructMarshalingMethod(BinderMethodID methodId, MethodTable* pMT)
     {
-        CONTRACT(MethodDesc*)
+        CONTRACTL
         {
             THROWS;
             GC_TRIGGERS;
             MODE_PREEMPTIVE;
             PRECONDITION(CheckPointer(pMT));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         MethodDesc* pPrimaryMD = CoreLibBinder::GetMethod(methodId);
 
@@ -1075,7 +1074,7 @@ namespace
             Instantiation(),
             FALSE);
 
-        RETURN pMD;
+        return pMD;
     }
 }
 

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -72,13 +72,12 @@ MethodDesc* ILStubCache::CreateAndLinkNewILStubMethodDesc(LoaderAllocator* pAllo
                                              Module* pSigModule, PCCOR_SIGNATURE pSig, DWORD cbSig, SigTypeContext *pTypeContext,
                                              ILStubLinker* pStubLinker, BOOL isAsync /* = FALSE */)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pMT, NULL_NOT_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     AllocMemTracker amTracker;
 
     MethodDesc *pStubMD = ILStubCache::CreateNewMethodDesc(pAllocator->GetHighFrequencyHeap(),
@@ -100,7 +99,7 @@ MethodDesc* ILStubCache::CreateAndLinkNewILStubMethodDesc(LoaderAllocator* pAllo
 
     pResolver->FinalizeILStub(pStubLinker);
 
-    RETURN pStubMD;
+    return pStubMD;
 }
 
 
@@ -148,13 +147,12 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
                                              Module* pSigModule, PCCOR_SIGNATURE pSig, DWORD cbSig, BOOL isAsync, SigTypeContext *pTypeContext,
                                              AllocMemTracker* pamTracker)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pMT, NULL_NOT_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // @TODO: reuse the same chunk for multiple methods
     MethodDescChunk* pChunk = MethodDescChunk::CreateChunk(pCreationHeap,
@@ -354,7 +352,7 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
     pMD->m_pDebugMethodTable = pMT;
 #endif // _DEBUG
 
-    RETURN pMD;
+    return pMD;
 }
 
 // Creates a DynamicMethodDesc that wraps pre-compiled R2R stub code.
@@ -369,7 +367,7 @@ MethodDesc* ILStubCache::CreateR2RBackedILStub(
     DWORD cbSig,
     AllocMemTracker* pamTracker)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pAllocator));
@@ -377,9 +375,8 @@ MethodDesc* ILStubCache::CreateR2RBackedILStub(
         PRECONDITION(r2rEntryPoint != (PCODE)NULL);
         PRECONDITION(stubType != DynamicMethodDesc::StubNotSet);
         PRECONDITION(CheckPointer(pamTracker));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DynamicMethodDesc::ILStubType ilStubType = (DynamicMethodDesc::ILStubType)stubType;
 
@@ -441,7 +438,7 @@ MethodDesc* ILStubCache::CreateR2RBackedILStub(
 
     LOG((LF_STUBS, LL_INFO1000, "ILSTUBCACHE: ILStubCache::CreateR2RBackedILStub StubMD: %p\n", pMD));
 
-    RETURN pMD;
+    return pMD;
 }
 
 //
@@ -450,15 +447,14 @@ MethodDesc* ILStubCache::CreateR2RBackedILStub(
 //
 MethodTable* ILStubCache::GetOrCreateStubMethodTable(Module* pModule)
 {
-    CONTRACT (MethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     if (pModule->IsSystem())
@@ -487,7 +483,7 @@ MethodTable* ILStubCache::GetOrCreateStubMethodTable(Module* pModule)
         }
     }
 
-    RETURN m_pStubMT;
+    return m_pStubMT;
 }
 
 
@@ -585,12 +581,11 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
     bool& bILStubCreator,
     MethodDesc *pLastMD)
 {
-    CONTRACT (MethodDesc*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodDesc*     pMD         = NULL;
 
@@ -675,7 +670,7 @@ MethodDesc* ILStubCache::GetStubMethodDesc(
 #endif // _DEBUG
 #endif // DACCESS_COMPILE
 
-    RETURN pMD;
+    return pMD;
 }
 
 void ILStubCache::DeleteEntry(ILStubHashBlob* pHashBlob)

--- a/src/coreclr/vm/ilstubresolver.cpp
+++ b/src/coreclr/vm/ilstubresolver.cpp
@@ -14,7 +14,7 @@
 // returns pointer to IL code
 BYTE* ILStubResolver::GetCodeInfo(unsigned* pCodeSize, unsigned* pStackSize, CorInfoOptions* pOptions, unsigned* pEHSize)
 {
-    CONTRACT(BYTE*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pCodeSize));
@@ -22,9 +22,8 @@ BYTE* ILStubResolver::GetCodeInfo(unsigned* pCodeSize, unsigned* pStackSize, Cor
         PRECONDITION(CheckPointer(pOptions));
         PRECONDITION(CheckPointer(pEHSize));
         PRECONDITION(CheckPointer(m_pCompileTimeState));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifndef DACCESS_COMPILE
     CORINFO_METHOD_INFO methodInfo;
@@ -35,10 +34,10 @@ BYTE* ILStubResolver::GetCodeInfo(unsigned* pCodeSize, unsigned* pStackSize, Cor
     *pOptions = methodInfo.options;
     *pEHSize = methodInfo.EHcount;
 
-    RETURN methodInfo.ILCode;
+    return methodInfo.ILCode;
 #else // DACCESS_COMPILE
     DacNotImpl();
-    RETURN NULL;
+    return NULL;
 #endif // DACCESS_COMPILE
 }
 

--- a/src/coreclr/vm/interopconverter.cpp
+++ b/src/coreclr/vm/interopconverter.cpp
@@ -80,7 +80,7 @@ namespace
 // Convert ObjectRef to a COM IP, based on MethodTable* pMT.
 IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnableCustomizedQueryInterface)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -88,9 +88,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         PRECONDITION(CheckPointer(poref));
         PRECONDITION(CheckPointer(pMT));
         PRECONDITION(g_fComStarted && "COM has not been started up, make sure EnsureComStarted is called before any COM objects are used!");
-        POSTCONDITION((*poref) != NULL ? CheckPointer(RETVAL) : CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     BOOL        fReleaseWrapper     = false;
     HRESULT     hr                  = E_NOINTERFACE;
@@ -98,7 +97,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
     size_t      ul                  = 0;
 
     if (*poref == NULL)
-        RETURN NULL;
+        return NULL;
 
     if (TryGetComIPFromObjectRefUsingComWrappers(*poref, &pUnk))
     {
@@ -110,7 +109,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        RETURN pvObj;
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
+        return pvObj;
     }
 
     if (!g_pConfig->IsBuiltInCOMSupported())
@@ -147,7 +147,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         COMPlusThrowHR(hr);
 
     pUnk.SuppressRelease();
-    RETURN pUnk;
+    return pUnk;
 }
 
 
@@ -156,7 +156,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
 // Convert ObjectRef to a COM IP of the requested type.
 IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType *pFetchedIpType)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -164,9 +164,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
         PRECONDITION((ReqIpType & (ComIpType_Dispatch | ComIpType_Unknown)) != 0);
         PRECONDITION(CheckPointer(poref));
         PRECONDITION(ReqIpType != 0);
-        POSTCONDITION((*poref) != NULL ? CheckPointer(RETVAL) : CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // COM had better be started up at this point.
     _ASSERTE(g_fComStarted && "COM has not been started up, make sure EnsureComStarted is called before any COM objects are used!");
@@ -178,7 +177,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
     ComIpType   FetchedIpType   = ComIpType_None;
 
     if (*poref == NULL)
-        RETURN NULL;
+        return NULL;
 
     if (TryGetComIPFromObjectRefUsingComWrappers(*poref, &pUnk))
     {
@@ -212,7 +211,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
         if (pFetchedIpType != NULL)
             *pFetchedIpType = FetchedIpType;
 
-        RETURN pvObj;
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
+        return pvObj;
     }
 
     if (!g_pConfig->IsBuiltInCOMSupported())
@@ -292,7 +292,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
     if (pFetchedIpType)
         *pFetchedIpType = FetchedIpType;
 
-    RETURN pUnk;
+    return pUnk;
 }
 
 
@@ -302,15 +302,14 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
 //+----------------------------------------------------------------------------
 IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComIP /* = true */)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(poref));
-        POSTCONDITION((*poref) != NULL ? CheckPointer(RETVAL, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ASSERT_PROTECTED(poref);
 
@@ -323,7 +322,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
     size_t      ul              = 0;
 
     if (*poref == NULL)
-        RETURN NULL;
+        return NULL;
 
     if (TryGetComIPFromObjectRefUsingComWrappers(*poref, &pUnk))
     {
@@ -333,7 +332,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        RETURN pvObj;
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pvObj, NULL_OK));
+        return pvObj;
     }
 
     MethodTable *pMT = (*poref)->GetMethodTable();
@@ -365,7 +365,8 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
     if (throwIfNoComIP && pUnk == NULL)
         COMPlusThrowHR(hr);
 
-    RETURN pUnk;
+    _ASSERTE((*poref) != NULL ? CheckPointer(pUnk, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pUnk, NULL_OK));
+    return pUnk;
 }
 
 

--- a/src/coreclr/vm/interopconverter.cpp
+++ b/src/coreclr/vm/interopconverter.cpp
@@ -109,7 +109,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
+        _ASSERTE(((*poref) != NULL) == (pvObj != NULL));
         return pvObj;
     }
 
@@ -211,7 +211,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
         if (pFetchedIpType != NULL)
             *pFetchedIpType = FetchedIpType;
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
+        _ASSERTE(((*poref) != NULL) == (pvObj != NULL));
         return pvObj;
     }
 
@@ -332,7 +332,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pvObj, NULL_OK));
+        _ASSERTE(((*poref) != NULL) == (pvObj != NULL));
         return pvObj;
     }
 
@@ -365,7 +365,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
     if (throwIfNoComIP && pUnk == NULL)
         COMPlusThrowHR(hr);
 
-    _ASSERTE((*poref) != NULL ? CheckPointer(pUnk, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pUnk, NULL_OK));
+    _ASSERTE(((*poref) != NULL) == (pUnk != NULL));
     return pUnk;
 }
 

--- a/src/coreclr/vm/interopconverter.cpp
+++ b/src/coreclr/vm/interopconverter.cpp
@@ -109,6 +109,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -210,6 +211,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
         if (pFetchedIpType != NULL)
             *pFetchedIpType = FetchedIpType;
 
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -330,6 +332,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
+        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -362,6 +365,7 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
     if (throwIfNoComIP && pUnk == NULL)
         COMPlusThrowHR(hr);
 
+    _ASSERTE((*poref) != NULL ? CheckPointer(pUnk, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pUnk, NULL_OK));
     return pUnk;
 }
 

--- a/src/coreclr/vm/interopconverter.cpp
+++ b/src/coreclr/vm/interopconverter.cpp
@@ -109,7 +109,6 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, MethodTable *pMT, BOOL bEnable
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -211,7 +210,6 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, ComIpType ReqIpType, ComIpType
         if (pFetchedIpType != NULL)
             *pFetchedIpType = FetchedIpType;
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -332,7 +330,6 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
         if (FAILED(hr))
             COMPlusThrowHR(hr);
 
-        _ASSERTE((*poref) != NULL ? CheckPointer(pvObj, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pvObj, NULL_OK));
         return pvObj;
     }
 
@@ -365,7 +362,6 @@ IUnknown *GetComIPFromObjectRef(OBJECTREF *poref, REFIID iid, bool throwIfNoComI
     if (throwIfNoComIP && pUnk == NULL)
         COMPlusThrowHR(hr);
 
-    _ASSERTE((*poref) != NULL ? CheckPointer(pUnk, throwIfNoComIP ? NULL_NOT_OK : NULL_OK) : CheckPointer(pUnk, NULL_OK));
     return pUnk;
 }
 

--- a/src/coreclr/vm/interoplibinterface_objc.cpp
+++ b/src/coreclr/vm/interoplibinterface_objc.cpp
@@ -274,7 +274,7 @@ void* ObjCMarshalNative::GetPropagatingExceptionCallback(
     _In_ OBJECTHANDLE throwable,
     _Outptr_ void** context)
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         THROWS;
         MODE_PREEMPTIVE;
@@ -282,7 +282,7 @@ void* ObjCMarshalNative::GetPropagatingExceptionCallback(
         PRECONDITION(throwable != NULL);
         PRECONDITION(context != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     void* callback = NULL;
     void* callbackContext = NULL;
@@ -315,7 +315,7 @@ void* ObjCMarshalNative::GetPropagatingExceptionCallback(
     }
 
     *context = callbackContext;
-    RETURN callback;
+    return callback;
 }
 
 void ObjCMarshalNative::BeforeRefCountedHandleCallbacks()

--- a/src/coreclr/vm/interoplibinterface_shared.cpp
+++ b/src/coreclr/vm/interoplibinterface_shared.cpp
@@ -37,7 +37,7 @@ ManagedToNativeExceptionCallback Interop::GetPropagatingExceptionCallback(
     _In_ OBJECTHANDLE throwable,
     _Outptr_ void** context)
 {
-    CONTRACT(ManagedToNativeExceptionCallback)
+    CONTRACTL
     {
         NOTHROW;
         MODE_PREEMPTIVE;
@@ -45,7 +45,7 @@ ManagedToNativeExceptionCallback Interop::GetPropagatingExceptionCallback(
         PRECONDITION(throwable != NULL);
         PRECONDITION(context != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ManagedToNativeExceptionCallback callback = NULL;
     *context = NULL;
@@ -67,7 +67,7 @@ ManagedToNativeExceptionCallback Interop::GetPropagatingExceptionCallback(
     EX_END_CATCH_UNREACHABLE;
 #endif // FEATURE_OBJCMARSHAL
 
-    RETURN callback;
+    return callback;
 }
 
 void Interop::OnGCStarted(_In_ int nCondemnedGeneration)

--- a/src/coreclr/vm/interoputil.cpp
+++ b/src/coreclr/vm/interoputil.cpp
@@ -1333,15 +1333,14 @@ void ReleaseRCWsInCachesNoThrow(LPVOID pCtxCookie)
 // has been aggregated
 ComCallWrapper* GetCCWFromIUnknown(IUnknown* pUnk, BOOL bEnableCustomization)
 {
-    CONTRACT (ComCallWrapper*)
+    CONTRACTL
     {
         NOTHROW;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pUnk));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ComCallWrapper* pWrap = MapIUnknownToWrapper(pUnk);
     if (pWrap != NULL)
@@ -1353,7 +1352,7 @@ ComCallWrapper* GetCCWFromIUnknown(IUnknown* pUnk, BOOL bEnableCustomization)
         }
     }
 
-    RETURN pWrap;
+    return pWrap;
 }
 
 HRESULT LoadRegTypeLib(_In_ REFGUID guid,
@@ -3653,7 +3652,7 @@ void GetComClassFromCLSID(REFCLSID clsid, _In_opt_z_ PCWSTR wszServer, OBJECTREF
 // if not set one up
 ClassFactoryBase *GetComClassFactory(MethodTable* pClassMT)
 {
-    CONTRACT (ClassFactoryBase*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -3661,9 +3660,8 @@ ClassFactoryBase *GetComClassFactory(MethodTable* pClassMT)
         INJECT_FAULT(ThrowOutOfMemory());
         PRECONDITION(CheckPointer(pClassMT));
         PRECONDITION(pClassMT->IsComObjectType());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Work our way up the hierarchy until we find the first COM import type.
     while (!pClassMT->IsComImport())
@@ -3699,7 +3697,7 @@ ClassFactoryBase *GetComClassFactory(MethodTable* pClassMT)
         pClsFac = pNewFactory.Extract();
     }
 
-    RETURN pClsFac;
+    return pClsFac;
 }
 #endif // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
 

--- a/src/coreclr/vm/interoputil.inl
+++ b/src/coreclr/vm/interoputil.inl
@@ -55,21 +55,21 @@ inline BOOL IsStandardTearOff(IUnknown* pUnk)
 // Convert an IUnknown to CCW, does not handle aggregation and ICustomQI.
 FORCEINLINE ComCallWrapper* MapIUnknownToWrapper(IUnknown* pUnk)
 {
-    CONTRACT (ComCallWrapper*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(CheckPointer(pUnk, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsStandardTearOff(pUnk))
-        RETURN ComCallWrapper::GetWrapperFromIP(pUnk);
+        return ComCallWrapper::GetWrapperFromIP(pUnk);
 
     if (IsSimpleTearOff(pUnk) || IsInnerUnknown(pUnk))
-        RETURN SimpleComCallWrapper::GetWrapperFromIP(pUnk)->GetMainWrapper();
+        return SimpleComCallWrapper::GetWrapperFromIP(pUnk)->GetMainWrapper();
 
-    RETURN NULL;
+    return NULL;
 }
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/invokeutil.cpp
+++ b/src/coreclr/vm/invokeutil.cpp
@@ -57,14 +57,13 @@ BOOL InvokeUtil::IsVoidPtr(TypeHandle th)
 
 OBJECTREF InvokeUtil::CreatePointer(TypeHandle th, void * p)
 {
-    CONTRACT(OBJECTREF) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(!th.IsNull());
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     OBJECTREF refObj = NULL;
     GCPROTECT_BEGIN(refObj);
@@ -77,51 +76,50 @@ OBJECTREF InvokeUtil::CreatePointer(TypeHandle th, void * p)
     SetObjectReference(&(((ReflectionPointer *)OBJECTREFToObject(refObj))->_ptrType), refType);
 
     GCPROTECT_END();
-    RETURN refObj;
+    _ASSERTE(refObj != NULL);
+    return refObj;
 }
 
 TypeHandle InvokeUtil::GetPointerType(OBJECTREF pObj) {
-    CONTRACT(TypeHandle) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_COOPERATIVE;
         PRECONDITION(pObj != NULL);
-        POSTCONDITION(!RETVAL.IsNull());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ReflectionPointer * pReflectionPointer = (ReflectionPointer *)OBJECTREFToObject(pObj);
     REFLECTCLASSBASEREF o = (REFLECTCLASSBASEREF)pReflectionPointer->_ptrType;
     TypeHandle typeHandle = o->GetType();
-    RETURN typeHandle;
+    _ASSERTE(!typeHandle.IsNull());
+    return typeHandle;
 }
 
 void* InvokeUtil::GetPointerValue(OBJECTREF pObj) {
-    CONTRACT(void*) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_COOPERATIVE;
         PRECONDITION(pObj != NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ReflectionPointer * pReflectionPointer = (ReflectionPointer *)OBJECTREFToObject(pObj);
     void *value = pReflectionPointer->_ptr;
-    RETURN value;
+    return value;
 }
 
 void *InvokeUtil::GetIntPtrValue(OBJECTREF pObj) {
-    CONTRACT(void*) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_COOPERATIVE;
         PRECONDITION(pObj != NULL);
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN *(void **)((pObj)->UnBox());
+    return *(void **)((pObj)->UnBox());
 }
 
 void InvokeUtil::CopyArg(TypeHandle th, PVOID argRef, ArgDestination *argDest) {
@@ -585,18 +583,17 @@ OBJECTREF InvokeUtil::CreateObjectAfterInvoke(TypeHandle th, void * pValue) {
 }
 
 OBJECTREF InvokeUtil::CreateTargetExcept(OBJECTREF* except) {
-    CONTRACT(OBJECTREF) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(except));
         PRECONDITION(IsProtectedByGCFrame (except));
 
-        POSTCONDITION(RETVAL != NULL);
 
         INJECT_FAULT(COMPlusThrowOM());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     struct
     {
@@ -618,7 +615,8 @@ OBJECTREF InvokeUtil::CreateTargetExcept(OBJECTREF* except) {
     createTargetExcept.InvokeThrowing(&gc.innerEx, &gc.oRet);
 
     GCPROTECT_END();
-    RETURN gc.oRet;
+    _ASSERTE(gc.oRet != NULL);
+    return gc.oRet;
 }
 
 // Ensure that the field is declared on the type or subtype of the type to which the typed reference refers.

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -405,7 +405,7 @@ CorInfoType CEEInfo::asCorInfoType(CorElementType eeType,
     if (clsRet)
         *clsRet = CORINFO_CLASS_HANDLE(typeHndUpdated.AsPtr());
 
-    RETURN res;
+    return res;
 }
 
 enum ConvToJitSigFlags : int

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -405,7 +405,7 @@ CorInfoType CEEInfo::asCorInfoType(CorElementType eeType,
     if (clsRet)
         *clsRet = CORINFO_CLASS_HANDLE(typeHndUpdated.AsPtr());
 
-    return res;
+    RETURN res;
 }
 
 enum ConvToJitSigFlags : int
@@ -4963,6 +4963,7 @@ void CEEInfo::getCallInfo(
 
     JIT_TO_EE_TRANSITION();
 
+    _ASSERTE(CheckPointer(pResult));
 
     INDEBUG(memset(pResult, 0xCC, sizeof(*pResult)));
 
@@ -8416,6 +8417,7 @@ static void getEHinfoHelper(
 {
     STANDARD_VM_CONTRACT;
 
+    _ASSERTE(CheckPointer(pILHeader->EH));
     _ASSERTE(EHnumber < pILHeader->EH->EHCount());
 
     COR_ILMETHOD_SECT_EH_CLAUSE_FAT ehClause;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -313,13 +313,13 @@ void CEEInfo::GetTypeContext(CORINFO_CONTEXT_HANDLE context, SigTypeContext *pTy
 CorInfoType CEEInfo::asCorInfoType(CorElementType eeType,
                                    TypeHandle typeHnd, /* optional in */
                                    CORINFO_CLASS_HANDLE *clsRet/* optional out */ ) {
-    CONTRACT(CorInfoType) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         PRECONDITION((CorTypeInfo::IsGenericVariable(eeType)) ==
                      (!typeHnd.IsNull() && typeHnd.IsGenericVariable()));
         PRECONDITION(eeType != ELEMENT_TYPE_GENERICINST);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     TypeHandle typeHndUpdated = typeHnd;
 
@@ -405,7 +405,7 @@ CorInfoType CEEInfo::asCorInfoType(CorElementType eeType,
     if (clsRet)
         *clsRet = CORINFO_CLASS_HANDLE(typeHndUpdated.AsPtr());
 
-    RETURN res;
+    return res;
 }
 
 enum ConvToJitSigFlags : int
@@ -4963,7 +4963,6 @@ void CEEInfo::getCallInfo(
 
     JIT_TO_EE_TRANSITION();
 
-    _ASSERTE(CheckPointer(pResult));
 
     INDEBUG(memset(pResult, 0xCC, sizeof(*pResult)));
 
@@ -8417,7 +8416,6 @@ static void getEHinfoHelper(
 {
     STANDARD_VM_CONTRACT;
 
-    _ASSERTE(CheckPointer(pILHeader->EH));
     _ASSERTE(EHnumber < pILHeader->EH->EHCount());
 
     COR_ILMETHOD_SECT_EH_CLAUSE_FAT ehClause;

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1699,15 +1699,14 @@ void LoaderAllocator::UninitVirtualCallStubManager()
 
 EEMarshalingData *LoaderAllocator::GetMarshalingData()
 {
-    CONTRACT (EEMarshalingData*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(m_pMarshalingData));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!m_pMarshalingData)
     {
@@ -1720,7 +1719,7 @@ EEMarshalingData *LoaderAllocator::GetMarshalingData()
         }
     }
 
-    RETURN m_pMarshalingData;
+    return m_pMarshalingData;
 }
 
 void LoaderAllocator::DeleteMarshalingData()

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -359,7 +359,7 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -369,7 +369,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!InlinedCallFrame::FrameHasActiveCall(this))
     {
@@ -415,7 +415,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 #ifdef FEATURE_HIJACK
@@ -427,14 +427,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl(void)
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(T_CONTEXT));
 
@@ -478,7 +478,7 @@ void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFlo
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    ResumableFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 void HijackFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)

--- a/src/coreclr/vm/managedmdimport.cpp
+++ b/src/coreclr/vm/managedmdimport.cpp
@@ -472,19 +472,19 @@ public:
 
     INT32* AllocateUnmanagedArray(INT32 length)
     {
-        CONTRACT(INT32*)
+        CONTRACTL
         {
             THROWS;
             MODE_PREEMPTIVE;
             PRECONDITION(_alloc == NULL);
-            POSTCONDITION((length == _length));
-            POSTCONDITION((RETVAL != NULL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         _alloc = new INT32[length];
         _length = length;
-        RETURN _alloc;
+        _ASSERTE((length == _length));
+        _ASSERTE((_alloc != NULL));
+        return _alloc;
     }
 
     void AllocateManagedArray(QCall::ObjectHandleOnStack& longResult)
@@ -512,15 +512,14 @@ static void* EnsureResultSize(
     INT32* shortResult,
     ResultMemory& resultMemory)
 {
-    CONTRACT(void*)
+    CONTRACTL
     {
         THROWS;
         MODE_PREEMPTIVE;
         PRECONDITION(shortResultLen > 0);
         PRECONDITION(shortResult != NULL);
-        POSTCONDITION((RETVAL != NULL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     void* p;
     if (resultLength <= shortResultLen)
@@ -533,7 +532,8 @@ static void* EnsureResultSize(
         p = resultMemory.AllocateUnmanagedArray(resultLength);
     }
     ZeroMemory(p, (size_t)resultLength * sizeof(INT32));
-    RETURN p;
+    _ASSERTE((p != NULL));
+    return p;
 }
 
 extern "C" void QCALLTYPE MetadataImport_Enum(

--- a/src/coreclr/vm/managedmdimport.cpp
+++ b/src/coreclr/vm/managedmdimport.cpp
@@ -482,8 +482,6 @@ public:
 
         _alloc = new INT32[length];
         _length = length;
-        _ASSERTE((length == _length));
-        _ASSERTE((_alloc != NULL));
         return _alloc;
     }
 

--- a/src/coreclr/vm/memberload.cpp
+++ b/src/coreclr/vm/memberload.cpp
@@ -1081,12 +1081,12 @@ MemberLoader::FindMethod(
     FM_Flags flags,                       // = FM_Default
     const Substitution *pDefSubst)        // = NULL
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         MODE_ANY;
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     LOG((LF_LOADER, LL_INFO10000, "ML::FM pMT:%p for %s sig:%p sigLen:%u\n",
         pMT, pszName, pSignature, cSignature));
@@ -1142,7 +1142,7 @@ MemberLoader::FindMethod(
         {
             if (CompareMethodSigWithCorrectSubstitution(pSignature, cSignature, pModule, pCurDeclMD, pDefSubst, pMT))
             {
-                RETURN pCurDeclMD;
+                return pCurDeclMD;
             }
         }
     }
@@ -1150,7 +1150,7 @@ MemberLoader::FindMethod(
     // No inheritance on value types or interfaces
     if (pMT->IsValueType() || pMT->IsInterface())
     {
-        RETURN NULL;
+        return NULL;
     }
 
     // Recurse up the hierarchy if the method was not found.
@@ -1211,14 +1211,14 @@ MemberLoader::FindMethod(
             {
                 if (CompareMethodSigWithCorrectSubstitution(pSignature, cSignature, pModule, pCurDeclMD, pDefSubst, pMT))
                 {
-                    RETURN pCurDeclMD;
+                    return pCurDeclMD;
                 }
             }
         }
     }
 #endif // FEATURE_METADATA_UPDATER
 
-    RETURN md;
+    return md;
 }
 
 //*******************************************************************************

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -1686,15 +1686,13 @@ BOOL MethodDesc::IsRuntimeMethodHandle()
 // C2.m2 -> C2.m2
 MethodDesc* MethodDesc::LoadTypicalMethodDefinition()
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL->IsTypicalMethodDefinition());
     }
-    CONTRACT_END
+    CONTRACTL_END
 
 #ifndef DACCESS_COMPILE
     if (HasClassOrMethodInstantiation())
@@ -1714,12 +1712,14 @@ MethodDesc* MethodDesc::LoadTypicalMethodDefinition()
         MethodDesc *resultMD = pMT->GetParallelMethodDesc(this);
         _ASSERTE(resultMD != NULL);
         resultMD->CheckRestore();
-        RETURN (resultMD);
+        _ASSERTE(CheckPointer((resultMD)));
+        _ASSERTE((resultMD)->IsTypicalMethodDefinition());
+        return (resultMD);
     }
     else
 #endif // !DACCESS_COMPILE
     {
-        RETURN(this);
+        return(this);
     }
 }
 
@@ -1802,29 +1802,28 @@ UINT MethodDesc::CbStackPop()
 // @todo check uses and clean this up
 MethodDesc* MethodDesc::StripMethodInstantiation()
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         FORBID_FAULT;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     if (!HasClassOrMethodInstantiation())
-        RETURN(this);
+        return(this);
 
     MethodTable *pMT = GetMethodTable()->GetCanonicalMethodTable();
     MethodDesc *resultMD = pMT->GetParallelMethodDesc(this);
     _ASSERTE(resultMD->IsGenericMethodDefinition() || !resultMD->HasMethodInstantiation());
-    RETURN(resultMD);
+    return(resultMD);
 }
 
 //*******************************************************************************
 MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDescCount,
     DWORD classification, BOOL fNonVtableSlot, BOOL fNativeCodeSlot, BOOL fAsyncMethodData, MethodTable *pInitialMT, AllocMemTracker *pamTracker, Module *pLoaderModule)
 {
-    CONTRACT(MethodDescChunk *)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
@@ -1834,9 +1833,8 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
         PRECONDITION(CheckPointer(pInitialMT));
         PRECONDITION(CheckPointer(pamTracker));
 
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SIZE_T oneSize = MethodDesc::GetBaseSize(classification);
 
@@ -1906,7 +1904,7 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
     }
     while (methodDescCount > 0);
 
-    RETURN pFirstChunk;
+    return pFirstChunk;
 }
 
 //--------------------------------------------------------------------
@@ -1926,7 +1924,7 @@ MethodDescChunk *MethodDescChunk::CreateChunk(LoaderHeap *pHeap, DWORD methodDes
 // handling of context proxies and other thunking layers.
 MethodDesc* MethodDesc::ResolveGenericVirtualMethod(OBJECTREF *orThis)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -1934,10 +1932,8 @@ MethodDesc* MethodDesc::ResolveGenericVirtualMethod(OBJECTREF *orThis)
         PRECONDITION(IsVtableMethod());
         PRECONDITION(HasMethodInstantiation());
         PRECONDITION(!ContainsGenericVariables());
-        POSTCONDITION(CheckPointer(RETVAL));
-        POSTCONDITION(RETVAL->HasMethodInstantiation());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Method table of target (might be instantiated)
     MethodTable *pObjMT = (*orThis)->GetMethodTable();
@@ -1968,7 +1964,7 @@ MethodDesc* MethodDesc::ResolveGenericVirtualMethod(OBJECTREF *orThis)
     // same as the static, i.e. the virtual method has not been overridden.
     if (!pTargetMT->IsSharedByGenericInstantiations() && !pTargetMT->IsValueType() &&
         pTargetMDBeforeGenericMethodArgs == pStaticMDWithoutGenericMethodArgs)
-        RETURN(pStaticMD);
+        return(pStaticMD);
 
     if (pTargetMT->IsSharedByGenericInstantiations())
     {
@@ -1977,7 +1973,7 @@ MethodDesc* MethodDesc::ResolveGenericVirtualMethod(OBJECTREF *orThis)
                                                                   pTargetMDBeforeGenericMethodArgs->GetExactClassInstantiation(TypeHandle(pObjMT))).GetMethodTable();
     }
 
-    RETURN(MethodDesc::FindOrCreateAssociatedMethodDesc(
+    return(MethodDesc::FindOrCreateAssociatedMethodDesc(
         pTargetMDBeforeGenericMethodArgs,
         pTargetMT,
         (pTargetMT->IsValueType()), /* get unboxing entry point if a struct*/
@@ -2051,16 +2047,15 @@ PCODE MethodDesc::GetSingleCallableAddrOfVirtualizedCode(OBJECTREF *orThis, Type
 
 MethodDesc* MethodDesc::GetMethodDescOfVirtualizedCode(OBJECTREF *orThis, TypeHandle staticTH)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
 
         PRECONDITION(IsVtableMethod());
         PRECONDITION(!staticTH.IsNull() || !IsInterface()); // If this is a non-interface method, staticTH may be null
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     // Method table of target (might be instantiated)
     MethodTable *pObjMT = (*orThis)->GetMethodTable();
 
@@ -2071,15 +2066,15 @@ MethodDesc* MethodDesc::GetMethodDescOfVirtualizedCode(OBJECTREF *orThis, TypeHa
     if (pStaticMD->HasMethodInstantiation())
     {
         CheckRestore();
-        RETURN(ResolveGenericVirtualMethod(orThis));
+        return(ResolveGenericVirtualMethod(orThis));
     }
 
     if (pStaticMD->IsInterface())
     {
-        RETURN(MethodTable::GetMethodDescForInterfaceMethodAndServer(staticTH, pStaticMD, orThis));
+        return(MethodTable::GetMethodDescForInterfaceMethodAndServer(staticTH, pStaticMD, orThis));
     }
 
-    RETURN(pObjMT->GetMethodDescForSlot(pStaticMD->GetSlot()));
+    return(pObjMT->GetMethodDescForSlot(pStaticMD->GetSlot()));
 }
 
 //*******************************************************************************
@@ -2088,16 +2083,15 @@ MethodDesc* MethodDesc::GetMethodDescOfVirtualizedCode(OBJECTREF *orThis, TypeHa
 // handling of context proxies and other thunking layers.
 PCODE MethodDesc::GetMultiCallableAddrOfVirtualizedCode(OBJECTREF *orThis, TypeHandle staticTH)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodDesc *pTargetMD = GetMethodDescOfVirtualizedCode(orThis, staticTH);
-    RETURN(pTargetMD->GetMultiCallableAddrOfCode());
+    return(pTargetMD->GetMultiCallableAddrOfCode());
 }
 
 //*******************************************************************************
@@ -2734,12 +2728,12 @@ void MethodDesc::CheckRestore(ClassLoadLevel level)
 // static
 MethodDesc* MethodDesc::GetMethodDescFromPrecode(PCODE addr, BOOL fSpeculative /*=FALSE*/)
 {
-    CONTRACT(MethodDesc *)
+    CONTRACTL
     {
         GC_NOTRIGGER;
         NOTHROW;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodDesc* pMD = NULL;
 
@@ -2754,7 +2748,7 @@ MethodDesc* MethodDesc::GetMethodDescFromPrecode(PCODE addr, BOOL fSpeculative /
 
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 
-    RETURN(pMD);
+    return(pMD);
 }
 
 //*******************************************************************************
@@ -3989,15 +3983,14 @@ MethodDescChunk::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 //*******************************************************************************
 MethodDesc *MethodDesc::GetInterfaceMD()
 {
-    CONTRACT (MethodDesc*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INSTANCE_CHECK;
         PRECONDITION(!IsInterface());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
-    } CONTRACT_END;
+    } CONTRACTL_END;
     MethodTable *pMT = GetMethodTable();
-    RETURN(pMT->ReverseInterfaceMDLookup(GetSlot()));
+    return(pMT->ReverseInterfaceMDLookup(GetSlot()));
 }
 #endif // !DACCESS_COMPILE
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -5310,13 +5310,11 @@ BOOL MethodTable::FindDispatchEntry(UINT32 typeID,
         if (pCurMT->FindDispatchEntryForCurrentType(
                 typeID, slotNumber, pEntry))
         {
-            _ASSERTE(!(TRUE) || pEntry->IsValid());
             return (TRUE);
         }
         pCurMT = pCurMT->GetParentMethodTable();
         iCurInheritanceChainDelta++;
     }
-    _ASSERTE(!(FALSE) || pEntry->IsValid());
     return (FALSE);
 }
 
@@ -5519,7 +5517,6 @@ MethodTable::FindDispatchImpl(
     *pImplSlot = GetRestoredSlot(slotNumber);
 
     // Successfully determined the target for the given target
-    _ASSERTE(!(TRUE) || !pImplSlot->IsNull() || IsComObjectType());
     return (TRUE);
 }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -5310,11 +5310,13 @@ BOOL MethodTable::FindDispatchEntry(UINT32 typeID,
         if (pCurMT->FindDispatchEntryForCurrentType(
                 typeID, slotNumber, pEntry))
         {
+            _ASSERTE(!(TRUE) || pEntry->IsValid());
             return (TRUE);
         }
         pCurMT = pCurMT->GetParentMethodTable();
         iCurInheritanceChainDelta++;
     }
+    _ASSERTE(!(FALSE) || pEntry->IsValid());
     return (FALSE);
 }
 
@@ -5517,6 +5519,7 @@ MethodTable::FindDispatchImpl(
     *pImplSlot = GetRestoredSlot(slotNumber);
 
     // Successfully determined the target for the given target
+    _ASSERTE(!(TRUE) || !pImplSlot->IsNull() || IsComObjectType());
     return (TRUE);
 }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -5310,13 +5310,12 @@ BOOL MethodTable::FindDispatchEntry(UINT32 typeID,
         if (pCurMT->FindDispatchEntryForCurrentType(
                 typeID, slotNumber, pEntry))
         {
-            _ASSERTE(!(TRUE) || pEntry->IsValid());
+            _ASSERTE(pEntry->IsValid());
             return (TRUE);
         }
         pCurMT = pCurMT->GetParentMethodTable();
         iCurInheritanceChainDelta++;
     }
-    _ASSERTE(!(FALSE) || pEntry->IsValid());
     return (FALSE);
 }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -471,7 +471,7 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
 /* static */ MethodDesc *MethodTable::GetMethodDescForInterfaceMethodAndServer(
                             TypeHandle ownerType, MethodDesc *pItfMD, OBJECTREF *pServer)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -480,9 +480,8 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
         PRECONDITION(pItfMD->IsInterface());
         PRECONDITION(!ownerType.IsNull());
         PRECONDITION(ownerType.GetMethodTable()->HasSameTypeDefAs(pItfMD->GetMethodTable()));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     VALIDATEOBJECTREF(*pServer);
 
 #ifdef _DEBUG
@@ -505,7 +504,7 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
             FALSE,              // allowInstParam
             TRUE);              // forceRemotableMethod
 
-        RETURN(pServerMT->GetMethodDescForComInterfaceMethod(pItfMD));
+        return(pServerMT->GetMethodDescForComInterfaceMethod(pItfMD));
     }
 #endif // !FEATURE_COMINTEROP
 
@@ -526,11 +525,11 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
         implTypeHandle = implTypeObj->GetType();
         GCPROTECT_END();
 
-        RETURN(implTypeHandle.GetMethodTable()->GetMethodDescForInterfaceMethod(ownerType, pItfMD, TRUE /* throwOnConflict */));
+        return(implTypeHandle.GetMethodTable()->GetMethodDescForInterfaceMethod(ownerType, pItfMD, TRUE /* throwOnConflict */));
     }
 
     // Handle pure CLR types.
-    RETURN (pServerMT->GetMethodDescForInterfaceMethod(ownerType, pItfMD, TRUE /* throwOnConflict */));
+    return (pServerMT->GetMethodDescForInterfaceMethod(ownerType, pItfMD, TRUE /* throwOnConflict */));
 }
 
 #ifdef FEATURE_COMINTEROP
@@ -538,7 +537,7 @@ PTR_MethodTable InterfaceInfo_t::GetApproxMethodTable(Module * pContainingModule
 // get the method desc given the interface method desc on a COM implemented server
 MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD)
 {
-    CONTRACT(MethodDesc*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -546,9 +545,8 @@ MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD)
         PRECONDITION(CheckPointer(pItfMD));
         PRECONDITION(pItfMD->IsInterface());
         PRECONDITION(IsComObjectType());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable * pItfMT =  pItfMD->GetMethodTable();
     _ASSERTE(pItfMT != NULL);
@@ -556,7 +554,7 @@ MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD)
         // We now handle __ComObject class that doesn't have Dynamic Interface Map
     if (!HasDynamicInterfaceMap())
     {
-        RETURN(pItfMD);
+        return(pItfMD);
     }
     else
     {
@@ -571,7 +569,7 @@ MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD)
 
         if (tgt != NULL)
         {
-            RETURN(NonVirtualEntry2MethodDesc(tgt));
+            return(NonVirtualEntry2MethodDesc(tgt));
         }
 
         // The interface is not in the static class definition so we need to look at the
@@ -581,7 +579,7 @@ MethodDesc *MethodTable::GetMethodDescForComInterfaceMethod(MethodDesc *pItfMD)
         // This interface was added to the class dynamically so it is implemented
         // by the COM object. We treat this dynamically added interface the same
         // way we treat COM objects. That is by using the interface vtable.
-        RETURN(pItfMD);
+        return(pItfMD);
     }
 }
 #endif // FEATURE_COMINTEROP
@@ -4079,16 +4077,15 @@ OBJECTREF MethodTable::FastBox(void** data)
 //==========================================================================
 OBJECTREF MethodTable::GetManagedClassObject()
 {
-    CONTRACT(OBJECTREF) {
+    CONTRACTL {
 
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(GetAuxiliaryData()->m_hExposedClassObject != 0);
         //REENTRANT
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef _DEBUG
     // Force a GC here because GetManagedClassObject could trigger GC nondeterministicaly
@@ -4101,7 +4098,7 @@ OBJECTREF MethodTable::GetManagedClassObject()
         CheckRestore();
         TypeHandle(this).AllocateManagedClassObject(&GetAuxiliaryDataForWrite()->m_hExposedClassObject);
     }
-    RETURN(GetManagedClassObjectIfExists());
+    return(GetManagedClassObjectIfExists());
 }
 
 #endif //!DACCESS_COMPILE
@@ -5297,14 +5294,13 @@ BOOL MethodTable::FindDispatchEntry(UINT32 typeID,
                                     UINT32 slotNumber,
                                     DispatchMapEntry *pEntry)
 {
-    CONTRACT (BOOL) {
+    CONTRACTL {
         INSTANCE_CHECK;
         MODE_ANY;
         THROWS;
         GC_TRIGGERS;
-        POSTCONDITION(!RETVAL || pEntry->IsValid());
         PRECONDITION(typeID != TYPE_ID_THIS_CLASS);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     // Start at the current type and work up the inheritance chain
     MethodTable *pCurMT = this;
@@ -5314,12 +5310,14 @@ BOOL MethodTable::FindDispatchEntry(UINT32 typeID,
         if (pCurMT->FindDispatchEntryForCurrentType(
                 typeID, slotNumber, pEntry))
         {
-            RETURN (TRUE);
+            _ASSERTE(!(TRUE) || pEntry->IsValid());
+            return (TRUE);
         }
         pCurMT = pCurMT->GetParentMethodTable();
         iCurInheritanceChainDelta++;
     }
-    RETURN (FALSE);
+    _ASSERTE(!(FALSE) || pEntry->IsValid());
+    return (FALSE);
 }
 
 #ifndef DACCESS_COMPILE
@@ -5374,12 +5372,11 @@ MethodTable::FindDispatchImpl(
     DispatchSlot * pImplSlot,
     BOOL           throwOnConflict)
 {
-    CONTRACT (BOOL) {
+    CONTRACTL {
         INSTANCE_CHECK;
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pImplSlot));
-        POSTCONDITION(!RETVAL || !pImplSlot->IsNull() || IsComObjectType());
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     LOG((LF_LOADER, LL_INFO10000, "SD: MT::FindDispatchImpl: searching %s.\n", GetClass()->GetDebugClassName()));
 
@@ -5422,7 +5419,7 @@ MethodTable::FindDispatchImpl(
                 if (!(pIfcMT->HasInstantiation()))
                 {
                     _ASSERTE(!"Should not have gotten here. If you did, it's probably because multiple interface instantiation hasn't been checked in yet. This code only works on top of that.");
-                    RETURN(FALSE);
+                    return(FALSE);
                 }
 
                 // Get the type of T (as in IList<T>)
@@ -5441,7 +5438,7 @@ MethodTable::FindDispatchImpl(
                    *pImplSlot = ds;
                 }
 
-                RETURN(TRUE);
+                return(TRUE);
 
             }
             else
@@ -5498,13 +5495,13 @@ MethodTable::FindDispatchImpl(
                             *pImplSlot = ds;
                         }
 
-                        RETURN(TRUE);
+                        return(TRUE);
                     }
                 }
             }
 
             // This contract is not implemented by this class or any parent class.
-            RETURN(FALSE);
+            return(FALSE);
         }
 
 
@@ -5522,7 +5519,8 @@ MethodTable::FindDispatchImpl(
     *pImplSlot = GetRestoredSlot(slotNumber);
 
     // Successfully determined the target for the given target
-    RETURN (TRUE);
+    _ASSERTE(!(TRUE) || !pImplSlot->IsNull() || IsComObjectType());
+    return (TRUE);
 }
 
 #ifndef DACCESS_COMPILE
@@ -5737,15 +5735,14 @@ BOOL MethodTable::FindDefaultInterfaceImplementation(
     ClassLoadLevel level
 )
 {
-    CONTRACT(BOOL) {
+    CONTRACTL {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         PRECONDITION(CheckPointer(pInterfaceMD));
         PRECONDITION(CheckPointer(pInterfaceMT));
         PRECONDITION(CheckPointer(ppDefaultMethod));
-        POSTCONDITION(!RETVAL || (*ppDefaultMethod) != nullptr);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
 #ifdef FEATURE_DEFAULT_INTERFACES
     struct MatchCandidate
@@ -5904,20 +5901,20 @@ BOOL MethodTable::FindDefaultInterfaceImplementation(
                 ThrowAmbiguousResolutionException(this, pInterfaceMT, pInterfaceMD);
 
             *ppDefaultMethod = pBestCandidateMD;
-            RETURN(FALSE);
+            return(FALSE);
         }
     }
 
     if (pBestCandidateMD != NULL)
     {
         *ppDefaultMethod = pBestCandidateMD;
-        RETURN(TRUE);
+        return(TRUE);
     }
 #else
     *ppDefaultMethod = NULL;
 #endif // FEATURE_DEFAULT_INTERFACES
 
-    RETURN(FALSE);
+    return(FALSE);
 }
 #endif // DACCESS_COMPILE
 
@@ -6830,7 +6827,6 @@ MethodDesc * MethodTable::MethodDataObject::GetDeclMethodDesc(UINT32 slotNumber)
     if (pMDRet == NULL)
     {
         pMDRet = GetImplMethodDesc(slotNumber)->GetDeclMethodDesc(slotNumber);
-        _ASSERTE(CheckPointer(pMDRet));
         pEntry->SetDeclMethodDesc(pMDRet);
     }
     else
@@ -6880,7 +6876,6 @@ MethodDesc *MethodTable::MethodDataObject::GetImplMethodDesc(UINT32 slotNumber)
     {
         _ASSERTE(slotNumber < GetNumVirtuals());
         pMDRet = m_pDeclMT->GetMethodDescForSlot_NoThrow(slotNumber);
-        _ASSERTE(CheckPointer(pMDRet));
         pEntry->SetImplMethodDesc(pMDRet);
     }
     else
@@ -8812,15 +8807,14 @@ EEClassNativeLayoutInfo const* MethodTable::EnsureNativeLayoutInfoInitialized()
 #ifndef DACCESS_COMPILE
 PTR_MethodTable MethodTable::InterfaceMapIterator::GetInterface(MethodTable* pMTOwner, ClassLoadLevel loadLevel /*= CLASS_LOADED*/)
 {
-    CONTRACT(PTR_MethodTable)
+    CONTRACTL
     {
         GC_TRIGGERS;
         THROWS;
         PRECONDITION(m_i != (DWORD) -1 && m_i < m_count);
         PRECONDITION(CheckPointer(pMTOwner));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable *pResult = m_pMap->GetMethodTable();
     if (pResult->IsSpecialMarkerTypeForGenericCasting() && !pMTOwner->GetAuxiliaryData()->MayHaveOpenInterfacesInInterfaceMap())
@@ -8835,7 +8829,8 @@ PTR_MethodTable MethodTable::InterfaceMapIterator::GetInterface(MethodTable* pMT
         if (pResult->IsFullyLoaded())
             SetInterface(pResult);
     }
-    RETURN (pResult);
+    _ASSERTE(CheckPointer((pResult)));
+    return (pResult);
 }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2302,29 +2302,28 @@ public:
         // Get the interface at the current position, with whatever its normal load level is
         inline PTR_MethodTable GetInterfaceApprox()
         {
-            CONTRACT(PTR_MethodTable)
+            CONTRACTL
             {
                 GC_NOTRIGGER;
                 NOTHROW;
                 SUPPORTS_DAC;
                 PRECONDITION(m_i != (DWORD) -1 && m_i < m_count);
-                POSTCONDITION(CheckPointer(RETVAL));
             }
-            CONTRACT_END;
+            CONTRACTL_END;
 
-            RETURN (m_pMap->GetMethodTable());
+            return (m_pMap->GetMethodTable());
         }
 
         inline bool CurrentInterfaceMatches(MethodTable* pMTOwner, MethodTable* pMT)
         {
-            CONTRACT(bool)
+            CONTRACTL
             {
                 GC_NOTRIGGER;
                 NOTHROW;
                 SUPPORTS_DAC;
                 PRECONDITION(m_i != (DWORD) -1 && m_i < m_count);
             }
-            CONTRACT_END;
+            CONTRACTL_END;
 
             MethodTable *pCurrentMethodTable = m_pMap->GetMethodTable();
 
@@ -2348,23 +2347,23 @@ public:
                 }
             }
 
-            RETURN (exactMatch);
+            return (exactMatch);
         }
 
         bool CurrentInterfaceEquivalentTo(MethodTable* pMTOwner, MethodTable* pMT);
 
         inline bool HasSameTypeDefAs(MethodTable* pMT)
         {
-            CONTRACT(bool)
+            CONTRACTL
             {
                 GC_NOTRIGGER;
                 NOTHROW;
                 SUPPORTS_DAC;
                 PRECONDITION(m_i != (DWORD) -1 && m_i < m_count);
             }
-            CONTRACT_END;
+            CONTRACTL_END;
 
-            RETURN (m_pMap->GetMethodTable()->HasSameTypeDefAs(pMT));
+            return (m_pMap->GetMethodTable()->HasSameTypeDefAs(pMT));
         }
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/methodtable.inl
+++ b/src/coreclr/vm/methodtable.inl
@@ -482,7 +482,6 @@ inline void MethodTable::CopySlotFrom(UINT32 slotNumber, MethodDataWrapper &hSou
     WRAPPER_NO_CONTRACT;
 
     MethodDesc *pMD = hSourceMTData->GetImplMethodDesc(slotNumber);
-    _ASSERTE(CheckPointer(pMD));
     _ASSERTE(pMD == pSourceMT->GetMethodDescForSlot_NoThrow(slotNumber));
     SetSlot(slotNumber, pMD->GetInitialEntryPointForCopiedSlot(NULL, NULL));
 }

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -10836,14 +10836,13 @@ MethodTable * MethodTableBuilder::AllocateNewMT(
         , AllocMemTracker *pamTracker
     )
 {
-    CONTRACT (MethodTable*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     DWORD dwNonVirtualSlots = dwVtableSlots - dwVirtuals;
 
@@ -11062,7 +11061,7 @@ MethodTable * MethodTableBuilder::AllocateNewMT(
     pMT->m_pAuxiliaryData->m_dwLastVerifedGCCnt = (DWORD)-1;
 #endif // _DEBUG
 
-    RETURN(pMT);
+    return(pMT);
 }
 
 
@@ -12826,15 +12825,13 @@ ClassLoader::CreateTypeHandleForTypeDefThrowing(
     Instantiation     inst,
     AllocMemTracker * pamTracker)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(GetThreadNULLOk() != NULL);
         PRECONDITION(CheckPointer(pModule));
-        POSTCONDITION(!RETVAL.IsNull());
-        POSTCONDITION(CheckPointer(RETVAL.GetMethodTable()));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     MethodTable * pMT = NULL;
 
@@ -13112,5 +13109,5 @@ ClassLoader::CreateTypeHandleForTypeDefThrowing(
         parentInst,
         (WORD)cInterfaces);
 
-    RETURN(TypeHandle(pMT));
+    return(TypeHandle(pMT));
 } // ClassLoader::CreateTypeHandleForTypeDefThrowing

--- a/src/coreclr/vm/mlinfo.cpp
+++ b/src/coreclr/vm/mlinfo.cpp
@@ -37,13 +37,12 @@ namespace
     //==========================================================================
     CustomMarshalerInfo *SetupCustomMarshalerInfo(LPCUTF8 strMarshalerTypeName, DWORD cMarshalerTypeNameBytes, LPCUTF8 strCookie, DWORD cCookieStrBytes, Assembly *pAssembly, TypeHandle hndManagedType)
     {
-        CONTRACT (CustomMarshalerInfo*)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
             PRECONDITION(CheckPointer(pAssembly));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         EEMarshalingData *pMarshalingData = NULL;
 
@@ -51,19 +50,18 @@ namespace
         pMarshalingData = pAssembly->GetLoaderAllocator()->GetMarshalingData();
 
         // Retrieve the custom marshaler helper from the EE marshaling data.
-        RETURN pMarshalingData->GetCustomMarshalerInfo(pAssembly, hndManagedType, strMarshalerTypeName, cMarshalerTypeNameBytes, strCookie, cCookieStrBytes);
+        return pMarshalingData->GetCustomMarshalerInfo(pAssembly, hndManagedType, strMarshalerTypeName, cMarshalerTypeNameBytes, strCookie, cCookieStrBytes);
     }
 
 #ifdef FEATURE_COMINTEROP
     CustomMarshalerInfo *GetIEnumeratorCustomMarshalerInfo(Assembly *pAssembly)
     {
-        CONTRACT (CustomMarshalerInfo*)
+        CONTRACTL
         {
             STANDARD_VM_CHECK;
             PRECONDITION(CheckPointer(pAssembly));
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         EEMarshalingData *pMarshalingData = NULL;
 
@@ -71,7 +69,7 @@ namespace
         pMarshalingData = pAssembly->GetLoaderAllocator()->GetMarshalingData();
 
         // Retrieve the custom marshaler helper from the EE marshaling data.
-        RETURN pMarshalingData->GetIEnumeratorMarshalerInfo();
+        return pMarshalingData->GetIEnumeratorMarshalerInfo();
     }
 #endif // FEATURE_COMINTEROP
 
@@ -442,20 +440,19 @@ EEMarshalingData::~EEMarshalingData()
 
 void *EEMarshalingData::operator new(size_t size, LoaderHeap *pHeap)
 {
-    CONTRACT (void*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pHeap));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     void* mem = pHeap->AllocMem(S_SIZE_T(sizeof(EEMarshalingData)));
 
-    RETURN mem;
+    return mem;
 }
 
 
@@ -468,14 +465,13 @@ void EEMarshalingData::operator delete(void *pMem)
 
 CustomMarshalerInfo *EEMarshalingData::GetCustomMarshalerInfo(Assembly *pAssembly, TypeHandle hndManagedType, LPCUTF8 strMarshalerTypeName, DWORD cMarshalerTypeNameBytes, LPCUTF8 strCookie, DWORD cCookieStrBytes)
 {
-    CONTRACT (CustomMarshalerInfo*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(CheckPointer(pAssembly));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CustomMarshalerInfo *pCMInfo = NULL;
     NewHolder<CustomMarshalerInfo> pNewCMInfo(NULL);
@@ -487,7 +483,9 @@ CustomMarshalerInfo *EEMarshalingData::GetCustomMarshalerInfo(Assembly *pAssembl
 
     // Lookup the custom marshaler helper in the hashtable.
     if (m_CMInfoHashTable.GetValue(&Key, (HashDatum*)&pCMInfo))
-        RETURN pCMInfo;
+        {
+            return pCMInfo;
+        }
 
     {
         GCX_COOP();
@@ -517,7 +515,7 @@ CustomMarshalerInfo *EEMarshalingData::GetCustomMarshalerInfo(Assembly *pAssembl
         // Verify that the custom marshaler helper has not already been added by another thread.
         if (m_CMInfoHashTable.GetValue(&Key, (HashDatum*)&pCMInfo))
         {
-            RETURN pCMInfo;
+            return pCMInfo;
         }
 
         // Add the custom marshaler helper to the hash table.
@@ -529,19 +527,18 @@ CustomMarshalerInfo *EEMarshalingData::GetCustomMarshalerInfo(Assembly *pAssembl
         // Release the lock and return the custom marshaler info.
     }
 
-    RETURN pNewCMInfo;
+    return pNewCMInfo;
 }
 
 #ifdef FEATURE_COMINTEROP
 CustomMarshalerInfo *EEMarshalingData::GetIEnumeratorMarshalerInfo()
 {
-    CONTRACT (CustomMarshalerInfo*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pIEnumeratorMarshalerInfo == NULL)
     {
@@ -556,7 +553,7 @@ CustomMarshalerInfo *EEMarshalingData::GetIEnumeratorMarshalerInfo()
         }
     }
 
-    RETURN m_pIEnumeratorMarshalerInfo;
+    return m_pIEnumeratorMarshalerInfo;
 }
 #endif // FEATURE_COMINTEROP
 
@@ -3067,15 +3064,14 @@ VOID MarshalInfo::DumpMarshalInfo(Module* pModule, SigPointer sig, const SigType
 #if defined(FEATURE_COMINTEROP)
 DispParamMarshaler *MarshalInfo::GenerateDispParamMarshaler()
 {
-    CONTRACT (DispParamMarshaler*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM());
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     NewHolder<DispParamMarshaler> pDispParamMarshaler = NULL;
 
@@ -3130,7 +3126,7 @@ DispParamMarshaler *MarshalInfo::GenerateDispParamMarshaler()
     }
 
     pDispParamMarshaler.SuppressRelease();
-    RETURN pDispParamMarshaler;
+    return pDispParamMarshaler;
 }
 
 DispatchWrapperType MarshalInfo::GetDispWrapperType()
@@ -3279,14 +3275,13 @@ void ArrayMarshalInfo::InitForSafeArray(MarshalInfo::MarshalScenario ms, TypeHan
 
 void ArrayMarshalInfo::InitElementInfo(CorNativeType arrayNativeType, MarshalInfo::MarshalScenario ms, TypeHandle thElement, CorNativeType ntElement, BOOL isAnsi)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         INJECT_FAULT(COMPlusThrowOM());
         PRECONDITION(!thElement.IsNull());
-        POSTCONDITION(!IsValid() || !m_thElement.IsNull());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CorElementType etElement = ELEMENT_TYPE_END;
 
@@ -3564,7 +3559,8 @@ void ArrayMarshalInfo::InitElementInfo(CorNativeType arrayNativeType, MarshalInf
 
 LExit:;
 
-    RETURN;
+    _ASSERTE(!IsValid() || !m_thElement.IsNull());
+    return;
 }
 
 bool IsUnsupportedTypedrefReturn(MetaSig& msig)

--- a/src/coreclr/vm/nativeimage.cpp
+++ b/src/coreclr/vm/nativeimage.cpp
@@ -48,7 +48,6 @@ NativeImage::NativeImage(AssemblyBinder *pAssemblyBinder, ReadyToRunLoadedImage 
     CONTRACTL
     {
         THROWS;
-        CONSTRUCTOR_CHECK;
         STANDARD_VM_CHECK;
         INJECT_FAULT(COMPlusThrowOM(););
     }

--- a/src/coreclr/vm/nativelibrary.cpp
+++ b/src/coreclr/vm/nativelibrary.cpp
@@ -785,13 +785,12 @@ namespace
 
 NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryFromMethodDesc(PInvokeMethodDesc * pMD)
 {
-    CONTRACT(NATIVE_LIBRARY_HANDLE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pMD));
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LoadLibErrorTracker errorTracker;
     NATIVE_LIBRARY_HANDLE hmod = LoadNativeLibrary(pMD, &errorTracker);
@@ -804,5 +803,6 @@ NATIVE_LIBRARY_HANDLE NativeLibrary::LoadLibraryFromMethodDesc(PInvokeMethodDesc
         errorTracker.Throw(ssLibName);
     }
 
-    RETURN hmod;
+    _ASSERTE(hmod != NULL);
+    return hmod;
 }

--- a/src/coreclr/vm/olecontexthelpers.cpp
+++ b/src/coreclr/vm/olecontexthelpers.cpp
@@ -88,7 +88,6 @@ LPVOID GetCurrentCtxCookie()
     if (CoGetContextToken(&ctxptr) != S_OK)
         ctxptr = 0;
 
-    _ASSERTE(CheckPointer((LPVOID)ctxptr, NULL_OK));
     return (LPVOID)ctxptr;
 }
 

--- a/src/coreclr/vm/olecontexthelpers.cpp
+++ b/src/coreclr/vm/olecontexthelpers.cpp
@@ -30,14 +30,13 @@ HRESULT GetCurrentObjCtx(IUnknown **ppObjCtx)
 // LPVOID SetupOleContext()
 LPVOID SetupOleContext()
 {
-    CONTRACT (LPVOID)
+    CONTRACTL
     {
         NOTHROW;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IUnknown* pObjCtx = NULL;
 
@@ -63,26 +62,25 @@ LPVOID SetupOleContext()
     }
 #endif // FEATURE_COMINTEROP
 
-    RETURN pObjCtx;
+    return pObjCtx;
 }
 
 //================================================================
 // LPVOID GetCurrentCtxCookie()
 LPVOID GetCurrentCtxCookie()
 {
-    CONTRACT (LPVOID)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #ifdef FEATURE_COMINTEROP
     // check if com is started
     if (!g_fComStarted)
-        RETURN NULL;
+        return NULL;
 #endif // FEATURE_COMINTEROP
 
     ULONG_PTR ctxptr = 0;
@@ -90,7 +88,8 @@ LPVOID GetCurrentCtxCookie()
     if (CoGetContextToken(&ctxptr) != S_OK)
         ctxptr = 0;
 
-    RETURN (LPVOID)ctxptr;
+    _ASSERTE(CheckPointer((LPVOID)ctxptr, NULL_OK));
+    return (LPVOID)ctxptr;
 }
 
 //+-------------------------------------------------------------------------

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -4143,8 +4143,6 @@ BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(pStringObj));
-
-        // A null BSTR should only be returned if the input string is null.
     }
     CONTRACTL_END;
 
@@ -4154,7 +4152,11 @@ BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
     }
 
     UnmanagedCallersOnlyCaller convertToNative(METHOD__BSTRMARSHALER__CONVERT_TO_NATIVE_UCO);
-    return (BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
+    BSTR result = convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
+
+    // A null BSTR should only be returned if the input string is null.
+    _ASSERTE(result != NULL);
+    return result;
 }
 
 extern "C" void QCALLTYPE Variant_ConvertValueTypeToRecord(QCall::ObjectHandleOnStack obj, VARIANT * pOle)

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -4152,7 +4152,7 @@ BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
     }
 
     UnmanagedCallersOnlyCaller convertToNative(METHOD__BSTRMARSHALER__CONVERT_TO_NATIVE_UCO);
-    BSTR result = convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
+    BSTR result = (BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
 
     // A null BSTR should only be returned if the input string is null.
     _ASSERTE(result != NULL);

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -717,17 +717,16 @@ MethodTable* OleVariant::GetNativeMethodTableForVarType(VARTYPE vt, MethodTable*
 
 const OleVariant::Marshaler *OleVariant::GetMarshalerForVarType(VARTYPE vt, BOOL fThrow)
 {
-    CONTRACT (const OleVariant::Marshaler*)
+    CONTRACTL
     {
         if (fThrow) THROWS; else NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
 #define RETURN_MARSHALER(ArrayOleToCom, ArrayComToOle, ClearArray) \
-    { static const Marshaler marshaler = { ArrayOleToCom, ArrayComToOle, ClearArray }; RETURN &marshaler; }
+    { static const Marshaler marshaler = { ArrayOleToCom, ArrayComToOle, ClearArray }; return &marshaler; }
 
 #ifdef FEATURE_COMINTEROP
     if (vt & VT_ARRAY)
@@ -806,7 +805,7 @@ VariantArray:
         );
 
     case VTHACK_BLITTABLERECORD:
-        RETURN NULL; // Requires no marshaling
+        return NULL; // Requires no marshaling
 
     case VTHACK_WINBOOL:
         RETURN_MARSHALER(
@@ -866,11 +865,11 @@ VariantArray:
         }
         else
         {
-            RETURN NULL;
+            return NULL;
         }
 
     default:
-        RETURN NULL;
+        return NULL;
     }
 } // OleVariant::Marshaler *OleVariant::GetMarshalerForVarType()
 
@@ -2285,7 +2284,7 @@ Exit:
 
 void OleVariant::MarshalObjectForOleVariant(const VARIANT * pOle, OBJECTREF * const & pObj)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2295,7 +2294,7 @@ void OleVariant::MarshalObjectForOleVariant(const VARIANT * pOle, OBJECTREF * co
         PRECONDITION(CheckPointer(pObj));
         PRECONDITION(*pObj == NULL || (IsProtectedByGCFrame (pObj)));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // if V_ISBYREF(pOle) and V_BYREF(pOle) is null then we have a problem,
     // unless we're dealing with VT_EMPTY or VT_NULL in which case that is ok??
@@ -2457,7 +2456,7 @@ void OleVariant::MarshalObjectForOleVariant(const VARIANT * pOle, OBJECTREF * co
         default:
             MarshalObjectForOleVariantUncommon(pOle, pObj);
         }
-        RETURN;
+        return;
     }
 
 /* ------------------------------------------------------------------------- *
@@ -2466,7 +2465,7 @@ void OleVariant::MarshalObjectForOleVariant(const VARIANT * pOle, OBJECTREF * co
 
 void OleVariant::ExtractContentsFromByrefVariant(VARIANT *pByrefVar, VARIANT *pDestVar)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2474,7 +2473,7 @@ void OleVariant::ExtractContentsFromByrefVariant(VARIANT *pByrefVar, VARIANT *pD
         PRECONDITION(CheckPointer(pByrefVar));
         PRECONDITION(CheckPointer(pDestVar));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     VARTYPE vt = V_VT(pByrefVar) & ~VT_BYREF;
 
@@ -2536,12 +2535,12 @@ void OleVariant::ExtractContentsFromByrefVariant(VARIANT *pByrefVar, VARIANT *pD
         }
     }
 
-    RETURN;
+    return;
 }
 
 void OleVariant::InsertContentsIntoByRefVariant(VARIANT *pSrcVar, VARIANT *pByrefVar)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2549,7 +2548,7 @@ void OleVariant::InsertContentsIntoByRefVariant(VARIANT *pSrcVar, VARIANT *pByre
         PRECONDITION(CheckPointer(pByrefVar));
         PRECONDITION(CheckPointer(pSrcVar));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(V_VT(pSrcVar) == (V_VT(pByrefVar) & ~VT_BYREF) || V_VT(pByrefVar) == (VT_BYREF | VT_VARIANT));
 
@@ -2594,12 +2593,12 @@ void OleVariant::InsertContentsIntoByRefVariant(VARIANT *pSrcVar, VARIANT *pByre
             break;
         }
     }
-    RETURN;
+    return;
 }
 
 void OleVariant::CreateByrefVariantForVariant(VARIANT *pSrcVar, VARIANT *pByrefVar)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2607,7 +2606,7 @@ void OleVariant::CreateByrefVariantForVariant(VARIANT *pSrcVar, VARIANT *pByrefV
         PRECONDITION(CheckPointer(pByrefVar));
         PRECONDITION(CheckPointer(pSrcVar));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Set the type of the byref variant based on the type of the source variant.
     VARTYPE vt = V_VT(pSrcVar);
@@ -2658,7 +2657,7 @@ void OleVariant::CreateByrefVariantForVariant(VARIANT *pSrcVar, VARIANT *pByrefV
         V_VT(pByrefVar) = vt | VT_BYREF;
     }
 
-    RETURN;
+    return;
 }
 
 /* ------------------------------------------------------------------------- *
@@ -3283,16 +3282,15 @@ void OleVariant::MarshalArrayVariantOleRefToObject(const VARIANT *pOleVariant,
 SAFEARRAY *OleVariant::CreateSafeArrayDescriptorForArrayRef(BASEARRAYREF *pArrayRef, VARTYPE vt,
                                                             MethodTable *pInterfaceMT)
 {
-    CONTRACT (SAFEARRAY*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(pArrayRef));
         PRECONDITION(!(vt & VT_ARRAY));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ASSERT_PROTECTED(pArrayRef);
 
@@ -3385,7 +3383,7 @@ SAFEARRAY *OleVariant::CreateSafeArrayDescriptorForArrayRef(BASEARRAYREF *pArray
     }
 
     pSafeArray.SuppressRelease();
-    RETURN pSafeArray;
+    return pSafeArray;
 }
 
 //
@@ -3397,7 +3395,7 @@ SAFEARRAY *OleVariant::CreateSafeArrayDescriptorForArrayRef(BASEARRAYREF *pArray
 SAFEARRAY *OleVariant::CreateSafeArrayForArrayRef(BASEARRAYREF *pArrayRef, VARTYPE vt,
                                                   MethodTable *pInterfaceMT)
 {
-    CONTRACT (SAFEARRAY*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -3406,7 +3404,7 @@ SAFEARRAY *OleVariant::CreateSafeArrayForArrayRef(BASEARRAYREF *pArrayRef, VARTY
 //        PRECONDITION(CheckPointer(*pArrayRef));
         PRECONDITION(vt != VT_EMPTY);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
     ASSERT_PROTECTED(pArrayRef);
 
     // Validate that the type of the managed array is the expected type.
@@ -3429,7 +3427,7 @@ SAFEARRAY *OleVariant::CreateSafeArrayForArrayRef(BASEARRAYREF *pArrayRef, VARTY
         COMPlusThrowHR(hr);
     }
 
-    RETURN pSafeArray;
+    return pSafeArray;
 }
 
 //
@@ -4139,7 +4137,7 @@ void OleVariant::ConvertBSTRToString(BSTR bstr, STRINGREF *pStringObj)
 
 BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
 {
-    CONTRACT(BSTR)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -4147,17 +4145,18 @@ BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
         PRECONDITION(CheckPointer(pStringObj));
 
         // A null BSTR should only be returned if the input string is null.
-        POSTCONDITION(RETVAL != NULL || *pStringObj == NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (*pStringObj == NULL)
     {
-        RETURN NULL;
+        _ASSERTE(NULL != NULL || *pStringObj == NULL);
+        return NULL;
     }
 
     UnmanagedCallersOnlyCaller convertToNative(METHOD__BSTRMARSHALER__CONVERT_TO_NATIVE_UCO);
-    RETURN (BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
+    _ASSERTE((BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj) != NULL || *pStringObj == NULL);
+    return (BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
 }
 
 extern "C" void QCALLTYPE Variant_ConvertValueTypeToRecord(QCall::ObjectHandleOnStack obj, VARIANT * pOle)

--- a/src/coreclr/vm/olevariant.cpp
+++ b/src/coreclr/vm/olevariant.cpp
@@ -4150,12 +4150,10 @@ BSTR OleVariant::ConvertStringToBSTR(STRINGREF *pStringObj)
 
     if (*pStringObj == NULL)
     {
-        _ASSERTE(NULL != NULL || *pStringObj == NULL);
         return NULL;
     }
 
     UnmanagedCallersOnlyCaller convertToNative(METHOD__BSTRMARSHALER__CONVERT_TO_NATIVE_UCO);
-    _ASSERTE((BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj) != NULL || *pStringObj == NULL);
     return (BSTR)convertToNative.InvokeThrowing_Ret<INT_PTR>(pStringObj);
 }
 

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -650,7 +650,6 @@ PEAssembly::PEAssembly(
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         PRECONDITION(CheckPointer(pEmit, NULL_OK));
         PRECONDITION(pBindResultInfo == NULL || pPEImage == NULL);
         STANDARD_VM_CHECK;

--- a/src/coreclr/vm/peassembly.cpp
+++ b/src/coreclr/vm/peassembly.cpp
@@ -56,16 +56,18 @@ static void ValidatePEFileMachineType(PEAssembly *pPEAssembly)
 
 void PEAssembly::EnsureLoaded()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(IsLoaded());
         STANDARD_VM_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsReflectionEmit())
-        RETURN;
+        {
+        _ASSERTE(IsLoaded());
+            return;
+        }
 
     // Ensure that loaded layout is available.
     PEImageLayout* pLayout = GetPEImage()->GetOrCreateLayout(
@@ -91,7 +93,8 @@ void PEAssembly::EnsureLoaded()
     }
 #endif
 
-    RETURN;
+    _ASSERTE(IsLoaded());
+    return;
 }
 
 // ------------------------------------------------------------
@@ -192,17 +195,15 @@ void PEAssembly::GetPathOrCodeBase(SString &result)
 
 PTR_CVOID PEAssembly::GetMetadata(COUNT_T *pSize)
 {
-    CONTRACT(PTR_CVOID)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(pSize, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsReflectionEmit()
          || !GetPEImage()->HasHeaders()
@@ -210,28 +211,26 @@ PTR_CVOID PEAssembly::GetMetadata(COUNT_T *pSize)
     {
         if (pSize != NULL)
             *pSize = 0;
-        RETURN NULL;
+        return NULL;
     }
     else
     {
-        RETURN GetPEImage()->GetMetadata(pSize);
+        return GetPEImage()->GetMetadata(pSize);
     }
 }
 #endif // #ifndef DACCESS_COMPILE
 
 PTR_CVOID PEAssembly::GetLoadedMetadata(COUNT_T *pSize)
 {
-    CONTRACT(PTR_CVOID)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(pSize, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!HasLoadedPEImage()
          || !GetLoadedLayout()->HasHeaders()
@@ -239,17 +238,17 @@ PTR_CVOID PEAssembly::GetLoadedMetadata(COUNT_T *pSize)
     {
         if (pSize != NULL)
             *pSize = 0;
-        RETURN NULL;
+        return NULL;
     }
     else
     {
-        RETURN GetLoadedLayout()->GetMetadata(pSize);
+        return GetLoadedLayout()->GetMetadata(pSize);
     }
 }
 
 TADDR PEAssembly::GetIL(RVA il)
 {
-    CONTRACT(TADDR)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(il != 0);
@@ -257,13 +256,12 @@ TADDR PEAssembly::GetIL(RVA il)
 #ifndef DACCESS_COMPILE
         PRECONDITION(HasLoadedPEImage());
 #endif
-        POSTCONDITION(RETVAL != NULL);
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PEImageLayout *image = NULL;
     image = GetLoadedLayout();
@@ -274,7 +272,7 @@ TADDR PEAssembly::GetIL(RVA il)
         COMPlusThrowHR(COR_E_BADIMAGEFORMAT, BFA_BAD_IL_RANGE);
 #endif
 
-    RETURN image->GetRvaData(il);
+    return image->GetRvaData(il);
 }
 
 #ifndef DACCESS_COMPILE
@@ -472,16 +470,15 @@ void PEAssembly::GetEmbeddedResource(DWORD dwOffset, DWORD *cbResource, PBYTE *p
 
 PEAssembly* PEAssembly::LoadAssembly(mdAssemblyRef kAssemblyRef)
 {
-    CONTRACT(PEAssembly *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IMDInternalImport* pImport = GetMDImport();
     if (((TypeFromToken(kAssemblyRef) != mdtAssembly) &&
@@ -495,7 +492,7 @@ PEAssembly* PEAssembly::LoadAssembly(mdAssemblyRef kAssemblyRef)
 
     spec.InitializeSpec(kAssemblyRef, pImport, GetAppDomain()->FindAssembly(this));
 
-    RETURN GetAppDomain()->BindAssemblySpec(&spec, TRUE);
+    return GetAppDomain()->BindAssemblySpec(&spec, TRUE);
 }
 
 // dwLocation maps to System.Reflection.ResourceLocation
@@ -824,18 +821,17 @@ PEAssembly *PEAssembly::OpenSystem()
 /* static */
 PEAssembly *PEAssembly::DoOpenSystem()
 {
-    CONTRACT(PEAssembly *)
+    CONTRACTL
     {
-        POSTCONDITION(CheckPointer(RETVAL));
         STANDARD_VM_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ETWOnStartup (FusionBinding_V1, FusionBindingEnd_V1);
     ReleaseHolder<BINDER_SPACE::Assembly> pBoundAssembly;
     IfFailThrow(GetAppDomain()->GetDefaultBinder()->BindToSystem(&pBoundAssembly));
 
-    RETURN new PEAssembly(pBoundAssembly, NULL, TRUE);
+    return new PEAssembly(pBoundAssembly, NULL, TRUE);
 }
 
 PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult)
@@ -846,19 +842,18 @@ PEAssembly* PEAssembly::Open(BINDER_SPACE::Assembly* pBindResult)
 /* static */
 PEAssembly *PEAssembly::Create(IMetaDataAssemblyEmit *pAssemblyEmit, AssemblyBinder *pFallbackBinder)
 {
-    CONTRACT(PEAssembly *)
+    CONTRACTL
     {
         PRECONDITION(CheckPointer(pAssemblyEmit));
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Set up the metadata pointers in the PEAssembly. (This is the only identity
     // we have.)
     SafeComHolder<IMetaDataEmit> pEmit;
     pAssemblyEmit->QueryInterface(IID_IMetaDataEmit, (void **)&pEmit);
-    RETURN new PEAssembly(NULL, pEmit, FALSE, pFallbackBinder);
+    return new PEAssembly(NULL, pEmit, FALSE, pFallbackBinder);
 }
 
 #endif // #ifndef DACCESS_COMPILE
@@ -941,12 +936,12 @@ void PEAssembly::PathToUrl(SString &string)
 
 void PEAssembly::UrlToPath(SString &string)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SString::Iterator i = string.Begin();
 
@@ -967,7 +962,7 @@ void PEAssembly::UrlToPath(SString &string)
     }
 #endif
 
-    RETURN;
+    return;
 }
 
 BOOL PEAssembly::FindLastPathSeparator(const SString &path, SString::Iterator &i)

--- a/src/coreclr/vm/peassembly.inl
+++ b/src/coreclr/vm/peassembly.inl
@@ -61,21 +61,21 @@ inline ULONG PEAssembly::AddRef()
 
 inline ULONG PEAssembly::Release()
 {
-    CONTRACT(COUNT_T)
+    CONTRACTL
     {
         DESTRUCTOR_CHECK;
         NOTHROW;
         GC_TRIGGERS;
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     LONG result = InterlockedDecrement(&m_refCount);
     _ASSERTE(result >= 0);
     if (result == 0)
         delete this;
 
-    RETURN result;
+    return result;
 }
 
 inline void PEAssembly::ValidateForExecution()
@@ -258,38 +258,36 @@ inline IMDInternalImport* PEAssembly::GetMDImport()
 
 inline IMetaDataImport2 *PEAssembly::GetRWImporter()
 {
-    CONTRACT(IMetaDataImport2 *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
         GC_NOTRIGGER;
         THROWS;
         MODE_ANY;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pImporter == NULL)
         OpenImporter();
 
-    RETURN m_pImporter;
+    return m_pImporter;
 }
 
 inline IMetaDataEmit *PEAssembly::GetEmitter()
 {
-    CONTRACT(IMetaDataEmit *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         MODE_ANY;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL));
         THROWS;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (m_pEmitter == NULL)
         OpenEmitter();
 
-    RETURN m_pEmitter;
+    return m_pEmitter;
 }
 
 
@@ -364,7 +362,7 @@ inline BOOL PEAssembly::IsILOnly()
 
 inline PTR_VOID PEAssembly::GetRvaField(RVA field)
 {
-    CONTRACT(void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsReflectionEmit());
@@ -374,14 +372,13 @@ inline PTR_VOID PEAssembly::GetRvaField(RVA field)
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Note that the native image Rva fields are currently cut off before
     // this point.  We should not get here for an IL only native image.
 
-    RETURN dac_cast<PTR_VOID>(GetLoadedLayout()->GetRvaData(field,NULL_OK));
+    return dac_cast<PTR_VOID>(GetLoadedLayout()->GetRvaData(field,NULL_OK));
 }
 
 inline CHECK PEAssembly::CheckRvaField(RVA field)
@@ -506,7 +503,7 @@ inline UINT32 PEAssembly::GetTlsIndex()
 
 inline const void *PEAssembly::GetInternalPInvokeTarget(RVA target)
 {
-    CONTRACT(void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsReflectionEmit());
@@ -515,11 +512,10 @@ inline const void *PEAssembly::GetInternalPInvokeTarget(RVA target)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN (void*)GetLoadedLayout()->GetRvaData(target);
+    return (void*)GetLoadedLayout()->GetRvaData(target);
 }
 
 inline CHECK PEAssembly::CheckInternalPInvokeTarget(RVA target)
@@ -543,30 +539,29 @@ inline CHECK PEAssembly::CheckInternalPInvokeTarget(RVA target)
 
 inline IMAGE_COR_VTABLEFIXUP *PEAssembly::GetVTableFixups(COUNT_T *pCount/*=NULL*/)
 {
-    CONTRACT(IMAGE_COR_VTABLEFIXUP *)
+    CONTRACTL
     {
         PRECONDITION(HasLoadedPEImage());
         INSTANCE_CHECK;
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (IsReflectionEmit() || IsILOnly())
     {
         if (pCount != NULL)
             *pCount = 0;
-        RETURN NULL;
+        return NULL;
     }
     else
-        RETURN GetLoadedLayout()->GetVTableFixups(pCount);
+        return GetLoadedLayout()->GetVTableFixups(pCount);
 }
 
 inline void *PEAssembly::GetVTable(RVA rva)
 {
-    CONTRACT(void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(!IsReflectionEmit());
@@ -576,11 +571,10 @@ inline void *PEAssembly::GetVTable(RVA rva)
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN (void *)GetLoadedLayout()->GetRvaData(rva);
+    return (void *)GetLoadedLayout()->GetRvaData(rva);
 }
 
 // @todo: this is bad to expose. But it is needed to support current IJW thunks
@@ -603,16 +597,15 @@ inline HMODULE PEAssembly::GetIJWBase()
 
 inline PTR_VOID PEAssembly::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
 {
-    CONTRACT(PTR_VOID)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CheckPointer(pSize, NULL_OK));
         WRAPPER(THROWS);
         WRAPPER(GC_TRIGGERS);
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // We cannot in general force a LoadLibrary; we might be in the
     // helper thread.  The debugger will have to expect a zero base
@@ -623,14 +616,14 @@ inline PTR_VOID PEAssembly::GetDebuggerContents(COUNT_T *pSize/*=NULL*/)
         if (pSize != NULL)
             *pSize = GetLoadedLayout()->GetSize();
 
-        RETURN GetLoadedLayout()->GetBase();
+        return GetLoadedLayout()->GetBase();
     }
     else
     {
         if (pSize != NULL)
             *pSize = 0;
 
-        RETURN NULL;
+        return NULL;
     }
 }
 
@@ -667,16 +660,15 @@ inline PTR_CVOID PEAssembly::GetLoadedImageContents(COUNT_T *pSize/*=NULL*/)
 #ifndef DACCESS_COMPILE
 inline const void *PEAssembly::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
 {
-    CONTRACT(const void *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(HasLoadedPEImage());
         WRAPPER(THROWS);
         WRAPPER(GC_TRIGGERS);
         MODE_ANY;
-        POSTCONDITION((!GetLoadedLayout()->GetSize()) || CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Right now, we will trigger a LoadLibrary for the caller's sake,
     // even if we are in a scenario where we could normally avoid it.
@@ -686,7 +678,7 @@ inline const void *PEAssembly::GetManagedFileContents(COUNT_T *pSize/*=NULL*/)
         *pSize = GetLoadedLayout()->GetSize();
 
 
-    RETURN GetLoadedLayout()->GetBase();
+    return GetLoadedLayout()->GetBase();
 }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -26,18 +26,20 @@ PtrHashMap *PEImage::s_ijwFixupDataHash;
 /* static */
 void PEImage::Startup()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckStartup());
         INJECT_FAULT(COMPlusThrowOM(););
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (CheckStartup())
-        RETURN;
+        {
+        _ASSERTE(CheckStartup());
+            return;
+        }
 
     s_hashLock.Init(CrstPEImage, (CrstFlags)(CRST_REENTRANCY|CRST_TAKEN_DURING_SHUTDOWN));
     LockOwner lock = { &s_hashLock, IsOwnerOfCrst };
@@ -49,7 +51,8 @@ void PEImage::Startup()
     s_ijwFixupDataHash = ::new PtrHashMap;
     s_ijwFixupDataHash->Init(CompareIJWDataBase, FALSE, &ijwLock);
 
-    RETURN;
+    _ASSERTE(CheckStartup());
+    return;
 }
 
 /* static */
@@ -711,11 +714,11 @@ PTR_PEImageLayout PEImage::CreateFlatLayout()
 /* static */
 PTR_PEImage PEImage::CreateFromByteArray(const BYTE* array, COUNT_T size)
 {
-    CONTRACT(PTR_PEImage)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PEImageHolder pImage(new PEImage(NULL /*path*/));
     PTR_PEImageLayout pLayout = PEImageLayout::CreateFromByteArray(pImage, array, size);
@@ -723,20 +726,19 @@ PTR_PEImage PEImage::CreateFromByteArray(const BYTE* array, COUNT_T size)
 
     SimpleWriteLockHolder lock(pImage->m_pLayoutLock);
     pImage->SetLayout(IMAGE_FLAT,pLayout);
-    RETURN dac_cast<PTR_PEImage>(pImage.Extract());
+    return dac_cast<PTR_PEImage>(pImage.Extract());
 }
 
 #ifndef TARGET_UNIX
 /* static */
 PTR_PEImage PEImage::CreateFromHMODULE(HMODULE hMod)
 {
-    CONTRACT(PTR_PEImage)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(hMod!=NULL);
-        POSTCONDITION(RETVAL->HasLoadedLayout());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     StackSString path;
     WszGetModuleFileName(hMod, path);
@@ -756,7 +758,8 @@ PTR_PEImage PEImage::CreateFromHMODULE(HMODULE hMod)
     }
 
     _ASSERTE(pImage->m_pLayouts[IMAGE_FLAT] != NULL);
-    RETURN dac_cast<PTR_PEImage>(pImage.Extract());
+    _ASSERTE(dac_cast<PTR_PEImage>(pImage.Extract())->HasLoadedLayout());
+    return dac_cast<PTR_PEImage>(pImage.Extract());
 }
 #endif // !TARGET_UNIX
 

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -36,10 +36,7 @@ void PEImage::Startup()
     CONTRACTL_END;
 
     if (CheckStartup())
-        {
-        _ASSERTE(CheckStartup());
-            return;
-        }
+        return;
 
     s_hashLock.Init(CrstPEImage, (CrstFlags)(CRST_REENTRANCY|CRST_TAKEN_DURING_SHUTDOWN));
     LockOwner lock = { &s_hashLock, IsOwnerOfCrst };

--- a/src/coreclr/vm/peimage.cpp
+++ b/src/coreclr/vm/peimage.cpp
@@ -755,7 +755,7 @@ PTR_PEImage PEImage::CreateFromHMODULE(HMODULE hMod)
     }
 
     _ASSERTE(pImage->m_pLayouts[IMAGE_FLAT] != NULL);
-    _ASSERTE(dac_cast<PTR_PEImage>(pImage.Extract())->HasLoadedLayout());
+    _ASSERTE(pImage->HasLoadedLayout());
     return dac_cast<PTR_PEImage>(pImage.Extract());
 }
 #endif // !TARGET_UNIX

--- a/src/coreclr/vm/peimage.inl
+++ b/src/coreclr/vm/peimage.inl
@@ -14,15 +14,15 @@
 
 inline ULONG PEImage::AddRef()
 {
-    CONTRACT(ULONG)
+    CONTRACTL
     {
         PRECONDITION(m_refCount>0 && m_refCount < COUNT_T_MAX);
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
-    RETURN (static_cast<ULONG>(InterlockedIncrement(&m_refCount)));
+    return (static_cast<ULONG>(InterlockedIncrement(&m_refCount)));
 }
 
 inline const SString &PEImage::GetPath()

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -490,7 +490,6 @@ ConvertedImageLayout::ConvertedImageLayout(FlatImageLayout* source, bool disable
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         STANDARD_VM_CHECK;
     }
     CONTRACTL_END;
@@ -581,7 +580,6 @@ LoadedImageLayout::LoadedImageLayout(PEImage* pOwner, HRESULT* loadFailure)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pOwner));
     }
@@ -679,7 +677,6 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pOwner));
     }
@@ -813,7 +810,6 @@ FlatImageLayout::FlatImageLayout(PEImage* pOwner, const BYTE* array, COUNT_T siz
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;

--- a/src/coreclr/vm/peimagelayout.inl
+++ b/src/coreclr/vm/peimagelayout.inl
@@ -11,17 +11,17 @@
 
 inline void PEImageLayout::AddRef()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         PRECONDITION(m_refCount>0 && m_refCount < COUNT_T_MAX);
         NOTHROW;
         GC_NOTRIGGER;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     InterlockedIncrement(&m_refCount);
 
-    RETURN;
+    return;
 }
 
 inline ULONG PEImageLayout::Release()

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1461,12 +1461,11 @@ void MethodDesc::CreateDerivedTargetSig(MetaSig& msig, SigBuilder *stubSigBuilde
 Stub * CreateUnboxingILStubForValueTypeMethods(MethodDesc* pTargetMD)
 {
 
-    CONTRACT(Stub*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SigTypeContext typeContext(pTargetMD);
 
@@ -1545,20 +1544,19 @@ Stub * CreateUnboxingILStubForValueTypeMethods(MethodDesc* pTargetMD)
     pResolver->SetStubTargetMethodSig(pTargetSig, cbTargetSig);
     pResolver->SetStubTargetMethodDesc(pTargetMD);
 
-    RETURN Stub::NewStub(JitILStub(pStubMD));
+    return Stub::NewStub(JitILStub(pStubMD));
 
 }
 
 Stub * CreateInstantiatingILStub(MethodDesc* pTargetMD, void* pHiddenArg)
 {
 
-    CONTRACT(Stub*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(CheckPointer(pHiddenArg));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SigTypeContext typeContext;
     MethodTable* pStubMT;
@@ -1639,18 +1637,17 @@ Stub * CreateInstantiatingILStub(MethodDesc* pTargetMD, void* pHiddenArg)
     pResolver->SetStubTargetMethodSig(pTargetSig, cbTargetSig);
     pResolver->SetStubTargetMethodDesc(pTargetMD);
 
-    RETURN Stub::NewStub(JitILStub(pStubMD));
+    return Stub::NewStub(JitILStub(pStubMD));
 }
 
 /* Make a stub that for a value class method that expects a BOXed this pointer */
 Stub * MakeUnboxingStubWorker(MethodDesc *pMD)
 {
-    CONTRACT(Stub*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Stub *pstub = NULL;
 
@@ -1687,31 +1684,30 @@ Stub * MakeUnboxingStubWorker(MethodDesc *pMD)
 
         sl.EmitComputedInstantiatingMethodStub(pUnboxedMD, &portableShuffle[0], NULL);
 
-        RETURN sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_INSTANTIATING_METHOD, "UnboxingStub");
+        return sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_INSTANTIATING_METHOD, "UnboxingStub");
     }
 #elif defined(TARGET_X86)
     CPUSTUBLINKER sl;
     if (sl.EmitUnboxMethodStub(pUnboxedMD))
     {
-        RETURN sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_NONE, "UnboxingStub");
+        return sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_NONE, "UnboxingStub");
     }
 #endif // FEATURE_PORTABLE_SHUFFLE_THUNKS || TARGET_X86
 
-    RETURN CreateUnboxingILStubForValueTypeMethods(pUnboxedMD);
+    return CreateUnboxingILStubForValueTypeMethods(pUnboxedMD);
 }
 
 #if defined(FEATURE_SHARE_GENERIC_CODE)
 Stub * MakeInstantiatingStubWorker(MethodDesc *pMD)
 {
-    CONTRACT(Stub*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
         PRECONDITION(pMD->IsInstantiatingStub());
         PRECONDITION(!pMD->RequiresInstArg());
         PRECONDITION(!pMD->IsSharedByGenericMethodInstantiations());
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Note: this should be kept idempotent ... in the sense that
     // if multiple threads get in here for the same pMD
@@ -1743,17 +1739,17 @@ Stub * MakeInstantiatingStubWorker(MethodDesc *pMD)
         _ASSERTE(pSharedMD != NULL && pSharedMD != pMD);
         sl.EmitComputedInstantiatingMethodStub(pSharedMD, &portableShuffle[0], extraArg);
 
-        RETURN sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_INSTANTIATING_METHOD, "InstantiatingStub");
+        return sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_INSTANTIATING_METHOD, "InstantiatingStub");
     }
 #elif defined(TARGET_X86)
     CPUSTUBLINKER sl;
     if (sl.EmitInstantiatingMethodStub(pSharedMD, extraArg))
     {
-        RETURN sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_NONE, "InstantiatingStub");
+        return sl.Link(pMD->GetLoaderAllocator()->GetStubHeap(), NEWSTUB_FL_NONE, "InstantiatingStub");
     }
 #endif // FEATURE_PORTABLE_SHUFFLE_THUNKS || TARGET_X86
 
-    RETURN CreateInstantiatingILStub(pSharedMD, extraArg);
+    return CreateInstantiatingILStub(pSharedMD, extraArg);
 }
 #endif // defined(FEATURE_SHARE_GENERIC_CODE)
 
@@ -1941,7 +1937,7 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
         pPFrame->Pop(CURRENT_THREAD);
     }
 
-    POSTCONDITION(pbRetVal != NULL);
+    _ASSERTE(pbRetVal != NULL);
 
     return pbRetVal;
 }
@@ -2145,12 +2141,11 @@ static void TestSEHGuardPageRestore()
 // pointer to the stub, and not a pointer directly to the JITted code.
 PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMode)
 {
-    CONTRACT(PCODE)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(RETVAL != NULL);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     Stub *pStub = NULL;
     PCODE pCode = (PCODE)NULL;
@@ -2223,7 +2218,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
 
         GetOrCreatePrecode()->SetTargetInterlocked(pCode);
 
-        RETURN GetStableEntryPoint();
+        return GetStableEntryPoint();
     }
 #endif // FEATURE_COMINTEROP
 
@@ -2478,7 +2473,8 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
 
 Return:
 
-    RETURN pCode;
+    _ASSERTE(pCode != NULL);
+    return pCode;
 }
 
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -759,7 +759,7 @@ GenerationTable::GenerationTable() : mutex(CrstLeafLock, CRST_UNSAFE_ANYMODE)
 
 void GenerationTable::AddRecord(int generation, BYTE* rangeStart, BYTE* rangeEnd, BYTE* rangeEndReserved)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -768,7 +768,7 @@ void GenerationTable::AddRecord(int generation, BYTE* rangeStart, BYTE* rangeEnd
         PRECONDITION(CheckPointer(rangeStart));
         PRECONDITION(CheckPointer(rangeEnd));
         PRECONDITION(CheckPointer(rangeEndReserved));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     CrstHolder holder(&mutex);
 
@@ -783,16 +783,16 @@ void GenerationTable::AddRecord(int generation, BYTE* rangeStart, BYTE* rangeEnd
             _ASSERTE (genDescTable[i].generation == generation);
             _ASSERTE (genDescTable[i].rangeEnd == rangeEnd);
             _ASSERTE (genDescTable[i].rangeEndReserved == rangeEndReserved);
-            RETURN;
+            return;
         }
     }
     AddRecordNoLock(generation, rangeStart, rangeEnd, rangeEndReserved);
-    RETURN;
+    return;
 }
 
 void GenerationTable::AddRecordNoLock(int generation, BYTE* rangeStart, BYTE* rangeEnd, BYTE* rangeEndReserved)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -801,7 +801,7 @@ void GenerationTable::AddRecordNoLock(int generation, BYTE* rangeStart, BYTE* ra
         PRECONDITION(CheckPointer(rangeStart));
         PRECONDITION(CheckPointer(rangeEnd));
         PRECONDITION(CheckPointer(rangeEndReserved));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     _ASSERTE (mutex.OwnedByCurrentThread());
     if (count >= capacity)
@@ -813,7 +813,7 @@ void GenerationTable::AddRecordNoLock(int generation, BYTE* rangeStart, BYTE* ra
             count = capacity = 0;
             delete[] genDescTable;
             genDescTable = nullptr;
-            RETURN;
+            return;
         }
         memcpy(newGenDescTable, genDescTable, sizeof(genDescTable[0]) * count);
         delete[] genDescTable;
@@ -828,7 +828,7 @@ void GenerationTable::AddRecordNoLock(int generation, BYTE* rangeStart, BYTE* ra
     genDescTable[count].rangeEndReserved = rangeEndReserved;
 
     count = count + 1;
-    RETURN;
+    return;
 }
 
 HRESULT GenerationTable::GetGenerationBounds(ULONG cObjectRanges, ULONG* pcObjectRanges, COR_PRF_GC_GENERATION_RANGE* ranges)
@@ -879,7 +879,7 @@ static void GenWalkFunc(void * context,
                         BYTE * rangeEnd,
                         BYTE * rangeEndReserved)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -889,11 +889,11 @@ static void GenWalkFunc(void * context,
         PRECONDITION(CheckPointer(rangeStart));
         PRECONDITION(CheckPointer(rangeEnd));
         PRECONDITION(CheckPointer(rangeEndReserved));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     GenerationTable *generationTable = (GenerationTable *)context;
     generationTable->AddRecordNoLock(generation, rangeStart, rangeEnd, rangeEndReserved);
-    RETURN;
+    return;
 }
 
 void GenerationTable::Refresh()
@@ -923,16 +923,15 @@ static Volatile<LONG> s_generationTableWriterCount;
 
 void __stdcall UpdateGenerationBounds()
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY; // can be called even on GC threads
 #ifdef PROFILING_SUPPORTED
         PRECONDITION(InterlockedIncrement(&s_generationTableWriterCount) == 1);
-        POSTCONDITION(InterlockedDecrement(&s_generationTableWriterCount) == 0);
 #endif // PROFILING_SUPPORTED
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
 #ifdef PROFILING_SUPPORTED
     // Notify the profiler of start of the collection
@@ -952,22 +951,24 @@ void __stdcall UpdateGenerationBounds()
 
         if (s_currentGenerationTable == nullptr)
         {
-            RETURN;
+            _ASSERTE(InterlockedDecrement(&s_generationTableWriterCount) == 0);
+            return;
         }
         s_currentGenerationTable->Refresh();
     }
 #endif // PROFILING_SUPPORTED
-    RETURN;
+    _ASSERTE(InterlockedDecrement(&s_generationTableWriterCount) == 0);
+    return;
 }
 
 void __stdcall ProfilerAddNewRegion(int generation, uint8_t* rangeStart, uint8_t* rangeEnd, uint8_t* rangeEndReserved)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY; // can be called even on GC threads
-    } CONTRACT_END;
+    } CONTRACTL_END;
 #ifdef PROFILING_SUPPORTED
     if (CORProfilerTrackGC() || CORProfilerTrackBasicGC())
     {
@@ -977,7 +978,7 @@ void __stdcall ProfilerAddNewRegion(int generation, uint8_t* rangeStart, uint8_t
         }
     }
 #endif // PROFILING_SUPPORTED
-    RETURN;
+    return;
 }
 
 #ifdef PROFILING_SUPPORTED

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -951,7 +951,7 @@ void __stdcall UpdateGenerationBounds()
 
         if (s_currentGenerationTable == nullptr)
         {
-#ifdef _DEBUG
+#ifdef ENABLE_CONTRACTS_IMPL
             LONG result = InterlockedDecrement(&s_generationTableWriterCount);
             _ASSERTE(result == 0);
 #endif
@@ -960,7 +960,7 @@ void __stdcall UpdateGenerationBounds()
         s_currentGenerationTable->Refresh();
     }
 #endif // PROFILING_SUPPORTED
-#ifdef _DEBUG
+#ifdef ENABLE_CONTRACTS_IMPL
     {
         LONG result = InterlockedDecrement(&s_generationTableWriterCount);
         _ASSERTE(result == 0);

--- a/src/coreclr/vm/proftoeeinterfaceimpl.cpp
+++ b/src/coreclr/vm/proftoeeinterfaceimpl.cpp
@@ -951,13 +951,21 @@ void __stdcall UpdateGenerationBounds()
 
         if (s_currentGenerationTable == nullptr)
         {
-            _ASSERTE(InterlockedDecrement(&s_generationTableWriterCount) == 0);
+#ifdef _DEBUG
+            LONG result = InterlockedDecrement(&s_generationTableWriterCount);
+            _ASSERTE(result == 0);
+#endif
             return;
         }
         s_currentGenerationTable->Refresh();
     }
 #endif // PROFILING_SUPPORTED
-    _ASSERTE(InterlockedDecrement(&s_generationTableWriterCount) == 0);
+#ifdef _DEBUG
+    {
+        LONG result = InterlockedDecrement(&s_generationTableWriterCount);
+        _ASSERTE(result == 0);
+    }
+#endif
     return;
 }
 

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -2123,7 +2123,7 @@ public:
     }
     Module *GetModuleIfLoaded(mdFile kFile) final
     {
-        CONTRACT(Module *)
+        CONTRACTL
         {
             INSTANCE_CHECK;
             NOTHROW;
@@ -2131,11 +2131,10 @@ public:
             MODE_ANY;
             PRECONDITION(TypeFromToken(kFile) == mdtFile
                         || TypeFromToken(kFile) == mdtModuleRef);
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
             FORBID_FAULT;
             SUPPORTS_DAC;
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         // Native manifest module functionality isn't actually multi-module assemblies, and File tokens are not useable
         if (TypeFromToken(kFile) == mdtFile)
@@ -2144,12 +2143,14 @@ public:
         _ASSERTE(TypeFromToken(kFile) == mdtModuleRef);
         Module* module = m_ModuleReferencesMap.GetElement(RidFromToken(kFile));
         if (module != NULL)
-            RETURN module;
+            {
+                return module;
+            }
 
         LPCSTR moduleName;
         if (FAILED(GetMDImport()->GetModuleRefProps(kFile, &moduleName)))
         {
-            RETURN NULL;
+            return NULL;
         }
 
         LPCSTR assemblyNameInModuleRef;
@@ -2178,7 +2179,7 @@ public:
                     mdToken assemblyRef;
                     if (FAILED(GetAssemblyRefTokenOfIndirectDependency(module, assemblyNameInModuleRef, assemblyNameLen, &assemblyRef)))
                     {
-                        RETURN NULL;
+                        return NULL;
                     }
 
                     if (assemblyRef == mdTokenNil)
@@ -2199,7 +2200,7 @@ public:
         if (module != NULL)
             m_ModuleReferencesMap.TrySetElement(RidFromToken(kFile), module);
 #endif
-        RETURN module;
+        return module;
     }
 
     Module *LoadModule(mdFile kFile) final

--- a/src/coreclr/vm/reflectclasswriter.cpp
+++ b/src/coreclr/vm/reflectclasswriter.cpp
@@ -14,23 +14,19 @@
 //******************************************************
 HRESULT RefClassWriter::Init(ICeeGenInternal *pCeeGen, IUnknown *pUnk, LPCWSTR szName)
 {
-    CONTRACT(HRESULT) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         // we know that the com implementation is ours so we use mode-any to simplify
         // having to switch mode
         MODE_ANY;
-        INJECT_FAULT(CONTRACT_RETURN(E_OUTOFMEMORY));
+        INJECT_FAULT(return(E_OUTOFMEMORY));
 
         PRECONDITION(CheckPointer(pCeeGen));
         PRECONDITION(CheckPointer(pUnk));
 
-        POSTCONDITION(SUCCEEDED(RETVAL) ? CheckPointer(m_emitter) : TRUE);
-        POSTCONDITION(SUCCEEDED(RETVAL) ? CheckPointer(m_importer) : TRUE);
-        POSTCONDITION(SUCCEEDED(RETVAL) ? CheckPointer(m_pEmitHelper) : TRUE);
-        POSTCONDITION(SUCCEEDED(RETVAL) ? CheckPointer(m_internalimport) : TRUE);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Initialize the Import and Emitter interfaces
     m_emitter = NULL;
@@ -44,26 +40,26 @@ HRESULT RefClassWriter::Init(ICeeGenInternal *pCeeGen, IUnknown *pUnk, LPCWSTR s
     // Get the interfaces
     HRESULT hr = pUnk->QueryInterface(IID_IMetaDataEmit2, (void**)&m_emitter);
     if (FAILED(hr))
-        RETURN(hr);
+        return(hr);
 
     hr = pUnk->QueryInterface(IID_IMetaDataImport, (void**)&m_importer);
     if (FAILED(hr))
-        RETURN(hr);
+        return(hr);
 
     hr = pUnk->QueryInterface(IID_IMetaDataEmitHelper, (void**)&m_pEmitHelper);
     if (FAILED(hr))
-        RETURN(hr);
+        return(hr);
 
     hr = GetMDInternalInterfaceFromPublic(pUnk, IID_IMDInternalImport, (void**)&m_internalimport);
     if (FAILED(hr))
-        RETURN(hr);
+        return(hr);
 
     // <TODO> We will need to set this at some point.</TODO>
     hr = m_emitter->SetModuleProps(szName);
     if (FAILED(hr))
-        RETURN(hr);
+        return(hr);
 
-    RETURN(S_OK);
+    return(S_OK);
 }
 
 

--- a/src/coreclr/vm/reflectclasswriter.cpp
+++ b/src/coreclr/vm/reflectclasswriter.cpp
@@ -59,6 +59,10 @@ HRESULT RefClassWriter::Init(ICeeGenInternal *pCeeGen, IUnknown *pUnk, LPCWSTR s
     if (FAILED(hr))
         return(hr);
 
+    _ASSERTE(m_emitter != nullptr);
+    _ASSERTE(m_importer != nullptr);
+    _ASSERTE(m_pEmitHelper != nullptr);
+    _ASSERTE(m_internalimport != nullptr);
     return(S_OK);
 }
 

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -324,7 +324,7 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -334,7 +334,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (!InlinedCallFrame::FrameHasActiveCall(this))
     {
@@ -384,7 +384,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    InlinedCallFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 #ifdef FEATURE_HIJACK
@@ -396,14 +396,14 @@ TADDR ResumableFrame::GetReturnAddressPtr_Impl(void)
 
 void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         SUPPORTS_DAC;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     CopyMemory(pRD->pCurrentContext, m_Regs, sizeof(T_CONTEXT));
 
@@ -448,7 +448,7 @@ void ResumableFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFlo
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    ResumableFrame::UpdateRegDisplay_Impl(pc:%p, sp:%p)\n", pRD->ControlPC, pRD->SP));
 
-    RETURN;
+    return;
 }
 
 void HijackFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -82,7 +82,7 @@ void ComClassFactory::ThrowHRMsg(HRESULT hr, DWORD dwMsgResID)
 //
 IUnknown *ComClassFactory::CreateInstanceFromClassFactory(IClassFactory *pClassFact, IUnknown *punkOuter, BOOL *pfDidContainment)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -92,9 +92,8 @@ IUnknown *ComClassFactory::CreateInstanceFromClassFactory(IClassFactory *pClassF
         PRECONDITION(CheckPointer(punkOuter, NULL_OK));
         PRECONDITION(CheckPointer(pfDidContainment, NULL_OK));
         PRECONDITION(CheckPointer(m_pClassMT, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hr = S_OK;
     SafeComHolder<IClassFactory2> pClassFact2 = NULL;
@@ -222,7 +221,7 @@ IUnknown *ComClassFactory::CreateInstanceFromClassFactory(IClassFactory *pClassF
     ComWrappersNative::MarkWrapperAsComActivated(pUnk);
 
     pUnk.SuppressRelease();
-    RETURN pUnk;
+    return pUnk;
 }
 
 
@@ -368,31 +367,29 @@ OBJECTREF ComClassFactory::CreateAggregatedInstance(MethodTable* pMTClass, BOOL 
 // Overridable
 IUnknown *ComClassFactory::CreateInstanceInternal(IUnknown *pOuter, BOOL *pfDidContainment)
 {
-    CONTRACT(IUnknown *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pOuter, NULL_OK));
         PRECONDITION(CheckPointer(pfDidContainment, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SafeComHolder<IClassFactory> pClassFactory = GetIClassFactory();
-    RETURN CreateInstanceFromClassFactory(pClassFactory, pOuter, pfDidContainment);
+    return CreateInstanceFromClassFactory(pClassFactory, pOuter, pfDidContainment);
 }
 
 IClassFactory *ComClassFactory::GetIClassFactory()
 {
-    CONTRACT(IClassFactory *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     HRESULT hr = S_OK;
     IClassFactory *pClassFactory = NULL;
@@ -442,7 +439,7 @@ IClassFactory *ComClassFactory::GetIClassFactory()
             COMPlusThrowHR(hr, IDS_EE_REMOTE_COGETCLASSOBJECT_FAILED, strHRHex, strClsid, m_wszServer, strHRDescription.GetUnicode());
     }
 
-    RETURN pClassFactory;
+    return pClassFactory;
 }
 
 //-------------------------------------------------------------
@@ -541,32 +538,30 @@ void ComClassFactory::Cleanup()
 // Obtain the appropriate wrapper cache from the current context.
 RCWCache* RCWCache::GetRCWCache()
 {
-    CONTRACT (RCWCache*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AppDomain * pDomain = GetAppDomain();
-    RETURN (pDomain ? pDomain->GetRCWCache() : NULL);
+    return (pDomain ? pDomain->GetRCWCache() : NULL);
 }
 
 RCWCache* RCWCache::GetRCWCacheNoCreate()
 {
-    CONTRACT (RCWCache*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     AppDomain * pDomain = GetAppDomain();
-    RETURN (pDomain ? pDomain->GetRCWCacheNoCreate() : NULL);
+    return (pDomain ? pDomain->GetRCWCacheNoCreate() : NULL);
 }
 
 
@@ -1206,14 +1201,14 @@ VOID RCWCleanupList::ReleaseRCWListRaw(RCW* pRCW)
 // The IUnknown passed in is AddRef'ed if we succeed in creating the wrapper.
 RCW* RCW::CreateRCW(IUnknown *pUnk, DWORD dwSyncBlockIndex, DWORD flags, MethodTable *pClassMT)
 {
-    CONTRACT (RCW*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         INJECT_FAULT(COMPlusThrowOM());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     RCW *pRCW = NULL;
 
@@ -1222,12 +1217,12 @@ RCW* RCW::CreateRCW(IUnknown *pUnk, DWORD dwSyncBlockIndex, DWORD flags, MethodT
         pRCW = RCW::CreateRCWInternal(pUnk, dwSyncBlockIndex, flags, pClassMT);
     }
 
-    RETURN pRCW;
+    return pRCW;
 }
 
 RCW* RCW::CreateRCWInternal(IUnknown *pUnk, DWORD dwSyncBlockIndex, DWORD flags, MethodTable *pClassMT)
 {
-    CONTRACT (RCW*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -1236,9 +1231,8 @@ RCW* RCW::CreateRCWInternal(IUnknown *pUnk, DWORD dwSyncBlockIndex, DWORD flags,
         PRECONDITION(CheckPointer(pUnk));
         PRECONDITION(dwSyncBlockIndex != 0);
         PRECONDITION(CheckPointer(pClassMT));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // now allocate the wrapper
     RCW *pWrap = new RCW();
@@ -1258,7 +1252,7 @@ RCW* RCW::CreateRCWInternal(IUnknown *pUnk, DWORD dwSyncBlockIndex, DWORD flags,
 
     pUnkHolder.SuppressRelease();
 
-    RETURN pWrap;
+    return pWrap;
 }
 
 //----------------------------------------------------------
@@ -1413,15 +1407,14 @@ LONG RCW::AddRef(RCWCache* pWrapCache)
 
 AppDomain* RCW::GetDomain()
 {
-    CONTRACT (AppDomain*)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
-    RETURN m_pRCWCache->GetDomain();
+    CONTRACTL_END;
+    return m_pRCWCache->GetDomain();
 }
 
 //--------------------------------------------------------------------------------
@@ -1698,14 +1691,13 @@ void RCW::CreateDuplicateWrapper(MethodTable *pNewMT, RCWHolder* pNewRCW)
 // instead of an IID.
 IUnknown* RCW::GetComIPFromRCW(REFIID iid)
 {
-    CONTRACT(IUnknown *)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SafeComHolder<IUnknown> pRet = NULL;
     HRESULT hr = S_OK;
@@ -1724,7 +1716,7 @@ IUnknown* RCW::GetComIPFromRCW(REFIID iid)
     }
 
     pRet.SuppressRelease();
-    RETURN pRet;
+    return pRet;
 }
 
 //--------------------------------------------------------------------------------
@@ -1732,26 +1724,25 @@ IUnknown* RCW::GetComIPFromRCW(REFIID iid)
 // if not found QI for the interface and store it
 IUnknown* RCW::GetComIPFromRCW(MethodTable* pMT)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pMT, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     if (pMT == NULL || pMT->IsObjectClass())
     {
         // give out the IUnknown or IDispatch
         IUnknown *result = GetIUnknown();
         _ASSERTE(result != NULL);
-        RETURN result;
+        return result;
     }
 
     // returns an AddRef'ed IP
-    RETURN GetComIPForMethodTableFromCache(pMT);
+    return GetComIPForMethodTableFromCache(pMT);
 }
 
 
@@ -1760,17 +1751,16 @@ IUnknown* RCW::GetComIPFromRCW(MethodTable* pMT)
 // make sure it is on the right thread
 IUnknown* RCW::GetIUnknown()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Try to retrieve the IUnknown in the current context.
-    RETURN m_UnkEntry.GetIUnknownForCurrContext(false);
+    return m_UnkEntry.GetIUnknownForCurrContext(false);
 }
 
 //-----------------------------------------------------------------
@@ -1779,29 +1769,27 @@ IUnknown* RCW::GetIUnknown()
 // otherwise NULL will be returned.
 IUnknown* RCW::GetIUnknown_NoAddRef()
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // Retrieve the IUnknown in the current context.
-    RETURN m_UnkEntry.GetIUnknownForCurrContext(true);
+    return m_UnkEntry.GetIUnknownForCurrContext(true);
 }
 
 IUnknown *RCW::GetWellKnownInterface(REFIID riid)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IUnknown *pUnk = NULL;
 
@@ -1815,7 +1803,7 @@ IUnknown *RCW::GetWellKnownInterface(REFIID riid)
     }
 
     // Return the IDispatch that is guaranteed to be valid on the current thread.
-    RETURN pUnk;
+    return pUnk;
 }
 
 //-----------------------------------------------------------------
@@ -1929,15 +1917,14 @@ HRESULT RCW::CallQueryInterface(MethodTable *pMT, Instantiation inst, IID *piid,
 // for the current apartment, use the cache and update the cache on miss
 IUnknown* RCW::GetComIPForMethodTableFromCache(MethodTable* pMT)
 {
-    CONTRACT(IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         PRECONDITION(CheckPointer(pMT));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     ULONG cbRef;
     IUnknown* pUnk = 0;
@@ -1964,7 +1951,7 @@ IUnknown* RCW::GetComIPForMethodTableFromCache(MethodTable* pMT)
 
                 cbRef = SafeAddRef(pUnk);
                 LogInteropAddRef(pUnk, cbRef, "RCW::GetComIPForMethodTableFromCache: Addref because returning pUnk fetched from InterfaceEntry cache");
-                RETURN pUnk;
+                return pUnk;
             }
         }
     }
@@ -1976,7 +1963,7 @@ IUnknown* RCW::GetComIPForMethodTableFromCache(MethodTable* pMT)
     hr = CallQueryInterface(pMT, Instantiation(), &iid, &pUnk);
 
     if (pUnk == NULL)
-        RETURN NULL;
+        return NULL;
 
     // try to cache the interface pointer in the inline cache. This cache can only store interface pointers
     // returned from QI's in the same context where we created the RCW.
@@ -1999,7 +1986,7 @@ IUnknown* RCW::GetComIPForMethodTableFromCache(MethodTable* pMT)
         }
     }
 
-    RETURN pUnk;
+    return pUnk;
 }
 
 //----------------------------------------------------------
@@ -2061,15 +2048,14 @@ HRESULT RCW::EnterContext(PFNCTXCALLBACK pCallbackFunc, LPVOID pData)
 // Callback called to release the IUnkEntry and the Interface entries.
 HRESULT __stdcall RCW::ReleaseAllInterfacesCallBack(LPVOID pData)
 {
-    CONTRACT(HRESULT)
+    CONTRACTL
     {
         NOTHROW;
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
         PRECONDITION(CheckPointer(pData));
-        POSTCONDITION(SUCCEEDED(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     RCW* pWrap = (RCW*)pData;
 
@@ -2096,7 +2082,8 @@ HRESULT __stdcall RCW::ReleaseAllInterfacesCallBack(LPVOID pData)
         }
     }
 
-    RETURN S_OK;
+    _ASSERTE(SUCCEEDED(S_OK));
+    return S_OK;
 }
 
 //---------------------------------------------------------------------
@@ -2310,7 +2297,7 @@ BOOL ComObject::SupportsInterface(OBJECTREF oref, MethodTable* pIntfTable)
 // ThrowInvalidCastException
 void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToMT)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
@@ -2318,9 +2305,8 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         PRECONDITION(pObj != NULL);
         PRECONDITION(*pObj != NULL);
         PRECONDITION(IsProtectedByGCFrame (pObj));
-        POSTCONDITION(!"This function should never return!");
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SafeComHolder<IUnknown> pItf = NULL;
     HRESULT hr = S_OK;
@@ -2425,7 +2411,8 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
     }
 
-    RETURN;
+    _ASSERTE(!"This function should never return!");
+    return;
 }
 
 //--------------------------------------------------------------------------------
@@ -2456,16 +2443,15 @@ void ComObject::ReleaseAllData(OBJECTREF oref)
 // static
 IUnknown *ComObject::GetComIPFromRCW(OBJECTREF *pObj, MethodTable* pIntfTable)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(IsProtectedByGCFrame(pObj));
         PRECONDITION(CheckPointer(pIntfTable, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK)); // NULL if we couldn't find match
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SafeComHolder<IUnknown> pIUnk;
 
@@ -2475,7 +2461,7 @@ IUnknown *ComObject::GetComIPFromRCW(OBJECTREF *pObj, MethodTable* pIntfTable)
     pIUnk = pRCW->GetComIPFromRCW(pIntfTable);
 
     RCWPROTECT_END(pRCW);
-    RETURN pIUnk.Extract();
+    return pIUnk.Extract();
 }
 
 //--------------------------------------------------------------------------
@@ -2483,23 +2469,22 @@ IUnknown *ComObject::GetComIPFromRCW(OBJECTREF *pObj, MethodTable* pIntfTable)
 // static
 IUnknown *ComObject::GetComIPFromRCWThrowing(OBJECTREF *pObj, MethodTable* pIntfTable)
 {
-    CONTRACT (IUnknown*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_COOPERATIVE;
         PRECONDITION(IsProtectedByGCFrame(pObj));
         PRECONDITION(CheckPointer(pIntfTable, NULL_OK));
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     IUnknown* pIUnk = GetComIPFromRCW(pObj, pIntfTable);
 
     if (pIUnk == NULL)
         ThrowInvalidCastException(pObj, pIntfTable);
 
-    RETURN pIUnk;
+    return pIUnk;
 }
 #endif // #ifndef DACCESS_COMPILE
 

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -2082,7 +2082,6 @@ HRESULT __stdcall RCW::ReleaseAllInterfacesCallBack(LPVOID pData)
         }
     }
 
-    _ASSERTE(SUCCEEDED(S_OK));
     return S_OK;
 }
 
@@ -2411,7 +2410,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
     }
 
-    _ASSERTE(!"This function should never return!");
+    UNREACHABLE();
     return;
 }
 

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -2082,6 +2082,7 @@ HRESULT __stdcall RCW::ReleaseAllInterfacesCallBack(LPVOID pData)
         }
     }
 
+    _ASSERTE(SUCCEEDED(S_OK));
     return S_OK;
 }
 
@@ -2410,6 +2411,7 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
     }
 
+    _ASSERTE(!"This function should never return!");
     return;
 }
 

--- a/src/coreclr/vm/runtimecallablewrapper.cpp
+++ b/src/coreclr/vm/runtimecallablewrapper.cpp
@@ -2082,7 +2082,6 @@ HRESULT __stdcall RCW::ReleaseAllInterfacesCallBack(LPVOID pData)
         }
     }
 
-    _ASSERTE(SUCCEEDED(S_OK));
     return S_OK;
 }
 
@@ -2411,7 +2410,6 @@ void ComObject::ThrowInvalidCastException(OBJECTREF *pObj, MethodTable *pCastToM
         }
     }
 
-    _ASSERTE(!"This function should never return!");
     return;
 }
 

--- a/src/coreclr/vm/runtimecallablewrapper.h
+++ b/src/coreclr/vm/runtimecallablewrapper.h
@@ -211,34 +211,32 @@ struct RCW
     // return exposed ComObject
     COMOBJECTREF GetExposedObject()
     {
-        CONTRACT(COMOBJECTREF)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
             PRECONDITION(m_SyncBlockIndex != 0);
-            POSTCONDITION(RETVAL != NULL);
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN (COMOBJECTREF) ObjectToOBJECTREF(g_pSyncTable[m_SyncBlockIndex].m_Object);
+        return (COMOBJECTREF) ObjectToOBJECTREF(g_pSyncTable[m_SyncBlockIndex].m_Object);
     }
 
     //-------------------------------------------------
     // returns the sync block for the RCW
     SyncBlock *GetSyncBlock()
     {
-        CONTRACT(SyncBlock*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
             PRECONDITION(m_SyncBlockIndex != 0);
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN g_pSyncTable[m_SyncBlockIndex].m_SyncBlock;
+        return g_pSyncTable[m_SyncBlockIndex].m_SyncBlock;
     }
 
     //--------------------------------------------------------------------------
@@ -384,33 +382,31 @@ struct RCW
     // GetWrapper context cookie
     LPVOID GetWrapperCtxCookie()
     {
-        CONTRACT (LPVOID)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_UnkEntry.m_pCtxCookie;
+        return m_UnkEntry.m_pCtxCookie;
     }
 
     inline Thread *GetSTAThread()
     {
-        CONTRACT (Thread *)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         CtxEntry *pCtxEntry = GetWrapperCtxEntryNoRef();
         if (pCtxEntry)
-            RETURN pCtxEntry->GetSTAThread();
-        RETURN NULL;
+            return pCtxEntry->GetSTAThread();
+        return NULL;
     }
 
     // Function to enter the context. The specified callback function will
@@ -551,35 +547,33 @@ private :
     // Returns an addref'ed context entry
     CtxEntry* GetWrapperCtxEntry()
     {
-        CONTRACT (CtxEntry*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(!IsFreeThreaded());         // Must not be free-threaded, otherwise CtxEntry = NULL
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         CtxEntry *pCtxEntry = m_UnkEntry.GetCtxEntry();
         pCtxEntry->AddRef();
-        RETURN pCtxEntry;
+        return pCtxEntry;
     }
 
     // Returns an non-addref'ed context entry
     CtxEntry *GetWrapperCtxEntryNoRef()
     {
-        CONTRACT (CtxEntry *)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         CtxEntry *pCtxEntry = m_UnkEntry.GetCtxEntry();
-        RETURN pCtxEntry;
+        return pCtxEntry;
     }
 };
 
@@ -1140,16 +1134,15 @@ public:
 
     AppDomain* GetDomain()
     {
-        CONTRACT (AppDomain*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pDomain;
+        return m_pDomain;
     }
 
     // Worker function called to release wrappers in the pCtxCookie context.
@@ -1190,21 +1183,20 @@ public:
 
     RCW* LookupWrapperUnsafe(LPVOID pUnk)
     {
-        CONTRACT (RCW*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_COOPERATIVE;
             PRECONDITION(CheckPointer(pUnk));
             PRECONDITION(LOCKHELD());
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         // We don't want the GC messing with the hash table underneath us.
         GCX_FORBID();
 
-        RETURN m_HashMap.Lookup(pUnk);
+        return m_HashMap.Lookup(pUnk);
     }
 
 #endif //DACCESS_COMPILE

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -43,6 +43,8 @@ extern "C" BOOL QCALLTYPE MdUtf8String_EqualsCaseInsensitive(LPCUTF8 szLhs, LPCU
 
     BEGIN_QCALL;
 
+    _ASSERTE(CheckPointer(szLhs));
+    _ASSERTE(CheckPointer(szRhs));
 
     // At this point, both the left and right strings are guaranteed to have the
     // same length.

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -43,8 +43,6 @@ extern "C" BOOL QCALLTYPE MdUtf8String_EqualsCaseInsensitive(LPCUTF8 szLhs, LPCU
 
     BEGIN_QCALL;
 
-    _ASSERTE(CheckPointer(szLhs));
-    _ASSERTE(CheckPointer(szRhs));
 
     // At this point, both the left and right strings are guaranteed to have the
     // same length.

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -623,7 +623,6 @@ void MetaSig::Init(
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         MODE_ANY;
         GC_NOTRIGGER;
@@ -798,7 +797,6 @@ MetaSig::MetaSig(BinderMethodID id)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         THROWS;
         MODE_ANY;
         GC_TRIGGERS;
@@ -818,7 +816,6 @@ MetaSig::MetaSig(LPHARDCODEDMETASIG pwzMetaSig)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         THROWS;
         MODE_ANY;
         GC_TRIGGERS;
@@ -839,7 +836,6 @@ MetaSig::MetaSig(FieldDesc *pFD, TypeHandle declaringType)
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         NOTHROW;
         MODE_ANY;
         GC_NOTRIGGER;
@@ -2086,7 +2082,6 @@ TypeHandle SigPointer::GetTypeVariableThrowing(ModuleBase *pModule, // unused - 
     }
 #endif
 
-    _ASSSERTE(CheckPointer(RETVAL, ((fLoadTypes == ClassLoader::LoadTypes) ? NULL_NOT_OK : NULL_OK)));
     return(res);
 }
 

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1108,7 +1108,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                  MethodTable*                 pMTInterfaceMapOwner,
                  HandleRecursiveGenericsForFieldLayoutLoad *pRecursiveFieldGenericHandling) const
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         if (FORBIDGC_LOADER_USE_ENABLED()) NOTHROW; else THROWS;
@@ -1118,10 +1118,9 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
         if (FORBIDGC_LOADER_USE_ENABLED() || fLoadTypes != ClassLoader::LoadTypes) { LOADS_TYPE(CLASS_LOAD_BEGIN); } else { LOADS_TYPE(level); }
         PRECONDITION(CheckPointer(pModule));
         PRECONDITION(level > CLASS_LOAD_BEGIN && level <= CLASS_LOADED);
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == ClassLoader::LoadTypes) ? NULL_NOT_OK : NULL_OK)));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     _ASSERTE(!pRecursiveFieldGenericHandling || dropGenericArgumentLevel); // pRecursiveFieldGenericHandling can only be set if dropGenericArgumentLevel is set
     if (pRecursiveFieldGenericHandling != NULL)
@@ -1957,7 +1956,8 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
 
     }
 
-    RETURN thRet;
+    _ASSERTE(CheckPointer(thRet, ((fLoadTypes == ClassLoader::LoadTypes) ? NULL_NOT_OK : NULL_OK)));
+    return thRet;
 }
 
 TypeHandle SigPointer::GetGenericInstType(ModuleBase *        pModule,
@@ -2066,7 +2066,7 @@ TypeHandle SigPointer::GetTypeVariableThrowing(ModuleBase *pModule, // unused - 
                                                ClassLoader::LoadTypesFlag fLoadTypes/*=LoadTypes*/,
                                                const SigTypeContext *pTypeContext)
 {
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CorTypeInfo::IsGenericVariable_NoThrow(et));
@@ -2074,10 +2074,9 @@ TypeHandle SigPointer::GetTypeVariableThrowing(ModuleBase *pModule, // unused - 
         MODE_ANY;
         if (FORBIDGC_LOADER_USE_ENABLED()) GC_NOTRIGGER; else GC_TRIGGERS;
         if (FORBIDGC_LOADER_USE_ENABLED()) FORBID_FAULT; else { INJECT_FAULT(COMPlusThrowOM()); }
-        POSTCONDITION(CheckPointer(RETVAL, ((fLoadTypes == ClassLoader::LoadTypes) ? NULL_NOT_OK : NULL_OK)));
         SUPPORTS_DAC;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     TypeHandle res = GetTypeVariable(et, pTypeContext);
 #ifndef DACCESS_COMPILE
@@ -2086,7 +2085,7 @@ TypeHandle SigPointer::GetTypeVariableThrowing(ModuleBase *pModule, // unused - 
        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
     }
 #endif
-    RETURN(res);
+    return(res);
 }
 
 // SigPointer should be just after E_T_VAR or E_T_MVAR
@@ -2094,23 +2093,22 @@ TypeHandle SigPointer::GetTypeVariable(CorElementType et,
                                        const SigTypeContext *pTypeContext)
 {
 
-    CONTRACT(TypeHandle)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         PRECONDITION(CorTypeInfo::IsGenericVariable_NoThrow(et));
         NOTHROW;
         GC_NOTRIGGER;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK)); // will return TypeHandle() if index is out of range
         SUPPORTS_DAC;
         MODE_ANY;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     uint32_t index;
     if (FAILED(GetData(&index)))
     {
         TypeHandle thNull;
-        RETURN(thNull);
+        return(thNull);
     }
 
     if (!pTypeContext
@@ -2124,15 +2122,15 @@ TypeHandle SigPointer::GetTypeVariable(CorElementType et,
         LOG((LF_ALWAYS, LL_INFO1000, "GENERICS: Error: GetTypeVariable on out-of-range type variable\n"));
         BAD_FORMAT_NOTHROW_ASSERT(!"Invalid type context: either this is an ill-formed signature (e.g. an invalid type variable number) or you have not provided a non-empty SigTypeContext where one is required.  Check back on the callstack for where the value of pTypeContext is first provided, and see if it is acquired from the correct place.  For calls originating from a JIT it should be acquired from the context parameter, which indicates the method being compiled.  For calls from other locations it should be acquired from the MethodTable, EEClass, TypeHandle, FieldDesc or MethodDesc being analyzed.");
         TypeHandle thNull;
-        RETURN(thNull);
+        return(thNull);
     }
     if (et == ELEMENT_TYPE_VAR)
     {
-        RETURN(pTypeContext->m_classInst[index]);
+        return(pTypeContext->m_classInst[index]);
     }
     else
     {
-        RETURN(pTypeContext->m_methodInst[index]);
+        return(pTypeContext->m_methodInst[index]);
     }
 }
 

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -2085,6 +2085,8 @@ TypeHandle SigPointer::GetTypeVariableThrowing(ModuleBase *pModule, // unused - 
        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
     }
 #endif
+
+    _ASSSERTE(CheckPointer(RETVAL, ((fLoadTypes == ClassLoader::LoadTypes) ? NULL_NOT_OK : NULL_OK)));
     return(res);
 }
 

--- a/src/coreclr/vm/stackingallocator.cpp
+++ b/src/coreclr/vm/stackingallocator.cpp
@@ -150,14 +150,14 @@ void *StackingAllocator::GetCheckpoint()
 
 bool StackingAllocator::AllocNewBlockForBytes(unsigned n)
 {
-    CONTRACT (bool)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_ANY;
         PRECONDITION(m_CheckpointDepth > 0);
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // already aligned and in the hard case
 
@@ -195,7 +195,7 @@ bool StackingAllocator::AllocNewBlockForBytes(unsigned n)
         // this allocator, to get even more MP scalability?</TODO>
         b = (StackBlock *)new (nothrow) char[allocSize];
         if (b == NULL)
-            RETURN false;
+            return false;
 
         // reserve space for the Block structure and then link it in
         b->m_Length = (unsigned) (allocSize - sizeof(StackBlock));
@@ -215,22 +215,21 @@ bool StackingAllocator::AllocNewBlockForBytes(unsigned n)
 
      INDEBUG(b->m_Sentinel = 0);
 
-     RETURN true;
+     return true;
 }
 
 
 void* StackingAllocator::UnsafeAllocSafeThrow(UINT32 Size)
 {
-    CONTRACT (void*)
+    CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(ThrowOutOfMemory());
         PRECONDITION(m_CheckpointDepth > 0);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // OOM fault injection in AllocNoThrow
 
@@ -238,21 +237,20 @@ void* StackingAllocator::UnsafeAllocSafeThrow(UINT32 Size)
     if (retval == NULL)
         ENCLOSE_IN_EXCEPTION_HANDLER ( ThrowOutOfMemory );
 
-    RETURN retval;
+    return retval;
 }
 
 void *StackingAllocator::UnsafeAlloc(UINT32 Size)
 {
-    CONTRACT (void*)
+    CONTRACTL
     {
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(ThrowOutOfMemory());
         PRECONDITION(m_CheckpointDepth > 0);
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     // OOM fault injection in AllocNoThrow
 
@@ -260,7 +258,7 @@ void *StackingAllocator::UnsafeAlloc(UINT32 Size)
     if (retval == NULL)
         ThrowOutOfMemory();
 
-    RETURN retval;
+    return retval;
 }
 
 

--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -124,7 +124,6 @@ public:
         //special case, 0 size alloc, return non-null but invalid pointer
         if (Size == 0)
         {
-            _ASSERTE(CheckPointer((void*)-1, NULL_OK));
             return (void*)-1;
         }
 

--- a/src/coreclr/vm/stackingallocator.h
+++ b/src/coreclr/vm/stackingallocator.h
@@ -106,16 +106,15 @@ public:
     // @todo move this into a .inl file as many class users of this class don't need to include this body
     FORCEINLINE void * UnsafeAllocNoThrow(unsigned Size)
     {
-        CONTRACT (void*)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
-            INJECT_FAULT(CONTRACT_RETURN NULL;);
+            INJECT_FAULT(return NULL;);
             PRECONDITION(m_CheckpointDepth > 0);
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
 #ifdef _DEBUG
         m_Allocs++;
@@ -125,7 +124,8 @@ public:
         //special case, 0 size alloc, return non-null but invalid pointer
         if (Size == 0)
         {
-            RETURN (void*)-1;
+            _ASSERTE(CheckPointer((void*)-1, NULL_OK));
+            return (void*)-1;
         }
 
         // Round size up to ensure alignment.
@@ -143,7 +143,7 @@ public:
         {
             if (!AllocNewBlockForBytes(n))
             {
-                RETURN NULL;
+                return NULL;
             }
         }
 
@@ -160,7 +160,7 @@ public:
         m_FirstBlock->m_Sentinel = new(m_FirstFree - sizeof(Sentinel)) Sentinel(m_FirstBlock->m_Sentinel);
 #endif
 
-        RETURN ret;
+        return ret;
     }
 
     FORCEINLINE void * AllocNoThrow(S_UINT32 size)

--- a/src/coreclr/vm/stubcache.cpp
+++ b/src/coreclr/vm/stubcache.cpp
@@ -77,12 +77,11 @@ StubCacheBase::~StubCacheBase()
 //---------------------------------------------------------
 Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
 {
-    CONTRACT (Stub*)
+    CONTRACTL
     {
         STANDARD_VM_CHECK;
-        POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     STUBHASHENTRY *phe = NULL;
 
@@ -101,7 +100,7 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
             stubWriterHolder.GetRW()->IncRef();
 
             pstub.SuppressRelease();
-            RETURN pstub;
+            return pstub;
         }
     }
 
@@ -163,7 +162,7 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
     }
 
     pstub.SuppressRelease();
-    RETURN pstub;
+    return pstub;
 }
 
 

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -213,7 +213,7 @@ static SOleTlsData* GetOrCreateOleTlsData()
         GC_TRIGGERS;
         MODE_COOPERATIVE;
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     SOleTlsData* pOleTlsData = TryGetOleTlsData();
     if (pOleTlsData == NULL)

--- a/src/coreclr/vm/stublink.h
+++ b/src/coreclr/vm/stublink.h
@@ -429,7 +429,7 @@ class Stub
         //-------------------------------------------------------------------
         static Stub* RecoverStubAndSize(PCODE pEntryPoint, DWORD *pSize)
         {
-            CONTRACT(Stub*)
+            CONTRACTL
             {
                 NOTHROW;
                 GC_NOTRIGGER;
@@ -437,11 +437,11 @@ class Stub
 
                 PRECONDITION(pEntryPoint && pSize);
             }
-            CONTRACT_END;
+            CONTRACTL_END;
 
             Stub *pStub = Stub::RecoverStub(pEntryPoint);
             *pSize = sizeof(Stub) + pStub->GetNumCodeBytes();
-            RETURN pStub;
+            return pStub;
         }
 
         HRESULT CloneStub(BYTE *pBuffer, DWORD dwBufferSize)

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -1557,16 +1557,15 @@ typedef Wrapper<SyncBlock*, DoNothing<SyncBlock*>, VoidDeleteSyncBlockMemory, 0>
 // get the sync block for an existing object
 SyncBlock *ObjHeader::GetSyncBlock()
 {
-    CONTRACT(SyncBlock *)
+    CONTRACTL
     {
         INSTANCE_CHECK;
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(CheckPointer(RETVAL));
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     PTR_SyncBlock syncBlock = GetBaseObject()->PassiveGetSyncBlock();
     DWORD      indx = 0;
@@ -1579,7 +1578,7 @@ SyncBlock *ObjHeader::GetSyncBlock()
         PTR_SyncTableEntry pEntries(SyncTableEntry::GetSyncTableEntry());
         _ASSERTE(pEntries[GetHeaderSyncBlockIndex()].m_Object == GetBaseObject());
 #endif // _DEBUG
-        RETURN syncBlock;
+        return syncBlock;
     }
 
     //Need to get it from the cache
@@ -1589,7 +1588,9 @@ SyncBlock *ObjHeader::GetSyncBlock()
         //Try one more time
         syncBlock = GetBaseObject()->PassiveGetSyncBlock();
         if (syncBlock)
-            RETURN syncBlock;
+            {
+                return syncBlock;
+            }
 
         SyncBlockMemoryHolder syncBlockMemoryHolder(SyncBlockCache::GetSyncBlockCache()->GetNextFreeSyncBlock());
         syncBlock = syncBlockMemoryHolder;
@@ -1663,7 +1664,7 @@ SyncBlock *ObjHeader::GetSyncBlock()
         // SyncBlockCache::LockHolder goes out of scope here
     }
 
-    RETURN syncBlock;
+    return syncBlock;
 }
 
 // ***************************************************************************

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -282,7 +282,6 @@ void SyncBlockCache::Init()
 {
     CONTRACTL
     {
-        CONSTRUCTOR_CHECK;
         THROWS;
         GC_NOTRIGGER;
         MODE_ANY;

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -501,14 +501,13 @@ class SyncBlock
     // Gets the InteropInfo block, creates a new one if none is present.
     InteropSyncBlockInfo* GetInteropInfo()
     {
-        CONTRACT (InteropSyncBlockInfo*)
+        CONTRACTL
         {
             THROWS;
             GC_TRIGGERS;
             MODE_ANY;
-            POSTCONDITION(CheckPointer(RETVAL));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
         if (!m_pInteropInfo)
         {
@@ -518,22 +517,22 @@ class SyncBlock
                 pInteropInfo.SuppressRelease();
         }
 
-        RETURN m_pInteropInfo;
+        _ASSERTE(m_pInteropInfo != NULL);
+        return m_pInteropInfo;
     }
 
     PTR_InteropSyncBlockInfo GetInteropInfoNoCreate()
     {
-        CONTRACT (PTR_InteropSyncBlockInfo)
+        CONTRACTL
         {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             SUPPORTS_DAC;
-            POSTCONDITION(CheckPointer(RETVAL, NULL_OK));
         }
-        CONTRACT_END;
+        CONTRACTL_END;
 
-        RETURN m_pInteropInfo;
+        return m_pInteropInfo;
     }
 
     // Returns false if the InteropInfo block was already set - does not overwrite the previous value.

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -502,7 +502,6 @@ static inline BOOL CheckSuspended(Thread *pThread)
     CONTRACTL_END;
 
     _ASSERTE(GetThreadNULLOk() != pThread);
-    _ASSERTE(CheckPointer(pThread));
 
 #ifndef DISABLE_THREADSUSPEND
     DWORD dwSuspendCount;
@@ -4118,7 +4117,7 @@ bool Thread::SysStartSuspendForDebug(AppDomain *pAppDomain)
 // This can be safely called if we're already suspended.
 bool Thread::SysSweepThreadsForDebug(bool forceSync)
 {
-    CONTRACT(bool) {
+    CONTRACTL {
         NOTHROW;
         DISABLED(GC_TRIGGERS); // WaitUntilConcurrentGCComplete toggle GC mode, disabled because called by unmanaged thread
 
@@ -4128,9 +4127,8 @@ bool Thread::SysSweepThreadsForDebug(bool forceSync)
         PRECONDITION(GetThreadNULLOk() == NULL);
 
         // Iff we return true, then we have the TSL (or the aux lock used in workarounds).
-        POSTCONDITION(ThreadStore::HoldingThreadStore());
     }
-    CONTRACT_END;
+    CONTRACTL_END;
 
     _ASSERTE(!forceSync); // deprecated parameter
 
@@ -4279,7 +4277,8 @@ Label_MarkThreadAsSynced:
         {
             // If that was the last thread, then the CLR is synced.
             // We return while own the thread store lock. We return true now, which indicates this to the caller.
-            RETURN true;
+            _ASSERTE(ThreadStore::HoldingThreadStore());
+            return true;
         }
         continue;
 
@@ -4287,13 +4286,15 @@ Label_MarkThreadAsSynced:
 
     if (m_DebugWillSyncCount < 0)
     {
-        RETURN true;
+        _ASSERTE(ThreadStore::HoldingThreadStore());
+        return true;
     }
 
     // The CLR is not yet synced. We release the threadstore lock and return false.
     hldSuspendRuntimeInProgress.Release();
 
-    RETURN false;
+    _ASSERTE(ThreadStore::HoldingThreadStore());
+    return false;
 }
 
 void Thread::SysResumeFromDebug(AppDomain *pAppDomain)

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -737,7 +737,6 @@ TypeHandle* TypeVarTypeDesc::GetConstraints(DWORD *pNumConstraints, ClassLoadLev
     }
     CONTRACTL_END;
 
-    _ASSERTE(CheckPointer(pNumConstraints));
     _ASSERTE(level == CLASS_DEPENDENCIES_LOADED || level == CLASS_LOADED);
 
     DWORD numConstraints = m_numConstraintsWithFlags;

--- a/src/coreclr/vm/typedesc.cpp
+++ b/src/coreclr/vm/typedesc.cpp
@@ -737,6 +737,7 @@ TypeHandle* TypeVarTypeDesc::GetConstraints(DWORD *pNumConstraints, ClassLoadLev
     }
     CONTRACTL_END;
 
+    _ASSERTE(CheckPointer(pNumConstraints));
     _ASSERTE(level == CLASS_DEPENDENCIES_LOADED || level == CLASS_LOADED);
 
     DWORD numConstraints = m_numConstraintsWithFlags;

--- a/src/coreclr/vm/typestring.cpp
+++ b/src/coreclr/vm/typestring.cpp
@@ -497,26 +497,26 @@ HRESULT TypeNameBuilder::Clear()
 // The following flags in the FormatFlags argument are significant: FormatNamespace
 void TypeString::AppendTypeDef(SString& ss, IMDInternalImport *pImport, mdTypeDef td, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         GC_NOTRIGGER;
         THROWS;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     {
         TypeNameBuilder tnb(&ss, TypeNameBuilder::ParseStateNAME);
         AppendTypeDef(tnb, pImport, td, format);
     }
 
-    RETURN;
+    return;
 }
 
 
 void TypeString::AppendTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pImport, mdTypeDef td, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         GC_NOTRIGGER;
@@ -524,7 +524,7 @@ void TypeString::AppendTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pImport,
         PRECONDITION(CheckPointer(pImport));
         PRECONDITION(TypeFromToken(td) == mdtTypeDef);
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     LPCUTF8 szName;
     LPCUTF8 szNameSpace;
@@ -543,12 +543,12 @@ void TypeString::AppendTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pImport,
 
     tnb.AddName(ssName.GetUnicode(), wszNameSpace);
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendNestedTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pImport, mdTypeDef td, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         GC_NOTRIGGER;
@@ -556,7 +556,7 @@ void TypeString::AppendNestedTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pI
         PRECONDITION(CheckPointer(pImport));
         PRECONDITION(TypeFromToken(td) == mdtTypeDef);
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     DWORD dwAttr;
     IfFailThrow(pImport->GetTypeDefProps(td, &dwAttr, NULL));
@@ -572,7 +572,7 @@ void TypeString::AppendNestedTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pI
     for(SCOUNT_T i = arNames.GetCount() - 1; i >= 0; i --)
         AppendTypeDef(tnb, pImport, arNames[i], format);
 
-    RETURN;
+    return;
 }
 
 // Append a square-bracket-enclosed, comma-separated list of n type parameters in inst to the string s
@@ -580,13 +580,13 @@ void TypeString::AppendNestedTypeDef(TypeNameBuilder& tnb, IMDInternalImport *pI
 // The following flags in the FormatFlags argument are significant: FormatNamespace FormatFullInst FormatAssembly
 void TypeString::AppendInst(SString& ss, Instantiation inst, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         THROWS;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     {
         TypeNameBuilder tnb(&ss, TypeNameBuilder::ParseStateNAME);
@@ -595,19 +595,19 @@ void TypeString::AppendInst(SString& ss, Instantiation inst, DWORD format)
         AppendInst(tnb, inst, format);
     }
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendInst(TypeNameBuilder& tnb, Instantiation inst, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         THROWS;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         PRECONDITION(!inst.IsEmpty());
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     tnb.OpenGenericArguments();
 
@@ -635,7 +635,7 @@ void TypeString::AppendInst(TypeNameBuilder& tnb, Instantiation inst, DWORD form
 
     tnb.CloseGenericArguments();
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendParamTypeQualifier(TypeNameBuilder& tnb, CorElementType kind, DWORD rank)
@@ -672,28 +672,28 @@ void TypeString::AppendParamTypeQualifier(TypeNameBuilder& tnb, CorElementType k
 // The following flags in the FormatFlags argument are significant: FormatNamespace FormatFullInst FormatAssembly
 void TypeString::AppendType(SString& ss, TypeHandle ty, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         THROWS;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     AppendType(ss, ty, Instantiation(), format);
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendType(SString& ss, TypeHandle ty, Instantiation typeInstantiation, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         THROWS;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     {
         TypeNameBuilder tnb(&ss);
@@ -702,12 +702,12 @@ void TypeString::AppendType(SString& ss, TypeHandle ty, Instantiation typeInstan
         AppendType(tnb, ty, typeInstantiation, format);
     }
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation typeInstantiation, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
 
@@ -719,7 +719,7 @@ void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation t
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         THROWS;
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     BOOL bToString = (format & (FormatNamespace|FormatFullInst|FormatAssembly)) == FormatNamespace;
 
@@ -892,7 +892,7 @@ void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation t
 
     }
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendMethod(SString& s, MethodDesc *pMD, Instantiation typeInstantiation, const DWORD format)
@@ -1120,14 +1120,14 @@ void TypeString::AppendTypeKeyDebug(SString& ss, const TypeKey *pTypeKey)
 
 void TypeString::AppendTypeKey(TypeNameBuilder& tnb, const TypeKey *pTypeKey, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         THROWS;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         PRECONDITION(CheckPointer(pTypeKey));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     Module *pModule = NULL;
 
@@ -1159,7 +1159,7 @@ void TypeString::AppendTypeKey(TypeNameBuilder& tnb, const TypeKey *pTypeKey, DW
     }
     else if (kind == ELEMENT_TYPE_FNPTR)
     {
-        RETURN;
+        return;
     }
 
     // ...otherwise it's just a plain type def or an instantiated type
@@ -1197,26 +1197,26 @@ void TypeString::AppendTypeKey(TypeNameBuilder& tnb, const TypeKey *pTypeKey, DW
         tnb.AddAssemblySpec(pAssemblyName.GetUnicode());
     }
 
-    RETURN;
+    return;
 }
 
 void TypeString::AppendTypeKey(SString& ss, const TypeKey *pTypeKey, DWORD format)
 {
-    CONTRACT_VOID
+    CONTRACTL
     {
         MODE_ANY;
         if (format & (FormatAssembly|FormatFullInst)) GC_TRIGGERS; else GC_NOTRIGGER;
         THROWS;
         PRECONDITION(CheckPointer(pTypeKey));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     {
         TypeNameBuilder tnb(&ss);
         AppendTypeKey(tnb, pTypeKey, format);
     }
 
-    RETURN;
+    return;
 }
 
 /*static*/

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -1023,13 +1023,12 @@ PCODE VirtualCallStubManager::GetCallStub(TypeHandle ownerType, MethodDesc *pMD)
 //find or create a stub
 PCODE VirtualCallStubManager::GetCallStub(DispatchToken token)
 {
-    CONTRACT (PCODE) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(RETVAL != NULL);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     GCX_COOP(); // This is necessary for BucketTable synchronization
 
@@ -1051,18 +1050,18 @@ PCODE VirtualCallStubManager::GetCallStub(DispatchToken token)
     _ASSERTE(stub != CALL_STUB_EMPTY_ENTRY);
     stats.site_counter++;
 
-    RETURN (stub);
+    _ASSERTE((stub) != NULL);
+    return (stub);
 }
 
 PCODE VirtualCallStubManager::GetVTableCallStub(DWORD slot)
 {
-    CONTRACT(PCODE) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(RETVAL != NULL);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     GCX_COOP(); // This is necessary for BucketTable synchronization
 
@@ -1080,18 +1079,17 @@ PCODE VirtualCallStubManager::GetVTableCallStub(DWORD slot)
     }
 
     _ASSERTE(stub != CALL_STUB_EMPTY_ENTRY);
-    RETURN(stub);
+    return(stub);
 }
 
 VTableCallHolder* VirtualCallStubManager::GenerateVTableCallStub(DWORD slot)
 {
-    CONTRACT(VTableCallHolder*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         MODE_ANY;
         INJECT_FAULT(COMPlusThrowOM(););
-        POSTCONDITION(RETVAL != NULL);
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     //allocate from the requisite heap and copy the template over it.
     size_t vtableHolderSize = VTableCallHolder::GetHolderSize(slot);
@@ -1111,7 +1109,7 @@ VTableCallHolder* VirtualCallStubManager::GenerateVTableCallStub(DWORD slot)
     PerfMap::LogStubs(__FUNCTION__, "GenerateVTableCallStub", (PCODE)pHolder->stub(), pHolder->stub()->size(), PerfMapStubType::IndividualWithinBlock);
 #endif
 
-    RETURN(pHolder);
+    return(pHolder);
 }
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
 
@@ -1138,13 +1136,12 @@ BYTE* GetStubIndirectionCell(BYTE** pBlocksStart, UINT32 index, UINT32 sizeOfInd
 
 BYTE *VirtualCallStubManager::GenerateStubIndirection(PCODE target, DispatchToken token, BOOL fUseRecycledCell /* = FALSE*/ )
 {
-    CONTRACT (BYTE*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(target != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     _ASSERTE(UseCachedInterfaceDispatch() || isStubStatic(target));
 
@@ -1215,7 +1212,7 @@ BYTE *VirtualCallStubManager::GenerateStubIndirection(PCODE target, DispatchToke
         *((PCODE *)ret) = target;
     )
 
-    RETURN ret;
+    return ret;
 }
 
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
@@ -2442,26 +2439,26 @@ VirtualCallStubManager::Resolver(
 // Given a contract, return true if the contract represents a slot on the target.
 BOOL VirtualCallStubManager::IsClassToken(DispatchToken token)
 {
-    CONTRACT (BOOL) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
-    } CONTRACT_END;
-    RETURN (token.IsThisToken());
+    } CONTRACTL_END;
+    return (token.IsThisToken());
 }
 
 //----------------------------------------------------------------------------
 // Given a contract, return true if the contract represents an interface, false if just a slot.
 BOOL VirtualCallStubManager::IsInterfaceToken(DispatchToken token)
 {
-    CONTRACT (BOOL) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
-    } CONTRACT_END;
+    } CONTRACTL_END;
     BOOL ret = token.IsTypedToken();
     // For now, only interfaces have typed dispatch tokens.
     CONSISTENCY_CHECK(!ret || CheckPointer(AppDomain::GetCurrentDomain()->LookupType(token.GetTypeID())));
     CONSISTENCY_CHECK(!ret || AppDomain::GetCurrentDomain()->LookupType(token.GetTypeID())->IsInterface());
-    RETURN (ret);
+    return (ret);
 }
 
 #ifndef DACCESS_COMPILE
@@ -2472,13 +2469,12 @@ VirtualCallStubManager::GetRepresentativeMethodDescFromToken(
     DispatchToken token,
     MethodTable * pMT)
 {
-    CONTRACT (MethodDesc *) {
+    CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         MODE_COOPERATIVE;
         PRECONDITION(CheckPointer(pMT));
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     // This is called in a context where managed references on the stack may not be fully protected,
     // so garbage collection must be forbidden here.
@@ -2491,7 +2487,7 @@ VirtualCallStubManager::GetRepresentativeMethodDescFromToken(
         token = DispatchToken::CreateDispatchToken(token.GetSlotNumber());
     }
     CONSISTENCY_CHECK(token.IsThisToken());
-    RETURN (pMT->GetMethodDescForSlot_NoThrow(token.GetSlotNumber()));
+    return (pMT->GetMethodDescForSlot_NoThrow(token.GetSlotNumber()));
 }
 
 //----------------------------------------------------------------------------
@@ -2785,7 +2781,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
                                                              size_t           dispatchToken,
                                                              bool *           pMayHaveReenteredCooperativeGCMode)
 {
-    CONTRACT (DispatchHolder*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
@@ -2794,8 +2790,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
         PRECONDITION(CheckPointer(pMTExpected));
         PRECONDITION(pMayHaveReenteredCooperativeGCMode != nullptr);
         PRECONDITION(!*pMayHaveReenteredCooperativeGCMode);
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     size_t dispatchHolderSize = sizeof(DispatchHolder);
 
@@ -2804,7 +2799,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
     if (m_fShouldAllocateLongJumpDispatchStubs
         INDEBUG(|| g_pConfig->ShouldGenerateLongJumpDispatchStub()))
     {
-        RETURN GenerateDispatchStubLong(addrOfCode,
+        return GenerateDispatchStubLong(addrOfCode,
                                         addrOfFail,
                                         pMTExpected,
                                         dispatchToken,
@@ -2822,7 +2817,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
     if (!DispatchHolder::CanShortJumpDispatchStubReachFailTarget(addrOfFail, (LPCBYTE)holder))
     {
         m_fShouldAllocateLongJumpDispatchStubs = TRUE;
-        RETURN GenerateDispatchStub(addrOfCode, addrOfFail, pMTExpected, dispatchToken, pMayHaveReenteredCooperativeGCMode);
+        return GenerateDispatchStub(addrOfCode, addrOfFail, pMTExpected, dispatchToken, pMayHaveReenteredCooperativeGCMode);
     }
 #endif
 
@@ -2860,7 +2855,8 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStub(PCODE            ad
     PerfMap::LogStubs(__FUNCTION__, "GenerateDispatchStub", (PCODE)holder->stub(), holder->stub()->size(), PerfMapStubType::IndividualWithinBlock);
 #endif
 
-    RETURN (holder);
+    _ASSERTE(CheckPointer((holder)));
+    return (holder);
 }
 
 #ifdef TARGET_AMD64
@@ -2874,7 +2870,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStubLong(PCODE          
                                                                  size_t           dispatchToken,
                                                                  bool *           pMayHaveReenteredCooperativeGCMode)
 {
-    CONTRACT (DispatchHolder*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
@@ -2883,8 +2879,7 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStubLong(PCODE          
         PRECONDITION(CheckPointer(pMTExpected));
         PRECONDITION(pMayHaveReenteredCooperativeGCMode != nullptr);
         PRECONDITION(!*pMayHaveReenteredCooperativeGCMode);
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     //allocate from the requisite heap and copy the template over it.
     size_t dispatchHolderSize = DispatchHolder::GetHolderSize(DispatchStub::e_TYPE_LONG);
@@ -2921,7 +2916,8 @@ DispatchHolder *VirtualCallStubManager::GenerateDispatchStubLong(PCODE          
     PerfMap::LogStubs(__FUNCTION__, "GenerateDispatchStub", (PCODE)holder->stub(), holder->stub()->size(), PerfMapStubType::IndividualWithinBlock);
 #endif
 
-    RETURN (holder);
+    _ASSERTE(CheckPointer((holder)));
+    return (holder);
 }
 #endif
 
@@ -2938,7 +2934,7 @@ ResolveHolder *VirtualCallStubManager::GenerateResolveStub(PCODE            addr
 #endif
                                                            )
 {
-    CONTRACT (ResolveHolder*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
@@ -2946,8 +2942,7 @@ ResolveHolder *VirtualCallStubManager::GenerateResolveStub(PCODE            addr
 #if defined(TARGET_X86)
         PRECONDITION(addrOfPatcher != NULL);
 #endif
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     _ASSERTE(addrOfResolver);
 
@@ -3019,7 +3014,8 @@ ResolveHolder *VirtualCallStubManager::GenerateResolveStub(PCODE            addr
     PerfMap::LogStubs(__FUNCTION__, "GenerateResolveStub", (PCODE)holder->stub(), holder->stub()->size(), PerfMapStubType::IndividualWithinBlock);
 #endif
 
-    RETURN (holder);
+    _ASSERTE(CheckPointer((holder)));
+    return (holder);
 }
 
 //----------------------------------------------------------------------------
@@ -3027,13 +3023,12 @@ ResolveHolder *VirtualCallStubManager::GenerateResolveStub(PCODE            addr
 */
 LookupHolder *VirtualCallStubManager::GenerateLookupStub(PCODE addrOfResolver, size_t dispatchToken)
 {
-    CONTRACT (LookupHolder*) {
+    CONTRACTL {
         THROWS;
         GC_TRIGGERS;
         INJECT_FAULT(COMPlusThrowOM(););
         PRECONDITION(addrOfResolver != NULL);
-        POSTCONDITION(CheckPointer(RETVAL));
-    } CONTRACT_END;
+    } CONTRACTL_END;
 
     //allocate from the requisite heap and copy the template over it.
     LookupHolder * holder     = (LookupHolder*) (void*) lookup_heap->AllocAlignedMem(sizeof(LookupHolder), CODE_SIZE_ALIGN);
@@ -3052,7 +3047,8 @@ LookupHolder *VirtualCallStubManager::GenerateLookupStub(PCODE addrOfResolver, s
     PerfMap::LogStubs(__FUNCTION__, "GenerateLookupStub", (PCODE)holder->stub(), holder->stub()->size(), PerfMapStubType::IndividualWithinBlock);
 #endif
 
-    RETURN (holder);
+    _ASSERTE(CheckPointer((holder)));
+    return (holder);
 }
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
 

--- a/src/coreclr/vm/virtualcallstub.h
+++ b/src/coreclr/vm/virtualcallstub.h
@@ -577,13 +577,13 @@ private:
     // This methods returns the a cell from ppList. It returns NULL if the list is empty.
     BYTE * GetOneIndCell(BYTE ** ppList)
     {
-        CONTRACT (BYTE*) {
+        CONTRACTL {
             NOTHROW;
             GC_NOTRIGGER;
             MODE_ANY;
             PRECONDITION(CheckPointer(ppList));
             PRECONDITION(m_indCellLock.OwnedByCurrentThread());
-        } CONTRACT_END;
+        } CONTRACTL_END;
 
         BYTE * temp = *ppList;
 
@@ -591,10 +591,10 @@ private:
         {
             BYTE * pNext = *((BYTE **)temp);
             *ppList = pNext;
-            RETURN temp;
+            return temp;
         }
 
-        RETURN NULL;
+        return NULL;
     }
 
     // insert a linked list of indirection cells at the beginning of m_FreeIndCellList

--- a/src/coreclr/vm/zapsig.cpp
+++ b/src/coreclr/vm/zapsig.cpp
@@ -290,7 +290,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
                                                      TypeHandle               handle,
                                                      const ZapSig::Context *  pZapSigContext)
 {
-    CONTRACT(BOOL)
+    CONTRACTL
     {
         NOTHROW;
         GC_NOTRIGGER;
@@ -303,7 +303,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         PRECONDITION(CheckPointer(handle));
         PRECONDITION(CheckPointer(pSig));
     }
-    CONTRACT_END
+    CONTRACTL_END
 
     mdToken      tk;
 
@@ -320,7 +320,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         {
             // Unknown type!
             _ASSERTE(!"Unknown type in ZapSig::CompareSignatureToTypeHandle");
-            RETURN(FALSE);
+            return(FALSE);
         }
 
         case ELEMENT_TYPE_MODULE_ZAPSIG:
@@ -329,9 +329,9 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
             CONTRACT_VIOLATION(ThrowsViolation|GCViolation);
             pModule = pZapSigContext->GetZapSigModule()->GetModuleFromIndexIfLoaded(ix);
             if (pModule == NULL)
-                RETURN FALSE;
+                return FALSE;
             else
-                RETURN(CompareSignatureToTypeHandle(pSig, pModule, handle, pZapSigContext));
+                return(CompareSignatureToTypeHandle(pSig, pModule, handle, pZapSigContext));
         }
 
         case ELEMENT_TYPE_U:
@@ -350,36 +350,36 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         case ELEMENT_TYPE_BOOLEAN:
         case ELEMENT_TYPE_CHAR:
         case ELEMENT_TYPE_TYPEDBYREF:
-            RETURN(sigType == handleType);
+            return(sigType == handleType);
 
         case ELEMENT_TYPE_STRING:
-            RETURN(handle == TypeHandle(g_pStringClass));
+            return(handle == TypeHandle(g_pStringClass));
 
         case ELEMENT_TYPE_OBJECT:
-            RETURN(handle == TypeHandle(g_pObjectClass));
+            return(handle == TypeHandle(g_pObjectClass));
 
         case ELEMENT_TYPE_CANON_ZAPSIG:
-            RETURN(handle == TypeHandle(g_pCanonMethodTableClass));
+            return(handle == TypeHandle(g_pCanonMethodTableClass));
 
         case ELEMENT_TYPE_VAR:
         case ELEMENT_TYPE_MVAR:
         {
             if (sigType != handleType)
-                RETURN(FALSE);
+                return(FALSE);
 
             unsigned varNum = CorSigUncompressData(pSig);
-            RETURN(varNum == (dac_cast<PTR_TypeVarTypeDesc>(handle.AsTypeDesc())->GetIndex()));
+            return(varNum == (dac_cast<PTR_TypeVarTypeDesc>(handle.AsTypeDesc())->GetIndex()));
         }
 
         case ELEMENT_TYPE_VAR_ZAPSIG:
         {
             if (!handle.IsGenericVariable())
-                RETURN(FALSE);
+                return(FALSE);
 
             TypeVarTypeDesc *pTypeVarTypeDesc = handle.AsGenericVariable();
 
             unsigned rid = CorSigUncompressData(pSig);
-            RETURN(TokenFromRid(rid, mdtGenericParam) == pTypeVarTypeDesc->GetToken() && pModule == pTypeVarTypeDesc->GetModule());
+            return(TokenFromRid(rid, mdtGenericParam) == pTypeVarTypeDesc->GetToken() && pModule == pTypeVarTypeDesc->GetModule());
         }
 
         // These take an additional argument, which is the element type
@@ -388,9 +388,9 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         case ELEMENT_TYPE_BYREF:
         {
             if (sigType != handleType)
-                RETURN(FALSE);
+                return(FALSE);
 
-            RETURN (CompareSignatureToTypeHandle(pSig, pModule, handle.GetTypeParam(), pZapSigContext));
+            return (CompareSignatureToTypeHandle(pSig, pModule, handle.GetTypeParam(), pZapSigContext));
         }
 
         case ELEMENT_TYPE_NATIVE_VALUETYPE_ZAPSIG:
@@ -398,7 +398,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
             sigType = CorSigUncompressElementType(pSig);
             _ASSERTE(sigType == ELEMENT_TYPE_VALUETYPE);
 
-            if (!handle.IsNativeValueType()) RETURN(FALSE);
+            if (!handle.IsNativeValueType()) return(FALSE);
             FALLTHROUGH;
         } // fall-through
 
@@ -421,25 +421,25 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
                 }
                 EX_END_CATCH
                 if (!resolved)
-                    RETURN(FALSE);
+                    return(FALSE);
             }
             _ASSERTE(TypeFromToken(tk) == mdtTypeDef);
-            RETURN (sigType == handleType && !handle.HasInstantiation() && pModule == handle.GetModule() && handle.GetCl() == tk);
+            return (sigType == handleType && !handle.HasInstantiation() && pModule == handle.GetModule() && handle.GetCl() == tk);
         }
 
         case ELEMENT_TYPE_FNPTR:
         {
             if (sigType != handleType)
-                RETURN(FALSE);
+                return(FALSE);
 
             FnPtrTypeDesc *pTD = handle.AsFnPtrType();
             DWORD callConv = CorSigUncompressData(pSig);
             if (callConv != pTD->GetCallConv())
-                RETURN(FALSE);
+                return(FALSE);
 
             DWORD numArgs = CorSigUncompressData(pSig);
             if (numArgs != pTD->GetNumArgs())
-                RETURN(FALSE);
+                return(FALSE);
 
             {
                 CONTRACT_VIOLATION(ThrowsViolation|GCViolation);
@@ -448,10 +448,10 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
                 {
                     SigPointer sp(pSig);
                     if (!CompareSignatureToTypeHandle(pSig, pOrigModule, pTD->GetRetAndArgTypes()[i], pZapSigContext))
-                        RETURN(FALSE);
+                        return(FALSE);
                     if (FAILED(sp.SkipExactlyOne()))
                     {
-                        RETURN(FALSE);
+                        return(FALSE);
                     }
                     pSig = sp.GetPtr();
                 }
@@ -462,11 +462,11 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         case ELEMENT_TYPE_GENERICINST:
         {
             if (!handle.HasInstantiation())
-                RETURN(FALSE);
+                return(FALSE);
 
             sigType = CorSigUncompressElementType(pSig);
             if (sigType != handleType)
-                RETURN(FALSE);
+                return(FALSE);
 
             pSig += CorSigUncompressToken(pSig, &tk);
             if (TypeFromToken(tk) == mdtTypeRef)
@@ -484,26 +484,26 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
                 }
                 EX_END_CATCH
                 if (!resolved)
-                    RETURN(FALSE);
+                    return(FALSE);
             }
             _ASSERTE(TypeFromToken(tk) == mdtTypeDef);
             if (pModule != handle.GetModule() || tk != handle.GetCl())
-                RETURN(FALSE);
+                return(FALSE);
 
             DWORD numGenericArgs = CorSigUncompressData(pSig);
 
             if (numGenericArgs != handle.GetNumGenericArgs())
-                RETURN(FALSE);
+                return(FALSE);
 
             Instantiation inst = handle.GetInstantiation();
             for (DWORD i = 0; i < inst.GetNumArgs(); i++)
             {
                 SigPointer sp(pSig);
                 if (!CompareSignatureToTypeHandle(pSig, pOrigModule, inst[i], pZapSigContext))
-                    RETURN(FALSE);
+                    return(FALSE);
                 if (FAILED(sp.SkipExactlyOne()))
                 {
-                    RETURN(FALSE);
+                    return(FALSE);
                 }
                 pSig = sp.GetPtr();
             }
@@ -513,26 +513,26 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
         case ELEMENT_TYPE_ARRAY:
         {
             if (sigType != handleType)
-                RETURN(FALSE);
+                return(FALSE);
 
             if (!CompareSignatureToTypeHandle(pSig, pModule, handle.GetArrayElementTypeHandle(), pZapSigContext))
-                RETURN(FALSE);
+                return(FALSE);
             SigPointer sp(pSig);
             if (FAILED(sp.SkipExactlyOne()))
-                RETURN(FALSE);
+                return(FALSE);
 
             uint32_t rank;
             if (FAILED(sp.GetData(&rank)))
-                RETURN(FALSE);
+                return(FALSE);
 
             if (rank != handle.GetRank())
-                RETURN(FALSE);
+                return(FALSE);
 
             break;
         }
     }
 
-    RETURN(TRUE);
+    return(TRUE);
 }
 
 /*static*/


### PR DESCRIPTION
> [!NOTE]
> This PR description was created with GitHub Copilot assistance.

The `POSTCONDITION(RETVAL)` support in the CoreCLR VM required us to use extremely obtuse compiler tricks to enable `RETURN xyz;` to work like `return xyz;` in the presence of contracts.

Very few of these post-conditions were actually interesting (most were checking for non-null pointers, may checking for always true conditions).

This PR removes POSTCONDITION support and `RETURN/RETVAL` support. For cases where the postconditions were actually interesting, the asserts are preserved and inserted before the return statements.