### PR TITLE
[release/8.0] Update branding to 8.0.27

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>8.0.26</ProductVersion>
+    <ProductVersion>8.0.27</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>8</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>26</PatchVersion>
+    <PatchVersion>27</PatchVersion>
     <SdkBandVersion>8.0.100</SdkBandVersion>
     <PackageVersionNet7>7.0.20</PackageVersionNet7>
     <PackageVersionNet6>6.0.36</PackageVersionNet6>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0`.

**Changes:**
- Repository: runtime
  - PatchVersion: `26` → `27`

**Files Modified:**
- eng/Versions.props (+2 -2)
