### PR TITLE
[release/9.0] Update branding to 9.0.16

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,11 +1,11 @@
 <Project>
   <PropertyGroup>
     <!-- The .NET product branding version -->
-    <ProductVersion>9.0.15</ProductVersion>
+    <ProductVersion>9.0.16</ProductVersion>
     <!-- File version numbers -->
     <MajorVersion>9</MajorVersion>
     <MinorVersion>0</MinorVersion>
-    <PatchVersion>15</PatchVersion>
+    <PatchVersion>16</PatchVersion>
     <SdkBandVersion>9.0.100</SdkBandVersion>
     <PackageVersionNet8>8.0.$([MSBuild]::Add($(PatchVersion),11))</PackageVersionNet8>
     <PackageVersionNet7>7.0.20</PackageVersionNet7>


### PR DESCRIPTION
This PR updates version branding on branch `release/9.0`.

**Changes:**
- Repository: runtime
  - PatchVersion: `15` → `16`

**Files Modified:**
- eng/Versions.props (+2 -2)
