### PR TITLE
Implement new ReadyToRunFixup that ensures that each assemblyref for the corresponding assembly is loaded via the correct ALC

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Reflection;
@@ -141,6 +142,58 @@ namespace System.Runtime.Loader
             {
                 *pException = ex;
                 return default;
+            }
+        }
+
+        [UnmanagedCallersOnly]
+        [RequiresUnsafe]
+        private static unsafe void RegisterSimpleNameLoadHookForAssembly(Assembly* pAssembly, sbyte** pAsmRefSimpleNames, int numAsmRefs, Exception* pException)
+        {
+            try
+            {
+                HashSet<string> simpleNames = [];
+                for (int i = 0; i < numAsmRefs; i++)
+                {
+                    simpleNames.Add(new string(pAsmRefSimpleNames[i]));
+                }
+
+                AssemblyLoadContext context = GetLoadContext(*pAssembly)!;
+
+                // First, load into the assembly's load context any already loaded assemblies that match the simple names of the assembly references.
+                foreach (Assembly loadedAssembly in GetLoadedAssemblies())
+                {
+                    string loadedSimpleName = loadedAssembly.GetName().Name!;
+                    if (simpleNames.Contains(loadedSimpleName))
+                    {
+                        context.LoadFromAssemblyName(loadedAssembly.GetName());
+                        simpleNames.Remove(loadedSimpleName);
+                    }
+                }
+
+                // For any names that remain, register a callback to the AppDomain.AssemblyLoad event to load into the provided Assembly's ALC as well.
+                if (simpleNames.Count > 0)
+                {
+                    AppDomain.CurrentDomain.AssemblyLoad += SimpleNameLoadHook;
+                }
+
+                void SimpleNameLoadHook(object? sender, AssemblyLoadEventArgs args)
+                {
+                    string loadedSimpleName = args.LoadedAssembly.GetName().Name!;
+                    if (simpleNames.Contains(loadedSimpleName))
+                    {
+                        context.LoadFromAssemblyName(args.LoadedAssembly.GetName());
+                        simpleNames.Remove(loadedSimpleName);
+
+                        if (simpleNames.Count == 0)
+                        {
+                            AppDomain.CurrentDomain.AssemblyLoad -= SimpleNameLoadHook;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                *pException = ex;
             }
         }
 

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -20,7 +20,7 @@
 // If you update this, ensure you run `git grep MINIMUM_READYTORUN_MAJOR_VERSION`
 // and handle pending work.
 #define READYTORUN_MAJOR_VERSION 18
-#define READYTORUN_MINOR_VERSION 0x0004
+#define READYTORUN_MINOR_VERSION 0x0005
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 18
 
@@ -55,6 +55,7 @@
 // R2R Version 18.2 adds InitClass and InitInstClass helpers
 // R2R Version 18.3 adds the ExternalTypeMaps, ProxyTypeMaps, TypeMapAssemblyTargets sections
 // R2R Version 18.4 adds ThrowArgument, ThrowArgumentOutOfRange, ThrowPlatformNotSupported, and ThrowNotImplemented helpers
+// R2R Version 18.5 adds the AssemblyRefSimpleNameLoad fixup
 
 struct READYTORUN_CORE_HEADER
 {
@@ -305,6 +306,8 @@ enum ReadyToRunFixupKind
     READYTORUN_FIXUP_Verify_IL_Body             = 0x36, /* Verify an IL body is defined the same at compile time and runtime. A failed match will cause a hard runtime failure. */
     READYTORUN_FIXUP_Continuation_Layout        = 0x37, /* Layout of an async method continuation type */
     READYTORUN_FIXUP_ResumptionStubEntryPoint   = 0x38, /* Entry point of an async method resumption stub */
+
+    READYTORUN_FIXUP_AssemblyRefSimpleNameLoad  = 0x39, /* Request that all assembly references are always loaded in the corresponding ALC when an assembly with a matching simple name is loaded in any ALC. */
 
     READYTORUN_FIXUP_ModuleOverride             = 0x80, /* followed by sig-encoded UInt with assemblyref index into either the assemblyref table of the MSIL metadata of the master context module for the signature or */
                                                         /* into the extra assemblyref table in the manifest metadata R2R header table (used in cases inlining brings in references to assemblies not seen in the MSIL). */

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -12,7 +12,7 @@ struct ReadyToRunHeaderConstants
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
     static const uint32_t CurrentMajorVersion = 18;
-    static const uint32_t CurrentMinorVersion = 4;
+    static const uint32_t CurrentMinorVersion = 5;
 };
 
 struct ReadyToRunHeader

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 18;
-        public const ushort CurrentMinorVersion = 4;
+        public const ushort CurrentMinorVersion = 5;
     }
 #if READYTORUN
 #pragma warning disable 0169

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -190,6 +190,8 @@ namespace Internal.ReadyToRunConstants
         ContinuationLayout = 0x37, /* Layout of an async method continuation type */
         ResumptionStubEntryPoint = 0x38, /* Entry point of an async method resumption stub */
 
+        AssemblyRefSimpleNameLoad  = 0x39, /* Request that all assembly references are always loaded in the corresponding ALC when an assembly with a matching simple name is loaded in any ALC. */
+
         ModuleOverride = 0x80,
         // followed by sig-encoded UInt with assemblyref index into either the assemblyref
         // table of the MSIL metadata of the master context module for the signature or

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunAssemblyRefSimpleNameLoadSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ReadyToRunAssemblyRefSimpleNameLoadSignature.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.Text;
+using Internal.ReadyToRunConstants;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    public sealed class ReadyToRunAssemblyRefSimpleNameLoadSignature(IEcmaModule module) : Signature
+    {
+        public override int ClassCode => -1334381239;
+
+        public IEcmaModule Module { get; } = module;
+
+        public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)
+        {
+            ObjectDataSignatureBuilder builder = new(factory, relocsOnly);
+            builder.AddSymbol(this);
+
+            if (relocsOnly)
+            {
+                return builder.ToObjectData();
+            }
+
+            builder.EmitFixup(factory, ReadyToRunFixupKind.AssemblyRefSimpleNameLoad, Module, factory.SignatureContext);
+
+            return builder.ToObjectData();
+        }
+
+        public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
+        {
+            sb.Append(nameMangler.CompilationUnitPrefix);
+            sb.Append("ReadyToRunAssemblyRefSimpleNameLoad_"u8);
+            sb.Append(Module.Assembly.Name);
+        }
+
+        public override int CompareToImpl(ISortableNode other, CompilerComparer comparer)
+        {
+            return Module.CompareTo(((ReadyToRunAssemblyRefSimpleNameLoadSignature)other).Module);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -65,6 +65,7 @@ namespace ILCompiler.DependencyAnalysis
         public bool IsComponentModule;
         public bool StripInliningInfo;
         public bool StripDebugInfo;
+        public bool ForceAssemblyLoadContextCompatibility;
     }
 
     // To make the code future compatible to the composite R2R story
@@ -886,6 +887,12 @@ namespace ILCompiler.DependencyAnalysis
                 ReadyToRunTypeMapManager typeMapManager = new(inputModule, metadata);
                 typeMapManager.AddToReadyToRunHeader(tableHeader, this, ImportReferenceProvider);
                 typeMapManager.AttachToDependencyGraph(graph);
+
+                if (OptimizationFlags.ForceAssemblyLoadContextCompatibility)
+                {
+                    Import assemblySimpleNameImport = new Import(EagerImports, new ReadyToRunAssemblyRefSimpleNameLoadSignature(inputModule));
+                    graph.AddRoot(assemblySimpleNameImport, "Assembly simple name load fixup");
+                }
             }
 
             if (!OptimizationFlags.StripInliningInfo)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Compiler\DependencyAnalysis\ImportReferenceProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\DeferredTillPhaseNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\EnclosingTypeMapNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ReadyToRunAssemblyRefSimpleNameLoadSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\ReadyToRunModuleSignature.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\TypeGenericInfoMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReadyToRun\MethodIsGenericMapNode.cs" />

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -148,6 +148,8 @@ namespace ILCompiler
             new("--strip-inlining-info") { Description = SR.StripInliningInfoOption };
         public Option<bool> StripDebugInfo { get; } =
             new("--strip-debug-info") { Description = SR.StripDebugInfoOption };
+        public Option<bool> ForceAssemblyLoadContextCompatibility { get; } =
+            new("--force-alc-compatibility") { Description = SR.ForceAssemblyLoadContextCompatibility };
         public Option<bool> SynthesizeRandomMibc { get; } =
             new("--synthesize-random-mibc");
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -646,6 +646,7 @@ namespace ILCompiler
                     nodeFactoryFlags.EnableCachedInterfaceDispatchSupport = Get(_command.EnableCachedInterfaceDispatchSupport) ?? !typeSystemContext.TargetAllowsRuntimeCodeGeneration;
                     nodeFactoryFlags.StripInliningInfo = Get(_command.StripInliningInfo);
                     nodeFactoryFlags.StripDebugInfo = Get(_command.StripDebugInfo);
+                    nodeFactoryFlags.ForceAssemblyLoadContextCompatibility = Get(_command.ForceAssemblyLoadContextCompatibility);
 
                     builder
                         .UseMapFile(Get(_command.Map))

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -450,4 +450,7 @@
   <data name="StripDebugInfoOption" xml:space="preserve">
     <value>Strip debug info from the R2R image.</value>
   </data>
+  <data name="ForceAssemblyLoadContextCompatibility" xml:space="preserve">
+    <value>Force compatibility with being loaded in a non-default AssemblyLoadContext.</value>
+  </data>
 </root>

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -187,10 +187,6 @@ void Assembly::Init(AllocMemTracker *pamTracker)
 
     PrepareModuleForAssembly(m_pModule, pamTracker);
 
-    // We'll load the friend assembly information lazily.  For the ngen case we should avoid
-    //  loading it entirely.
-    //CacheFriendAssemblyInfo();
-
     if (IsCollectible() && !pPEAssembly->IsReflectionEmit())
     {
         COUNT_T size;

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -1024,6 +1024,9 @@ DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  ON_ASSEMBLY_RESOLVE,        OnAssemblyResolv
 DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  START_ASSEMBLY_LOAD,        StartAssemblyLoad,          SM_PtrGuid_PtrGuid_PtrException_RetVoid)
 DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  STOP_ASSEMBLY_LOAD,         StopAssemblyLoad,           SM_PtrGuid_PtrException_RetVoid)
 DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  INITIALIZE_DEFAULT_CONTEXT, InitializeDefaultContext,   SM_PtrException_RetVoid)
+#ifdef FEATURE_READYTORUN
+DEFINE_METHOD(ASSEMBLYLOADCONTEXT,  REGISTER_SIMPLE_NAME_LOAD_HOOK_FOR_ASSEMBLY, RegisterSimpleNameLoadHookForAssembly, SM_PtrAssembly_PtrException_RetVoid)
+#endif
 
 DEFINE_CLASS(VALUE_TYPE,            System,                 ValueType)
 DEFINE_METHOD(VALUE_TYPE,           GET_HASH_CODE,          GetHashCode,            IM_RetInt)

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -14684,6 +14684,42 @@ BOOL LoadDynamicInfoEntry(Module *currentModule,
             }
             break;
         }
+    case READYTORUN_FIXUP_AssemblyRefSimpleNameLoad:
+        {
+            GCX_COOP();
+
+            OBJECTREF assemblyObject = currentModule->GetAssembly()->GetExposedObject();
+
+            GCPROTECT_BEGIN(assemblyObject);
+
+            SArray<LPCSTR> simpleNames;
+
+            HENUMInternal assemblyEnum;
+
+            IMDInternalImport* pMdImport = currentModule->GetMDImport();
+            HRESULT hr = pMdImport->EnumAllInit(mdtAssemblyRef, &assemblyEnum);
+            mdAssemblyRef assemblyRef;
+            while (pMdImport->EnumNext(&assemblyEnum, &assemblyRef))
+            {
+                LPCSTR assemblyName;
+                hr = pMdImport->GetAssemblyRefProps(assemblyRef, NULL, NULL, &assemblyName, NULL, NULL, NULL, NULL);
+                if (FAILED(hr))
+                {
+                    _ASSERTE(false);
+                    continue;
+                }
+                simpleNames.Append(assemblyName);
+            }
+
+            UnmanagedCallersOnlyCaller registerSimpleNameLoadHookForAssembly{METHOD__ASSEMBLYLOADCONTEXT__REGISTER_SIMPLE_NAME_LOAD_HOOK_FOR_ASSEMBLY};
+
+            registerSimpleNameLoadHookForAssembly.InvokeThrowing(&assemblyObject, &simpleNames[0], simpleNames.GetCount());
+
+            GCPROTECT_END();
+
+            result = 1;
+            break;
+        }
     default:
         STRESS_LOG1(LF_ZAP, LL_WARNING, "Unknown ReadyToRunFixupKind %d\n", kind);
         _ASSERTE(!"Unknown ReadyToRunFixupKind");

--- a/src/coreclr/vm/metasig.h
+++ b/src/coreclr/vm/metasig.h
@@ -405,6 +405,7 @@ DEFINE_METASIG_T(SM(Str_AssemblyBase_Bool_UInt_RetIntPtr, s C(ASSEMBLYBASE) F K,
 DEFINE_METASIG_T(SM(PtrAssembly_PtrException_RetVoid, P(C(ASSEMBLY)) P(C(EXCEPTION)), v))
 DEFINE_METASIG_T(SM(PtrAssembly_PtrByte_PtrAssembly_PtrException_RetVoid, P(C(ASSEMBLY)) P(b) P(C(ASSEMBLY)) P(C(EXCEPTION)), v))
 DEFINE_METASIG_T(SM(PtrAssembly_PtrChar_PtrAssembly_PtrException_RetVoid, P(C(ASSEMBLY)) P(u) P(C(ASSEMBLY)) P(C(EXCEPTION)), v))
+DEFINE_METASIG_T(SM(PtrAssembly_PtrPtrSByte_Int_PtrException_RetVoid, P(C(ASSEMBLY)) P(P(B)) i P(C(EXCEPTION)), v))
 DEFINE_METASIG_T(SM(IntPtr_PtrAssemblyName_PtrAssemblyBase_PtrException_RetVoid, I P(C(ASSEMBLY_NAME)) P(C(ASSEMBLYBASE)) P(C(EXCEPTION)), v))
 DEFINE_METASIG_T(SM(PtrException_RetVoid, P(C(EXCEPTION)), v))
 DEFINE_METASIG_T(SM(PtrObj_PtrException_RetVoid, P(j) P(C(EXCEPTION)), v))


### PR DESCRIPTION
This is needed to help correctly support cross-module generics with ready to run info loaded in non-default ALCs.