### PR TITLE
Move the cache for the marshaler methods to be stored on the RuntimeType instead of in a ConditionalWeakTable

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -234,25 +234,21 @@ namespace System.Runtime.InteropServices
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern int GetExceptionCode();
 
-        internal sealed class LayoutTypeMarshalerMethods
+        internal sealed class LayoutTypeMarshalerMethods : RuntimeType.IGenericCacheEntry<LayoutTypeMarshalerMethods>
         {
             private static MemberInfo ConvertToUnmanagedMethod => field ??= typeof(BoxedLayoutTypeMarshaler<>).GetMethod(nameof(BoxedLayoutTypeMarshaler<object>.ConvertToUnmanaged), BindingFlags.Public | BindingFlags.Static)!;
             private static MemberInfo ConvertToManagedMethod => field ??= typeof(BoxedLayoutTypeMarshaler<>).GetMethod(nameof(BoxedLayoutTypeMarshaler<object>.ConvertToManaged), BindingFlags.Public | BindingFlags.Static)!;
             private static MemberInfo FreeMethod => field ??= typeof(BoxedLayoutTypeMarshaler<>).GetMethod(nameof(BoxedLayoutTypeMarshaler<object>.Free), BindingFlags.Public | BindingFlags.Static)!;
 
-            private unsafe delegate void ConvertToUnmanagedDelegate(object obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList);
-            private unsafe delegate void ConvertToManagedDelegate(object obj, byte* native, ref CleanupWorkListElement? cleanupWorkList);
-            private unsafe delegate void FreeDelegate(object? obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList);
+            private readonly unsafe delegate*<object, byte*, int, ref CleanupWorkListElement?, void> _convertToUnmanaged;
+            private readonly unsafe delegate*<object, byte*, ref CleanupWorkListElement?, void> _convertToManaged;
+            private readonly unsafe delegate*<object?, byte*, int, ref CleanupWorkListElement?, void> _free;
 
-            private readonly ConvertToUnmanagedDelegate _convertToUnmanaged;
-            private readonly ConvertToManagedDelegate _convertToManaged;
-            private readonly FreeDelegate _free;
-
-            internal LayoutTypeMarshalerMethods(Type instantiatedType)
+            internal unsafe LayoutTypeMarshalerMethods(Type instantiatedType)
             {
-                _convertToUnmanaged = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToUnmanagedMethod)).CreateDelegate<ConvertToUnmanagedDelegate>();
-                _convertToManaged = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToManagedMethod)).CreateDelegate<ConvertToManagedDelegate>();
-                _free = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(FreeMethod)).CreateDelegate<FreeDelegate>();
+                _convertToUnmanaged = (delegate*<object, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToUnmanagedMethod)).MethodHandle.GetFunctionPointer();
+                _convertToManaged = (delegate*<object, byte*, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToManagedMethod)).MethodHandle.GetFunctionPointer();
+                _free = (delegate*<object?, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(FreeMethod)).MethodHandle.GetFunctionPointer();
             }
 
             public unsafe void ConvertToManaged(object obj, byte* native, ref CleanupWorkListElement? cleanupWorkList)
@@ -270,18 +266,26 @@ namespace System.Runtime.InteropServices
                 _free(obj, native, nativeSize, ref cleanupWorkList);
             }
 
-            private static readonly ConditionalWeakTable<Type, LayoutTypeMarshalerMethods> s_marshalerCache = [];
-
-            [RequiresDynamicCode("Marshalling code for the object might not be available.")]
             internal static LayoutTypeMarshalerMethods GetMarshalMethodsForType(Type t)
             {
-                return s_marshalerCache.GetOrAdd(t, CreateMarshalMethods);
+                return ((RuntimeType)t).GetOrCreateCacheEntry<LayoutTypeMarshalerMethods>();
+            }
 
-                static LayoutTypeMarshalerMethods CreateMarshalMethods(Type type)
-                {
-                    Type instantiatedMarshaler = typeof(BoxedLayoutTypeMarshaler<>).MakeGenericType([type]);
-                    return new LayoutTypeMarshalerMethods(instantiatedMarshaler);
-                }
+            [RequiresDynamicCode("Marshalling code for the object might not be available.")]
+            public static LayoutTypeMarshalerMethods Create(RuntimeType type)
+            {
+                Type instantiatedMarshaler = typeof(BoxedLayoutTypeMarshaler<>).MakeGenericType([type]);
+                return new LayoutTypeMarshalerMethods(instantiatedMarshaler);
+            }
+
+            public static ref LayoutTypeMarshalerMethods? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry)
+            {
+                return ref compositeEntry._marshalerMethods;
+            }
+
+            public void InitializeCompositeCache(RuntimeType.CompositeCacheEntry compositeEntry)
+            {
+                compositeEntry._marshalerMethods = this;
             }
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -320,7 +320,16 @@ namespace System.Runtime.InteropServices
             if (type.IsGenericType)
                 throw new ArgumentException(SR.Argument_NeedNonGenericObject, nameof(structure));
 
-            LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
+            LayoutTypeMarshalerMethods methods;
+            try
+            {
+                methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
+            }
+            catch (ArgumentException e)
+            {
+                // COMPAT: preserve legacy ParamName for non-marshalable structure values.
+                throw new ArgumentException(e.Message, nameof(structure), e);
+            }
 
             if (fDeleteOld)
             {
@@ -340,7 +349,16 @@ namespace System.Runtime.InteropServices
             if (!allowValueClasses && type.IsValueType)
                 throw new ArgumentException(SR.Argument_StructMustNotBeValueClass, nameof(structure));
 
-            LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
+            LayoutTypeMarshalerMethods methods;
+            try
+            {
+                methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
+            }
+            catch (ArgumentException e)
+            {
+                // COMPAT: preserve legacy ParamName for non-marshalable structure values.
+                throw new ArgumentException(e.Message, nameof(structure), e);
+            }
 
             methods.ConvertToManaged(structure, (byte*)ptr);
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -366,7 +366,7 @@ namespace System.Runtime.InteropServices
             {
                 LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(rt);
 
-                methods.Free((byte*)ptr);   
+                methods.Free((byte*)ptr);
             }
             catch (ArgumentException)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -240,16 +240,21 @@ namespace System.Runtime.InteropServices
             private static MemberInfo ConvertToManagedMethod => field ??= typeof(BoxedLayoutTypeMarshaler<>).GetMethod(nameof(BoxedLayoutTypeMarshaler<object>.ConvertToManaged), BindingFlags.Public | BindingFlags.Static)!;
             private static MemberInfo FreeMethod => field ??= typeof(BoxedLayoutTypeMarshaler<>).GetMethod(nameof(BoxedLayoutTypeMarshaler<object>.Free), BindingFlags.Public | BindingFlags.Static)!;
 
-            private readonly unsafe delegate*<object, byte*, int, ref CleanupWorkListElement?, void> _convertToUnmanaged;
-            private readonly unsafe delegate*<object, byte*, ref CleanupWorkListElement?, void> _convertToManaged;
-            private readonly unsafe delegate*<object?, byte*, int, ref CleanupWorkListElement?, void> _free;
+            private unsafe delegate void ConvertToUnmanagedDelegate(object obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList);
+            private unsafe delegate void ConvertToManagedDelegate(object obj, byte* native, ref CleanupWorkListElement? cleanupWorkList);
+            private unsafe delegate void FreeDelegate(object? obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList);
+
+            private readonly ConvertToUnmanagedDelegate _convertToUnmanaged;
+            private readonly ConvertToManagedDelegate _convertToManaged;
+            private readonly FreeDelegate _free;
+
             private readonly int _nativeSize;
 
-            internal unsafe LayoutTypeMarshalerMethods(Type instantiatedType, int nativeSize)
+            internal LayoutTypeMarshalerMethods(Type instantiatedType, int nativeSize)
             {
-                _convertToUnmanaged = (delegate*<object, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToUnmanagedMethod)).MethodHandle.GetFunctionPointer();
-                _convertToManaged = (delegate*<object, byte*, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToManagedMethod)).MethodHandle.GetFunctionPointer();
-                _free = (delegate*<object?, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(FreeMethod)).MethodHandle.GetFunctionPointer();
+                _convertToUnmanaged = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToUnmanagedMethod)).CreateDelegate<ConvertToUnmanagedDelegate>();
+                _convertToManaged = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToManagedMethod)).CreateDelegate<ConvertToManagedDelegate>();
+                _free = ((MethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(FreeMethod)).CreateDelegate<FreeDelegate>();
                 _nativeSize = nativeSize;
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -243,39 +243,44 @@ namespace System.Runtime.InteropServices
             private readonly unsafe delegate*<object, byte*, int, ref CleanupWorkListElement?, void> _convertToUnmanaged;
             private readonly unsafe delegate*<object, byte*, ref CleanupWorkListElement?, void> _convertToManaged;
             private readonly unsafe delegate*<object?, byte*, int, ref CleanupWorkListElement?, void> _free;
+            private readonly int _nativeSize;
 
-            internal unsafe LayoutTypeMarshalerMethods(Type instantiatedType)
+            internal unsafe LayoutTypeMarshalerMethods(Type instantiatedType, int nativeSize)
             {
                 _convertToUnmanaged = (delegate*<object, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToUnmanagedMethod)).MethodHandle.GetFunctionPointer();
                 _convertToManaged = (delegate*<object, byte*, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(ConvertToManagedMethod)).MethodHandle.GetFunctionPointer();
                 _free = (delegate*<object?, byte*, int, ref CleanupWorkListElement?, void>)((RuntimeMethodInfo)instantiatedType.GetMemberWithSameMetadataDefinitionAs(FreeMethod)).MethodHandle.GetFunctionPointer();
+                _nativeSize = nativeSize;
             }
 
-            public unsafe void ConvertToManaged(object obj, byte* native, ref CleanupWorkListElement? cleanupWorkList)
+            public unsafe void ConvertToManaged(object obj, byte* native)
             {
-                _convertToManaged(obj, native, ref cleanupWorkList);
+                _convertToManaged(obj, native, ref Unsafe.NullRef<CleanupWorkListElement?>());
             }
 
-            public unsafe void ConvertToUnmanaged(object obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
+            public unsafe void ConvertToUnmanaged(object obj, byte* native, ref CleanupWorkListElement? cleanupWorkList)
             {
-                _convertToUnmanaged(obj, native, nativeSize, ref cleanupWorkList);
+                _convertToUnmanaged(obj, native, _nativeSize, ref cleanupWorkList);
             }
 
-            public unsafe void Free(object? obj, byte* native, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
+            public unsafe void Free(byte* native)
             {
-                _free(obj, native, nativeSize, ref cleanupWorkList);
+                _free(null, native, _nativeSize, ref Unsafe.NullRef<CleanupWorkListElement?>());
             }
 
-            internal static LayoutTypeMarshalerMethods GetMarshalMethodsForType(Type t)
+            internal static LayoutTypeMarshalerMethods GetMarshalMethodsForType(RuntimeType t)
             {
-                return ((RuntimeType)t).GetOrCreateCacheEntry<LayoutTypeMarshalerMethods>();
+                return t.GetOrCreateCacheEntry<LayoutTypeMarshalerMethods>();
             }
 
             [RequiresDynamicCode("Marshalling code for the object might not be available.")]
             public static LayoutTypeMarshalerMethods Create(RuntimeType type)
             {
+                if (!HasLayout(new QCallTypeHandle(ref type), out _, out int size))
+                    throw new ArgumentException(SR.Argument_MustHaveLayoutOrBeBlittable, nameof(type));
+
                 Type instantiatedMarshaler = typeof(BoxedLayoutTypeMarshaler<>).MakeGenericType([type]);
-                return new LayoutTypeMarshalerMethods(instantiatedMarshaler);
+                return new LayoutTypeMarshalerMethods(instantiatedMarshaler, size);
             }
 
             public static ref LayoutTypeMarshalerMethods? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry)
@@ -310,23 +315,14 @@ namespace System.Runtime.InteropServices
             if (type.IsGenericType)
                 throw new ArgumentException(SR.Argument_NeedNonGenericObject, nameof(structure));
 
-            if (!HasLayout(new QCallTypeHandle(ref type), out bool isBlittable, out int size))
-                throw new ArgumentException(SR.Argument_MustHaveLayoutOrBeBlittable, nameof(structure));
-
-            if (isBlittable)
-            {
-                SpanHelpers.Memmove(ref *(byte*)ptr, ref structure.GetRawData(), (nuint)size);
-                return;
-            }
-
             LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
 
             if (fDeleteOld)
             {
-                methods.Free(structure, (byte*)ptr, size, ref Unsafe.NullRef<CleanupWorkListElement?>());
+                methods.Free((byte*)ptr);
             }
 
-            methods.ConvertToUnmanaged(structure, (byte*)ptr, size, ref Unsafe.NullRef<CleanupWorkListElement?>());
+            methods.ConvertToUnmanaged(structure, (byte*)ptr, ref Unsafe.NullRef<CleanupWorkListElement?>());
         }
 
         /// <summary>
@@ -339,18 +335,9 @@ namespace System.Runtime.InteropServices
             if (!allowValueClasses && type.IsValueType)
                 throw new ArgumentException(SR.Argument_StructMustNotBeValueClass, nameof(structure));
 
-            if (!HasLayout(new QCallTypeHandle(ref type), out bool isBlittable, out int size))
-                throw new ArgumentException(SR.Argument_MustHaveLayoutOrBeBlittable, nameof(structure));
-
-            if (isBlittable)
-            {
-                SpanHelpers.Memmove(ref structure.GetRawData(), ref *(byte*)ptr, (nuint)size);
-                return;
-            }
-
             LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
 
-            methods.ConvertToManaged(structure, (byte*)ptr, ref Unsafe.NullRef<CleanupWorkListElement?>());
+            methods.ConvertToManaged(structure, (byte*)ptr);
         }
 
         /// <summary>
@@ -370,15 +357,9 @@ namespace System.Runtime.InteropServices
             if (rt.IsGenericType)
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(structuretype));
 
-            if (!HasLayout(new QCallTypeHandle(ref rt), out bool isBlittable, out int size))
-                throw new ArgumentException(SR.Argument_MustHaveLayoutOrBeBlittable, nameof(structuretype));
+            LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(rt);
 
-            if (!isBlittable)
-            {
-                LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(structuretype);
-
-                methods.Free(null, (byte*)ptr, size, ref Unsafe.NullRef<CleanupWorkListElement?>());
-            }
+            methods.Free((byte*)ptr);
         }
 
         // Note: Callers are required to keep obj alive

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -362,9 +362,17 @@ namespace System.Runtime.InteropServices
             if (rt.IsGenericType)
                 throw new ArgumentException(SR.Argument_NeedNonGenericType, nameof(structuretype));
 
-            LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(rt);
+            try
+            {
+                LayoutTypeMarshalerMethods methods = LayoutTypeMarshalerMethods.GetMarshalMethodsForType(rt);
 
-            methods.Free((byte*)ptr);
+                methods.Free((byte*)ptr);   
+            }
+            catch (ArgumentException)
+            {
+                // COMPAT: rethrow the argument exception with the correct argument name.
+                throw new ArgumentException(SR.Argument_MustHaveLayoutOrBeBlittable, nameof(structuretype));
+            }
         }
 
         // Note: Callers are required to keep obj alive

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.GenericCache.cs
@@ -23,6 +23,7 @@ namespace System
             internal Array.ArrayInitializeCache? _arrayInitializeCache;
             internal IGenericCacheEntry? _enumInfo;
             internal BoxCache? _boxCache;
+            internal Marshal.LayoutTypeMarshalerMethods? _marshalerMethods;
 
             void IGenericCacheEntry.InitializeCompositeCache(CompositeCacheEntry compositeEntry) => throw new UnreachableException();
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1457,10 +1457,9 @@ namespace System.StubHelpers
 
         public static void Free(ref T managed, byte* unmanaged, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
         {
-            FreeCore(ref managed, unmanaged, ref cleanupWorkList);
-
             if (unmanaged != null)
             {
+                FreeCore(ref managed, unmanaged, ref cleanupWorkList);
                 NativeMemory.Clear(unmanaged, (nuint)nativeSize);
             }
         }
@@ -1601,10 +1600,9 @@ namespace System.StubHelpers
 
         public static void Free(T? managed, byte* unmanaged, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
         {
-            FreeCore(managed, unmanaged, ref cleanupWorkList);
-
             if (unmanaged != null)
             {
+                FreeCore(managed, unmanaged, ref cleanupWorkList);
                 NativeMemory.Clear(unmanaged, (nuint)nativeSize);
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1461,7 +1461,7 @@ namespace System.StubHelpers
 
             if (unmanaged != null)
             {
-                NativeMemory.Clear(unmanaged, (nuint)nativeSize);   
+                NativeMemory.Clear(unmanaged, (nuint)nativeSize);
             }
         }
     }
@@ -1605,7 +1605,7 @@ namespace System.StubHelpers
 
             if (unmanaged != null)
             {
-                NativeMemory.Clear(unmanaged, (nuint)nativeSize);   
+                NativeMemory.Clear(unmanaged, (nuint)nativeSize);
             }
         }
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1947,21 +1947,13 @@ namespace System.StubHelpers
         internal static unsafe void LayoutTypeConvertToUnmanaged(object obj, byte* pNative, ref CleanupWorkListElement? pCleanupWorkList)
         {
             RuntimeType type = (RuntimeType)obj.GetType();
-            bool hasLayout = Marshal.HasLayout(new QCallTypeHandle(ref type), out bool isBlittable, out int size);
-            Debug.Assert(hasLayout);
-
-            if (isBlittable)
-            {
-                SpanHelpers.Memmove(ref *pNative, ref obj.GetRawData(), (nuint)size);
-                return;
-            }
-
             Marshal.LayoutTypeMarshalerMethods methods = Marshal.LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
 
-            methods.ConvertToUnmanaged(obj, pNative, size, ref pCleanupWorkList);
+            methods.ConvertToUnmanaged(obj, pNative, ref pCleanupWorkList);
         }
 
         [UnmanagedCallersOnly]
+        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToUnmanaged(object* obj, byte* pNative, Exception* pException)
         {
             try
@@ -1978,21 +1970,13 @@ namespace System.StubHelpers
         internal static unsafe void LayoutTypeConvertToManaged(object obj, byte* pNative)
         {
             RuntimeType type = (RuntimeType)obj.GetType();
-            bool hasLayout = Marshal.HasLayout(new QCallTypeHandle(ref type), out bool isBlittable, out int size);
-            Debug.Assert(hasLayout);
-
-            if (isBlittable)
-            {
-                SpanHelpers.Memmove(ref obj.GetRawData(), ref *pNative, (nuint)size);
-                return;
-            }
-
             Marshal.LayoutTypeMarshalerMethods methods = Marshal.LayoutTypeMarshalerMethods.GetMarshalMethodsForType(type);
 
-            methods.ConvertToManaged(obj, pNative, ref Unsafe.NullRef<CleanupWorkListElement?>());
+            methods.ConvertToManaged(obj, pNative);
         }
 
         [UnmanagedCallersOnly]
+        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToManaged(object* obj, byte* pNative, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1458,7 +1458,11 @@ namespace System.StubHelpers
         public static void Free(ref T managed, byte* unmanaged, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
         {
             FreeCore(ref managed, unmanaged, ref cleanupWorkList);
-            NativeMemory.Clear(unmanaged, (nuint)nativeSize);
+
+            if (unmanaged != null)
+            {
+                NativeMemory.Clear(unmanaged, (nuint)nativeSize);   
+            }
         }
     }
 
@@ -1598,7 +1602,11 @@ namespace System.StubHelpers
         public static void Free(T? managed, byte* unmanaged, int nativeSize, ref CleanupWorkListElement? cleanupWorkList)
         {
             FreeCore(managed, unmanaged, ref cleanupWorkList);
-            NativeMemory.Clear(unmanaged, (nuint)nativeSize);
+
+            if (unmanaged != null)
+            {
+                NativeMemory.Clear(unmanaged, (nuint)nativeSize);   
+            }
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/126608

Move the marshalling info to be cached on the type itself instead of in a ConditionalWeakTable.

Move some of the validation (in particular the "has layout" validation) to be done only at "create" time so we don't have to rerun it for every time someone calls the Marshal methods with the same (valid) type.

Use the blittable fallbacks on `StructureMarshaler<T>` and `LayoutClassMarshaler<T>` instead of inlining the calls. The cost may go up slightly (delegate call to a method that calls `SpanHelpers.Memmove` instead of direct call to `SpanHelpers.Memmove`) but still much faster than the existing implementation that does the "is blittable" checks each time.