### PR TITLE
[Runtime Async] Reuse ValueTaskSourceNotifier instance

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -217,7 +217,7 @@ namespace System.Runtime.CompilerServices
             // to one of these notifiers.
             public ICriticalNotifyCompletion? CriticalNotifier;
             public INotifyCompletion? Notifier;
-            public IValueTaskSourceNotifier? ValueTaskSourceNotifier;
+            public ValueTaskSourceNotifier? ValueTaskSourceNotifier;
             public Task? TaskNotifier;
 
             public ExecutionContext? ExecutionContext;
@@ -310,7 +310,7 @@ namespace System.Runtime.CompilerServices
             }
             else
             {
-                state.ValueTaskSourceNotifier = (IValueTaskSourceNotifier)o;
+                state.ValueTaskSourceNotifier = (ValueTaskSourceNotifier)o;
             }
 
             state.CaptureContexts();
@@ -366,7 +366,7 @@ namespace System.Runtime.CompilerServices
 
                 ICriticalNotifyCompletion? critNotifier = state.CriticalNotifier;
                 INotifyCompletion? notifier = state.Notifier;
-                IValueTaskSourceNotifier? vtsNotifier = state.ValueTaskSourceNotifier;
+                ValueTaskSourceNotifier? vtsNotifier = state.ValueTaskSourceNotifier;
                 Task? taskNotifier = state.TaskNotifier;
 
                 state.CriticalNotifier = null;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -179,9 +179,13 @@ namespace System.Threading.Tasks
                 GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource>(obj));
         }
 
-        private static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted =
-            (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
-                Unsafe.As<IValueTaskSource>(obj).OnCompleted(continuation, state, token, flags);
+        // A class to not have a static initializer directly on ValueTask
+        private static class OnCompleted
+        {
+            internal static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> s_action =
+                static (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                   Unsafe.As<IValueTaskSource>(obj).OnCompleted(continuation, state, token, flags);
+        }
 
         internal object AsTaskOrNotifier()
         {
@@ -189,7 +193,7 @@ namespace System.Threading.Tasks
             Debug.Assert(obj is Task || obj is IValueTaskSource);
             return
                 obj as Task ??
-                (object)ValueTaskSourceNotifier.GetInstance(obj, onCompleted, _token);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, OnCompleted.s_action, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask"/> that may be used at any point in the future.</summary>
@@ -601,9 +605,13 @@ namespace System.Threading.Tasks
             return GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj));
         }
 
-        private static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted =
-            (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
-                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(continuation, state, token, flags);
+        // A class to not have a static initializer directly on ValueTask<T>
+        private static class OnCompleted
+        {
+            internal static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> s_action =
+                static (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(continuation, state, token, flags);
+        }
 
         internal object AsTaskOrNotifier()
         {
@@ -611,7 +619,7 @@ namespace System.Threading.Tasks
             Debug.Assert(obj is Task<TResult> || obj is IValueTaskSource<TResult>);
             return
                 obj as Task ??
-                (object)ValueTaskSourceNotifier.GetInstance(obj, onCompleted, _token);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, OnCompleted.s_action, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask{TResult}"/> that may be used at any point in the future.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -179,21 +179,19 @@ namespace System.Threading.Tasks
                 GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource>(obj));
         }
 
-        // A class to not have a static initializer directly on ValueTask
-        private static class OnCompleted
-        {
-            internal static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> s_action =
-                static (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
-                   Unsafe.As<IValueTaskSource>(obj).OnCompleted(continuation, state, token, flags);
-        }
+        /// <summary>
+        /// Helper to invoke IValueTaskSource.OnCompleted from a caller that does not know the actual type of the source.
+        /// </summary>
+        private static void OnCompleted(object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                Unsafe.As<IValueTaskSource>(obj).OnCompleted(continuation, state, token, flags);
 
-        internal object AsTaskOrNotifier()
+        internal unsafe object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task || obj is IValueTaskSource);
             return
                 obj as Task ??
-                (object)ValueTaskSourceNotifier.GetInstance(obj, OnCompleted.s_action, _token);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, &OnCompleted, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask"/> that may be used at any point in the future.</summary>
@@ -605,21 +603,19 @@ namespace System.Threading.Tasks
             return GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj));
         }
 
-        // A class to not have a static initializer directly on ValueTask<T>
-        private static class OnCompleted
-        {
-            internal static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> s_action =
-                static (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
-                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(continuation, state, token, flags);
-        }
+        /// <summary>
+        /// Helper to invoke IValueTaskSource.OnCompleted from a caller that does not know the actual type of the source.
+        /// </summary>
+        private static void OnCompleted(object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(continuation, state, token, flags);
 
-        internal object AsTaskOrNotifier()
+        internal unsafe object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task<TResult> || obj is IValueTaskSource<TResult>);
             return
                 obj as Task ??
-                (object)ValueTaskSourceNotifier.GetInstance(obj, OnCompleted.s_action, _token);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, &OnCompleted, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask{TResult}"/> that may be used at any point in the future.</summary>
@@ -883,7 +879,7 @@ namespace System.Threading.Tasks
         }
     }
 
-    internal sealed class ValueTaskSourceNotifier
+    internal unsafe sealed class ValueTaskSourceNotifier
     {
         // ValueTaskSourceNotifier is used only during suspension sequence, thus
         // a given thread will never need more than one instance.
@@ -892,12 +888,12 @@ namespace System.Threading.Tasks
         private static ValueTaskSourceNotifier? t_instance;
 
         private object _source;
-        private Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> _onCompleted;
+        private delegate* managed<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags, void> _onCompleted;
         private short _token;
 
         private ValueTaskSourceNotifier(
             object source,
-            Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted,
+            delegate* managed<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags, void> onCompleted,
             short token)
         {
             _source = source;
@@ -907,7 +903,7 @@ namespace System.Threading.Tasks
 
         public static ValueTaskSourceNotifier GetInstance(
             object source,
-            Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted,
+            delegate* managed<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags, void> onCompleted,
             short token)
         {
             ValueTaskSourceNotifier? instance = t_instance;
@@ -928,9 +924,8 @@ namespace System.Threading.Tasks
             _onCompleted(_source, continuation, state, _token, flags);
 
             // The data that we store is effectively single-use.
-            // Once used, clear the fields to not retain unknown data.
-            _source = _onCompleted = null!;
-            _token = 0;
+            // Once used, clear the _source to not retain unknown data.
+            _source = null!;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -179,28 +179,17 @@ namespace System.Threading.Tasks
                 GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource>(obj));
         }
 
+        private static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted =
+            (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                Unsafe.As<IValueTaskSource>(obj).OnCompleted(continuation, state, token, flags);
+
         internal object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task || obj is IValueTaskSource);
             return
                 obj as Task ??
-                (object)new ValueTaskSourceNotifier(Unsafe.As<IValueTaskSource>(obj), _token);
-        }
-
-        private sealed class ValueTaskSourceNotifier : IValueTaskSourceNotifier
-        {
-            private IValueTaskSource _valueTaskSource;
-            private short _token;
-
-            public ValueTaskSourceNotifier(IValueTaskSource valueTaskSource, short token)
-            {
-                _valueTaskSource = valueTaskSource;
-                _token = token;
-            }
-
-            public void OnCompleted(Action<object?> continuation, object? state, ValueTaskSourceOnCompletedFlags flags) =>
-                _valueTaskSource.OnCompleted(continuation, state, _token, flags);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, onCompleted, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask"/> that may be used at any point in the future.</summary>
@@ -612,28 +601,17 @@ namespace System.Threading.Tasks
             return GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj));
         }
 
+        private static readonly Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted =
+            (object obj, Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(continuation, state, token, flags);
+
         internal object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task<TResult> || obj is IValueTaskSource<TResult>);
             return
                 obj as Task ??
-                (object)new ValueTaskSourceNotifier(Unsafe.As<IValueTaskSource<TResult>>(obj), _token);
-        }
-
-        private sealed class ValueTaskSourceNotifier : IValueTaskSourceNotifier
-        {
-            private IValueTaskSource<TResult> _valueTaskSource;
-            private short _token;
-
-            public ValueTaskSourceNotifier(IValueTaskSource<TResult> valueTaskSource, short token)
-            {
-                _valueTaskSource = valueTaskSource;
-                _token = token;
-            }
-
-            public void OnCompleted(Action<object?> continuation, object? state, ValueTaskSourceOnCompletedFlags flags) =>
-                _valueTaskSource.OnCompleted(continuation, state, _token, flags);
+                (object)ValueTaskSourceNotifier.GetInstance(obj, onCompleted, _token);
         }
 
         /// <summary>Gets a <see cref="ValueTask{TResult}"/> that may be used at any point in the future.</summary>
@@ -897,8 +875,54 @@ namespace System.Threading.Tasks
         }
     }
 
-    internal interface IValueTaskSourceNotifier
+    internal sealed class ValueTaskSourceNotifier
     {
-        void OnCompleted(Action<object?> continuation, object? state, ValueTaskSourceOnCompletedFlags flags);
+        // ValueTaskSourceNotifier is used only during suspension sequence, thus
+        // a given thread will never need more than one instance.
+        // We will just reuse the same instance when needed.
+        [ThreadStatic]
+        private static ValueTaskSourceNotifier? t_instance;
+
+        private object _source;
+        private Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> _onCompleted;
+        private short _token;
+
+        private ValueTaskSourceNotifier(
+            object source,
+            Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted,
+            short token)
+        {
+            _source = source;
+            _onCompleted = onCompleted;
+            _token = token;
+        }
+
+        public static ValueTaskSourceNotifier GetInstance(
+            object source,
+            Action<object, Action<object?>, object?, short, ValueTaskSourceOnCompletedFlags> onCompleted,
+            short token)
+        {
+            ValueTaskSourceNotifier? instance = t_instance;
+            if (instance == null)
+            {
+                return t_instance = new ValueTaskSourceNotifier(source, onCompleted, token);
+            }
+
+            instance._source = source;
+            instance._onCompleted = onCompleted;
+            instance._token = token;
+
+            return instance;
+        }
+
+        public void OnCompleted(Action<object?> continuation, object? state, ValueTaskSourceOnCompletedFlags flags)
+        {
+            _onCompleted(_source, continuation, state, _token, flags);
+
+            // The data that we store is effectively single-use.
+            // Once used, clear the fields to not retain unknown data.
+            _source = _onCompleted = null!;
+            _token = 0;
+        }
     }
 }


### PR DESCRIPTION

This avoids allocation on every time we need to suspend on a `ValueTaskSource`.