### PR TITLE
Enhance type and nullability handling for collection items in schema import

### DIFF
--- a/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -616,6 +616,10 @@ namespace System.Runtime.Serialization.DataContracts
             internal ClassDataContractCriticalHelper([DynamicallyAccessedMembers(DataContractPreserveMemberTypes)]
                 Type type) : base(type)
             {
+                // When importing from schemas, we don't want to fill in all this stuff just yet.
+                if (type == Globals.TypeOfSchemaDefinedType)
+                    return;
+
                 XmlQualifiedName xmlName = GetXmlNameAndSetHasDataContract(type);
                 if (type == Globals.TypeOfDBNull)
                 {

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/CodeExporter.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/CodeExporter.cs
@@ -405,6 +405,13 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
+        private bool GetCollectionItemNullability(DataContract collectionContract)
+        {
+            ContractCodeDomInfo contractCodeDomInfo = GetContractCodeDomInfo(collectionContract);
+            return contractCodeDomInfo.CollectionItemIsNullable ?? collectionContract.IsCollectionItemNullable();
+        }
+
+        [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
         private void GenerateType(DataContract dataContract, ContractCodeDomInfo contractCodeDomInfo)
         {
             if (!contractCodeDomInfo.IsProcessed)
@@ -612,7 +619,7 @@ namespace System.Runtime.Serialization
                     {
                         GenerateKeyValueType(itemContract.As(DataContractType.ClassDataContract));
                     }
-                    bool isItemTypeNullable = collectionContract.IsItemTypeNullable();
+                    bool isItemTypeNullable = GetCollectionItemNullability(collectionContract);
                     if (!TryGetReferencedListType(itemContract, isItemTypeNullable, out typeReference))
                     {
                         CodeTypeReference? elementTypeReference = GetElementTypeReference(itemContract, isItemTypeNullable);
@@ -626,7 +633,7 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
-        private static bool HasDefaultCollectionNames(DataContract collectionContract)
+        private bool HasDefaultCollectionNames(DataContract collectionContract)
         {
             Debug.Assert(collectionContract.Is(DataContractType.CollectionDataContract));
 
@@ -639,7 +646,7 @@ namespace System.Runtime.Serialization
             if (isDictionary && (keyName != ImportGlobals.KeyLocalName || valueName != ImportGlobals.ValueLocalName))
                 return false;
 
-            XmlQualifiedName expectedType = itemContract.GetArrayTypeName(collectionContract.IsItemTypeNullable());
+            XmlQualifiedName expectedType = itemContract.GetArrayTypeName(GetCollectionItemNullability(collectionContract));
             return (collectionContract.XmlName.Name == expectedType.Name && collectionContract.XmlName.Namespace == expectedType.Namespace);
         }
 
@@ -1204,7 +1211,7 @@ namespace System.Runtime.Serialization
 
             // ItemContract - aka BaseContract - is never null for CollectionDataContract
             DataContract itemContract = collectionContract.BaseContract!;
-            bool isItemTypeNullable = collectionContract.IsItemTypeNullable();
+            bool isItemTypeNullable = GetCollectionItemNullability(collectionContract);
             bool isDictionary = collectionContract.IsDictionaryLike(out string? keyName, out string? valueName, out string? itemName);
 
             CodeTypeReference? baseTypeReference;

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/ContractCodeDomInfo.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/ContractCodeDomInfo.cs
@@ -44,6 +44,8 @@ namespace System.Runtime.Serialization
 
         internal bool UsesWildcardNamespace { get; set; }
 
+        internal bool? CollectionItemIsNullable { get; set; }
+
         internal HashSet<string> GetMemberNames()
         {
             if (ReferencedTypeExists)

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/SchemaImportHelper.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/SchemaImportHelper.cs
@@ -42,12 +42,44 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
-        internal static bool IsItemTypeNullable(this DataContract collectionDataContract)
+        internal static bool IsCollectionItemNullable(this DataContract collectionDataContract)
         {
             if (collectionDataContract.GetContractType() == DataContractType.CollectionDataContract)
             {
-                // ItemContract - aka BaseContract - is never null for CollectionDataContract
-                return SchemaImportHelper.IsTypeNullable(collectionDataContract.BaseContract!.UnderlyingType);
+                // This would be easier if we had included a way to read 'IsItemTypeNullable' from
+                // CollectionDataContract. But let's do our best to see if we can figure out the
+                // nullability of the collection item type.
+
+                // If the item type is not a value type, then it's nullable.
+                // Dictionary KeyValuePair's are imported as value types.
+                DataContract itemContract = collectionDataContract.BaseContract!;
+                if (!itemContract.IsValueType)
+                    return true;
+
+                // GetArrayTypeName()) generates the default DCS stable XML name for a collection of this item contract
+                // One of these variants should match for our item type, unless the imported schema is using a non-standard
+                // XML name for the collection item type.
+
+                // First check the standard non-nullable collection XML name for this item type.
+                XmlQualifiedName nonNullableCollectionType = itemContract.GetArrayTypeName(isNullable: false);
+                if (collectionDataContract.XmlName.Name == nonNullableCollectionType.Name &&
+                    collectionDataContract.XmlName.Namespace == nonNullableCollectionType.Namespace)
+                {
+                    return false;
+                }
+
+                // Then check the standard nullable collection XML name for this item type.
+                XmlQualifiedName nullableCollectionType = itemContract.GetArrayTypeName(isNullable: true);
+                if (collectionDataContract.XmlName.Name == nullableCollectionType.Name &&
+                    collectionDataContract.XmlName.Namespace == nullableCollectionType.Namespace)
+                {
+                    return true;
+                }
+
+                // If we get here, then the collection is using non-standard XML naming.
+                // UnderlyingType might be an actual CLR type, or it might be the SchemaDefinedType placeholder.
+                // This is just a best effort attempt at this point.
+                return SchemaImportHelper.IsTypeNullable(itemContract.UnderlyingType);
             }
 
             return false;

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/SchemaImportHelper.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/SchemaImportHelper.cs
@@ -56,7 +56,7 @@ namespace System.Runtime.Serialization
                 if (!itemContract.IsValueType)
                     return true;
 
-                // GetArrayTypeName()) generates the default DCS stable XML name for a collection of this item contract
+                // GetArrayTypeName() generates the default DCS stable XML name for a collection of this item contract
                 // One of these variants should match for our item type, unless the imported schema is using a non-standard
                 // XML name for the collection item type.
 

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/XsdDataContractImporter.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/XsdDataContractImporter.cs
@@ -323,26 +323,13 @@ namespace System.Runtime.Serialization
         {
             itemElement = null;
 
-            foreach (XmlSchema schema in schemas.Schemas())
+            if (schemas.GlobalTypes[typeName] is not XmlSchemaComplexType { Particle: XmlSchemaSequence rootSequence } || rootSequence.Items.Count != 1)
             {
-                string schemaNamespace = schema.TargetNamespace ?? string.Empty;
-                if (!string.Equals(schemaNamespace, typeName.Namespace, StringComparison.Ordinal))
-                    continue;
-
-                foreach (XmlSchemaObject schemaObject in schema.Items)
-                {
-                    if (schemaObject is XmlSchemaType { Name: not null } schemaType &&
-                        schemaType.Name == typeName.Name &&
-                        schemaType is XmlSchemaComplexType { Particle: XmlSchemaSequence rootSequence } &&
-                        rootSequence.Items.Count == 1)
-                    {
-                        itemElement = rootSequence.Items[0] as XmlSchemaElement;
-                        return itemElement is not null;
-                    }
-                }
+                return false;
             }
 
-            return false;
+            itemElement = rootSequence.Items[0] as XmlSchemaElement;
+            return itemElement != null;
         }
 
         [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]

--- a/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/XsdDataContractImporter.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/src/System/Runtime/Serialization/Schema/XsdDataContractImporter.cs
@@ -297,6 +297,55 @@ namespace System.Runtime.Serialization
         }
 
         [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
+        private void CacheCollectionItemNullability(XmlSchemaSet schemas)
+        {
+            foreach (KeyValuePair<XmlQualifiedName, DataContract> pair in DataContractSet.Contracts)
+            {
+                DataContract dataContract = pair.Value;
+                if (!dataContract.Is(DataContractType.CollectionDataContract) ||
+                    !TryGetCollectionItemElement(schemas, pair.Key, out XmlSchemaElement? itemElement))
+                {
+                    continue;
+                }
+
+                if (!DataContractSet.ProcessedContracts.TryGetValue(dataContract, out object? info) ||
+                    info is not ContractCodeDomInfo contractCodeDomInfo)
+                {
+                    contractCodeDomInfo = new ContractCodeDomInfo();
+                    DataContractSet.ProcessedContracts[dataContract] = contractCodeDomInfo;
+                }
+
+                contractCodeDomInfo.CollectionItemIsNullable = itemElement.IsNillable;
+            }
+        }
+
+        private static bool TryGetCollectionItemElement(XmlSchemaSet schemas, XmlQualifiedName typeName, [NotNullWhen(true)] out XmlSchemaElement? itemElement)
+        {
+            itemElement = null;
+
+            foreach (XmlSchema schema in schemas.Schemas())
+            {
+                string schemaNamespace = schema.TargetNamespace ?? string.Empty;
+                if (!string.Equals(schemaNamespace, typeName.Namespace, StringComparison.Ordinal))
+                    continue;
+
+                foreach (XmlSchemaObject schemaObject in schema.Items)
+                {
+                    if (schemaObject is XmlSchemaType { Name: not null } schemaType &&
+                        schemaType.Name == typeName.Name &&
+                        schemaType is XmlSchemaComplexType { Particle: XmlSchemaSequence rootSequence } &&
+                        rootSequence.Items.Count == 1)
+                    {
+                        itemElement = rootSequence.Items[0] as XmlSchemaElement;
+                        return itemElement is not null;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        [RequiresUnreferencedCode(ImportGlobals.SerializerTrimmerWarning)]
         private IList<XmlQualifiedName>? InternalImport(XmlSchemaSet schemas, ICollection<XmlQualifiedName>? typeNames, ICollection<XmlSchemaElement>? elements)
         {
             DataContractSet? oldValue = (_dataContractSet == null) ? null : new DataContractSet(_dataContractSet);
@@ -307,6 +356,8 @@ namespace System.Runtime.Serialization
                     elementTypeNames = DataContractSet.ImportSchemaSet(schemas, elements, ImportXmlDataType);
                 else
                     DataContractSet.ImportSchemaSet(schemas, typeNames, ImportXmlDataType);
+
+                CacheCollectionItemNullability(schemas);
 
                 CodeExporter codeExporter = new CodeExporter(DataContractSet, Options, CodeCompileUnit);
                 codeExporter.Export();

--- a/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
+++ b/src/libraries/System.Runtime.Serialization.Schema/tests/System/Runtime/Serialization/Schema/RoundTripTest.cs
@@ -56,15 +56,22 @@ namespace System.Runtime.Serialization.Schema.Tests
             Assert.Contains(@"public System.Nullable<System.Runtime.Serialization.Schema.Tests.RoundTripTestDataContractStruct> NullableDataContractStruct2", code);
             Assert.Contains(@"[System.Runtime.Serialization.DataContractAttribute(Name=""RoundTripTest.EncodingMismatchClass"", Namespace=""http://schemas.datacontract.org/2004/07/System.Runtime.Serialization.Schema.Tests""", code);
             Assert.Contains(@"public partial class RoundTripTestEncodingMismatchClass : object, System.Runtime.Serialization.IExtensibleDataObject", code);
+            Assert.Contains(@"public int[][] intLists", code);
+            Assert.Contains(@"public System.Nullable<int>[] listOfNullableInt", code);
             Assert.Contains(@"public enum RoundTripTestMyEnum : int", code);
             Assert.Contains(@"TwoHundred = 200", code);
             Assert.Contains(@"public enum RoundTripTestMyFlagsEnum : int", code);
             Assert.Contains(@"Four = 4,", code);
-            Assert.Contains(@"public class ArrayOfNullableOfRoundTripTestMyEnumho3BZmza : System.Collections.Generic.List<System.Runtime.Serialization.Schema.Tests.RoundTripTestMyEnum>", code);
-            Assert.Contains(@"namespace schemas.microsoft.com._2003._10.Serialization.Arrays", code);
-            Assert.Contains(@"public partial class ArrayOfKeyValueOfintArrayOfstringty7Ep6D1 : object, System.Xml.Serialization.IXmlSerializable", code);
-            Assert.Contains(@"private static System.Xml.XmlQualifiedName typeName = new System.Xml.XmlQualifiedName(""ArrayOfKeyValueOfintArrayOfstringty7Ep6D1"", ""http://schemas.microsoft.com/2003/10/Serialization/Arrays"");", code);
-            Assert.Contains(@"public partial class ArrayOfKeyValueOfNullableOfunsignedByteNullableOfunsignedByte_ShTDFhl_P : object, System.Xml.Serialization.IXmlSerializable", code);
+            Assert.Contains(@"public System.Runtime.Serialization.Schema.Tests.RoundTripTestDataContractStruct[] arrayOfDataContractStruct", code);
+            Assert.Contains(@"public System.Nullable<System.Runtime.Serialization.Schema.Tests.RoundTripTestMyEnum>[] arrayOfNullableOfMyEnum", code);
+            Assert.Contains(@"public System.Collections.Generic.Dictionary<int, string[]>[] dictionaries", code);
+            Assert.Contains(@"public System.Collections.Generic.Dictionary<System.Nullable<byte>, System.Nullable<byte>> nullableKeyAndValues", code);
+            Assert.Contains(@"public System.Collections.Generic.Dictionary<string, System.Nullable<int>> nullableValues", code);
+            // Schema import when re-introduced in net7.0 did not correctly handle some collections, and we were generating a different code shape than NetFx. These redirection types shouldn't get created.
+            Assert.DoesNotContain(@"namespace schemas.microsoft.com._2003._10.Serialization.Arrays", code);
+            Assert.DoesNotContain(@"class ArrayOfNullableOfRoundTripTestMyEnum", code);
+            Assert.DoesNotContain(@"class ArrayOfKeyValueOfintArrayOfstringty", code);
+            Assert.DoesNotContain(@"class ArrayOfKeyValueOfNullableOfunsignedByteNullableOfunsignedByte", code);
 
             if (autoImportKVP)
             {
@@ -113,7 +120,6 @@ namespace System.Runtime.Serialization.Schema.Tests
             Assert.True(code.Length > 616);
         }
 
-
 #pragma warning disable CS0169, CS0414, IDE0051, IDE1006
         #region RoundTripTest DataContracts
         [DataContract]
@@ -134,6 +140,7 @@ namespace System.Runtime.Serialization.Schema.Tests
             [DataMember] DataContractStruct?[] arrayOfNullableOfDataContractStruct;
             [DataMember] DataSet dataSet;
             [DataMember] IList<IList<int>> intLists;
+            [DataMember] IList<int?> listOfNullableInt;
             [DataMember] IList<IDictionary<int, IEnumerable<string>>> dictionaries;
             [DataMember] IDictionary<string, int?> nullableValues;
             [DataMember] IDictionary<byte?, byte?> nullableKeyAndValues;


### PR DESCRIPTION
This pull request improves the accuracy of collection item nullability detection when importing schemas and generating code, leading to more correct handling of collections in generated data contracts. It introduces logic to inspect schema information for collection item types and nullability, updates internal APIs for clarity, and enhances test coverage for these scenarios.

**Schema Import and Nullability Detection Improvements:**

* Added logic in `XsdDataContractImporter` to cache and track the nullability of collection items by inspecting schema definitions, storing this information in `ContractCodeDomInfo.CollectionItemIsNullable`. [[1]](diffhunk://#diff-3121c4a1ab278d023d05299c0f603a89cf85d0d4ed585ee9eac065dcca625e6cR299-R347) [[2]](diffhunk://#diff-3121c4a1ab278d023d05299c0f603a89cf85d0d4ed585ee9eac065dcca625e6cR360-R361) [[3]](diffhunk://#diff-3914de1fbd80b6dd97450ef0fec075a4d89774ab921d8bf44f38bee14a162f55R47-R48)
* Updated the code generation pipeline (`CodeExporter`) to use the cached nullability information when determining if collection items are nullable, improving accuracy over previous heuristics. [[1]](diffhunk://#diff-aed5d73b49483bcc99c574cae5c5e7635ba4dcb43fa6ecc1404e6d95e1a9feebR407-R413) [[2]](diffhunk://#diff-aed5d73b49483bcc99c574cae5c5e7635ba4dcb43fa6ecc1404e6d95e1a9feebL615-R622) [[3]](diffhunk://#diff-aed5d73b49483bcc99c574cae5c5e7635ba4dcb43fa6ecc1404e6d95e1a9feebL629-R636) [[4]](diffhunk://#diff-aed5d73b49483bcc99c574cae5c5e7635ba4dcb43fa6ecc1404e6d95e1a9feebL642-R649) [[5]](diffhunk://#diff-aed5d73b49483bcc99c574cae5c5e7635ba4dcb43fa6ecc1404e6d95e1a9feebL1207-R1214)

**API and Naming Consistency:**

* Renamed the extension method `IsItemTypeNullable` to `IsCollectionItemNullable` and improved its logic for determining item nullability, including handling of non-standard XML naming and fallback for schema-defined types.

**Schema Import Bypass in Special Cases:**

* Modified `ClassDataContractCriticalHelper` to avoid unnecessary initialization when importing from schemas, improving efficiency and correctness for schema-defined types.

**Test Enhancements:**

* Expanded round-trip tests to assert correct code generation for nullable collections and to ensure that legacy redirection types are not generated, reflecting the improved schema import behavior. [[1]](diffhunk://#diff-b4b159faa3eaae2f256a634ee4d2617a1acd369eaec1775650b3f5c0f8efb7d3R59-R74) [[2]](diffhunk://#diff-b4b159faa3eaae2f256a634ee4d2617a1acd369eaec1775650b3f5c0f8efb7d3L116) [[3]](diffhunk://#diff-b4b159faa3eaae2f256a634ee4d2617a1acd369eaec1775650b3f5c0f8efb7d3R143)…ation

- Introduced CollectionItemIsNullable property in ContractCodeDomInfo.
- Added GetCollectionItemNullability method to determine item type nullability.
- Updated related methods in CodeExporter and SchemaImportHelper for improved nullability checks.
- Implemented CacheCollectionItemNullability to cache nullability information during schema import.
- Enhanced RoundTripTest to validate new collection item nullability scenarios.

Fixes #98240