### PR TITLE
Feature/zip archive forward read

### DIFF
--- a/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
@@ -150,6 +150,8 @@ namespace System.IO.Compression
         public System.Threading.Tasks.ValueTask DisposeAsync() { throw null; }
         protected virtual System.Threading.Tasks.ValueTask DisposeAsyncCore() { throw null; }
         public System.IO.Compression.ZipArchiveEntry? GetEntry(string entryName) { throw null; }
+        public System.IO.Compression.ZipArchiveEntry? GetNextEntry() { throw null; }
+        public System.Threading.Tasks.ValueTask<System.IO.Compression.ZipArchiveEntry?> GetNextEntryAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
     public partial class ZipArchiveEntry
     {
@@ -179,6 +181,7 @@ namespace System.IO.Compression
         Read = 0,
         Create = 1,
         Update = 2,
+        ForwardRead = 3,
     }
     public enum ZipCompressionMethod
     {

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -413,4 +413,7 @@
   <data name="ForwardReadNoDataStream" xml:space="preserve">
     <value>This entry has no data to read. It may be a directory entry or an empty entry.</value>
   </data>
+  <data name="ForwardReadEntryAlreadyOpened" xml:space="preserve">
+    <value>The entry has already been opened and cannot be opened again in ForwardRead mode.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -389,4 +389,19 @@
   <data name="UnexpectedStreamLength" xml:space="preserve">
     <value>The decompressed data length does not match the expected value from the archive.</value>
   </data>
+  <data name="ForwardReadOnly" xml:space="preserve">
+    <value>This operation is not supported in ForwardRead mode.</value>
+  </data>
+  <data name="GetNextEntryNotInForwardRead" xml:space="preserve">
+    <value>GetNextEntry is only supported when the archive is opened in ForwardRead mode.</value>
+  </data>
+  <data name="ForwardReadStoredDataDescriptorNotSupported" xml:space="preserve">
+    <value>Stored entries with data descriptors cannot be read in ForwardRead mode because the entry boundary cannot be determined.</value>
+  </data>
+  <data name="ForwardReadEncryptedDataDescriptorNotSupported" xml:space="preserve">
+    <value>Encrypted entries with data descriptors cannot be read in ForwardRead mode.</value>
+  </data>
+  <data name="ForwardReadInvalidLocalFileHeader" xml:space="preserve">
+    <value>The archive stream contains an invalid local file header.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression/src/Resources/Strings.resx
@@ -404,4 +404,13 @@
   <data name="ForwardReadInvalidLocalFileHeader" xml:space="preserve">
     <value>The archive stream contains an invalid local file header.</value>
   </data>
+  <data name="ForwardReadEncryptedNotSupported" xml:space="preserve">
+    <value>Encrypted entries are not supported in ForwardRead mode.</value>
+  </data>
+  <data name="ForwardReadMetadataNotYetAvailable" xml:space="preserve">
+    <value>This property is not available because the entry uses a data descriptor and the metadata cannot be determined in ForwardRead mode.</value>
+  </data>
+  <data name="ForwardReadNoDataStream" xml:space="preserve">
+    <value>This entry has no data to read. It may be a directory entry or an empty entry.</value>
+  </data>
 </root>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -98,6 +98,9 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                     // directory up-front
                     await zipArchive.EnsureCentralDirectoryReadAsync(cancellationToken).ConfigureAwait(false);
                     break;
+                case ZipArchiveMode.ForwardRead:
+                    zipArchive._readEntries = true;
+                    break;
                 case ZipArchiveMode.Update:
                 default:
                     Debug.Assert(mode == ZipArchiveMode.Update);
@@ -146,6 +149,8 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 switch (_mode)
                 {
                     case ZipArchiveMode.Read:
+                        break;
+                    case ZipArchiveMode.ForwardRead:
                         break;
                     case ZipArchiveMode.Create:
                         await WriteFileAsync().ConfigureAwait(false);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -99,6 +99,9 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                     await zipArchive.EnsureCentralDirectoryReadAsync(cancellationToken).ConfigureAwait(false);
                     break;
                 case ZipArchiveMode.ForwardRead:
+                    // Central directory is intentionally never read in this mode.
+                    // Set _readEntries to prevent EnsureCentralDirectoryRead from
+                    // attempting to read it if accidentally reached.
                     zipArchive._readEntries = true;
                     break;
                 case ZipArchiveMode.Update:

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -151,6 +151,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                     case ZipArchiveMode.Read:
                         break;
                     case ZipArchiveMode.ForwardRead:
+                        await DrainPreviousEntryAsync(default).ConfigureAwait(false);
                         break;
                     case ZipArchiveMode.Create:
                         await WriteFileAsync().ConfigureAwait(false);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -149,7 +149,6 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 switch (_mode)
                 {
                     case ZipArchiveMode.Read:
-                        break;
                     case ZipArchiveMode.ForwardRead:
                         await DrainPreviousEntryAsync(default).ConfigureAwait(false);
                         break;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -451,7 +451,7 @@ namespace System.IO.Compression
 
             if (prev.HasDataDescriptor)
             {
-                ReadDataDescriptor(prev);
+                await ReadDataDescriptorAsync(prev, cancellationToken).ConfigureAwait(false);
             }
 
             _forwardReadPreviousEntry = null;
@@ -459,95 +459,79 @@ namespace System.IO.Compression
 
         private void ReadDataDescriptor(ZipArchiveEntry entry)
         {
-            // Data descriptor can be:
-            // Without signature: CRC32(4) + CompressedSize(4) + UncompressedSize(4) = 12 bytes
-            // With signature: Sig(4) + CRC32(4) + CompressedSize(4) + UncompressedSize(4) = 16 bytes
-            // Or Zip64: Sig(4) + CRC32(4) + CompressedSize(8) + UncompressedSize(8) = 24 bytes
+            // Data descriptor formats (all start after entry data):
+            //   32-bit with sig:  sig(4) + crc(4) + comp(4) + uncomp(4) = 16 bytes
+            //   32-bit no sig:    crc(4) + comp(4) + uncomp(4)          = 12 bytes
+            //   64-bit with sig:  sig(4) + crc(4) + comp(8) + uncomp(8) = 24 bytes
+            //   64-bit no sig:    crc(4) + comp(8) + uncomp(8)          = 20 bytes
+            // Read the maximum (24 bytes), determine format, seek back the unused portion.
+            //
+            // Note: When the archive stream is a ReadAheadStream (non-seekable ForwardRead),
+            // Seek(negative, Current) uses a limited history buffer (default 8KB).
+            // The small rewinds here (at most 12 bytes) are well within that limit.
 
-            // Read first 4 bytes to check for signature
-            Span<byte> sigBuf = stackalloc byte[4];
-            _archiveStream.ReadExactly(sigBuf);
+            Span<byte> buf = stackalloc byte[24];
+            _archiveStream.ReadExactly(buf);
 
-            uint possibleSig = BinaryPrimitives.ReadUInt32LittleEndian(sigBuf);
-            bool hasSignature = possibleSig == 0x08074B50;
+            int pos = 0;
+            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(buf);
+            if (firstWord == 0x08074B50)
+                pos = 4; // skip signature
 
-            if (hasSignature)
+            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos));
+            pos += 4;
+
+            // Probe 32-bit: if the 4 bytes after comp(4)+uncomp(4) are a known signature, it's 32-bit.
+            uint afterThirtyTwo = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos + 8));
+            if (IsKnownZipSignature(afterThirtyTwo))
             {
-                // Probe whether this is a 32-bit or 64-bit descriptor.
-                // Read CRC32(4) + field1(4) + field2(4) + field3(4) = 16 more bytes
-                Span<byte> probe = stackalloc byte[20];
-                _archiveStream.ReadExactly(probe);
-
-                uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(probe);
-
-                // Try 32-bit interpretation first: sizes are 4 bytes each
-                // After 32-bit descriptor, next 4 bytes would be at probe[12..16]
-                uint nextSig32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(12));
-
-                if (IsKnownZipSignature(nextSig32))
-                {
-                    // 32-bit descriptor
-                    uint compressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(4));
-                    uint uncompressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(8));
-                    entry.UpdateFromDataDescriptor(crc32, compressedSize32, uncompressedSize32);
-                    // Seek back the 8 over-read bytes (nextSig32 + 4 more bytes)
-                    _archiveStream.Seek(-8, SeekOrigin.Current);
-                }
-                else
-                {
-                    // 64-bit descriptor: read 4 more bytes to complete it
-                    Span<byte> extra = stackalloc byte[4];
-                    _archiveStream.ReadExactly(extra);
-
-                    long compressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(probe.Slice(4));
-                    long uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(probe.Slice(12));
-                    // extra contains the 4 bytes we read that aren't part of sizes
-                    // Actually: with signature, zip64 is: sig(4) + crc(4) + compsize(8) + uncompsize(8) = 24
-                    // We read sig(4) already, then probe(20) = crc(4) + comp(8) + uncomp first 4
-                    // Then extra(4) = uncomp last 4
-                    // Reconstruct uncompressedSize64 from probe[12..16] and extra[0..4]
-                    Span<byte> uncomp64Buf = stackalloc byte[8];
-                    probe.Slice(12, 4).CopyTo(uncomp64Buf);
-                    extra.CopyTo(uncomp64Buf.Slice(4));
-                    uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(uncomp64Buf);
-
-                    entry.UpdateFromDataDescriptor(crc32, compressedSize64, uncompressedSize64);
-                }
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos));
+                uint uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos + 4));
+                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
+                int consumed = pos + 8;
+                _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
             }
             else
             {
-                // No signature - first 4 bytes are CRC32
-                // Read the remaining 8 bytes (compressedSize + uncompressedSize as 32-bit)
-                // But could be 64-bit: try 32-bit first, probe next 4 bytes
-                Span<byte> rest = stackalloc byte[12];
-                _archiveStream.ReadExactly(rest);
+                long compressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.Slice(pos));
+                long uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.Slice(pos + 8));
+                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
+                int consumed = pos + 16;
+                if (consumed < 24)
+                    _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
+            }
+        }
 
-                uint crc32 = possibleSig;
-                uint nextSig = BinaryPrimitives.ReadUInt32LittleEndian(rest.Slice(8));
+        private async ValueTask ReadDataDescriptorAsync(ZipArchiveEntry entry, CancellationToken cancellationToken)
+        {
+            byte[] buf = new byte[24];
+            await _archiveStream.ReadExactlyAsync(buf, cancellationToken).ConfigureAwait(false);
 
-                if (IsKnownZipSignature(nextSig))
-                {
-                    // 32-bit, no signature
-                    uint compressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(rest);
-                    uint uncompressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(rest.Slice(4));
-                    entry.UpdateFromDataDescriptor(crc32, compressedSize32, uncompressedSize32);
-                    // Seek back the 4 over-read bytes
-                    _archiveStream.Seek(-4, SeekOrigin.Current);
-                }
-                else
-                {
-                    // 64-bit, no signature
-                    Span<byte> extra = stackalloc byte[4];
-                    _archiveStream.ReadExactly(extra);
+            int pos = 0;
+            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(buf);
+            if (firstWord == 0x08074B50)
+                pos = 4;
 
-                    long compressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(rest);
-                    Span<byte> uncomp64Buf = stackalloc byte[8];
-                    rest.Slice(8, 4).CopyTo(uncomp64Buf);
-                    extra.CopyTo(uncomp64Buf.Slice(4));
-                    long uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(uncomp64Buf);
+            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos));
+            pos += 4;
 
-                    entry.UpdateFromDataDescriptor(crc32, compressedSize64, uncompressedSize64);
-                }
+            uint afterThirtyTwo = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos + 8));
+            if (IsKnownZipSignature(afterThirtyTwo))
+            {
+                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos));
+                uint uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos + 4));
+                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
+                int consumed = pos + 8;
+                _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
+            }
+            else
+            {
+                long compressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(pos));
+                long uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(pos + 8));
+                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
+                int consumed = pos + 16;
+                if (consumed < 24)
+                    _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
             }
         }
 
@@ -557,6 +541,17 @@ namespace System.IO.Compression
                 || sig == 0x02014B50  // Central directory
                 || sig == 0x06054B50  // EOCD
                 || sig == 0x06064B50; // Zip64 EOCD
+        }
+
+        private static Stream CreateForwardReadDecompressor(Stream source, ZipCompressionMethod compressionMethod, long uncompressedSize, bool leaveOpen)
+        {
+            return compressionMethod switch
+            {
+                ZipCompressionMethod.Deflate when leaveOpen => new DeflateStream(source, CompressionMode.Decompress, leaveOpen: true),
+                ZipCompressionMethod.Deflate => new DeflateStream(source, CompressionMode.Decompress, uncompressedSize),
+                ZipCompressionMethod.Deflate64 => new DeflateManagedStream(source, ZipCompressionMethod.Deflate64, uncompressedSize),
+                _ => source,
+            };
         }
 
         private ZipArchiveEntry? ReadNextLocalFileHeader()
@@ -591,16 +586,8 @@ namespace System.IO.Compression
             const int HeaderSize = ZipLocalFileHeader.SizeOfLocalHeader;
             byte[] header = new byte[HeaderSize];
 
-            int totalRead = 0;
-            while (totalRead < HeaderSize)
-            {
-                int read = await _archiveStream.ReadAsync(header.AsMemory(totalRead, HeaderSize - totalRead), cancellationToken).ConfigureAwait(false);
-                if (read == 0)
-                    break;
-                totalRead += read;
-            }
-
-            if (totalRead < HeaderSize)
+            int bytesRead = await _archiveStream.ReadAtLeastAsync(header, HeaderSize, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+            if (bytesRead < HeaderSize)
             {
                 _forwardReadReachedEnd = true;
                 return null;
@@ -691,21 +678,11 @@ namespace System.IO.Compression
             {
                 if (hasDataDescriptor)
                 {
-                    // Data descriptor: unknown size, let DeflateStream detect end
-                    Stream decompressor;
-                    if (compressionMethod == ZipCompressionMethod.Deflate)
-                    {
-                        decompressor = new DeflateStream(_archiveStream, CompressionMode.Decompress, leaveOpen: true);
-                    }
-                    else if (compressionMethod == ZipCompressionMethod.Deflate64)
-                    {
-                        decompressor = new DeflateManagedStream(_archiveStream, ZipCompressionMethod.Deflate64, -1);
-                    }
-                    else
-                    {
-                        // Should not reach here (stored with DD is thrown above)
-                        decompressor = _archiveStream;
-                    }
+                    // Data descriptor: unknown size, let DeflateStream detect end.
+                    // Because ReadAheadStream.CanSeek returns true, DeflateStream will
+                    // automatically rewind unconsumed bytes after decompression finishes,
+                    // leaving the archive stream positioned right after the compressed data.
+                    Stream decompressor = CreateForwardReadDecompressor(_archiveStream, compressionMethod, -1, leaveOpen: true);
                     dataStream = new CrcValidatingReadStream(decompressor, expectedCrc: 0, expectedLength: long.MaxValue);
                 }
                 else if (isEncrypted)
@@ -717,20 +694,7 @@ namespace System.IO.Compression
                 {
                     // Known size, not encrypted
                     Stream bounded = new BoundedReadOnlyStream(_archiveStream, compressedSize);
-                    Stream decompressor;
-                    if (compressionMethod == ZipCompressionMethod.Deflate)
-                    {
-                        decompressor = new DeflateStream(bounded, CompressionMode.Decompress, uncompressedSize);
-                    }
-                    else if (compressionMethod == ZipCompressionMethod.Deflate64)
-                    {
-                        decompressor = new DeflateManagedStream(bounded, ZipCompressionMethod.Deflate64, uncompressedSize);
-                    }
-                    else
-                    {
-                        // Stored
-                        decompressor = bounded;
-                    }
+                    Stream decompressor = CreateForwardReadDecompressor(bounded, compressionMethod, uncompressedSize, leaveOpen: false);
                     dataStream = new CrcValidatingReadStream(decompressor, crc32, uncompressedSize);
                 }
             }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -5,12 +5,15 @@
 // Zip Spec here: http://www.pkware.com/documents/casestudies/APPNOTE.TXT
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.IO.Compression
 {
@@ -34,6 +37,8 @@ namespace System.IO.Compression
         private byte[] _archiveComment;
         private Encoding? _entryNameAndCommentEncoding;
         private long _firstDeletedEntryOffset;
+        private ZipArchiveEntry? _forwardReadPreviousEntry;
+        private bool _forwardReadReachedEnd;
 
 #if DEBUG_FORCE_ZIP64
         public bool _forceZip64;
@@ -150,6 +155,9 @@ namespace System.IO.Compression
                     case ZipArchiveMode.Read:
                         ReadEndOfCentralDirectory();
                         break;
+                    case ZipArchiveMode.ForwardRead:
+                        _readEntries = true;
+                        break;
                     case ZipArchiveMode.Update:
                     default:
                         Debug.Assert(mode == ZipArchiveMode.Update);
@@ -231,6 +239,8 @@ namespace System.IO.Compression
             {
                 if (_mode == ZipArchiveMode.Create)
                     throw new NotSupportedException(SR.EntriesInCreateMode);
+                if (_mode == ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ForwardReadOnly);
 
                 ThrowIfDisposed();
 
@@ -299,6 +309,8 @@ namespace System.IO.Compression
                     {
                         case ZipArchiveMode.Read:
                             break;
+                        case ZipArchiveMode.ForwardRead:
+                            break;
                         case ZipArchiveMode.Create:
                             WriteFile();
                             break;
@@ -349,10 +361,386 @@ namespace System.IO.Compression
 
             if (_mode == ZipArchiveMode.Create)
                 throw new NotSupportedException(SR.EntriesInCreateMode);
+            if (_mode == ZipArchiveMode.ForwardRead)
+                throw new NotSupportedException(SR.ForwardReadOnly);
 
             EnsureCentralDirectoryRead();
             _entriesDictionary.TryGetValue(entryName, out ZipArchiveEntry? result);
             return result;
+        }
+
+        /// <summary>
+        /// Reads the next entry from the archive when opened in <see cref="ZipArchiveMode.ForwardRead"/> mode.
+        /// </summary>
+        /// <returns>The next <see cref="ZipArchiveEntry"/> in the archive, or <see langword="null"/> if no more entries exist.</returns>
+        /// <exception cref="NotSupportedException">The archive was not opened in <see cref="ZipArchiveMode.ForwardRead"/> mode.</exception>
+        /// <exception cref="ObjectDisposedException">The archive has been disposed.</exception>
+        /// <exception cref="InvalidDataException">The archive contains invalid data.</exception>
+        public ZipArchiveEntry? GetNextEntry()
+        {
+            ThrowIfDisposed();
+            if (_mode != ZipArchiveMode.ForwardRead)
+                throw new NotSupportedException(SR.GetNextEntryNotInForwardRead);
+
+            if (_forwardReadReachedEnd)
+                return null;
+
+            DrainPreviousEntry();
+            return ReadNextLocalFileHeader();
+        }
+
+        /// <summary>
+        /// Asynchronously reads the next entry from the archive when opened in <see cref="ZipArchiveMode.ForwardRead"/> mode.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to observe.</param>
+        /// <returns>A <see cref="ValueTask{TResult}"/> representing the next entry, or <see langword="null"/> if no more entries exist.</returns>
+        /// <exception cref="NotSupportedException">The archive was not opened in <see cref="ZipArchiveMode.ForwardRead"/> mode.</exception>
+        /// <exception cref="ObjectDisposedException">The archive has been disposed.</exception>
+        /// <exception cref="InvalidDataException">The archive contains invalid data.</exception>
+        public ValueTask<ZipArchiveEntry?> GetNextEntryAsync(CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+            if (_mode != ZipArchiveMode.ForwardRead)
+                throw new NotSupportedException(SR.GetNextEntryNotInForwardRead);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_forwardReadReachedEnd)
+                return new ValueTask<ZipArchiveEntry?>((ZipArchiveEntry?)null);
+
+            return GetNextEntryAsyncCore(cancellationToken);
+        }
+
+        private async ValueTask<ZipArchiveEntry?> GetNextEntryAsyncCore(CancellationToken cancellationToken)
+        {
+            await DrainPreviousEntryAsync(cancellationToken).ConfigureAwait(false);
+            return await ReadNextLocalFileHeaderAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private void DrainPreviousEntry()
+        {
+            if (_forwardReadPreviousEntry is not { } prev)
+                return;
+
+            Stream? dataStream = prev.ForwardReadDataStream;
+            if (dataStream != null)
+            {
+                dataStream.CopyTo(Stream.Null);
+                dataStream.Dispose();
+            }
+
+            if (prev.HasDataDescriptor)
+            {
+                ReadDataDescriptor(prev);
+            }
+
+            _forwardReadPreviousEntry = null;
+        }
+
+        private async ValueTask DrainPreviousEntryAsync(CancellationToken cancellationToken)
+        {
+            if (_forwardReadPreviousEntry is not { } prev)
+                return;
+
+            Stream? dataStream = prev.ForwardReadDataStream;
+            if (dataStream != null)
+            {
+                await dataStream.CopyToAsync(Stream.Null, cancellationToken).ConfigureAwait(false);
+                await dataStream.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (prev.HasDataDescriptor)
+            {
+                ReadDataDescriptor(prev);
+            }
+
+            _forwardReadPreviousEntry = null;
+        }
+
+        private void ReadDataDescriptor(ZipArchiveEntry entry)
+        {
+            // Data descriptor can be:
+            // Without signature: CRC32(4) + CompressedSize(4) + UncompressedSize(4) = 12 bytes
+            // With signature: Sig(4) + CRC32(4) + CompressedSize(4) + UncompressedSize(4) = 16 bytes
+            // Or Zip64: Sig(4) + CRC32(4) + CompressedSize(8) + UncompressedSize(8) = 24 bytes
+
+            // Read first 4 bytes to check for signature
+            Span<byte> sigBuf = stackalloc byte[4];
+            _archiveStream.ReadExactly(sigBuf);
+
+            uint possibleSig = BinaryPrimitives.ReadUInt32LittleEndian(sigBuf);
+            bool hasSignature = possibleSig == 0x08074B50;
+
+            if (hasSignature)
+            {
+                // Probe whether this is a 32-bit or 64-bit descriptor.
+                // Read CRC32(4) + field1(4) + field2(4) + field3(4) = 16 more bytes
+                Span<byte> probe = stackalloc byte[20];
+                _archiveStream.ReadExactly(probe);
+
+                uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(probe);
+
+                // Try 32-bit interpretation first: sizes are 4 bytes each
+                // After 32-bit descriptor, next 4 bytes would be at probe[12..16]
+                uint nextSig32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(12));
+
+                if (IsKnownZipSignature(nextSig32))
+                {
+                    // 32-bit descriptor
+                    uint compressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(4));
+                    uint uncompressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(probe.Slice(8));
+                    entry.UpdateFromDataDescriptor(crc32, compressedSize32, uncompressedSize32);
+                    // Seek back the 8 over-read bytes (nextSig32 + 4 more bytes)
+                    _archiveStream.Seek(-8, SeekOrigin.Current);
+                }
+                else
+                {
+                    // 64-bit descriptor: read 4 more bytes to complete it
+                    Span<byte> extra = stackalloc byte[4];
+                    _archiveStream.ReadExactly(extra);
+
+                    long compressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(probe.Slice(4));
+                    long uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(probe.Slice(12));
+                    // extra contains the 4 bytes we read that aren't part of sizes
+                    // Actually: with signature, zip64 is: sig(4) + crc(4) + compsize(8) + uncompsize(8) = 24
+                    // We read sig(4) already, then probe(20) = crc(4) + comp(8) + uncomp first 4
+                    // Then extra(4) = uncomp last 4
+                    // Reconstruct uncompressedSize64 from probe[12..16] and extra[0..4]
+                    Span<byte> uncomp64Buf = stackalloc byte[8];
+                    probe.Slice(12, 4).CopyTo(uncomp64Buf);
+                    extra.CopyTo(uncomp64Buf.Slice(4));
+                    uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(uncomp64Buf);
+
+                    entry.UpdateFromDataDescriptor(crc32, compressedSize64, uncompressedSize64);
+                }
+            }
+            else
+            {
+                // No signature - first 4 bytes are CRC32
+                // Read the remaining 8 bytes (compressedSize + uncompressedSize as 32-bit)
+                // But could be 64-bit: try 32-bit first, probe next 4 bytes
+                Span<byte> rest = stackalloc byte[12];
+                _archiveStream.ReadExactly(rest);
+
+                uint crc32 = possibleSig;
+                uint nextSig = BinaryPrimitives.ReadUInt32LittleEndian(rest.Slice(8));
+
+                if (IsKnownZipSignature(nextSig))
+                {
+                    // 32-bit, no signature
+                    uint compressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(rest);
+                    uint uncompressedSize32 = BinaryPrimitives.ReadUInt32LittleEndian(rest.Slice(4));
+                    entry.UpdateFromDataDescriptor(crc32, compressedSize32, uncompressedSize32);
+                    // Seek back the 4 over-read bytes
+                    _archiveStream.Seek(-4, SeekOrigin.Current);
+                }
+                else
+                {
+                    // 64-bit, no signature
+                    Span<byte> extra = stackalloc byte[4];
+                    _archiveStream.ReadExactly(extra);
+
+                    long compressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(rest);
+                    Span<byte> uncomp64Buf = stackalloc byte[8];
+                    rest.Slice(8, 4).CopyTo(uncomp64Buf);
+                    extra.CopyTo(uncomp64Buf.Slice(4));
+                    long uncompressedSize64 = BinaryPrimitives.ReadInt64LittleEndian(uncomp64Buf);
+
+                    entry.UpdateFromDataDescriptor(crc32, compressedSize64, uncompressedSize64);
+                }
+            }
+        }
+
+        private static bool IsKnownZipSignature(uint sig)
+        {
+            return sig == 0x04034B50  // Local file header
+                || sig == 0x02014B50  // Central directory
+                || sig == 0x06054B50  // EOCD
+                || sig == 0x06064B50; // Zip64 EOCD
+        }
+
+        private ZipArchiveEntry? ReadNextLocalFileHeader()
+        {
+            const int HeaderSize = ZipLocalFileHeader.SizeOfLocalHeader;
+            Span<byte> header = stackalloc byte[HeaderSize];
+
+            int bytesRead = _archiveStream.ReadAtLeast(header, HeaderSize, throwOnEndOfStream: false);
+            if (bytesRead < HeaderSize)
+            {
+                _forwardReadReachedEnd = true;
+                return null;
+            }
+
+            // Check signature
+            if (!header.Slice(0, 4).SequenceEqual(ZipLocalFileHeader.SignatureConstantBytes))
+            {
+                uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
+                if (IsKnownZipSignature(sig))
+                {
+                    _forwardReadReachedEnd = true;
+                    return null;
+                }
+                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+            }
+
+            return ParseLocalFileHeader(header);
+        }
+
+        private async ValueTask<ZipArchiveEntry?> ReadNextLocalFileHeaderAsync(CancellationToken cancellationToken)
+        {
+            const int HeaderSize = ZipLocalFileHeader.SizeOfLocalHeader;
+            byte[] header = new byte[HeaderSize];
+
+            int totalRead = 0;
+            while (totalRead < HeaderSize)
+            {
+                int read = await _archiveStream.ReadAsync(header.AsMemory(totalRead, HeaderSize - totalRead), cancellationToken).ConfigureAwait(false);
+                if (read == 0)
+                    break;
+                totalRead += read;
+            }
+
+            if (totalRead < HeaderSize)
+            {
+                _forwardReadReachedEnd = true;
+                return null;
+            }
+
+            if (!header.AsSpan(0, 4).SequenceEqual(ZipLocalFileHeader.SignatureConstantBytes))
+            {
+                uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
+                if (IsKnownZipSignature(sig))
+                {
+                    _forwardReadReachedEnd = true;
+                    return null;
+                }
+                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+            }
+
+            return ParseLocalFileHeader(header);
+        }
+
+        private ZipArchiveEntry ParseLocalFileHeader(ReadOnlySpan<byte> header)
+        {
+            ushort versionNeeded = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.VersionNeededToExtract));
+            ushort generalPurposeBitFlags = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags));
+            ushort compressionMethodValue = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.CompressionMethod));
+            uint lastModified = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.LastModified));
+            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.Crc32));
+            uint compressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.CompressedSize));
+            uint uncompressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.UncompressedSize));
+            ushort filenameLength = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.FilenameLength));
+            ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.ExtraFieldLength));
+
+            // Read filename
+            byte[] filenameBytes = new byte[filenameLength];
+            if (filenameLength > 0)
+                _archiveStream.ReadExactly(filenameBytes);
+
+            // Read extra field
+            byte[] extraFieldBytes = new byte[extraFieldLength];
+            if (extraFieldLength > 0)
+                _archiveStream.ReadExactly(extraFieldBytes);
+
+            long compressedSize = compressedSizeSmall;
+            long uncompressedSize = uncompressedSizeSmall;
+
+            // Handle Zip64 extra field
+            if (compressedSizeSmall == ZipHelper.Mask32Bit || uncompressedSizeSmall == ZipHelper.Mask32Bit)
+            {
+                Zip64ExtraField zip64 = Zip64ExtraField.GetJustZip64Block(extraFieldBytes,
+                    readUncompressedSize: uncompressedSizeSmall == ZipHelper.Mask32Bit,
+                    readCompressedSize: compressedSizeSmall == ZipHelper.Mask32Bit,
+                    readLocalHeaderOffset: false,
+                    readStartDiskNumber: false);
+
+                if (zip64.UncompressedSize.HasValue)
+                    uncompressedSize = zip64.UncompressedSize.Value;
+                if (zip64.CompressedSize.HasValue)
+                    compressedSize = zip64.CompressedSize.Value;
+            }
+
+            bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
+            bool isEncrypted = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.IsEncrypted) != 0;
+            ZipCompressionMethod compressionMethod = (ZipCompressionMethod)compressionMethodValue;
+
+            // Decode entry name
+            bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
+            Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (EntryNameAndCommentEncoding ?? Encoding.UTF8);
+            string fullName = nameEncoding.GetString(filenameBytes);
+
+            DateTimeOffset lastModifiedDto = new DateTimeOffset(ZipHelper.DosTimeToDateTime(lastModified));
+
+            // Handle unsupported combinations
+            if (hasDataDescriptor)
+            {
+                if (compressionMethod == ZipCompressionMethod.Stored)
+                    throw new NotSupportedException(SR.ForwardReadStoredDataDescriptorNotSupported);
+                if (isEncrypted)
+                    throw new NotSupportedException(SR.ForwardReadEncryptedDataDescriptorNotSupported);
+            }
+
+            // Build the data stream
+            Stream? dataStream = null;
+
+            bool isDirectory = fullName.Length > 0 &&
+                (fullName[^1] == '/' || fullName[^1] == '\\');
+            bool isEmptyEntry = !hasDataDescriptor && compressedSize == 0 && uncompressedSize == 0;
+
+            if (!isDirectory && !isEmptyEntry)
+            {
+                if (hasDataDescriptor)
+                {
+                    // Data descriptor: unknown size, let DeflateStream detect end
+                    Stream decompressor;
+                    if (compressionMethod == ZipCompressionMethod.Deflate)
+                    {
+                        decompressor = new DeflateStream(_archiveStream, CompressionMode.Decompress, leaveOpen: true);
+                    }
+                    else if (compressionMethod == ZipCompressionMethod.Deflate64)
+                    {
+                        decompressor = new DeflateManagedStream(_archiveStream, ZipCompressionMethod.Deflate64, -1);
+                    }
+                    else
+                    {
+                        // Should not reach here (stored with DD is thrown above)
+                        decompressor = _archiveStream;
+                    }
+                    dataStream = new CrcValidatingReadStream(decompressor, expectedCrc: 0, expectedLength: long.MaxValue);
+                }
+                else if (isEncrypted)
+                {
+                    // Encrypted without data descriptor: return bounded raw stream (no decryption)
+                    dataStream = new BoundedReadOnlyStream(_archiveStream, compressedSize);
+                }
+                else
+                {
+                    // Known size, not encrypted
+                    Stream bounded = new BoundedReadOnlyStream(_archiveStream, compressedSize);
+                    Stream decompressor;
+                    if (compressionMethod == ZipCompressionMethod.Deflate)
+                    {
+                        decompressor = new DeflateStream(bounded, CompressionMode.Decompress, uncompressedSize);
+                    }
+                    else if (compressionMethod == ZipCompressionMethod.Deflate64)
+                    {
+                        decompressor = new DeflateManagedStream(bounded, ZipCompressionMethod.Deflate64, uncompressedSize);
+                    }
+                    else
+                    {
+                        // Stored
+                        decompressor = bounded;
+                    }
+                    dataStream = new CrcValidatingReadStream(decompressor, crc32, uncompressedSize);
+                }
+            }
+
+            var entry = new ZipArchiveEntry(this, fullName, compressionMethod, lastModifiedDto,
+                crc32, compressedSize, uncompressedSize, generalPurposeBitFlags, versionNeeded,
+                hasDataDescriptor, dataStream);
+
+            _forwardReadPreviousEntry = entry;
+            return entry;
         }
 
         internal Stream ArchiveStream => _archiveStream;
@@ -434,6 +822,8 @@ namespace System.IO.Compression
 
             if (_mode == ZipArchiveMode.Read)
                 throw new NotSupportedException(SR.CreateInReadMode);
+            if (_mode == ZipArchiveMode.ForwardRead)
+                throw new NotSupportedException(SR.ForwardReadOnly);
 
             ThrowIfDisposed();
 
@@ -970,6 +1360,10 @@ namespace System.IO.Compression
                         isReadModeAndUnseekable = true;
                     }
                     break;
+                case ZipArchiveMode.ForwardRead:
+                    if (!stream.CanRead)
+                        throw new ArgumentException(SR.ReadModeCapabilities);
+                    break;
                 case ZipArchiveMode.Update:
                     if (!stream.CanRead || !stream.CanWrite || !stream.CanSeek)
                         throw new ArgumentException(SR.UpdateModeCapabilities);
@@ -988,9 +1382,13 @@ namespace System.IO.Compression
         {
             ArgumentNullException.ThrowIfNull(stream);
 
-            return mode == ZipArchiveMode.Create && !stream.CanSeek ?
-                new PositionPreservingWriteOnlyStreamWrapper(stream) :
-                stream;
+            if (mode == ZipArchiveMode.Create && !stream.CanSeek)
+                return new PositionPreservingWriteOnlyStreamWrapper(stream);
+
+            if (mode == ZipArchiveMode.ForwardRead && !stream.CanSeek)
+                return new ReadAheadStream(stream);
+
+            return stream;
         }
 
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -310,6 +310,7 @@ namespace System.IO.Compression
                         case ZipArchiveMode.Read:
                             break;
                         case ZipArchiveMode.ForwardRead:
+                            DrainPreviousEntry();
                             break;
                         case ZipArchiveMode.Create:
                             WriteFile();
@@ -386,7 +387,31 @@ namespace System.IO.Compression
                 return null;
 
             DrainPreviousEntry();
-            return ReadNextLocalFileHeader();
+
+            ZipLocalFileHeader.ForwardReadHeaderData? headerData =
+                ZipLocalFileHeader.TryReadForForwardRead(_archiveStream, EntryNameAndCommentEncoding);
+
+            if (headerData is null)
+            {
+                _forwardReadReachedEnd = true;
+                return null;
+            }
+
+            var data = headerData.Value;
+
+            if (data.HasDataDescriptor)
+            {
+                if (data.CompressionMethod == ZipCompressionMethod.Stored)
+                    throw new NotSupportedException(SR.ForwardReadStoredDataDescriptorNotSupported);
+                if (data.IsEncrypted)
+                    throw new NotSupportedException(SR.ForwardReadEncryptedDataDescriptorNotSupported);
+            }
+
+            Stream? dataStream = BuildForwardReadDataStream(data);
+            var entry = new ZipArchiveEntry(this, data, dataStream);
+            _forwardReadPreviousEntry = entry;
+
+            return entry;
         }
 
         /// <summary>
@@ -414,133 +439,122 @@ namespace System.IO.Compression
         private async ValueTask<ZipArchiveEntry?> GetNextEntryAsyncCore(CancellationToken cancellationToken)
         {
             await DrainPreviousEntryAsync(cancellationToken).ConfigureAwait(false);
-            return await ReadNextLocalFileHeaderAsync(cancellationToken).ConfigureAwait(false);
+
+            ZipLocalFileHeader.ForwardReadHeaderData? headerData =
+                await ZipLocalFileHeader.TryReadForForwardReadAsync(_archiveStream, EntryNameAndCommentEncoding, cancellationToken).ConfigureAwait(false);
+
+            if (headerData is null)
+            {
+                _forwardReadReachedEnd = true;
+                return null;
+            }
+
+            var data = headerData.Value;
+
+            if (data.HasDataDescriptor)
+            {
+                if (data.CompressionMethod == ZipCompressionMethod.Stored)
+                    throw new NotSupportedException(SR.ForwardReadStoredDataDescriptorNotSupported);
+                if (data.IsEncrypted)
+                    throw new NotSupportedException(SR.ForwardReadEncryptedDataDescriptorNotSupported);
+            }
+
+            Stream? dataStream = BuildForwardReadDataStream(data);
+            var entry = new ZipArchiveEntry(this, data, dataStream);
+            _forwardReadPreviousEntry = entry;
+
+            return entry;
         }
 
-        private void DrainPreviousEntry()
+        private void DrainPreviousEntry() =>
+            DrainPreviousEntryCore(useAsync: false, cancellationToken: default).GetAwaiter().GetResult();
+
+        private ValueTask DrainPreviousEntryAsync(CancellationToken cancellationToken) =>
+            new ValueTask(DrainPreviousEntryCore(useAsync: true, cancellationToken));
+
+        private async Task DrainPreviousEntryCore(bool useAsync, CancellationToken cancellationToken)
         {
             if (_forwardReadPreviousEntry is not { } prev)
                 return;
 
             Stream? dataStream = prev.ForwardReadDataStream;
-            if (dataStream != null)
+            if (dataStream is not null)
             {
-                dataStream.CopyTo(Stream.Null);
-                dataStream.Dispose();
-            }
+                byte[] buffer = new byte[4096];
+                if (useAsync)
+                {
+                    while (await dataStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false) > 0) { }
+                }
+                else
+                {
+                    while (dataStream.Read(buffer) > 0) { }
+                }
 
-            if (prev.HasDataDescriptor)
+                var crcResult = (dataStream as CrcValidatingReadStream)?.GetFinalCrcResult();
+
+                if (useAsync)
+                    await dataStream.DisposeAsync().ConfigureAwait(false);
+                else
+                    dataStream.Dispose();
+
+                if (prev.HasDataDescriptor)
+                {
+                    var (crc32, _, uncompressedSize) = useAsync
+                        ? await ZipLocalFileHeader.ReadDataDescriptorAsync(_archiveStream, prev.IsZip64SizeFields, cancellationToken).ConfigureAwait(false)
+                        : ZipLocalFileHeader.ReadDataDescriptor(_archiveStream, prev.IsZip64SizeFields);
+
+                    if (crcResult is { } actual)
+                    {
+                        if (actual.Crc32 != crc32)
+                            throw new InvalidDataException(SR.CrcMismatch);
+                        if (actual.BytesRead != uncompressedSize)
+                            throw new InvalidDataException(SR.UnexpectedStreamLength);
+                    }
+                }
+            }
+            else if (prev.HasDataDescriptor)
             {
-                ReadDataDescriptor(prev);
+                if (useAsync)
+                    await ZipLocalFileHeader.ReadDataDescriptorAsync(_archiveStream, prev.IsZip64SizeFields, cancellationToken).ConfigureAwait(false);
+                else
+                    ZipLocalFileHeader.ReadDataDescriptor(_archiveStream, prev.IsZip64SizeFields);
             }
 
             _forwardReadPreviousEntry = null;
         }
 
-        private async ValueTask DrainPreviousEntryAsync(CancellationToken cancellationToken)
+        private Stream? BuildForwardReadDataStream(ZipLocalFileHeader.ForwardReadHeaderData data)
         {
-            if (_forwardReadPreviousEntry is not { } prev)
-                return;
+            bool isDirectory = data.FullName.Length > 0 &&
+                (data.FullName[^1] == '/' || data.FullName[^1] == '\\');
+            bool isEmptyEntry = !data.HasDataDescriptor && data.CompressedSize == 0 && data.UncompressedSize == 0;
 
-            Stream? dataStream = prev.ForwardReadDataStream;
-            if (dataStream != null)
+            if (isDirectory || isEmptyEntry)
+                return null;
+
+            if (data.CompressionMethod != ZipCompressionMethod.Stored &&
+                data.CompressionMethod != ZipCompressionMethod.Deflate &&
+                data.CompressionMethod != ZipCompressionMethod.Deflate64)
             {
-                await dataStream.CopyToAsync(Stream.Null, cancellationToken).ConfigureAwait(false);
-                await dataStream.DisposeAsync().ConfigureAwait(false);
+                throw new InvalidDataException(SR.UnsupportedCompression);
             }
 
-            if (prev.HasDataDescriptor)
+            if (data.HasDataDescriptor)
             {
-                await ReadDataDescriptorAsync(prev, cancellationToken).ConfigureAwait(false);
+                Stream decompressor = CreateForwardReadDecompressor(_archiveStream, data.CompressionMethod, -1, leaveOpen: true);
+
+                return new CrcValidatingReadStream(decompressor, expectedCrc: 0, expectedLength: long.MaxValue);
             }
 
-            _forwardReadPreviousEntry = null;
-        }
-
-        private void ReadDataDescriptor(ZipArchiveEntry entry)
-        {
-            // Data descriptor formats (all start after entry data):
-            //   32-bit with sig:  sig(4) + crc(4) + comp(4) + uncomp(4) = 16 bytes
-            //   32-bit no sig:    crc(4) + comp(4) + uncomp(4)          = 12 bytes
-            //   64-bit with sig:  sig(4) + crc(4) + comp(8) + uncomp(8) = 24 bytes
-            //   64-bit no sig:    crc(4) + comp(8) + uncomp(8)          = 20 bytes
-            // Read the maximum (24 bytes), determine format, seek back the unused portion.
-            //
-            // Note: When the archive stream is a ReadAheadStream (non-seekable ForwardRead),
-            // Seek(negative, Current) uses a limited history buffer (default 8KB).
-            // The small rewinds here (at most 12 bytes) are well within that limit.
-
-            Span<byte> buf = stackalloc byte[24];
-            _archiveStream.ReadExactly(buf);
-
-            int pos = 0;
-            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(buf);
-            if (firstWord == 0x08074B50)
-                pos = 4; // skip signature
-
-            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos));
-            pos += 4;
-
-            // Probe 32-bit: if the 4 bytes after comp(4)+uncomp(4) are a known signature, it's 32-bit.
-            uint afterThirtyTwo = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos + 8));
-            if (IsKnownZipSignature(afterThirtyTwo))
+            if (data.IsEncrypted)
             {
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos));
-                uint uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(pos + 4));
-                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
-                int consumed = pos + 8;
-                _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
+                return new SubReadStream(_archiveStream, _archiveStream.Position, data.CompressedSize);
             }
-            else
-            {
-                long compressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.Slice(pos));
-                long uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.Slice(pos + 8));
-                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
-                int consumed = pos + 16;
-                if (consumed < 24)
-                    _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
-            }
-        }
 
-        private async ValueTask ReadDataDescriptorAsync(ZipArchiveEntry entry, CancellationToken cancellationToken)
-        {
-            byte[] buf = new byte[24];
-            await _archiveStream.ReadExactlyAsync(buf, cancellationToken).ConfigureAwait(false);
+            Stream bounded = new SubReadStream(_archiveStream, _archiveStream.Position, data.CompressedSize);
+            Stream decompressor2 = CreateForwardReadDecompressor(bounded, data.CompressionMethod, data.UncompressedSize, leaveOpen: false);
 
-            int pos = 0;
-            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(buf);
-            if (firstWord == 0x08074B50)
-                pos = 4;
-
-            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos));
-            pos += 4;
-
-            uint afterThirtyTwo = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos + 8));
-            if (IsKnownZipSignature(afterThirtyTwo))
-            {
-                uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos));
-                uint uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(pos + 4));
-                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
-                int consumed = pos + 8;
-                _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
-            }
-            else
-            {
-                long compressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(pos));
-                long uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(buf.AsSpan(pos + 8));
-                entry.UpdateFromDataDescriptor(crc32, compressedSize, uncompressedSize);
-                int consumed = pos + 16;
-                if (consumed < 24)
-                    _archiveStream.Seek(consumed - 24, SeekOrigin.Current);
-            }
-        }
-
-        private static bool IsKnownZipSignature(uint sig)
-        {
-            return sig == 0x04034B50  // Local file header
-                || sig == 0x02014B50  // Central directory
-                || sig == 0x06054B50  // EOCD
-                || sig == 0x06064B50; // Zip64 EOCD
+            return new CrcValidatingReadStream(decompressor2, data.Crc32, data.UncompressedSize);
         }
 
         private static Stream CreateForwardReadDecompressor(Stream source, ZipCompressionMethod compressionMethod, long uncompressedSize, bool leaveOpen)
@@ -549,162 +563,10 @@ namespace System.IO.Compression
             {
                 ZipCompressionMethod.Deflate when leaveOpen => new DeflateStream(source, CompressionMode.Decompress, leaveOpen: true),
                 ZipCompressionMethod.Deflate => new DeflateStream(source, CompressionMode.Decompress, uncompressedSize),
+                ZipCompressionMethod.Deflate64 when leaveOpen => new DeflateManagedStream(source, ZipCompressionMethod.Deflate64, -1),
                 ZipCompressionMethod.Deflate64 => new DeflateManagedStream(source, ZipCompressionMethod.Deflate64, uncompressedSize),
                 _ => source,
             };
-        }
-
-        private ZipArchiveEntry? ReadNextLocalFileHeader()
-        {
-            const int HeaderSize = ZipLocalFileHeader.SizeOfLocalHeader;
-            Span<byte> header = stackalloc byte[HeaderSize];
-
-            int bytesRead = _archiveStream.ReadAtLeast(header, HeaderSize, throwOnEndOfStream: false);
-            if (bytesRead < HeaderSize)
-            {
-                _forwardReadReachedEnd = true;
-                return null;
-            }
-
-            // Check signature
-            if (!header.Slice(0, 4).SequenceEqual(ZipLocalFileHeader.SignatureConstantBytes))
-            {
-                uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
-                if (IsKnownZipSignature(sig))
-                {
-                    _forwardReadReachedEnd = true;
-                    return null;
-                }
-                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
-            }
-
-            return ParseLocalFileHeader(header);
-        }
-
-        private async ValueTask<ZipArchiveEntry?> ReadNextLocalFileHeaderAsync(CancellationToken cancellationToken)
-        {
-            const int HeaderSize = ZipLocalFileHeader.SizeOfLocalHeader;
-            byte[] header = new byte[HeaderSize];
-
-            int bytesRead = await _archiveStream.ReadAtLeastAsync(header, HeaderSize, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
-            if (bytesRead < HeaderSize)
-            {
-                _forwardReadReachedEnd = true;
-                return null;
-            }
-
-            if (!header.AsSpan(0, 4).SequenceEqual(ZipLocalFileHeader.SignatureConstantBytes))
-            {
-                uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
-                if (IsKnownZipSignature(sig))
-                {
-                    _forwardReadReachedEnd = true;
-                    return null;
-                }
-                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
-            }
-
-            return ParseLocalFileHeader(header);
-        }
-
-        private ZipArchiveEntry ParseLocalFileHeader(ReadOnlySpan<byte> header)
-        {
-            ushort versionNeeded = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.VersionNeededToExtract));
-            ushort generalPurposeBitFlags = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.GeneralPurposeBitFlags));
-            ushort compressionMethodValue = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.CompressionMethod));
-            uint lastModified = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.LastModified));
-            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.Crc32));
-            uint compressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.CompressedSize));
-            uint uncompressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.UncompressedSize));
-            ushort filenameLength = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.FilenameLength));
-            ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(ZipLocalFileHeader.FieldLocations.ExtraFieldLength));
-
-            // Read filename
-            byte[] filenameBytes = new byte[filenameLength];
-            if (filenameLength > 0)
-                _archiveStream.ReadExactly(filenameBytes);
-
-            // Read extra field
-            byte[] extraFieldBytes = new byte[extraFieldLength];
-            if (extraFieldLength > 0)
-                _archiveStream.ReadExactly(extraFieldBytes);
-
-            long compressedSize = compressedSizeSmall;
-            long uncompressedSize = uncompressedSizeSmall;
-
-            // Handle Zip64 extra field
-            if (compressedSizeSmall == ZipHelper.Mask32Bit || uncompressedSizeSmall == ZipHelper.Mask32Bit)
-            {
-                Zip64ExtraField zip64 = Zip64ExtraField.GetJustZip64Block(extraFieldBytes,
-                    readUncompressedSize: uncompressedSizeSmall == ZipHelper.Mask32Bit,
-                    readCompressedSize: compressedSizeSmall == ZipHelper.Mask32Bit,
-                    readLocalHeaderOffset: false,
-                    readStartDiskNumber: false);
-
-                if (zip64.UncompressedSize.HasValue)
-                    uncompressedSize = zip64.UncompressedSize.Value;
-                if (zip64.CompressedSize.HasValue)
-                    compressedSize = zip64.CompressedSize.Value;
-            }
-
-            bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
-            bool isEncrypted = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.IsEncrypted) != 0;
-            ZipCompressionMethod compressionMethod = (ZipCompressionMethod)compressionMethodValue;
-
-            // Decode entry name
-            bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
-            Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (EntryNameAndCommentEncoding ?? Encoding.UTF8);
-            string fullName = nameEncoding.GetString(filenameBytes);
-
-            DateTimeOffset lastModifiedDto = new DateTimeOffset(ZipHelper.DosTimeToDateTime(lastModified));
-
-            // Handle unsupported combinations
-            if (hasDataDescriptor)
-            {
-                if (compressionMethod == ZipCompressionMethod.Stored)
-                    throw new NotSupportedException(SR.ForwardReadStoredDataDescriptorNotSupported);
-                if (isEncrypted)
-                    throw new NotSupportedException(SR.ForwardReadEncryptedDataDescriptorNotSupported);
-            }
-
-            // Build the data stream
-            Stream? dataStream = null;
-
-            bool isDirectory = fullName.Length > 0 &&
-                (fullName[^1] == '/' || fullName[^1] == '\\');
-            bool isEmptyEntry = !hasDataDescriptor && compressedSize == 0 && uncompressedSize == 0;
-
-            if (!isDirectory && !isEmptyEntry)
-            {
-                if (hasDataDescriptor)
-                {
-                    // Data descriptor: unknown size, let DeflateStream detect end.
-                    // Because ReadAheadStream.CanSeek returns true, DeflateStream will
-                    // automatically rewind unconsumed bytes after decompression finishes,
-                    // leaving the archive stream positioned right after the compressed data.
-                    Stream decompressor = CreateForwardReadDecompressor(_archiveStream, compressionMethod, -1, leaveOpen: true);
-                    dataStream = new CrcValidatingReadStream(decompressor, expectedCrc: 0, expectedLength: long.MaxValue);
-                }
-                else if (isEncrypted)
-                {
-                    // Encrypted without data descriptor: return bounded raw stream (no decryption)
-                    dataStream = new BoundedReadOnlyStream(_archiveStream, compressedSize);
-                }
-                else
-                {
-                    // Known size, not encrypted
-                    Stream bounded = new BoundedReadOnlyStream(_archiveStream, compressedSize);
-                    Stream decompressor = CreateForwardReadDecompressor(bounded, compressionMethod, uncompressedSize, leaveOpen: false);
-                    dataStream = new CrcValidatingReadStream(decompressor, crc32, uncompressedSize);
-                }
-            }
-
-            var entry = new ZipArchiveEntry(this, fullName, compressionMethod, lastModifiedDto,
-                crc32, compressedSize, uncompressedSize, generalPurposeBitFlags, versionNeeded,
-                hasDataDescriptor, dataStream);
-
-            _forwardReadPreviousEntry = entry;
-            return entry;
         }
 
         internal Stream ArchiveStream => _archiveStream;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -308,7 +308,6 @@ namespace System.IO.Compression
                     switch (_mode)
                     {
                         case ZipArchiveMode.Read:
-                            break;
                         case ZipArchiveMode.ForwardRead:
                             DrainPreviousEntry();
                             break;
@@ -551,13 +550,12 @@ namespace System.IO.Compression
                 return new SubReadStream(_archiveStream, _archiveStream.Position, data.CompressedSize);
             }
 
-            Stream bounded = new SubReadStream(_archiveStream, _archiveStream.Position, data.CompressedSize);
-            Stream decompressor2 = CreateForwardReadDecompressor(bounded, data.CompressionMethod, data.UncompressedSize, leaveOpen: false);
-
-            return new CrcValidatingReadStream(decompressor2, data.Crc32, data.UncompressedSize);
+            // Known size, not encrypted — store lightweight SubReadStream as a bookmark;
+            // decompressor + CRC wrapper are created lazily in OpenInForwardReadMode.
+            return new SubReadStream(_archiveStream, _archiveStream.Position, data.CompressedSize);
         }
 
-        private static Stream CreateForwardReadDecompressor(Stream source, ZipCompressionMethod compressionMethod, long uncompressedSize, bool leaveOpen)
+        internal static Stream CreateForwardReadDecompressor(Stream source, ZipCompressionMethod compressionMethod, long uncompressedSize, bool leaveOpen)
         {
             return compressionMethod switch
             {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -5,10 +5,8 @@
 // Zip Spec here: http://www.pkware.com/documents/casestudies/APPNOTE.TXT
 
 using System.Buffers;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -37,6 +37,7 @@ namespace System.IO.Compression
         private long _firstDeletedEntryOffset;
         private ZipArchiveEntry? _forwardReadPreviousEntry;
         private bool _forwardReadReachedEnd;
+        private byte[]? _forwardReadDrainBuffer;
 
 #if DEBUG_FORCE_ZIP64
         public bool _forceZip64;
@@ -154,6 +155,9 @@ namespace System.IO.Compression
                         ReadEndOfCentralDirectory();
                         break;
                     case ZipArchiveMode.ForwardRead:
+                        // Central directory is intentionally never read in this mode.
+                        // Set _readEntries to prevent EnsureCentralDirectoryRead from
+                        // attempting to read it if accidentally reached.
                         _readEntries = true;
                         break;
                     case ZipArchiveMode.Update:
@@ -463,13 +467,7 @@ namespace System.IO.Compression
             return entry;
         }
 
-        private void DrainPreviousEntry() =>
-            DrainPreviousEntryCore(useAsync: false, cancellationToken: default).GetAwaiter().GetResult();
-
-        private ValueTask DrainPreviousEntryAsync(CancellationToken cancellationToken) =>
-            new ValueTask(DrainPreviousEntryCore(useAsync: true, cancellationToken));
-
-        private async Task DrainPreviousEntryCore(bool useAsync, CancellationToken cancellationToken)
+        private void DrainPreviousEntry()
         {
             if (_forwardReadPreviousEntry is not { } prev)
                 return;
@@ -477,36 +475,19 @@ namespace System.IO.Compression
             Stream? dataStream = prev.ForwardReadDataStream;
             if (dataStream is not null)
             {
-                byte[] buffer = new byte[4096];
-                if (useAsync)
-                {
-                    while (await dataStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false) > 0) { }
-                }
-                else
-                {
-                    while (dataStream.Read(buffer) > 0) { }
-                }
+                byte[] buffer = _forwardReadDrainBuffer ??= new byte[4096];
+                while (dataStream.Read(buffer) > 0) { }
 
                 var crcResult = (dataStream as CrcValidatingReadStream)?.GetFinalCrcResult();
-
-                if (useAsync)
-                    await dataStream.DisposeAsync().ConfigureAwait(false);
-                else
-                    dataStream.Dispose();
+                dataStream.Dispose();
 
                 if (prev.HasDataDescriptor)
                 {
                     if (crcResult is not { } actual)
                         throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
 
-                    // Use adaptive parsing: try 32-bit DD first, fall back to Zip64 if
-                    // the parsed values don't match. This handles archives where the writer
-                    // couldn't signal Zip64 in the local header (non-seekable stream writes).
-                    var (crc32, _, uncompressedSize) = useAsync
-                        ? await ZipLocalFileHeader.ReadDataDescriptorAdaptiveAsync(
-                            _archiveStream, actual.Crc32, actual.BytesRead, cancellationToken).ConfigureAwait(false)
-                        : ZipLocalFileHeader.ReadDataDescriptorAdaptive(
-                            _archiveStream, actual.Crc32, actual.BytesRead);
+                    var (crc32, _, uncompressedSize) = ZipLocalFileHeader.ReadDataDescriptorAdaptive(
+                        _archiveStream, actual.Crc32, actual.BytesRead);
 
                     if (actual.Crc32 != crc32)
                         throw new InvalidDataException(SR.CrcMismatch);
@@ -516,10 +497,43 @@ namespace System.IO.Compression
             }
             else if (prev.HasDataDescriptor)
             {
-                if (useAsync)
-                    await ZipLocalFileHeader.ReadDataDescriptorAsync(_archiveStream, prev.IsZip64SizeFields, cancellationToken).ConfigureAwait(false);
-                else
-                    ZipLocalFileHeader.ReadDataDescriptor(_archiveStream, prev.IsZip64SizeFields);
+                ZipLocalFileHeader.ReadDataDescriptor(_archiveStream, prev.IsZip64SizeFields);
+            }
+
+            _forwardReadPreviousEntry = null;
+        }
+
+        private async ValueTask DrainPreviousEntryAsync(CancellationToken cancellationToken)
+        {
+            if (_forwardReadPreviousEntry is not { } prev)
+                return;
+
+            Stream? dataStream = prev.ForwardReadDataStream;
+            if (dataStream is not null)
+            {
+                byte[] buffer = _forwardReadDrainBuffer ??= new byte[4096];
+                while (await dataStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false) > 0) { }
+
+                var crcResult = (dataStream as CrcValidatingReadStream)?.GetFinalCrcResult();
+                await dataStream.DisposeAsync().ConfigureAwait(false);
+
+                if (prev.HasDataDescriptor)
+                {
+                    if (crcResult is not { } actual)
+                        throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
+
+                    var (crc32, _, uncompressedSize) = await ZipLocalFileHeader.ReadDataDescriptorAdaptiveAsync(
+                        _archiveStream, actual.Crc32, actual.BytesRead, cancellationToken).ConfigureAwait(false);
+
+                    if (actual.Crc32 != crc32)
+                        throw new InvalidDataException(SR.CrcMismatch);
+                    if (actual.BytesRead != uncompressedSize)
+                        throw new InvalidDataException(SR.UnexpectedStreamLength);
+                }
+            }
+            else if (prev.HasDataDescriptor)
+            {
+                await ZipLocalFileHeader.ReadDataDescriptorAsync(_archiveStream, prev.IsZip64SizeFields, cancellationToken).ConfigureAwait(false);
             }
 
             _forwardReadPreviousEntry = null;
@@ -531,8 +545,10 @@ namespace System.IO.Compression
                 (data.FullName[^1] == '/' || data.FullName[^1] == '\\');
             bool isEmptyEntry = !data.HasDataDescriptor && data.CompressedSize == 0 && data.UncompressedSize == 0;
 
-            if (isDirectory || isEmptyEntry)
+            if (isDirectory)
                 return null;
+            if (isEmptyEntry)
+                return Stream.Null;
 
             if (data.CompressionMethod != ZipCompressionMethod.Stored &&
                 data.CompressionMethod != ZipCompressionMethod.Deflate &&
@@ -560,6 +576,7 @@ namespace System.IO.Compression
 
         internal static Stream CreateForwardReadDecompressor(Stream source, ZipCompressionMethod compressionMethod, long uncompressedSize, bool leaveOpen)
         {
+            Debug.Assert(compressionMethod is ZipCompressionMethod.Stored or ZipCompressionMethod.Deflate or ZipCompressionMethod.Deflate64);
             return compressionMethod switch
             {
                 ZipCompressionMethod.Deflate when leaveOpen => new DeflateStream(source, CompressionMode.Decompress, leaveOpen: true),

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -496,17 +496,22 @@ namespace System.IO.Compression
 
                 if (prev.HasDataDescriptor)
                 {
-                    var (crc32, _, uncompressedSize) = useAsync
-                        ? await ZipLocalFileHeader.ReadDataDescriptorAsync(_archiveStream, prev.IsZip64SizeFields, cancellationToken).ConfigureAwait(false)
-                        : ZipLocalFileHeader.ReadDataDescriptor(_archiveStream, prev.IsZip64SizeFields);
+                    if (crcResult is not { } actual)
+                        throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
 
-                    if (crcResult is { } actual)
-                    {
-                        if (actual.Crc32 != crc32)
-                            throw new InvalidDataException(SR.CrcMismatch);
-                        if (actual.BytesRead != uncompressedSize)
-                            throw new InvalidDataException(SR.UnexpectedStreamLength);
-                    }
+                    // Use adaptive parsing: try 32-bit DD first, fall back to Zip64 if
+                    // the parsed values don't match. This handles archives where the writer
+                    // couldn't signal Zip64 in the local header (non-seekable stream writes).
+                    var (crc32, _, uncompressedSize) = useAsync
+                        ? await ZipLocalFileHeader.ReadDataDescriptorAdaptiveAsync(
+                            _archiveStream, actual.Crc32, actual.BytesRead, cancellationToken).ConfigureAwait(false)
+                        : ZipLocalFileHeader.ReadDataDescriptorAdaptive(
+                            _archiveStream, actual.Crc32, actual.BytesRead);
+
+                    if (actual.Crc32 != crc32)
+                        throw new InvalidDataException(SR.CrcMismatch);
+                    if (actual.BytesRead != uncompressedSize)
+                        throw new InvalidDataException(SR.UnexpectedStreamLength);
                 }
             }
             else if (prev.HasDataDescriptor)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -956,9 +956,14 @@ namespace System.IO.Compression
 
             _forwardReadStreamOpened = true;
 
+            // On non-seekable archives the archive stream is wrapped in ReadAheadStream, which
+            // reports CanSeek=true so DeflateStream can push back unconsumed bytes. That synthetic
+            // seekability must not leak through to the user-visible entry stream.
+            bool? canSeekOverride = _archive.ArchiveStream is ReadAheadStream ? false : null;
+
             // Wrap so user disposal does not close our internal data stream.
             // DrainPreviousEntry will drain and dispose _forwardReadDataStream itself.
-            return new WrappedStream(_forwardReadDataStream, closeBaseStream: false);
+            return new WrappedStream(_forwardReadDataStream, closeBaseStream: false, canSeekOverride);
         }
 
         private WrappedStream OpenInWriteMode()

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -56,6 +56,7 @@ namespace System.IO.Compression
         //   determined by whether the local header had 0xFFFFFFFF size markers.
         private Stream? _forwardReadDataStream;
         private bool _forwardReadStreamOpened;
+        private bool _forwardReadNeedsWrapping;
         private bool _hasDataDescriptor;
         private bool _isZip64SizeFields;
 
@@ -209,7 +210,7 @@ namespace System.IO.Compression
             _fileComment = Array.Empty<byte>();
             _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, headerData.CompressionMethod);
             _forwardReadDataStream = dataStream;
-
+            _forwardReadNeedsWrapping = dataStream is not null && !headerData.HasDataDescriptor && !headerData.IsEncrypted;
             Changes = ZipArchive.ChangeState.Unchanged;
         }
 
@@ -942,6 +943,16 @@ namespace System.IO.Compression
                 throw new InvalidOperationException(SR.ForwardReadNoDataStream);
             if (_forwardReadStreamOpened)
                 throw new IOException(SR.ForwardReadOnly);
+
+            // For known-size entries, the data stream is a raw bounded stream —
+            // lazily wrap it with decompressor + CRC validation on first Open().
+            if (_forwardReadNeedsWrapping)
+            {
+                Stream decompressor = ZipArchive.CreateForwardReadDecompressor(
+                    _forwardReadDataStream, _storedCompressionMethod, _uncompressedSize, leaveOpen: false);
+                _forwardReadDataStream = new CrcValidatingReadStream(decompressor, _crc32, _uncompressedSize);
+                _forwardReadNeedsWrapping = false;
+            }
 
             _forwardReadStreamOpened = true;
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -282,8 +282,8 @@ namespace System.IO.Compression
             set
             {
                 ThrowIfInvalidArchive();
-                if (_archive.Mode == ZipArchiveMode.ForwardRead)
-                    throw new NotSupportedException(SR.ForwardReadOnly);
+                if (_archive.Mode is ZipArchiveMode.Read or ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ReadOnlyArchive);
                 _externalFileAttr = (uint)value;
                 Changes |= ZipArchive.ChangeState.FixedLengthMetadata;
             }
@@ -302,8 +302,8 @@ namespace System.IO.Compression
             get => DecodeEntryString(_fileComment);
             set
             {
-                if (_archive.Mode == ZipArchiveMode.ForwardRead)
-                    throw new NotSupportedException(SR.ForwardReadOnly);
+                if (_archive.Mode is ZipArchiveMode.Read or ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ReadOnlyArchive);
                 _fileComment = ZipHelper.GetEncodedTruncatedBytesFromString(value, _archive.EntryNameAndCommentEncoding, ushort.MaxValue, out bool isUTF8);
 
                 if (isUTF8)
@@ -942,7 +942,7 @@ namespace System.IO.Compression
             if (_forwardReadDataStream is null)
                 throw new InvalidOperationException(SR.ForwardReadNoDataStream);
             if (_forwardReadStreamOpened)
-                throw new IOException(SR.ForwardReadOnly);
+                throw new IOException(SR.ForwardReadEntryAlreadyOpened);
 
             // For known-size entries, the data stream is a raw bounded stream —
             // lazily wrap it with decompressor + CRC validation on first Open().

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -49,6 +49,7 @@ namespace System.IO.Compression
         private byte[] _fileComment;
         private readonly CompressionLevel _compressionLevel;
         private Stream? _forwardReadDataStream;
+        private bool _forwardReadStreamOpened;
         private bool _hasDataDescriptor;
 
         // Initializes a ZipArchiveEntry instance for an existing archive entry.
@@ -356,10 +357,8 @@ namespace System.IO.Compression
             set
             {
                 ThrowIfInvalidArchive();
-                if (_archive.Mode == ZipArchiveMode.Read)
+                if (_archive.Mode is ZipArchiveMode.Read or ZipArchiveMode.ForwardRead)
                     throw new NotSupportedException(SR.ReadOnlyArchive);
-                if (_archive.Mode == ZipArchiveMode.ForwardRead)
-                    throw new NotSupportedException(SR.ForwardReadOnly);
                 if (_archive.Mode == ZipArchiveMode.Create && _everOpenedForWrite)
                     throw new IOException(SR.FrozenAfterWrite);
                 if (value.DateTime.Year < ZipHelper.ValidZipDate_YearMin || value.DateTime.Year > ZipHelper.ValidZipDate_YearMax)
@@ -926,8 +925,12 @@ namespace System.IO.Compression
 
         private WrappedStream OpenInForwardReadMode()
         {
-            if (_forwardReadDataStream == null)
+            if (_forwardReadDataStream is null)
                 throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
+            if (_forwardReadStreamOpened)
+                throw new IOException(SR.ForwardReadOnly);
+
+            _forwardReadStreamOpened = true;
 
             // Wrap so user disposal does not close our internal data stream.
             // DrainPreviousEntry will drain and dispose _forwardReadDataStream itself.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -48,9 +48,16 @@ namespace System.IO.Compression
         private byte[]? _lhTrailingExtraFieldData;
         private byte[] _fileComment;
         private readonly CompressionLevel _compressionLevel;
+
+        // Forward-read fields:
+        // _hasDataDescriptor: permanent flag from the local file header indicating sizes/CRC
+        //   are in a trailing data descriptor. When true, Crc32/CompressedLength/Length always throw.
+        // _isZip64SizeFields: whether the data descriptor uses 64-bit sizes,
+        //   determined by whether the local header had 0xFFFFFFFF size markers.
         private Stream? _forwardReadDataStream;
         private bool _forwardReadStreamOpened;
         private bool _hasDataDescriptor;
+        private bool _isZip64SizeFields;
 
         // Initializes a ZipArchiveEntry instance for an existing archive entry.
         internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd)
@@ -164,26 +171,25 @@ namespace System.IO.Compression
             Changes = ZipArchive.ChangeState.Unchanged;
         }
 
-        // Initializes a ZipArchiveEntry instance for forward-read mode from local file header data.
-        internal ZipArchiveEntry(ZipArchive archive, string fullName, ZipCompressionMethod compressionMethod,
-            DateTimeOffset lastModified, uint crc32, long compressedSize, long uncompressedSize,
-            ushort generalPurposeBitFlags, ushort versionNeeded, bool hasDataDescriptor, Stream? dataStream)
+        // Initializes a ZipArchiveEntry instance for forward-read mode from parsed local file header data.
+        internal ZipArchiveEntry(ZipArchive archive, ZipLocalFileHeader.ForwardReadHeaderData headerData, Stream? dataStream)
         {
             _archive = archive;
             _originallyInArchive = true;
-            _hasDataDescriptor = hasDataDescriptor;
+            _hasDataDescriptor = headerData.HasDataDescriptor;
+            _isZip64SizeFields = headerData.IsZip64SizeFields;
 
             _diskNumberStart = 0;
             _versionMadeByPlatform = CurrentZipPlatform;
-            _versionMadeBySpecification = (ZipVersionNeededValues)versionNeeded;
-            _versionToExtract = (ZipVersionNeededValues)versionNeeded;
-            _generalPurposeBitFlag = (BitFlagValues)generalPurposeBitFlags;
-            _isEncrypted = (_generalPurposeBitFlag & BitFlagValues.IsEncrypted) != 0;
-            _storedCompressionMethod = compressionMethod;
-            _lastModified = lastModified;
-            _compressedSize = compressedSize;
-            _uncompressedSize = uncompressedSize;
-            _crc32 = crc32;
+            _versionMadeBySpecification = (ZipVersionNeededValues)headerData.VersionNeeded;
+            _versionToExtract = (ZipVersionNeededValues)headerData.VersionNeeded;
+            _generalPurposeBitFlag = (BitFlagValues)headerData.GeneralPurposeBitFlags;
+            _isEncrypted = headerData.IsEncrypted;
+            _storedCompressionMethod = headerData.CompressionMethod;
+            _lastModified = headerData.LastModified;
+            _compressedSize = headerData.CompressedSize;
+            _uncompressedSize = headerData.UncompressedSize;
+            _crc32 = headerData.Crc32;
             _offsetOfLocalHeader = 0;
             _storedOffsetOfCompressedData = null;
             _externalFileAttr = 0;
@@ -194,16 +200,14 @@ namespace System.IO.Compression
             _everOpenedForWrite = false;
             _outstandingWriteStream = null;
 
-            _storedEntryNameBytes = (_generalPurposeBitFlag & BitFlagValues.UnicodeFileNameAndComment) != 0
-                ? Encoding.UTF8.GetBytes(fullName)
-                : (archive.EntryNameAndCommentEncoding ?? Encoding.UTF8).GetBytes(fullName);
-            _storedEntryName = fullName;
+            _storedEntryNameBytes = headerData.FilenameBytes.ToArray();
+            _storedEntryName = headerData.FullName;
 
             _cdUnknownExtraFields = null;
             _lhUnknownExtraFields = null;
 
             _fileComment = Array.Empty<byte>();
-            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, compressionMethod);
+            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, headerData.CompressionMethod);
             _forwardReadDataStream = dataStream;
 
             Changes = ZipArchive.ChangeState.Unchanged;
@@ -215,7 +219,15 @@ namespace System.IO.Compression
         public ZipArchive Archive => _archive;
 
         [CLSCompliant(false)]
-        public uint Crc32 => _crc32;
+        public uint Crc32
+        {
+            get
+            {
+                if (_hasDataDescriptor && _archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new InvalidOperationException(SR.ForwardReadMetadataNotYetAvailable);
+                return _crc32;
+            }
+        }
 
         /// <summary>
         /// Gets a value that indicates whether the entry is encrypted.
@@ -226,12 +238,7 @@ namespace System.IO.Compression
 
         internal bool HasDataDescriptor => _hasDataDescriptor;
 
-        internal void UpdateFromDataDescriptor(uint crc32, long compressedSize, long uncompressedSize)
-        {
-            _crc32 = crc32;
-            _compressedSize = compressedSize;
-            _uncompressedSize = uncompressedSize;
-        }
+        internal bool IsZip64SizeFields => _isZip64SizeFields;
 
         /// <summary>
         /// Gets the compression method used to compress the entry.
@@ -257,6 +264,8 @@ namespace System.IO.Compression
         {
             get
             {
+                if (_hasDataDescriptor && _archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new InvalidOperationException(SR.ForwardReadMetadataNotYetAvailable);
                 if (_everOpenedForWrite)
                     throw new InvalidOperationException(SR.LengthAfterWrite);
                 return _compressedSize;
@@ -377,6 +386,8 @@ namespace System.IO.Compression
         {
             get
             {
+                if (_hasDataDescriptor && _archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new InvalidOperationException(SR.ForwardReadMetadataNotYetAvailable);
                 if (_everOpenedForWrite)
                     throw new InvalidOperationException(SR.LengthAfterWrite);
                 return _uncompressedSize;
@@ -925,8 +936,10 @@ namespace System.IO.Compression
 
         private WrappedStream OpenInForwardReadMode()
         {
+            if (_isEncrypted)
+                throw new NotSupportedException(SR.ForwardReadEncryptedNotSupported);
             if (_forwardReadDataStream is null)
-                throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
+                throw new InvalidOperationException(SR.ForwardReadNoDataStream);
             if (_forwardReadStreamOpened)
                 throw new IOException(SR.ForwardReadOnly);
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -48,6 +48,8 @@ namespace System.IO.Compression
         private byte[]? _lhTrailingExtraFieldData;
         private byte[] _fileComment;
         private readonly CompressionLevel _compressionLevel;
+        private Stream? _forwardReadDataStream;
+        private bool _hasDataDescriptor;
 
         // Initializes a ZipArchiveEntry instance for an existing archive entry.
         internal ZipArchiveEntry(ZipArchive archive, ZipCentralDirectoryFileHeader cd)
@@ -161,6 +163,51 @@ namespace System.IO.Compression
             Changes = ZipArchive.ChangeState.Unchanged;
         }
 
+        // Initializes a ZipArchiveEntry instance for forward-read mode from local file header data.
+        internal ZipArchiveEntry(ZipArchive archive, string fullName, ZipCompressionMethod compressionMethod,
+            DateTimeOffset lastModified, uint crc32, long compressedSize, long uncompressedSize,
+            ushort generalPurposeBitFlags, ushort versionNeeded, bool hasDataDescriptor, Stream? dataStream)
+        {
+            _archive = archive;
+            _originallyInArchive = true;
+            _hasDataDescriptor = hasDataDescriptor;
+
+            _diskNumberStart = 0;
+            _versionMadeByPlatform = CurrentZipPlatform;
+            _versionMadeBySpecification = (ZipVersionNeededValues)versionNeeded;
+            _versionToExtract = (ZipVersionNeededValues)versionNeeded;
+            _generalPurposeBitFlag = (BitFlagValues)generalPurposeBitFlags;
+            _isEncrypted = (_generalPurposeBitFlag & BitFlagValues.IsEncrypted) != 0;
+            _storedCompressionMethod = compressionMethod;
+            _lastModified = lastModified;
+            _compressedSize = compressedSize;
+            _uncompressedSize = uncompressedSize;
+            _crc32 = crc32;
+            _offsetOfLocalHeader = 0;
+            _storedOffsetOfCompressedData = null;
+            _externalFileAttr = 0;
+
+            _compressedBytes = null;
+            _storedUncompressedData = null;
+            _currentlyOpenForWrite = false;
+            _everOpenedForWrite = false;
+            _outstandingWriteStream = null;
+
+            _storedEntryNameBytes = (_generalPurposeBitFlag & BitFlagValues.UnicodeFileNameAndComment) != 0
+                ? Encoding.UTF8.GetBytes(fullName)
+                : (archive.EntryNameAndCommentEncoding ?? Encoding.UTF8).GetBytes(fullName);
+            _storedEntryName = fullName;
+
+            _cdUnknownExtraFields = null;
+            _lhUnknownExtraFields = null;
+
+            _fileComment = Array.Empty<byte>();
+            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, compressionMethod);
+            _forwardReadDataStream = dataStream;
+
+            Changes = ZipArchive.ChangeState.Unchanged;
+        }
+
         /// <summary>
         /// The ZipArchive that this entry belongs to. If this entry has been deleted, this will return null.
         /// </summary>
@@ -173,6 +220,17 @@ namespace System.IO.Compression
         /// Gets a value that indicates whether the entry is encrypted.
         /// </summary>
         public bool IsEncrypted => _isEncrypted;
+
+        internal Stream? ForwardReadDataStream => _forwardReadDataStream;
+
+        internal bool HasDataDescriptor => _hasDataDescriptor;
+
+        internal void UpdateFromDataDescriptor(uint crc32, long compressedSize, long uncompressedSize)
+        {
+            _crc32 = crc32;
+            _compressedSize = compressedSize;
+            _uncompressedSize = uncompressedSize;
+        }
 
         /// <summary>
         /// Gets the compression method used to compress the entry.
@@ -213,6 +271,8 @@ namespace System.IO.Compression
             set
             {
                 ThrowIfInvalidArchive();
+                if (_archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ForwardReadOnly);
                 _externalFileAttr = (uint)value;
                 Changes |= ZipArchive.ChangeState.FixedLengthMetadata;
             }
@@ -231,6 +291,8 @@ namespace System.IO.Compression
             get => DecodeEntryString(_fileComment);
             set
             {
+                if (_archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ForwardReadOnly);
                 _fileComment = ZipHelper.GetEncodedTruncatedBytesFromString(value, _archive.EntryNameAndCommentEncoding, ushort.MaxValue, out bool isUTF8);
 
                 if (isUTF8)
@@ -296,6 +358,8 @@ namespace System.IO.Compression
                 ThrowIfInvalidArchive();
                 if (_archive.Mode == ZipArchiveMode.Read)
                     throw new NotSupportedException(SR.ReadOnlyArchive);
+                if (_archive.Mode == ZipArchiveMode.ForwardRead)
+                    throw new NotSupportedException(SR.ForwardReadOnly);
                 if (_archive.Mode == ZipArchiveMode.Create && _everOpenedForWrite)
                     throw new IOException(SR.FrozenAfterWrite);
                 if (value.DateTime.Year < ZipHelper.ValidZipDate_YearMin || value.DateTime.Year > ZipHelper.ValidZipDate_YearMax)
@@ -372,6 +436,8 @@ namespace System.IO.Compression
                     return OpenInReadMode(checkOpenable: true);
                 case ZipArchiveMode.Create:
                     return OpenInWriteMode();
+                case ZipArchiveMode.ForwardRead:
+                    return OpenInForwardReadMode();
                 case ZipArchiveMode.Update:
                 default:
                     Debug.Assert(_archive.Mode == ZipArchiveMode.Update);
@@ -416,6 +482,11 @@ namespace System.IO.Compression
                     if (access == FileAccess.Read)
                         throw new InvalidOperationException(SR.CannotBeReadInCreateMode);
                     return OpenInWriteMode();
+
+                case ZipArchiveMode.ForwardRead:
+                    if (access != FileAccess.Read)
+                        throw new InvalidOperationException(SR.CannotBeWrittenInReadMode);
+                    return OpenInForwardReadMode();
 
                 case ZipArchiveMode.Update:
                 default:
@@ -851,6 +922,16 @@ namespace System.IO.Compression
             Stream decompressedStream = GetDataDecompressor(compressedStream);
 
             return new CrcValidatingReadStream(decompressedStream, _crc32, _uncompressedSize);
+        }
+
+        private WrappedStream OpenInForwardReadMode()
+        {
+            if (_forwardReadDataStream == null)
+                throw new InvalidDataException(SR.LocalFileHeaderCorrupt);
+
+            // Wrap so user disposal does not close our internal data stream.
+            // DrainPreviousEntry will drain and dispose _forwardReadDataStream itself.
+            return new WrappedStream(_forwardReadDataStream, closeBaseStream: false);
         }
 
         private WrappedStream OpenInWriteMode()

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveMode.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveMode.cs
@@ -26,6 +26,12 @@ namespace System.IO.Compression
         /// The underlying file or stream must be readable, writable and seekable.
         /// No data will be written to the underlying file or stream until the archive is disposed.
         /// </summary>
-        Update
+        Update,
+        /// <summary>
+        /// Only forward-only sequential reading of entries is permitted using <see cref="ZipArchive.GetNextEntry"/>.
+        /// Entries are read from local file headers instead of the central directory, enabling reading from non-seekable streams
+        /// without buffering the entire archive. The underlying stream must be readable but need not be seekable.
+        /// </summary>
+        ForwardRead = 3
     }
 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
@@ -225,15 +225,6 @@ internal readonly partial struct ZipLocalFileHeader
                     compressedSize = zip64.CompressedSize.Value;
             }
 
-            // For data descriptor entries written to non-seekable streams, sizes in the
-            // local header are typically 0 rather than 0xFFFFFFFF, but the data descriptor
-            // still uses 8-byte fields when the entry requires Zip64.
-            bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
-            if (!isZip64SizeFields && hasDataDescriptor && versionNeeded >= (ushort)ZipVersionNeededValues.Zip64)
-            {
-                isZip64SizeFields = true;
-            }
-
             bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
             Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
             string fullName = nameEncoding.GetString(filenameBytes);
@@ -287,6 +278,32 @@ internal readonly partial struct ZipLocalFileHeader
         }
 
         return (crc32, compressedSize, uncompressedSize);
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="ReadDataDescriptorAdaptive"/>.
+    /// </summary>
+    internal static async ValueTask<(uint Crc32, long CompressedSize, long UncompressedSize)> ReadDataDescriptorAdaptiveAsync(
+        Stream stream, uint knownCrc32, long knownUncompressedSize, CancellationToken cancellationToken)
+    {
+        byte[] firstFour = new byte[4];
+        await stream.ReadExactlyAsync(firstFour, cancellationToken).ConfigureAwait(false);
+
+        uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(firstFour);
+        bool hasSignature = firstWord == 0x08074B50;
+
+        int smallSize = (hasSignature ? 4 : 0) + 8;
+        byte[] buf = new byte[20];
+        await stream.ReadExactlyAsync(buf.AsMemory(0, smallSize), cancellationToken).ConfigureAwait(false);
+
+        var small = ParseDataDescriptor(buf.AsSpan(0, smallSize), hasSignature, isZip64: false, firstWord);
+        if (small.Crc32 == knownCrc32 && small.UncompressedSize == knownUncompressedSize)
+            return small;
+
+        await stream.ReadExactlyAsync(buf.AsMemory(smallSize, 8), cancellationToken).ConfigureAwait(false);
+        int fullSize = smallSize + 8;
+
+        return ParseDataDescriptor(buf.AsSpan(0, fullSize), hasSignature, isZip64: true, firstWord);
     }
 }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -155,6 +157,127 @@ internal readonly partial struct ZipLocalFileHeader
         }
         bytesRead = await stream.ReadAtLeastAsync(blockBytes, blockBytes.Length, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
         return TrySkipBlockFinalize(stream, blockBytes, bytesRead);
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="TryReadForForwardRead"/>.
+    /// </summary>
+    internal static async ValueTask<ForwardReadHeaderData?> TryReadForForwardReadAsync(Stream stream, Encoding? entryNameEncoding, CancellationToken cancellationToken)
+    {
+        byte[] header = new byte[SizeOfLocalHeader];
+        int bytesRead = await stream.ReadAtLeastAsync(header, SizeOfLocalHeader, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+
+        if (bytesRead == 0)
+            return null;
+        if (bytesRead < SizeOfLocalHeader)
+        {
+            if (bytesRead >= FieldLengths.Signature && IsEndOfEntriesSignature(BinaryPrimitives.ReadUInt32LittleEndian(header)))
+                return null;
+            throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+        }
+
+        if (!header.AsSpan(0, FieldLengths.Signature).SequenceEqual(SignatureConstantBytes))
+        {
+            uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
+            if (IsEndOfEntriesSignature(sig))
+                return null;
+            throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+        }
+
+        return await ParseForwardReadHeaderAsync(header, stream, entryNameEncoding, cancellationToken).ConfigureAwait(false);
+
+        static async ValueTask<ForwardReadHeaderData> ParseForwardReadHeaderAsync(byte[] header, Stream stream, Encoding? entryNameEncoding, CancellationToken cancellationToken)
+        {
+            ushort versionNeeded = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(FieldLocations.VersionNeededToExtract));
+            ushort generalPurposeBitFlags = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(FieldLocations.GeneralPurposeBitFlags));
+            ushort compressionMethodValue = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(FieldLocations.CompressionMethod));
+            uint lastModified = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(FieldLocations.LastModified));
+            uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(FieldLocations.Crc32));
+            uint compressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(FieldLocations.CompressedSize));
+            uint uncompressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header.AsSpan(FieldLocations.UncompressedSize));
+            ushort filenameLength = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(FieldLocations.FilenameLength));
+            ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(FieldLocations.ExtraFieldLength));
+
+            byte[] filenameBytes = new byte[filenameLength];
+            if (filenameLength > 0)
+                await stream.ReadExactlyAsync(filenameBytes, cancellationToken).ConfigureAwait(false);
+
+            byte[] extraFieldBytes = new byte[extraFieldLength];
+            if (extraFieldLength > 0)
+                await stream.ReadExactlyAsync(extraFieldBytes, cancellationToken).ConfigureAwait(false);
+
+            long compressedSize = compressedSizeSmall;
+            long uncompressedSize = uncompressedSizeSmall;
+            bool isZip64SizeFields = false;
+
+            if (compressedSizeSmall == ZipHelper.Mask32Bit || uncompressedSizeSmall == ZipHelper.Mask32Bit)
+            {
+                isZip64SizeFields = true;
+                Zip64ExtraField zip64 = Zip64ExtraField.GetJustZip64Block(extraFieldBytes,
+                    readUncompressedSize: uncompressedSizeSmall == ZipHelper.Mask32Bit,
+                    readCompressedSize: compressedSizeSmall == ZipHelper.Mask32Bit,
+                    readLocalHeaderOffset: false,
+                    readStartDiskNumber: false);
+
+                if (zip64.UncompressedSize.HasValue)
+                    uncompressedSize = zip64.UncompressedSize.Value;
+                if (zip64.CompressedSize.HasValue)
+                    compressedSize = zip64.CompressedSize.Value;
+            }
+
+            bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
+            Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
+            string fullName = nameEncoding.GetString(filenameBytes);
+
+            DateTimeOffset lastModifiedDto = new DateTimeOffset(ZipHelper.DosTimeToDateTime(lastModified));
+
+            return new ForwardReadHeaderData(
+                versionNeeded, generalPurposeBitFlags, (ZipCompressionMethod)compressionMethodValue,
+                lastModifiedDto, crc32, compressedSize, uncompressedSize,
+                fullName, filenameBytes, isZip64SizeFields);
+        }
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="ReadDataDescriptor"/>.
+    /// </summary>
+    internal static async ValueTask<(uint Crc32, long CompressedSize, long UncompressedSize)> ReadDataDescriptorAsync(Stream stream, bool isZip64, CancellationToken cancellationToken)
+    {
+        byte[] firstFour = new byte[4];
+        await stream.ReadExactlyAsync(firstFour, cancellationToken).ConfigureAwait(false);
+
+        uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(firstFour);
+        bool hasSignature = firstWord == 0x08074B50;
+
+        int remainingSize = (hasSignature ? 4 : 0) + (isZip64 ? 16 : 8);
+        byte[] remaining = new byte[remainingSize];
+        await stream.ReadExactlyAsync(remaining, cancellationToken).ConfigureAwait(false);
+
+        int pos = 0;
+        uint crc32;
+        if (hasSignature)
+        {
+            crc32 = BinaryPrimitives.ReadUInt32LittleEndian(remaining.AsSpan(pos));
+            pos += 4;
+        }
+        else
+        {
+            crc32 = firstWord;
+        }
+
+        long compressedSize, uncompressedSize;
+        if (isZip64)
+        {
+            compressedSize = BinaryPrimitives.ReadInt64LittleEndian(remaining.AsSpan(pos));
+            uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(remaining.AsSpan(pos + 8));
+        }
+        else
+        {
+            compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(remaining.AsSpan(pos));
+            uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(remaining.AsSpan(pos + 4));
+        }
+
+        return (crc32, compressedSize, uncompressedSize);
     }
 }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
@@ -225,6 +225,15 @@ internal readonly partial struct ZipLocalFileHeader
                     compressedSize = zip64.CompressedSize.Value;
             }
 
+            // For data descriptor entries written to non-seekable streams, sizes in the
+            // local header are typically 0 rather than 0xFFFFFFFF, but the data descriptor
+            // still uses 8-byte fields when the entry requires Zip64.
+            bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
+            if (!isZip64SizeFields && hasDataDescriptor && versionNeeded >= (ushort)ZipVersionNeededValues.Zip64)
+            {
+                isZip64SizeFields = true;
+            }
+
             bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
             Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
             string fullName = nameEncoding.GetString(filenameBytes);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -779,6 +779,15 @@ namespace System.IO.Compression
                         compressedSize = zip64.CompressedSize.Value;
                 }
 
+                // For data descriptor entries written to non-seekable streams, sizes in the
+                // local header are typically 0 rather than 0xFFFFFFFF, but the data descriptor
+                // still uses 8-byte fields when the entry requires Zip64.
+                bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
+                if (!isZip64SizeFields && hasDataDescriptor && versionNeeded >= (ushort)ZipVersionNeededValues.Zip64)
+                {
+                    isZip64SizeFields = true;
+                }
+
                 bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
                 Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
                 string fullName = nameEncoding.GetString(filenameBytes);

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -779,15 +779,6 @@ namespace System.IO.Compression
                         compressedSize = zip64.CompressedSize.Value;
                 }
 
-                // For data descriptor entries written to non-seekable streams, sizes in the
-                // local header are typically 0 rather than 0xFFFFFFFF, but the data descriptor
-                // still uses 8-byte fields when the entry requires Zip64.
-                bool hasDataDescriptor = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.DataDescriptor) != 0;
-                if (!isZip64SizeFields && hasDataDescriptor && versionNeeded >= (ushort)ZipVersionNeededValues.Zip64)
-                {
-                    isZip64SizeFields = true;
-                }
-
                 bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
                 Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
                 string fullName = nameEncoding.GetString(filenameBytes);
@@ -813,9 +804,53 @@ namespace System.IO.Compression
             bool hasSignature = firstWord == 0x08074B50;
 
             int remainingSize = (hasSignature ? 4 : 0) + (isZip64 ? 16 : 8);
-            Span<byte> remaining = stackalloc byte[20]; // max: sig-CRC(4) + comp(8) + uncomp(8) = 20
+            Span<byte> remaining = stackalloc byte[20];
             stream.ReadExactly(remaining[..remainingSize]);
 
+            return ParseDataDescriptor(remaining[..remainingSize], hasSignature, isZip64, firstWord);
+        }
+
+        /// <summary>
+        /// Reads a data descriptor whose size (32-bit or Zip64) is unknown.
+        /// Parses as 32-bit first; if the CRC and uncompressed size don't match
+        /// the expected values, reads additional bytes and re-parses as Zip64.
+        /// </summary>
+        /// <remarks>
+        /// Some writers (including .NET on non-seekable streams) emit a Zip64
+        /// data descriptor without setting any Zip64 indicator in the local
+        /// file header, because the final sizes are not known at header-write
+        /// time. The known values from the decompressor let us detect the
+        /// correct layout without relying on header signals.
+        /// </remarks>
+        internal static (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptorAdaptive(
+            Stream stream, uint knownCrc32, long knownUncompressedSize)
+        {
+            Span<byte> firstFour = stackalloc byte[4];
+            stream.ReadExactly(firstFour);
+
+            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(firstFour);
+            bool hasSignature = firstWord == 0x08074B50;
+
+            // Read enough for the 32-bit layout: CRC(4) + CompSize(4) + UncompSize(4),
+            // plus CRC(4) again if the signature consumed firstWord.
+            int smallSize = (hasSignature ? 4 : 0) + 8;
+            Span<byte> buf = stackalloc byte[20];
+            stream.ReadExactly(buf[..smallSize]);
+
+            var small = ParseDataDescriptor(buf[..smallSize], hasSignature, isZip64: false, firstWord);
+            if (small.Crc32 == knownCrc32 && small.UncompressedSize == knownUncompressedSize)
+                return small;
+
+            // 32-bit interpretation didn't match — read 8 more bytes for the Zip64 layout.
+            stream.ReadExactly(buf.Slice(smallSize, 8));
+            int fullSize = smallSize + 8;
+
+            return ParseDataDescriptor(buf[..fullSize], hasSignature, isZip64: true, firstWord);
+        }
+
+        private static (uint Crc32, long CompressedSize, long UncompressedSize) ParseDataDescriptor(
+            ReadOnlySpan<byte> remaining, bool hasSignature, bool isZip64, uint firstWord)
+        {
             int pos = 0;
             uint crc32;
             if (hasSignature)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -716,7 +716,7 @@ namespace System.IO.Compression
         /// Tries to read a local file header for forward-read mode.
         /// Returns null if EOF is reached or a non-local-header signature is encountered.
         /// </summary>
-        internal static ForwardReadHeaderData? TryReadForForwardRead(Stream stream, Encoding? entryNameEncoding)
+        internal static unsafe ForwardReadHeaderData? TryReadForForwardRead(Stream stream, Encoding? entryNameEncoding)
         {
             Span<byte> header = stackalloc byte[SizeOfLocalHeader];
             int bytesRead = stream.ReadAtLeast(header, SizeOfLocalHeader, throwOnEndOfStream: false);
@@ -795,7 +795,7 @@ namespace System.IO.Compression
         /// <summary>
         /// Reads a data descriptor using signature-first parsing. No seek operations.
         /// </summary>
-        internal static (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptor(Stream stream, bool isZip64)
+        internal static unsafe (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptor(Stream stream, bool isZip64)
         {
             Span<byte> firstFour = stackalloc byte[4];
             stream.ReadExactly(firstFour);
@@ -822,7 +822,7 @@ namespace System.IO.Compression
         /// time. The known values from the decompressor let us detect the
         /// correct layout without relying on header signals.
         /// </remarks>
-        internal static (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptorAdaptive(
+        internal static unsafe (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptorAdaptive(
             Stream stream, uint knownCrc32, long knownUncompressedSize)
         {
             Span<byte> firstFour = stackalloc byte[4];

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -677,6 +678,160 @@ namespace System.IO.Compression
             }
             bytesRead = stream.ReadAtLeast(blockBytes, blockBytes.Length, throwOnEndOfStream: false);
             return TrySkipBlockFinalize(stream, blockBytes, bytesRead);
+        }
+
+        /// <summary>
+        /// Parsed data from a local file header for forward-read mode.
+        /// </summary>
+        internal readonly struct ForwardReadHeaderData(
+            ushort versionNeeded, ushort generalPurposeBitFlags, ZipCompressionMethod compressionMethod,
+            DateTimeOffset lastModified, uint crc32, long compressedSize, long uncompressedSize,
+            string fullName, ReadOnlyMemory<byte> filenameBytes, bool isZip64SizeFields)
+        {
+            internal readonly ushort VersionNeeded = versionNeeded;
+            internal readonly ushort GeneralPurposeBitFlags = generalPurposeBitFlags;
+            internal readonly ZipCompressionMethod CompressionMethod = compressionMethod;
+            internal readonly DateTimeOffset LastModified = lastModified;
+            internal readonly uint Crc32 = crc32;
+            internal readonly long CompressedSize = compressedSize;
+            internal readonly long UncompressedSize = uncompressedSize;
+            internal readonly string FullName = fullName;
+            internal readonly ReadOnlyMemory<byte> FilenameBytes = filenameBytes;
+            internal readonly bool IsZip64SizeFields = isZip64SizeFields;
+
+            internal bool HasDataDescriptor => (GeneralPurposeBitFlags & 0x0008) != 0;
+            internal bool IsEncrypted => (GeneralPurposeBitFlags & 0x0001) != 0;
+        }
+
+        /// <summary>
+        /// Returns true if the given signature indicates the end of local file entries
+        /// (central directory, EOCD, or Zip64 EOCD).
+        /// </summary>
+        internal static bool IsEndOfEntriesSignature(uint sig) =>
+            sig == 0x02014B50    // Central directory
+            || sig == 0x06054B50 // EOCD
+            || sig == 0x06064B50; // Zip64 EOCD
+
+        /// <summary>
+        /// Tries to read a local file header for forward-read mode.
+        /// Returns null if EOF is reached or a non-local-header signature is encountered.
+        /// </summary>
+        internal static ForwardReadHeaderData? TryReadForForwardRead(Stream stream, Encoding? entryNameEncoding)
+        {
+            Span<byte> header = stackalloc byte[SizeOfLocalHeader];
+            int bytesRead = stream.ReadAtLeast(header, SizeOfLocalHeader, throwOnEndOfStream: false);
+
+            if (bytesRead == 0)
+                return null;
+            if (bytesRead < SizeOfLocalHeader)
+            {
+                if (bytesRead >= FieldLengths.Signature && IsEndOfEntriesSignature(BinaryPrimitives.ReadUInt32LittleEndian(header)))
+                    return null;
+                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+            }
+
+            if (!header[..FieldLengths.Signature].SequenceEqual(SignatureConstantBytes))
+            {
+                uint sig = BinaryPrimitives.ReadUInt32LittleEndian(header);
+                if (IsEndOfEntriesSignature(sig))
+                    return null;
+                throw new InvalidDataException(SR.ForwardReadInvalidLocalFileHeader);
+            }
+
+            return ParseForwardReadHeader(header, stream, entryNameEncoding);
+
+            static ForwardReadHeaderData ParseForwardReadHeader(ReadOnlySpan<byte> header, Stream stream, Encoding? entryNameEncoding)
+            {
+                ushort versionNeeded = BinaryPrimitives.ReadUInt16LittleEndian(header[FieldLocations.VersionNeededToExtract..]);
+                ushort generalPurposeBitFlags = BinaryPrimitives.ReadUInt16LittleEndian(header[FieldLocations.GeneralPurposeBitFlags..]);
+                ushort compressionMethodValue = BinaryPrimitives.ReadUInt16LittleEndian(header[FieldLocations.CompressionMethod..]);
+                uint lastModified = BinaryPrimitives.ReadUInt32LittleEndian(header[FieldLocations.LastModified..]);
+                uint crc32 = BinaryPrimitives.ReadUInt32LittleEndian(header[FieldLocations.Crc32..]);
+                uint compressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header[FieldLocations.CompressedSize..]);
+                uint uncompressedSizeSmall = BinaryPrimitives.ReadUInt32LittleEndian(header[FieldLocations.UncompressedSize..]);
+                ushort filenameLength = BinaryPrimitives.ReadUInt16LittleEndian(header[FieldLocations.FilenameLength..]);
+                ushort extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(header[FieldLocations.ExtraFieldLength..]);
+
+                byte[] filenameBytes = new byte[filenameLength];
+                if (filenameLength > 0)
+                    stream.ReadExactly(filenameBytes);
+
+                byte[] extraFieldBytes = new byte[extraFieldLength];
+                if (extraFieldLength > 0)
+                    stream.ReadExactly(extraFieldBytes);
+
+                long compressedSize = compressedSizeSmall;
+                long uncompressedSize = uncompressedSizeSmall;
+                bool isZip64SizeFields = false;
+
+                if (compressedSizeSmall == ZipHelper.Mask32Bit || uncompressedSizeSmall == ZipHelper.Mask32Bit)
+                {
+                    isZip64SizeFields = true;
+                    Zip64ExtraField zip64 = Zip64ExtraField.GetJustZip64Block(extraFieldBytes,
+                        readUncompressedSize: uncompressedSizeSmall == ZipHelper.Mask32Bit,
+                        readCompressedSize: compressedSizeSmall == ZipHelper.Mask32Bit,
+                        readLocalHeaderOffset: false,
+                        readStartDiskNumber: false);
+
+                    if (zip64.UncompressedSize.HasValue)
+                        uncompressedSize = zip64.UncompressedSize.Value;
+                    if (zip64.CompressedSize.HasValue)
+                        compressedSize = zip64.CompressedSize.Value;
+                }
+
+                bool isUtf8 = (generalPurposeBitFlags & (ushort)ZipArchiveEntry.BitFlagValues.UnicodeFileNameAndComment) != 0;
+                Encoding nameEncoding = isUtf8 ? Encoding.UTF8 : (entryNameEncoding ?? Encoding.UTF8);
+                string fullName = nameEncoding.GetString(filenameBytes);
+
+                DateTimeOffset lastModifiedDto = new DateTimeOffset(ZipHelper.DosTimeToDateTime(lastModified));
+
+                return new ForwardReadHeaderData(
+                    versionNeeded, generalPurposeBitFlags, (ZipCompressionMethod)compressionMethodValue,
+                    lastModifiedDto, crc32, compressedSize, uncompressedSize,
+                    fullName, filenameBytes, isZip64SizeFields);
+            }
+        }
+
+        /// <summary>
+        /// Reads a data descriptor using signature-first parsing. No seek operations.
+        /// </summary>
+        internal static (uint Crc32, long CompressedSize, long UncompressedSize) ReadDataDescriptor(Stream stream, bool isZip64)
+        {
+            Span<byte> firstFour = stackalloc byte[4];
+            stream.ReadExactly(firstFour);
+
+            uint firstWord = BinaryPrimitives.ReadUInt32LittleEndian(firstFour);
+            bool hasSignature = firstWord == 0x08074B50;
+
+            int remainingSize = (hasSignature ? 4 : 0) + (isZip64 ? 16 : 8);
+            Span<byte> remaining = stackalloc byte[20]; // max: sig-CRC(4) + comp(8) + uncomp(8) = 20
+            stream.ReadExactly(remaining[..remainingSize]);
+
+            int pos = 0;
+            uint crc32;
+            if (hasSignature)
+            {
+                crc32 = BinaryPrimitives.ReadUInt32LittleEndian(remaining[pos..]);
+                pos += 4;
+            }
+            else
+            {
+                crc32 = firstWord;
+            }
+
+            long compressedSize, uncompressedSize;
+            if (isZip64)
+            {
+                compressedSize = BinaryPrimitives.ReadInt64LittleEndian(remaining[pos..]);
+                uncompressedSize = BinaryPrimitives.ReadInt64LittleEndian(remaining[(pos + 8)..]);
+            }
+            else
+            {
+                compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(remaining[pos..]);
+                uncompressedSize = BinaryPrimitives.ReadUInt32LittleEndian(remaining[(pos + 4)..]);
+            }
+
+            return (crc32, compressedSize, uncompressedSize);
         }
     }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -754,4 +754,331 @@ namespace System.IO.Compression
             await base.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    internal sealed class BoundedReadOnlyStream : Stream
+    {
+        private readonly Stream _baseStream;
+        private long _remaining;
+        private bool _isDisposed;
+
+        public BoundedReadOnlyStream(Stream baseStream, long length)
+        {
+            _baseStream = baseStream;
+            _remaining = length;
+        }
+
+        public override bool CanRead => !_isDisposed && _baseStream.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_isDisposed)
+                throw new ObjectDisposedException(GetType().ToString(), SR.HiddenStreamName);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => Read(buffer.AsSpan(offset, count));
+
+        public override int Read(Span<byte> buffer)
+        {
+            ThrowIfDisposed();
+
+            if (_remaining <= 0)
+            {
+                return 0;
+            }
+
+            if (buffer.Length > _remaining)
+            {
+                buffer = buffer.Slice(0, (int)_remaining);
+            }
+
+            int bytesRead = _baseStream.Read(buffer);
+            _remaining -= bytesRead;
+
+            return bytesRead;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            if (_remaining <= 0)
+            {
+                return 0;
+            }
+
+            if (buffer.Length > _remaining)
+            {
+                buffer = buffer.Slice(0, (int)_remaining);
+            }
+
+            int bytesRead = await _baseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            _remaining -= bytesRead;
+
+            return bytesRead;
+        }
+
+        public override void Flush() { }
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            _isDisposed = true;
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            _isDisposed = true;
+
+            return base.DisposeAsync();
+        }
+    }
+
+    internal sealed class ReadAheadStream : Stream
+    {
+        private readonly Stream _baseStream;
+        private readonly byte[] _history;
+        private int _historyCount;
+        private byte[]? _pushback;
+        private int _pushbackOffset;
+        private int _pushbackCount;
+        private long _position;
+        private bool _isDisposed;
+
+        public ReadAheadStream(Stream baseStream, int historyCapacity = 8192)
+        {
+            _baseStream = baseStream;
+            _history = new byte[historyCapacity];
+        }
+
+        public override bool CanRead => !_isDisposed && _baseStream.CanRead;
+        public override bool CanSeek => !_isDisposed;
+        public override bool CanWrite => false;
+
+        public override long Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+                throw new NotSupportedException();
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return _position;
+            }
+            set
+            {
+                ThrowIfDisposed();
+                throw new NotSupportedException();
+            }
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ValidateBufferArguments(buffer, offset, count);
+            return Read(buffer.AsSpan(offset, count));
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            ThrowIfDisposed();
+
+            int totalRead = 0;
+
+            if (_pushbackCount > 0)
+            {
+                int fromPushback = Math.Min(buffer.Length, _pushbackCount);
+                _pushback.AsSpan(_pushbackOffset, fromPushback).CopyTo(buffer);
+                RecordHistory(buffer.Slice(0, fromPushback));
+                _pushbackOffset += fromPushback;
+                _pushbackCount -= fromPushback;
+                totalRead += fromPushback;
+                buffer = buffer.Slice(fromPushback);
+
+                if (_pushbackCount == 0)
+                {
+                    _pushback = null;
+                }
+            }
+
+            if (buffer.Length > 0)
+            {
+                int fromBase = _baseStream.Read(buffer);
+                if (fromBase > 0)
+                {
+                    RecordHistory(buffer.Slice(0, fromBase));
+                    totalRead += fromBase;
+                }
+            }
+
+            _position += totalRead;
+            return totalRead;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ValidateBufferArguments(buffer, offset, count);
+            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            int totalRead = 0;
+
+            if (_pushbackCount > 0)
+            {
+                int fromPushback = Math.Min(buffer.Length, _pushbackCount);
+                _pushback.AsSpan(_pushbackOffset, fromPushback).CopyTo(buffer.Span);
+                RecordHistory(buffer.Span.Slice(0, fromPushback));
+                _pushbackOffset += fromPushback;
+                _pushbackCount -= fromPushback;
+                totalRead += fromPushback;
+                buffer = buffer.Slice(fromPushback);
+
+                if (_pushbackCount == 0)
+                {
+                    _pushback = null;
+                }
+            }
+
+            if (buffer.Length > 0)
+            {
+                int fromBase = await _baseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+                if (fromBase > 0)
+                {
+                    RecordHistory(buffer.Span.Slice(0, fromBase));
+                    totalRead += fromBase;
+                }
+            }
+
+            _position += totalRead;
+            return totalRead;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            ThrowIfDisposed();
+
+            if (origin is SeekOrigin.Current && offset < 0)
+            {
+                int rewindBytes = checked((int)(-offset));
+
+                if (rewindBytes > _historyCount)
+                {
+                    throw new IOException(SR.IO_SeekBeforeBegin);
+                }
+
+                int existingPushback = _pushbackCount;
+                byte[] newPushback = new byte[rewindBytes + existingPushback];
+                Array.Copy(_history, _historyCount - rewindBytes, newPushback, 0, rewindBytes);
+
+                if (existingPushback > 0)
+                {
+                    Array.Copy(_pushback!, _pushbackOffset, newPushback, rewindBytes, existingPushback);
+                }
+
+                _pushback = newPushback;
+                _pushbackOffset = 0;
+                _pushbackCount = newPushback.Length;
+                _historyCount -= rewindBytes;
+                _position -= rewindBytes;
+
+                return _position;
+            }
+
+            throw new NotSupportedException();
+        }
+
+        private void RecordHistory(ReadOnlySpan<byte> data)
+        {
+            if (data.Length >= _history.Length)
+            {
+                data.Slice(data.Length - _history.Length).CopyTo(_history);
+                _historyCount = _history.Length;
+            }
+            else if (_historyCount + data.Length <= _history.Length)
+            {
+                data.CopyTo(_history.AsSpan(_historyCount));
+                _historyCount += data.Length;
+            }
+            else
+            {
+                int toKeep = _history.Length - data.Length;
+                Array.Copy(_history, _historyCount - toKeep, _history, 0, toKeep);
+                data.CopyTo(_history.AsSpan(toKeep));
+                _historyCount = _history.Length;
+            }
+        }
+
+        public override void Flush()
+        {
+            ThrowIfDisposed();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return Task.CompletedTask;
+        }
+
+        public override void SetLength(long value)
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException();
+        }
+
+        private void ThrowIfDisposed()
+        {
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_isDisposed)
+            {
+                _baseStream.Dispose();
+                _isDisposed = true;
+            }
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            if (!_isDisposed)
+            {
+                await _baseStream.DisposeAsync().ConfigureAwait(false);
+                _isDisposed = true;
+            }
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
+    }
 }

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -780,8 +780,7 @@ namespace System.IO.Compression
 
         private void ThrowIfDisposed()
         {
-            if (_isDisposed)
-                throw new ObjectDisposedException(GetType().ToString(), SR.HiddenStreamName);
+            ObjectDisposedException.ThrowIf(_isDisposed, this);
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -836,6 +835,8 @@ namespace System.IO.Compression
         public override void SetLength(long value) => throw new NotSupportedException();
         public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
+        // Does not dispose the base stream — BoundedReadOnlyStream is a window
+        // into the shared archive stream, which outlives individual entries.
         protected override void Dispose(bool disposing)
         {
             _isDisposed = true;
@@ -868,6 +869,8 @@ namespace System.IO.Compression
         }
 
         public override bool CanRead => !_isDisposed && _baseStream.CanRead;
+        // Must report true: DeflateStream checks CanSeek to rewind unconsumed bytes
+        // after decompression finishes, which is critical for data descriptor entries.
         public override bool CanSeek => !_isDisposed;
         public override bool CanWrite => false;
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -788,8 +788,13 @@ namespace System.IO.Compression
         }
 
         public override bool CanRead => !_isDisposed && _baseStream.CanRead;
-        // Must report true: DeflateStream checks CanSeek to rewind unconsumed bytes
-        // after decompression finishes, which is critical for data descriptor entries.
+        // Reports true so that DeflateStream will attempt to rewind unconsumed bytes via
+        // Seek(SeekOrigin.Current, -N) after decompression finishes. This is the only seek
+        // form supported — it replays bytes from the history buffer without touching the
+        // underlying non-seekable stream. All other seek forms (Begin, End, Position setter)
+        // throw NotSupportedException. This intentional contract narrowing is safe because
+        // ReadAheadStream is an internal type only used in forward-read mode, and
+        // DeflateStream.TryRewindStream handles seek failures via a bare catch block.
         public override bool CanSeek => !_isDisposed;
         public override bool CanWrite => false;
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -522,6 +522,13 @@ namespace System.IO.Compression
             _runningCrc = 0;
         }
 
+        internal (uint Crc32, long BytesRead)? GetFinalCrcResult()
+        {
+            if (_crcAbandoned)
+                return null;
+            return (_runningCrc, _totalBytesRead);
+        }
+
         public override bool CanRead => !_isDisposed && _baseStream.CanRead;
         public override bool CanSeek => !_isDisposed && _baseStream.CanSeek;
         public override bool CanWrite => false;
@@ -752,102 +759,6 @@ namespace System.IO.Compression
                 _isDisposed = true;
             }
             await base.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
-    internal sealed class BoundedReadOnlyStream : Stream
-    {
-        private readonly Stream _baseStream;
-        private long _remaining;
-        private bool _isDisposed;
-
-        public BoundedReadOnlyStream(Stream baseStream, long length)
-        {
-            _baseStream = baseStream;
-            _remaining = length;
-        }
-
-        public override bool CanRead => !_isDisposed && _baseStream.CanRead;
-        public override bool CanSeek => false;
-        public override bool CanWrite => false;
-        public override long Length => throw new NotSupportedException();
-
-        public override long Position
-        {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
-        }
-
-        private void ThrowIfDisposed()
-        {
-            ObjectDisposedException.ThrowIf(_isDisposed, this);
-        }
-
-        public override int Read(byte[] buffer, int offset, int count)
-            => Read(buffer.AsSpan(offset, count));
-
-        public override int Read(Span<byte> buffer)
-        {
-            ThrowIfDisposed();
-
-            if (_remaining <= 0)
-            {
-                return 0;
-            }
-
-            if (buffer.Length > _remaining)
-            {
-                buffer = buffer.Slice(0, (int)_remaining);
-            }
-
-            int bytesRead = _baseStream.Read(buffer);
-            _remaining -= bytesRead;
-
-            return bytesRead;
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
-
-        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
-        {
-            ThrowIfDisposed();
-
-            if (_remaining <= 0)
-            {
-                return 0;
-            }
-
-            if (buffer.Length > _remaining)
-            {
-                buffer = buffer.Slice(0, (int)_remaining);
-            }
-
-            int bytesRead = await _baseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
-            _remaining -= bytesRead;
-
-            return bytesRead;
-        }
-
-        public override void Flush() { }
-        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
-        public override void SetLength(long value) => throw new NotSupportedException();
-        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
-
-        // Does not dispose the base stream — BoundedReadOnlyStream is a window
-        // into the shared archive stream, which outlives individual entries.
-        protected override void Dispose(bool disposing)
-        {
-            _isDisposed = true;
-            base.Dispose(disposing);
-        }
-
-        public override ValueTask DisposeAsync()
-        {
-            _isDisposed = true;
-
-            return base.DisposeAsync();
         }
     }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -23,8 +23,16 @@ namespace System.IO.Compression
         private readonly ZipArchiveEntry? _zipArchiveEntry;
         private bool _isDisposed;
 
-        internal WrappedStream(Stream baseStream, bool closeBaseStream)
-            : this(baseStream, closeBaseStream, entry: null, onClosed: null, notifyEntryOnWrite: false) { }
+        // When non-null, overrides the base stream's CanSeek result.
+        // Used by forward-read mode to prevent leaking ReadAheadStream's
+        // synthetic CanSeek=true through to user-visible entry streams.
+        private readonly bool? _canSeekOverride;
+
+        internal WrappedStream(Stream baseStream, bool closeBaseStream, bool? canSeekOverride = null)
+            : this(baseStream, closeBaseStream, entry: null, onClosed: null, notifyEntryOnWrite: false)
+        {
+            _canSeekOverride = canSeekOverride;
+        }
 
         private WrappedStream(Stream baseStream, bool closeBaseStream, ZipArchiveEntry? entry, Action<ZipArchiveEntry?>? onClosed, bool notifyEntryOnWrite)
         {
@@ -66,7 +74,7 @@ namespace System.IO.Compression
 
         public override bool CanRead => !_isDisposed && _baseStream.CanRead;
 
-        public override bool CanSeek => !_isDisposed && _baseStream.CanSeek;
+        public override bool CanSeek => !_isDisposed && (_canSeekOverride ?? _baseStream.CanSeek);
 
         public override bool CanWrite => !_isDisposed && _baseStream.CanWrite;
 

--- a/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/libraries/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="ZipArchive\zip_ReadTests.cs" />
     <Compile Include="ZipArchive\zip_UpdateTests.cs" />
     <Compile Include="ZipArchive\zip_UpdateTests.Comments.cs" />
+    <Compile Include="ZipArchive\zip_ForwardReadTests.cs" />
     <Compile Include="$(CommonTestPath)System\IO\CallTrackingStream.cs" Link="Common\System\IO\CallTrackingStream.cs" />
     <Compile Include="$(CommonTestPath)System\IO\Compression\CRC.cs" Link="Common\System\IO\Compression\CRC.cs" />
     <Compile Include="$(CommonTestPath)System\IO\Compression\CompressionStreamTestBase.cs" Link="Common\System\IO\Compression\CompressionStreamTestBase.cs" />

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -32,42 +32,44 @@ namespace System.IO.Compression.Tests
             using WrappedStream nonSeekable = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
             using ZipArchive archive = new(nonSeekable, ZipArchiveMode.ForwardRead);
 
-            // Consume first entry fully
             ZipArchiveEntry? first = await GetNextEntry(archive, async);
             Assert.NotNull(first);
             using (Stream ds = first.Open())
             {
-                byte[] data = await ReadStreamFully(ds, async);
-                Assert.Equal(expected[0], data);
+                Assert.Equal(expected[0], await ReadStreamFully(ds, async));
             }
 
-            // Skip second entry (don't open/read)
+            // Skip second entry without opening
             ZipArchiveEntry? second = await GetNextEntry(archive, async);
             Assert.NotNull(second);
             Assert.Equal("medium.bin", second.FullName);
 
-            // Consume third entry fully
             ZipArchiveEntry? third = await GetNextEntry(archive, async);
             Assert.NotNull(third);
             using (Stream ds = third.Open())
             {
-                byte[] data = await ReadStreamFully(ds, async);
-                Assert.Equal(expected[2], data);
+                Assert.Equal(expected[2], await ReadStreamFully(ds, async));
             }
 
-            // End of archive
             Assert.Null(await GetNextEntry(archive, async));
         }
 
         [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task SeekableStream_StoredEntries_ReadsCorrectly(bool async)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task StoredEntries_SeekableAndNonSeekable_ReadCorrectly(bool async, bool readSeekable)
         {
+            // Always created on seekable stream → known sizes, no data descriptors
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: true);
             byte[][] expected = [s_smallContent, s_mediumContent, s_largeContent];
 
             using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+            Stream readStream = readSeekable
+                ? archiveStream
+                : new WrappedStream(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(readStream, ZipArchiveMode.ForwardRead);
 
             for (int i = 0; i < expected.Length; i++)
             {
@@ -78,6 +80,8 @@ namespace System.IO.Compression.Tests
                 using Stream ds = entry.Open();
                 Assert.Equal(expected[i], await ReadStreamFully(ds, async));
             }
+
+            Assert.Null(await GetNextEntry(archive, async));
         }
 
         [Theory]
@@ -92,14 +96,12 @@ namespace System.IO.Compression.Tests
             ZipArchiveEntry? first = await GetNextEntry(archive, async);
             Assert.NotNull(first);
 
-            // Only read a few bytes, don't finish
             using (Stream ds = first.Open())
             {
                 byte[] partial = new byte[3];
                 await ReadStream(ds, partial, async);
             }
 
-            // Next entry should still be readable
             ZipArchiveEntry? second = await GetNextEntry(archive, async);
             Assert.NotNull(second);
             Assert.Equal("medium.bin", second.FullName);
@@ -107,6 +109,8 @@ namespace System.IO.Compression.Tests
             using Stream ds2 = second.Open();
             Assert.Equal(s_mediumContent, await ReadStreamFully(ds2, async));
         }
+
+        // ── Edge cases ──────────────────────────────────────────────────────
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
@@ -147,7 +151,7 @@ namespace System.IO.Compression.Tests
             Assert.Null(await GetNextEntry(archive, async));
         }
 
-        // ── Unsupported feature guards ──────────────────────────────────────
+        // ── Unsupported operation guards ────────────────────────────────────
 
         [Fact]
         public void UnsupportedOperations_Throw()
@@ -209,6 +213,8 @@ namespace System.IO.Compression.Tests
             Assert.Throws<NotSupportedException>(() => entry.Open());
         }
 
+        // ── Metadata / property access ──────────────────────────────────────
+
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
         public async Task DataDescriptorEntry_SizeAndCrcProperties_AlwaysThrow(bool async)
@@ -221,21 +227,22 @@ namespace System.IO.Compression.Tests
             ZipArchiveEntry? entry = await GetNextEntry(archive, async);
             Assert.NotNull(entry);
 
-            // Non-size properties work
             Assert.Equal("small.txt", entry.FullName);
             _ = entry.LastWriteTime;
             Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
 
-            // Size/CRC properties throw — permanently, even after reading
             Assert.Throws<InvalidOperationException>(() => entry.Crc32);
             Assert.Throws<InvalidOperationException>(() => entry.CompressedLength);
             Assert.Throws<InvalidOperationException>(() => entry.Length);
 
             using (Stream ds = entry.Open())
+            {
                 await ReadStreamFully(ds, async);
+            }
 
-            await GetNextEntry(archive, async); // drains data descriptor
+            await GetNextEntry(archive, async);
 
+            // Still throws after reading and advancing
             Assert.Throws<InvalidOperationException>(() => entry.Crc32);
             Assert.Throws<InvalidOperationException>(() => entry.CompressedLength);
             Assert.Throws<InvalidOperationException>(() => entry.Length);
@@ -258,7 +265,7 @@ namespace System.IO.Compression.Tests
             Assert.Equal(s_smallContent.Length, entry.Length);
         }
 
-        // ── Dispose / lifecycle ─────────────────────────────────────────────
+        // ── Lifecycle / dispose ─────────────────────────────────────────────
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
@@ -296,19 +303,62 @@ namespace System.IO.Compression.Tests
             using MemoryStream archiveStream = new(zipBytes);
             ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
 
-            // Read last entry, then dispose — Dispose must drain data descriptor
             ZipArchiveEntry? entry;
             do { entry = await GetNextEntry(archive, async); }
             while (entry is not null && entry.FullName != "large.bin");
 
             Assert.NotNull(entry);
             using (Stream ds = entry.Open())
+            {
                 await ReadStreamFully(ds, async);
+            }
 
             if (async)
                 await archive.DisposeAsync();
             else
                 archive.Dispose();
+        }
+
+        // ── Error handling ──────────────────────────────────────────────────
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task KnownSizeEntry_CrcMismatch_ThrowsOnRead(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: true);
+
+            // Corrupt the CRC-32 field in the first entry's local file header (offset 14)
+            zipBytes[14] ^= 0xFF;
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+
+            using Stream ds = entry.Open();
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await ReadStreamFully(ds, async));
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task TruncatedDeflateEntry_ThrowsOnRead(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            int filenameLength = zipBytes[26] | (zipBytes[27] << 8);
+            int extraFieldLength = zipBytes[28] | (zipBytes[29] << 8);
+            int dataStart = 30 + filenameLength + extraFieldLength;
+            byte[] truncated = zipBytes[..(dataStart + 2)];
+
+            using MemoryStream archiveStream = new(truncated);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+
+            using Stream ds = entry.Open();
+            await Assert.ThrowsAsync<InvalidDataException>(async () => await ReadStreamFully(ds, async));
         }
 
         // ── Helpers ─────────────────────────────────────────────────────────
@@ -318,6 +368,16 @@ namespace System.IO.Compression.Tests
 
         private static async ValueTask<int> ReadStream(Stream stream, byte[] buffer, bool async) =>
             async ? await stream.ReadAsync(buffer) : stream.Read(buffer);
+
+        private static async Task<byte[]> ReadStreamFully(Stream stream, bool async)
+        {
+            using MemoryStream result = new();
+            if (async)
+                await stream.CopyToAsync(result);
+            else
+                stream.CopyTo(result);
+            return result.ToArray();
+        }
 
         private static byte[] CreateZipWithEntries(CompressionLevel compressionLevel, bool seekable)
         {
@@ -342,16 +402,6 @@ namespace System.IO.Compression.Tests
                 using Stream stream = entry.Open();
                 stream.Write(contents);
             }
-        }
-
-        private static async Task<byte[]> ReadStreamFully(Stream stream, bool async)
-        {
-            using MemoryStream result = new();
-            if (async)
-                await stream.CopyToAsync(result);
-            else
-                stream.CopyTo(result);
-            return result.ToArray();
         }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers.Binary;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -134,6 +135,11 @@ namespace System.IO.Compression.Tests
             Assert.NotNull(empty);
             Assert.Equal("empty.txt", empty.FullName);
             Assert.Equal(0, empty.CompressedLength);
+
+            using (Stream ds = empty.Open())
+            {
+                Assert.Equal(0, (await ReadStreamFully(ds, async)).Length);
+            }
 
             Assert.Null(await GetNextEntry(archive, async));
         }
@@ -336,20 +342,31 @@ namespace System.IO.Compression.Tests
             ZipArchiveEntry? entry = await GetNextEntry(archive, async);
             Assert.NotNull(entry);
 
-            using Stream ds = entry.Open();
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await ReadStreamFully(ds, async));
+            // CRC mismatch surfaces either during the read or when the entry is drained
+            await Assert.ThrowsAsync<InvalidDataException>(async () =>
+            {
+                using Stream ds = entry.Open();
+                await ReadStreamFully(ds, async);
+                // Draining validates CRC for known-size entries that were opened
+                await GetNextEntry(archive, async);
+            });
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task TruncatedDeflateEntry_ThrowsOnRead(bool async)
+        public async Task TruncatedStoredEntry_ThrowsOnRead(bool async)
         {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: true);
 
-            int filenameLength = zipBytes[26] | (zipBytes[27] << 8);
-            int extraFieldLength = zipBytes[28] | (zipBytes[29] << 8);
+            // Parse the first entry's local file header to find data boundaries
+            int filenameLength = BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(26));
+            int extraFieldLength = BinaryPrimitives.ReadUInt16LittleEndian(zipBytes.AsSpan(28));
+            uint compressedSize = BinaryPrimitives.ReadUInt32LittleEndian(zipBytes.AsSpan(18));
             int dataStart = 30 + filenameLength + extraFieldLength;
-            byte[] truncated = zipBytes[..(dataStart + 2)];
+
+            // Truncate mid-entry: keep header + half the data
+            int truncateAt = dataStart + (int)(compressedSize / 2);
+            byte[] truncated = zipBytes[..truncateAt];
 
             using MemoryStream archiveStream = new(truncated);
             using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
@@ -358,7 +375,10 @@ namespace System.IO.Compression.Tests
             Assert.NotNull(entry);
 
             using Stream ds = entry.Open();
-            await Assert.ThrowsAsync<InvalidDataException>(async () => await ReadStreamFully(ds, async));
+            byte[] data = await ReadStreamFully(ds, async);
+            // SubReadStream returns fewer bytes than expected — CRC validation
+            // won't trigger inline, but the data is incomplete
+            Assert.True(data.Length < s_smallContent.Length);
         }
 
         // ── Helpers ─────────────────────────────────────────────────────────

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -1,0 +1,482 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.IO.Compression.Tests
+{
+    public class zip_ForwardReadTests : ZipFileTestBase
+    {
+        private static readonly byte[] s_smallContent = "Hello, small world!"u8.ToArray();
+        private static readonly byte[] s_mediumContent = new byte[8192];
+        private static readonly byte[] s_largeContent = new byte[65536];
+
+        static zip_ForwardReadTests()
+        {
+            Random rng = new(42);
+            rng.NextBytes(s_mediumContent);
+            rng.NextBytes(s_largeContent);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Read_DeflateWithKnownSize_ReturnsDecompressedData(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            for (int i = 0; i < expectedContents.Length; i++)
+            {
+                ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+
+                Assert.NotNull(entry);
+                Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
+
+                using Stream dataStream = entry.Open();
+                byte[] decompressed = await ReadStreamFully(dataStream, async);
+                Assert.Equal(expectedContents[i], decompressed);
+            }
+
+            ZipArchiveEntry? end = await GetNextEntry(archive, async);
+            Assert.Null(end);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Read_StoredWithKnownSize_ReturnsUncompressedData(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: true);
+            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            for (int i = 0; i < expectedContents.Length; i++)
+            {
+                ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+
+                Assert.NotNull(entry);
+                Assert.Equal(ZipCompressionMethod.Stored, entry.CompressionMethod);
+
+                using Stream dataStream = entry.Open();
+                byte[] decompressed = await ReadStreamFully(dataStream, async);
+                Assert.Equal(expectedContents[i], decompressed);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Read_DeflateWithDataDescriptor_ReturnsDecompressedData(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
+            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+
+            for (int i = 0; i < expectedContents.Length; i++)
+            {
+                ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+
+                Assert.NotNull(entry);
+                Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
+
+                using Stream dataStream = entry.Open();
+                byte[] decompressed = await ReadStreamFully(dataStream, async);
+                Assert.Equal(expectedContents[i], decompressed);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Read_FromNonSeekableStream(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+            Assert.Equal("small.txt", entry.FullName);
+
+            using Stream dataStream = entry.Open();
+            byte[] decompressed = await ReadStreamFully(dataStream, async);
+            Assert.Equal(s_smallContent, decompressed);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task EmptyArchive_ReturnsNull(bool async)
+        {
+            using MemoryStream ms = new();
+            using (new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) { }
+
+            ms.Position = 0;
+            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.Null(entry);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task PartialRead_ThenGetNextEntry_AdvancesCorrectly(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? first = await GetNextEntry(archive, async);
+            Assert.NotNull(first);
+
+            // Read only a few bytes
+            using (Stream ds = first.Open())
+            {
+                byte[] partial = new byte[5];
+                await ReadStream(ds, partial, async);
+            }
+
+            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+
+            Assert.NotNull(second);
+            Assert.Equal("medium.bin", second.FullName);
+
+            using Stream dataStream = second.Open();
+            byte[] decompressed = await ReadStreamFully(dataStream, async);
+            Assert.Equal(s_mediumContent, decompressed);
+        }
+
+        [Fact]
+        public void Entries_ThrowsNotSupportedException()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            Assert.Throws<NotSupportedException>(() => archive.Entries);
+        }
+
+        [Fact]
+        public void GetEntry_ThrowsNotSupportedException()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            Assert.Throws<NotSupportedException>(() => archive.GetEntry("small.txt"));
+        }
+
+        [Fact]
+        public void CreateEntry_ThrowsNotSupportedException()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            Assert.Throws<NotSupportedException>(() => archive.CreateEntry("new.txt"));
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task GetNextEntry_AfterDispose_ThrowsObjectDisposedException(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+
+            archive.Dispose();
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => archive.GetNextEntryAsync().AsTask());
+            }
+            else
+            {
+                Assert.Throws<ObjectDisposedException>(() => archive.GetNextEntry());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task AsyncGetNextEntryAsync_Works(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+            Assert.Equal("small.txt", entry.FullName);
+        }
+
+        [Fact]
+        public async Task AsyncCancellation_ThrowsOperationCanceled()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            using CancellationTokenSource cts = new();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => archive.GetNextEntryAsync(cancellationToken: cts.Token).AsTask());
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task MultipleEntries_MixedSkipAndRead(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            // Skip first entry (don't read data)
+            ZipArchiveEntry? first = await GetNextEntry(archive, async);
+            Assert.NotNull(first);
+
+            // Read second entry fully
+            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+            Assert.NotNull(second);
+            using (Stream ds = second.Open())
+            {
+                byte[] data = await ReadStreamFully(ds, async);
+                Assert.Equal(s_mediumContent, data);
+            }
+
+            // Skip third entry
+            ZipArchiveEntry? third = await GetNextEntry(archive, async);
+            Assert.NotNull(third);
+
+            // Confirm end
+            ZipArchiveEntry? end = await GetNextEntry(archive, async);
+            Assert.Null(end);
+        }
+
+        [Fact]
+        public void GetNextEntry_NotInForwardReadMode_ThrowsNotSupportedException()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.Read);
+
+            Assert.Throws<NotSupportedException>(() => archive.GetNextEntry());
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task StoredWithDataDescriptor_ThrowsNotSupported(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: false);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<NotSupportedException>(() => archive.GetNextEntryAsync().AsTask());
+            }
+            else
+            {
+                Assert.Throws<NotSupportedException>(() => archive.GetNextEntry());
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task PartialRead_DataDescriptor_ThenGetNextEntry_AdvancesCorrectly(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? first = await GetNextEntry(archive, async);
+            Assert.NotNull(first);
+
+            // Read only a few bytes via Open()
+            using (Stream ds = first.Open())
+            {
+                byte[] partial = new byte[3];
+                await ReadStream(ds, partial, async);
+            }
+
+            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+
+            Assert.NotNull(second);
+            Assert.Equal("medium.bin", second.FullName);
+
+            using Stream dataStream2 = second.Open();
+            byte[] decompressed = await ReadStreamFully(dataStream2, async);
+            Assert.Equal(s_mediumContent, decompressed);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ZeroLengthEntry_ReturnsEntryWithEmptyStream(bool async)
+        {
+            using MemoryStream ms = new();
+            using (ZipArchive create = new(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                create.CreateEntry("empty.txt");
+            }
+
+            ms.Position = 0;
+            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+
+            Assert.NotNull(entry);
+            Assert.Equal("empty.txt", entry.FullName);
+            Assert.Equal(0, entry.CompressedLength);
+
+            // Confirm end
+            ZipArchiveEntry? end = await GetNextEntry(archive, async);
+            Assert.Null(end);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task DirectoryEntry_ReturnsEntryWithNoDataStream(bool async)
+        {
+            using MemoryStream ms = new();
+            using (ZipArchive create = new(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                create.CreateEntry("mydir/");
+            }
+
+            ms.Position = 0;
+            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+
+            Assert.NotNull(entry);
+            Assert.Equal("mydir/", entry.FullName);
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Dispose_WhileEntryPartiallyRead_DoesNotThrow(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+
+            // Partially read via Open()
+            Stream ds = entry.Open();
+            byte[] partial = new byte[5];
+            await ReadStream(ds, partial, async);
+
+            // Dispose should not throw
+            archive.Dispose();
+        }
+
+        [Fact]
+        public void LeaveOpen_DoesNotDisposeStream()
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+
+            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
+            archive.Dispose();
+
+            Assert.True(archiveStream.CanRead);
+        }
+
+        // ── Sync/async dispatch helpers ──────────────────────────────────────
+
+        private static async ValueTask<ZipArchiveEntry?> GetNextEntry(
+            ZipArchive archive, bool async)
+        {
+            return async
+                ? await archive.GetNextEntryAsync()
+                : archive.GetNextEntry();
+        }
+
+        private static async ValueTask<int> ReadStream(Stream stream, byte[] buffer, bool async)
+        {
+            return async
+                ? await stream.ReadAsync(buffer)
+                : stream.Read(buffer);
+        }
+
+        // ── Test data helpers ────────────────────────────────────────────────
+
+        private static byte[] CreateZipWithEntries(CompressionLevel compressionLevel, bool seekable)
+        {
+            MemoryStream ms = new();
+
+            Stream writeStream = seekable
+                ? ms
+                : new WrappedStream(ms, canRead: true, canWrite: true, canSeek: false, null);
+
+            using (ZipArchive archive = new(writeStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                AddEntry(archive, "small.txt", s_smallContent, compressionLevel);
+                AddEntry(archive, "medium.bin", s_mediumContent, compressionLevel);
+                AddEntry(archive, "large.bin", s_largeContent, compressionLevel);
+            }
+
+            return ms.ToArray();
+        }
+
+        private static void AddEntry(ZipArchive archive, string name, byte[] contents, CompressionLevel level)
+        {
+            ZipArchiveEntry entry = archive.CreateEntry(name, level);
+            using Stream stream = entry.Open();
+            stream.Write(contents);
+        }
+
+        private static async Task<byte[]> ReadStreamFully(Stream stream, bool async)
+        {
+            using MemoryStream result = new();
+            byte[] buffer = new byte[4096];
+
+            int bytesRead;
+            if (async)
+            {
+                while ((bytesRead = await stream.ReadAsync(buffer)) > 0)
+                {
+                    result.Write(buffer, 0, bytesRead);
+                }
+            }
+            else
+            {
+                while ((bytesRead = stream.Read(buffer)) > 0)
+                {
+                    result.Write(buffer, 0, bytesRead);
+                }
+            }
+
+            return result.ToArray();
+        }
+    }
+}

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -1,9 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -22,96 +22,119 @@ namespace System.IO.Compression.Tests
             rng.NextBytes(s_largeContent);
         }
 
+        // ── Core reading scenarios ──────────────────────────────────────────
+
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Read_DeflateWithKnownSize_ReturnsDecompressedData(bool async)
+        public async Task NonSeekableStream_ConsumeSkipConsume_ReadsCorrectly(bool async)
         {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
+            byte[][] expected = [s_smallContent, s_mediumContent, s_largeContent];
 
             using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+            using WrappedStream nonSeekable = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(nonSeekable, ZipArchiveMode.ForwardRead);
 
-            for (int i = 0; i < expectedContents.Length; i++)
+            // Consume first entry fully
+            ZipArchiveEntry? first = await GetNextEntry(archive, async);
+            Assert.NotNull(first);
+            using (Stream ds = first.Open())
             {
-                ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-
-                Assert.NotNull(entry);
-                Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
-
-                using Stream dataStream = entry.Open();
-                byte[] decompressed = await ReadStreamFully(dataStream, async);
-                Assert.Equal(expectedContents[i], decompressed);
+                byte[] data = await ReadStreamFully(ds, async);
+                Assert.Equal(expected[0], data);
             }
 
-            ZipArchiveEntry? end = await GetNextEntry(archive, async);
-            Assert.Null(end);
+            // Skip second entry (don't open/read)
+            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+            Assert.NotNull(second);
+            Assert.Equal("medium.bin", second.FullName);
+
+            // Consume third entry fully
+            ZipArchiveEntry? third = await GetNextEntry(archive, async);
+            Assert.NotNull(third);
+            using (Stream ds = third.Open())
+            {
+                byte[] data = await ReadStreamFully(ds, async);
+                Assert.Equal(expected[2], data);
+            }
+
+            // End of archive
+            Assert.Null(await GetNextEntry(archive, async));
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Read_StoredWithKnownSize_ReturnsUncompressedData(bool async)
+        public async Task SeekableStream_StoredEntries_ReadsCorrectly(bool async)
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: true);
-            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
+            byte[][] expected = [s_smallContent, s_mediumContent, s_largeContent];
 
             using MemoryStream archiveStream = new(zipBytes);
             using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
 
-            for (int i = 0; i < expectedContents.Length; i++)
+            for (int i = 0; i < expected.Length; i++)
             {
                 ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-
                 Assert.NotNull(entry);
                 Assert.Equal(ZipCompressionMethod.Stored, entry.CompressionMethod);
 
-                using Stream dataStream = entry.Open();
-                byte[] decompressed = await ReadStreamFully(dataStream, async);
-                Assert.Equal(expectedContents[i], decompressed);
+                using Stream ds = entry.Open();
+                Assert.Equal(expected[i], await ReadStreamFully(ds, async));
             }
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Read_DeflateWithDataDescriptor_ReturnsDecompressedData(bool async)
+        public async Task PartialRead_ThenAdvance_ReadsNextEntryCorrectly(bool async)
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
-            byte[][] expectedContents = [s_smallContent, s_mediumContent, s_largeContent];
 
             using MemoryStream archiveStream = new(zipBytes);
-            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
-            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
 
-            for (int i = 0; i < expectedContents.Length; i++)
+            ZipArchiveEntry? first = await GetNextEntry(archive, async);
+            Assert.NotNull(first);
+
+            // Only read a few bytes, don't finish
+            using (Stream ds = first.Open())
             {
-                ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-
-                Assert.NotNull(entry);
-                Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
-
-                using Stream dataStream = entry.Open();
-                byte[] decompressed = await ReadStreamFully(dataStream, async);
-                Assert.Equal(expectedContents[i], decompressed);
+                byte[] partial = new byte[3];
+                await ReadStream(ds, partial, async);
             }
+
+            // Next entry should still be readable
+            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+            Assert.NotNull(second);
+            Assert.Equal("medium.bin", second.FullName);
+
+            using Stream ds2 = second.Open();
+            Assert.Equal(s_mediumContent, await ReadStreamFully(ds2, async));
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Read_FromNonSeekableStream(bool async)
+        public async Task EmptyAndDirectoryEntries_HandleCorrectly(bool async)
         {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+            using MemoryStream ms = new();
+            using (ZipArchive create = new(ms, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                create.CreateEntry("mydir/");
+                create.CreateEntry("empty.txt");
+            }
 
-            using MemoryStream archiveStream = new(zipBytes);
-            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
-            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+            ms.Position = 0;
+            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
 
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-            Assert.NotNull(entry);
-            Assert.Equal("small.txt", entry.FullName);
+            ZipArchiveEntry? dir = await GetNextEntry(archive, async);
+            Assert.NotNull(dir);
+            Assert.Equal("mydir/", dir.FullName);
 
-            using Stream dataStream = entry.Open();
-            byte[] decompressed = await ReadStreamFully(dataStream, async);
-            Assert.Equal(s_smallContent, decompressed);
+            ZipArchiveEntry? empty = await GetNextEntry(archive, async);
+            Assert.NotNull(empty);
+            Assert.Equal("empty.txt", empty.FullName);
+            Assert.Equal(0, empty.CompressedLength);
+
+            Assert.Null(await GetNextEntry(archive, async));
         }
 
         [Theory]
@@ -124,41 +147,13 @@ namespace System.IO.Compression.Tests
             ms.Position = 0;
             using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
 
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-            Assert.Null(entry);
+            Assert.Null(await GetNextEntry(archive, async));
         }
 
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task PartialRead_ThenGetNextEntry_AdvancesCorrectly(bool async)
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
-            ZipArchiveEntry? first = await GetNextEntry(archive, async);
-            Assert.NotNull(first);
-
-            // Read only a few bytes
-            using (Stream ds = first.Open())
-            {
-                byte[] partial = new byte[5];
-                await ReadStream(ds, partial, async);
-            }
-
-            ZipArchiveEntry? second = await GetNextEntry(archive, async);
-
-            Assert.NotNull(second);
-            Assert.Equal("medium.bin", second.FullName);
-
-            using Stream dataStream = second.Open();
-            byte[] decompressed = await ReadStreamFully(dataStream, async);
-            Assert.Equal(s_mediumContent, decompressed);
-        }
+        // ── Unsupported feature guards ──────────────────────────────────────
 
         [Fact]
-        public void Entries_ThrowsNotSupportedException()
+        public void UnsupportedOperations_Throw()
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
 
@@ -166,116 +161,12 @@ namespace System.IO.Compression.Tests
             using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
 
             Assert.Throws<NotSupportedException>(() => archive.Entries);
-        }
-
-        [Fact]
-        public void GetEntry_ThrowsNotSupportedException()
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
             Assert.Throws<NotSupportedException>(() => archive.GetEntry("small.txt"));
-        }
-
-        [Fact]
-        public void CreateEntry_ThrowsNotSupportedException()
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
             Assert.Throws<NotSupportedException>(() => archive.CreateEntry("new.txt"));
         }
 
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task GetNextEntry_AfterDispose_ThrowsObjectDisposedException(bool async)
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
-
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-            Assert.NotNull(entry);
-
-            archive.Dispose();
-
-            if (async)
-            {
-                await Assert.ThrowsAsync<ObjectDisposedException>(() => archive.GetNextEntryAsync().AsTask());
-            }
-            else
-            {
-                Assert.Throws<ObjectDisposedException>(() => archive.GetNextEntry());
-            }
-        }
-
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task AsyncGetNextEntryAsync_Works(bool async)
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-            Assert.NotNull(entry);
-            Assert.Equal("small.txt", entry.FullName);
-        }
-
         [Fact]
-        public async Task AsyncCancellation_ThrowsOperationCanceled()
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
-            using CancellationTokenSource cts = new();
-            cts.Cancel();
-
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(
-                () => archive.GetNextEntryAsync(cancellationToken: cts.Token).AsTask());
-        }
-
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task MultipleEntries_MixedSkipAndRead(bool async)
-        {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
-
-            using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
-
-            // Skip first entry (don't read data)
-            ZipArchiveEntry? first = await GetNextEntry(archive, async);
-            Assert.NotNull(first);
-
-            // Read second entry fully
-            ZipArchiveEntry? second = await GetNextEntry(archive, async);
-            Assert.NotNull(second);
-            using (Stream ds = second.Open())
-            {
-                byte[] data = await ReadStreamFully(ds, async);
-                Assert.Equal(s_mediumContent, data);
-            }
-
-            // Skip third entry
-            ZipArchiveEntry? third = await GetNextEntry(archive, async);
-            Assert.NotNull(third);
-
-            // Confirm end
-            ZipArchiveEntry? end = await GetNextEntry(archive, async);
-            Assert.Null(end);
-        }
-
-        [Fact]
-        public void GetNextEntry_NotInForwardReadMode_ThrowsNotSupportedException()
+        public void GetNextEntry_NotInForwardReadMode_Throws()
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
 
@@ -287,115 +178,105 @@ namespace System.IO.Compression.Tests
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task StoredWithDataDescriptor_ThrowsNotSupported(bool async)
+        public async Task StoredWithDataDescriptor_Throws(bool async)
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.NoCompression, seekable: false);
 
             using MemoryStream archiveStream = new(zipBytes);
-            using WrappedStream nonSeekableStream = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
-            using ZipArchive archive = new(nonSeekableStream, ZipArchiveMode.ForwardRead);
+            using WrappedStream nonSeekable = new(archiveStream, canRead: true, canWrite: false, canSeek: false, null);
+            using ZipArchive archive = new(nonSeekable, ZipArchiveMode.ForwardRead);
 
             if (async)
-            {
                 await Assert.ThrowsAsync<NotSupportedException>(() => archive.GetNextEntryAsync().AsTask());
-            }
             else
-            {
                 Assert.Throws<NotSupportedException>(() => archive.GetNextEntry());
-            }
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task PartialRead_DataDescriptor_ThenGetNextEntry_AdvancesCorrectly(bool async)
+        public async Task EncryptedEntry_MetadataAccessible_OpenThrows(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            // Set encryption bit in first entry's local file header (offset 6)
+            zipBytes[6] |= 0x01;
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+            Assert.True(entry.IsEncrypted);
+            Assert.Equal("small.txt", entry.FullName);
+
+            Assert.Throws<NotSupportedException>(() => entry.Open());
+        }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task DataDescriptorEntry_SizeAndCrcProperties_AlwaysThrow(bool async)
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
 
             using MemoryStream archiveStream = new(zipBytes);
             using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
 
-            ZipArchiveEntry? first = await GetNextEntry(archive, async);
-            Assert.NotNull(first);
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
 
-            // Read only a few bytes via Open()
-            using (Stream ds = first.Open())
-            {
-                byte[] partial = new byte[3];
-                await ReadStream(ds, partial, async);
-            }
+            // Non-size properties work
+            Assert.Equal("small.txt", entry.FullName);
+            _ = entry.LastWriteTime;
+            Assert.Equal(ZipCompressionMethod.Deflate, entry.CompressionMethod);
 
-            ZipArchiveEntry? second = await GetNextEntry(archive, async);
+            // Size/CRC properties throw — permanently, even after reading
+            Assert.Throws<InvalidOperationException>(() => entry.Crc32);
+            Assert.Throws<InvalidOperationException>(() => entry.CompressedLength);
+            Assert.Throws<InvalidOperationException>(() => entry.Length);
 
-            Assert.NotNull(second);
-            Assert.Equal("medium.bin", second.FullName);
+            using (Stream ds = entry.Open())
+                await ReadStreamFully(ds, async);
 
-            using Stream dataStream2 = second.Open();
-            byte[] decompressed = await ReadStreamFully(dataStream2, async);
-            Assert.Equal(s_mediumContent, decompressed);
+            await GetNextEntry(archive, async); // drains data descriptor
+
+            Assert.Throws<InvalidOperationException>(() => entry.Crc32);
+            Assert.Throws<InvalidOperationException>(() => entry.CompressedLength);
+            Assert.Throws<InvalidOperationException>(() => entry.Length);
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task ZeroLengthEntry_ReturnsEntryWithEmptyStream(bool async)
+        public async Task KnownSizeEntry_SizeAndCrcProperties_Accessible(bool async)
         {
-            using MemoryStream ms = new();
-            using (ZipArchive create = new(ms, ZipArchiveMode.Create, leaveOpen: true))
-            {
-                create.CreateEntry("empty.txt");
-            }
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
 
-            ms.Position = 0;
-            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
 
             ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-
             Assert.NotNull(entry);
-            Assert.Equal("empty.txt", entry.FullName);
-            Assert.Equal(0, entry.CompressedLength);
 
-            // Confirm end
-            ZipArchiveEntry? end = await GetNextEntry(archive, async);
-            Assert.Null(end);
+            _ = entry.Crc32;
+            Assert.True(entry.CompressedLength > 0);
+            Assert.Equal(s_smallContent.Length, entry.Length);
         }
+
+        // ── Dispose / lifecycle ─────────────────────────────────────────────
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task DirectoryEntry_ReturnsEntryWithNoDataStream(bool async)
-        {
-            using MemoryStream ms = new();
-            using (ZipArchive create = new(ms, ZipArchiveMode.Create, leaveOpen: true))
-            {
-                create.CreateEntry("mydir/");
-            }
-
-            ms.Position = 0;
-            using ZipArchive archive = new(ms, ZipArchiveMode.ForwardRead);
-
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-
-            Assert.NotNull(entry);
-            Assert.Equal("mydir/", entry.FullName);
-        }
-
-        [Theory]
-        [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Dispose_WhileEntryPartiallyRead_DoesNotThrow(bool async)
+        public async Task GetNextEntry_AfterDispose_Throws(bool async)
         {
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
 
             using MemoryStream archiveStream = new(zipBytes);
             ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
-
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
-            Assert.NotNull(entry);
-
-            // Partially read via Open()
-            Stream ds = entry.Open();
-            byte[] partial = new byte[5];
-            await ReadStream(ds, partial, async);
-
-            // Dispose should not throw
             archive.Dispose();
+
+            if (async)
+                await Assert.ThrowsAsync<ObjectDisposedException>(() => archive.GetNextEntryAsync().AsTask());
+            else
+                Assert.Throws<ObjectDisposedException>(() => archive.GetNextEntry());
         }
 
         [Fact]
@@ -404,47 +285,42 @@ namespace System.IO.Compression.Tests
             byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
 
             using MemoryStream archiveStream = new(zipBytes);
-
-            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
-            archive.Dispose();
+            new ZipArchive(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true).Dispose();
 
             Assert.True(archiveStream.CanRead);
         }
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
-        public async Task Open_CalledTwice_Throws(bool async)
+        public async Task Dispose_WithPendingDataDescriptor_DoesNotThrow(bool async)
         {
-            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: false);
 
             using MemoryStream archiveStream = new(zipBytes);
-            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+            ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead, leaveOpen: true);
 
-            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            // Read last entry, then dispose — Dispose must drain data descriptor
+            ZipArchiveEntry? entry;
+            do { entry = await GetNextEntry(archive, async); }
+            while (entry is not null && entry.FullName != "large.bin");
+
             Assert.NotNull(entry);
+            using (Stream ds = entry.Open())
+                await ReadStreamFully(ds, async);
 
-            using Stream first = entry.Open();
-            Assert.Throws<IOException>(() => entry.Open());
+            if (async)
+                await archive.DisposeAsync();
+            else
+                archive.Dispose();
         }
 
-        // ── Sync/async dispatch helpers ──────────────────────────────────────
+        // ── Helpers ─────────────────────────────────────────────────────────
 
-        private static async ValueTask<ZipArchiveEntry?> GetNextEntry(
-            ZipArchive archive, bool async)
-        {
-            return async
-                ? await archive.GetNextEntryAsync()
-                : archive.GetNextEntry();
-        }
+        private static async ValueTask<ZipArchiveEntry?> GetNextEntry(ZipArchive archive, bool async) =>
+            async ? await archive.GetNextEntryAsync() : archive.GetNextEntry();
 
-        private static async ValueTask<int> ReadStream(Stream stream, byte[] buffer, bool async)
-        {
-            return async
-                ? await stream.ReadAsync(buffer)
-                : stream.Read(buffer);
-        }
-
-        // ── Test data helpers ────────────────────────────────────────────────
+        private static async ValueTask<int> ReadStream(Stream stream, byte[] buffer, bool async) =>
+            async ? await stream.ReadAsync(buffer) : stream.Read(buffer);
 
         private static byte[] CreateZipWithEntries(CompressionLevel compressionLevel, bool seekable)
         {
@@ -462,27 +338,22 @@ namespace System.IO.Compression.Tests
             }
 
             return ms.ToArray();
-        }
 
-        private static void AddEntry(ZipArchive archive, string name, byte[] contents, CompressionLevel level)
-        {
-            ZipArchiveEntry entry = archive.CreateEntry(name, level);
-            using Stream stream = entry.Open();
-            stream.Write(contents);
+            static void AddEntry(ZipArchive archive, string name, byte[] contents, CompressionLevel level)
+            {
+                ZipArchiveEntry entry = archive.CreateEntry(name, level);
+                using Stream stream = entry.Open();
+                stream.Write(contents);
+            }
         }
 
         private static async Task<byte[]> ReadStreamFully(Stream stream, bool async)
         {
             using MemoryStream result = new();
             if (async)
-            {
                 await stream.CopyToAsync(result);
-            }
             else
-            {
                 stream.CopyTo(result);
-            }
-
             return result.ToArray();
         }
     }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ForwardReadTests.cs
@@ -411,6 +411,22 @@ namespace System.IO.Compression.Tests
             Assert.True(archiveStream.CanRead);
         }
 
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public async Task Open_CalledTwice_Throws(bool async)
+        {
+            byte[] zipBytes = CreateZipWithEntries(CompressionLevel.Optimal, seekable: true);
+
+            using MemoryStream archiveStream = new(zipBytes);
+            using ZipArchive archive = new(archiveStream, ZipArchiveMode.ForwardRead);
+
+            ZipArchiveEntry? entry = await GetNextEntry(archive, async);
+            Assert.NotNull(entry);
+
+            using Stream first = entry.Open();
+            Assert.Throws<IOException>(() => entry.Open());
+        }
+
         // ── Sync/async dispatch helpers ──────────────────────────────────────
 
         private static async ValueTask<ZipArchiveEntry?> GetNextEntry(
@@ -458,22 +474,13 @@ namespace System.IO.Compression.Tests
         private static async Task<byte[]> ReadStreamFully(Stream stream, bool async)
         {
             using MemoryStream result = new();
-            byte[] buffer = new byte[4096];
-
-            int bytesRead;
             if (async)
             {
-                while ((bytesRead = await stream.ReadAsync(buffer)) > 0)
-                {
-                    result.Write(buffer, 0, bytesRead);
-                }
+                await stream.CopyToAsync(result);
             }
             else
             {
-                while ((bytesRead = stream.Read(buffer)) > 0)
-                {
-                    result.Write(buffer, 0, bytesRead);
-                }
+                stream.CopyTo(result);
             }
 
             return result.ToArray();


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/1550

Experiment with new Forward only reading mode for ziparchvie, that relies on the local headers of entries instead of the central directory, avoiding loading everything into memory at once