### PR TITLE
Remove stderr logging in GSSAPI initialization

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
@@ -15,14 +15,13 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
         private static partial int EnsureGssInitialized();
 
-        private static readonly int s_GssInitResult;
         private const string GssApiLibraryName = "libgssapi_krb5.so.2";
 
         static NetSecurityNative()
         {
             GssInitializer.Initialize();
 
-            if (s_GssInitResult != 0)
+            if (GssInitializer.InitResult != 0)
             {
                 throw new DllNotFoundException(GssApiLibraryName);
             }
@@ -30,14 +29,10 @@ internal static partial class Interop
 
         internal static class GssInitializer
         {
-            static GssInitializer()
-            {
-                s_GssInitResult = EnsureGssInitialized();
-            }
+            internal static readonly int InitResult = EnsureGssInitialized();
 
             internal static void Initialize()
             {
-                // No-op that exists to provide a hook for other static constructors.
             }
         }
     }

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
@@ -15,19 +15,24 @@ internal static partial class Interop
         [LibraryImport(Interop.Libraries.NetSecurityNative, EntryPoint = "NetSecurityNative_EnsureGssInitialized")]
         private static partial int EnsureGssInitialized();
 
+        private static readonly int s_GssInitResult;
+        private const string GssApiLibraryName = "libgssapi_krb5.so.2";
+
         static NetSecurityNative()
         {
             GssInitializer.Initialize();
+
+            if (s_GssInitResult != 0)
+            {
+                throw new DllNotFoundException(GssApiLibraryName);
+            }
         }
 
         internal static class GssInitializer
         {
             static GssInitializer()
             {
-                if (EnsureGssInitialized() != 0)
-                {
-                    throw new InvalidOperationException();
-                }
+                s_GssInitResult = EnsureGssInitialized();
             }
 
             internal static void Initialize()

--- a/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Net.Security.Native/Interop.NetSecurityNative.IsNtlmInstalled.cs
@@ -19,20 +19,9 @@ internal static partial class Interop
 
         static NetSecurityNative()
         {
-            GssInitializer.Initialize();
-
-            if (GssInitializer.InitResult != 0)
+            if (EnsureGssInitialized() != 0)
             {
                 throw new DllNotFoundException(GssApiLibraryName);
-            }
-        }
-
-        internal static class GssInitializer
-        {
-            internal static readonly int InitResult = EnsureGssInitialized();
-
-            internal static void Initialize()
-            {
             }
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -40,20 +40,21 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(clientOptions);
             }
-            catch (Interop.NetSecurityNative.GssApiException gex)
+            catch (Exception ex)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, gex);
-                NegotiateAuthenticationStatusCode statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
-                if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
+                NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+
+                if (ex is Interop.NetSecurityNative.GssApiException gex)
                 {
-                    statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                    statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
+                    if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                    {
+                        statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                    }
                 }
+
                 return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode);
-            }
-            catch (EntryPointNotFoundException)
-            {
-                // GSSAPI shim may not be available on some platforms (Linux Bionic)
-                return new UnsupportedNegotiateAuthenticationPal(clientOptions);
             }
         }
 
@@ -63,20 +64,21 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(serverOptions);
             }
-            catch (Interop.NetSecurityNative.GssApiException gex)
+            catch (Exception ex)
             {
-                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, gex);
-                NegotiateAuthenticationStatusCode statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
-                if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
+
+                NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+
+                if (ex is Interop.NetSecurityNative.GssApiException gex)
                 {
-                    statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                    statusCode = UnixNegotiateAuthenticationPal.GetErrorCode(gex);
+                    if (statusCode <= NegotiateAuthenticationStatusCode.GenericFailure)
+                    {
+                        statusCode = NegotiateAuthenticationStatusCode.Unsupported;
+                    }
                 }
                 return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode);
-            }
-            catch (EntryPointNotFoundException)
-            {
-                // GSSAPI shim may not be available on some platforms (Linux Bionic)
-                return new UnsupportedNegotiateAuthenticationPal(serverOptions);
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -40,7 +40,7 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(clientOptions);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Interop.NetSecurityNative.GssApiException or TypeInitializationException)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
                 NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported;
@@ -64,7 +64,7 @@ namespace System.Net
             {
                 return new UnixNegotiateAuthenticationPal(serverOptions);
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is Interop.NetSecurityNative.GssApiException or TypeInitializationException)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Error(null, ex);
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -54,7 +54,7 @@ namespace System.Net
                     }
                 }
 
-                return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode);
+                return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode, ex);
             }
         }
 
@@ -78,7 +78,7 @@ namespace System.Net
                         statusCode = NegotiateAuthenticationStatusCode.Unsupported;
                     }
                 }
-                return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode);
+                return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode, ex);
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -54,7 +54,7 @@ namespace System.Net
                     }
                 }
 
-                return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode, ex);
+                return new UnsupportedNegotiateAuthenticationPal(clientOptions, statusCode);
             }
         }
 
@@ -78,7 +78,7 @@ namespace System.Net
                         statusCode = NegotiateAuthenticationStatusCode.Unsupported;
                     }
                 }
-                return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode, ex);
+                return new UnsupportedNegotiateAuthenticationPal(serverOptions, statusCode);
             }
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
@@ -16,6 +16,7 @@ namespace System.Net
             private string _package;
             private string? _targetName;
             private NegotiateAuthenticationStatusCode _statusCode;
+            private Exception? _exception;
 
             public override bool IsAuthenticated => false;
             public override bool IsSigned => false;
@@ -26,17 +27,19 @@ namespace System.Net
             public override IIdentity RemoteIdentity => throw new InvalidOperationException();
             public override System.Security.Principal.TokenImpersonationLevel ImpersonationLevel => System.Security.Principal.TokenImpersonationLevel.Impersonation;
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported, Exception? innerException = null)
             {
                 _package = clientOptions.Package;
                 _targetName = clientOptions.TargetName;
                 _statusCode = statusCode;
+                _exception = innerException;
             }
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported, Exception? innerException = null)
             {
                 _package = serverOptions.Package;
                 _statusCode = statusCode;
+                _exception = innerException;
             }
 
             public override void Dispose()

--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unsupported.cs
@@ -16,7 +16,6 @@ namespace System.Net
             private string _package;
             private string? _targetName;
             private NegotiateAuthenticationStatusCode _statusCode;
-            private Exception? _exception;
 
             public override bool IsAuthenticated => false;
             public override bool IsSigned => false;
@@ -27,19 +26,17 @@ namespace System.Net
             public override IIdentity RemoteIdentity => throw new InvalidOperationException();
             public override System.Security.Principal.TokenImpersonationLevel ImpersonationLevel => System.Security.Principal.TokenImpersonationLevel.Impersonation;
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported, Exception? innerException = null)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationClientOptions clientOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
             {
                 _package = clientOptions.Package;
                 _targetName = clientOptions.TargetName;
                 _statusCode = statusCode;
-                _exception = innerException;
             }
 
-            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported, Exception? innerException = null)
+            public UnsupportedNegotiateAuthenticationPal(NegotiateAuthenticationServerOptions serverOptions, NegotiateAuthenticationStatusCode statusCode = NegotiateAuthenticationStatusCode.Unsupported)
             {
                 _package = serverOptions.Package;
                 _statusCode = statusCode;
-                _exception = innerException;
             }
 
             public override void Dispose()

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -135,7 +135,7 @@ static int32_t ensure_gss_shim_initialized(void)
     //   if (gss_accept_sec_context_ptr == NULL) { fprintf(stderr, "Cannot get symbol %s from %s \nError: %s\n", "gss_accept_sec_context", gss_lib_name, dlerror()); return -1; }
 #define PER_FUNCTION_BLOCK(fn) \
     fn##_ptr = (TYPEOF(fn)*)dlsym(s_gssLib, #fn); \
-    if (fn##_ptr == NULL) { fprintf(stderr, "Cannot get symbol " #fn " from %s \nError: %s\n", gss_lib_name, dlerror()); return -1; }
+    if (fn##_ptr == NULL) { fprintf(stderr, "Cannot get symbol " #fn " from %s \nError: %s\n", gss_lib_name, dlerror()); abort(); }
 
     FOR_ALL_GSS_FUNCTIONS
 #undef PER_FUNCTION_BLOCK

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -122,7 +122,7 @@ static void* volatile s_gssLib = NULL;
 static int32_t ensure_gss_shim_initialized(void)
 {
     void* lib = dlopen(gss_lib_name, RTLD_LAZY);
-    if (lib == NULL) { fprintf(stderr, "Cannot load library %s \nError: %s\n", gss_lib_name, dlerror()); return -1; }
+    if (lib == NULL) { return -1; }
 
     // check is someone else has opened and published s_gssLib already
     if (!pal_atomic_cas_ptr(&s_gssLib, lib, NULL))

--- a/src/native/libs/System.Net.Security.Native/pal_gssapi.c
+++ b/src/native/libs/System.Net.Security.Native/pal_gssapi.c
@@ -130,9 +130,7 @@ static int32_t ensure_gss_shim_initialized(void)
         dlclose(lib);
     }
 
-    // initialize indirection pointers for all functions, like:
-    //   gss_accept_sec_context_ptr = (TYPEOF(gss_accept_sec_context)*)dlsym(s_gssLib, "gss_accept_sec_context");
-    //   if (gss_accept_sec_context_ptr == NULL) { fprintf(stderr, "Cannot get symbol %s from %s \nError: %s\n", "gss_accept_sec_context", gss_lib_name, dlerror()); return -1; }
+    // initialize indirection pointers for all functions
 #define PER_FUNCTION_BLOCK(fn) \
     fn##_ptr = (TYPEOF(fn)*)dlsym(s_gssLib, #fn); \
     if (fn##_ptr == NULL) { fprintf(stderr, "Cannot get symbol " #fn " from %s \nError: %s\n", gss_lib_name, dlerror()); abort(); }


### PR DESCRIPTION
Eliminate stderr logging in the GSSAPI initialization process to streamline error handling and improve code clarity. Adjust error handling to use exceptions instead of logging directly to stderr.

Replaces #126300.
Closes #126251.
