### PR TITLE
Use the paths feature in global.json to point to our local .NET SDK.

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,7 +2,12 @@
   "sdk": {
     "version": "11.0.100-preview.3.26170.106",
     "allowPrerelease": true,
-    "rollForward": "major"
+    "rollForward": "major",
+    "paths": [
+      ".dotnet",
+      "$host$"
+    ],
+    "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
   },
   "tools": {
     "dotnet": "11.0.100-preview.3.26170.106"

--- a/global.json
+++ b/global.json
@@ -7,7 +7,7 @@
       ".dotnet",
       "$host$"
     ],
-    "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.cmd/sh to install it."
+    "errorMessage": "The required .NET SDK wasn't found. Please run ./eng/common/dotnet.sh (Unix) or eng\\common\\dotnet.cmd (Windows) to install it."
   },
   "tools": {
     "dotnet": "11.0.100-preview.3.26170.106"

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -110,7 +110,7 @@
       <Output TaskParameter="ExitCode" PropertyName="_DotNetVersionExitCode" />
     </Exec>
 
-    <!-- If `dotnet -version` failed, then run it again, so we can surface the output as *Errors*.
+    <!-- If `dotnet --version` failed, then run it again, so we can surface the output as *Errors*.
          This allows the errors to show up correctly, versus trying to use the output lines with
          the Error task -->
     <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*"

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -99,7 +99,13 @@
       <_DotNetVersionCommand>$(_DotNetPath) --version</_DotNetVersionCommand>
     </PropertyGroup>
 
-    <Exec Command="$(_DotNetVersionCommand)" ConsoleToMsBuild="true" StandardOutputImportance="Low" IgnoreExitCode="true">
+    <!-- Write an empty global.json so the SDK resolver uses the SDK in this directory
+         instead of walking up to the repo root's global.json which has relative "paths"
+         entries that would resolve to the wrong SDK. -->
+    <WriteLinesToFile File="$(_SdkWithNoWorkloadPath)global.json" Lines="{}" Overwrite="true" />
+
+    <Exec Command="$(_DotNetVersionCommand)" ConsoleToMsBuild="true" StandardOutputImportance="Low" IgnoreExitCode="true"
+          WorkingDirectory="$(_SdkWithNoWorkloadPath)">
       <Output TaskParameter="ConsoleOutput" PropertyName="_DotNetVersionOutput" />
       <Output TaskParameter="ExitCode" PropertyName="_DotNetVersionExitCode" />
     </Exec>
@@ -107,7 +113,8 @@
     <!-- If `dotnet -version` failed, then run it again, so we can surface the output as *Errors*.
          This allows the errors to show up correctly, versus trying to use the output lines with
          the Error task -->
-    <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*" />
+    <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*"
+          WorkingDirectory="$(_SdkWithNoWorkloadPath)" />
 
     <PropertyGroup>
       <SdkBandVersionForWorkload_ComputedFromInstaller>$(SdkBandVersion)$([System.Text.RegularExpressions.Regex]::Match($(_DotNetVersionOutput), `-(?!rtm|release)[A-z]*[\.]*\d*`))</SdkBandVersionForWorkload_ComputedFromInstaller>
@@ -129,7 +136,8 @@
 
   <Target Name="_FirstDotNetRun">
     <!-- info`, or version don't trigger workload integrity check -->
-    <Exec Command="$(_DotNetPath) workload list" ConsoleToMsBuild="true" StandardOutputImportance="Low" />
+    <Exec Command="$(_DotNetPath) workload list" ConsoleToMsBuild="true" StandardOutputImportance="Low"
+          WorkingDirectory="$(_SdkWithNoWorkloadPath)" />
   </Target>
 
   <Target Name="_SetPackageVersionForWorkloadsTesting">

--- a/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
+++ b/src/mono/nuget/Microsoft.NET.Runtime.WorkloadTesting.Internal/Sdk/WorkloadTesting.Core.targets
@@ -110,7 +110,7 @@
       <Output TaskParameter="ExitCode" PropertyName="_DotNetVersionExitCode" />
     </Exec>
 
-    <!-- If `dotnet --version` failed, then run it again, so we can surface the output as *Errors*.
+    <!-- If `$(_DotNetVersionCommand)` failed, then run it again, so we can surface the output as *Errors*.
          This allows the errors to show up correctly, versus trying to use the output lines with
          the Error task -->
     <Exec Condition="$(_DotNetVersionExitCode) != '0'" Command="$(_DotNetVersionCommand)" CustomErrorRegularExpression=".*"

--- a/src/mono/wasi/Wasi.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasi/Wasi.Build.Tests/BuildTestBase.cs
@@ -148,6 +148,12 @@ namespace Wasm.Build.Tests
         {
             targetFramework ??= DefaultTargetFramework;
             Directory.CreateDirectory(dir);
+
+            // Create an empty global.json so the SDK resolver doesn't walk up
+            // to the repo root's global.json which may contain relative "paths"
+            // entries that don't apply in the test directory.
+            File.WriteAllText(Path.Combine(dir, "global.json"), "{}");
+
             File.WriteAllText(Path.Combine(dir, "Directory.Build.props"), s_buildEnv.DirectoryBuildPropsContents);
             File.WriteAllText(Path.Combine(dir, "Directory.Build.targets"), s_buildEnv.DirectoryBuildTargetsContents);
             File.Copy(BuildEnvironment.WasmOverridePacksTargetsPath, Path.Combine(dir, Path.GetFileName(BuildEnvironment.WasmOverridePacksTargetsPath)), overwrite: true);

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/BlazorWasmTestBase.cs
@@ -90,6 +90,11 @@ public abstract class BlazorWasmTestBase : WasmTemplateTestsBase
             Directory.Delete(_projectDir, recursive: true);
         Directory.CreateDirectory(_projectDir);
 
+        // Create an empty global.json so the SDK resolver doesn't walk up
+        // to the repo root's global.json which may contain relative "paths"
+        // entries that don't apply in the test directory.
+        File.WriteAllText(Path.Combine(_projectDir, "global.json"), "{}");
+
         File.WriteAllText(Path.Combine(_projectDir, "nuget.config"),
                             GetNuGetConfigWithLocalPackagesPath(
                                         GetNuGetConfigPath(),

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -240,6 +240,12 @@ namespace Wasm.Build.Tests
             if (Directory.Exists(dir))
                 Directory.Delete(dir, recursive: true);
             Directory.CreateDirectory(dir);
+
+            // Create an empty global.json so the SDK resolver doesn't walk up
+            // to the repo root's global.json which may contain relative "paths"
+            // entries that don't apply in the test directory.
+            File.WriteAllText(Path.Combine(dir, "global.json"), "{}");
+
             File.WriteAllText(Path.Combine(dir, "Directory.Build.props"), s_buildEnv.DirectoryBuildPropsContents);
             File.WriteAllText(Path.Combine(dir, "Directory.Build.targets"), s_buildEnv.DirectoryBuildTargetsContents);
             if (UseWBTOverridePackTargets)

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -65,13 +65,6 @@ namespace Microsoft.Workload.Build.Tasks
             if (Directory.Exists(_tempDir))
                 Directory.Delete(_tempDir, recursive: true);
             Directory.CreateDirectory(_tempDir);
-
-            // Create an empty global.json so the SDK resolver doesn't walk up to a
-            // parent global.json that may contain relative "paths" entries (e.g. ".dotnet").
-            // Without this, the workload install invokes dotnet from a different SDK directory
-            // but the resolver picks up the wrong SDK from the repo-local .dotnet directory.
-            File.WriteAllText(Path.Combine(_tempDir, "global.json"), "{}");
-
             _nugetCachePath = Path.Combine(_tempDir, "nuget-cache");
             if (SkipTempDirectoryCleanup)
             {
@@ -80,6 +73,12 @@ namespace Microsoft.Workload.Build.Tasks
 
             try
             {
+                // Create an empty global.json so the SDK resolver doesn't walk up to a
+                // parent global.json that may contain relative "paths" entries (e.g. ".dotnet").
+                // Without this, the workload install invokes dotnet from a different SDK directory
+                // but the resolver picks up the wrong SDK from the repo-local .dotnet directory.
+                File.WriteAllText(Path.Combine(_tempDir, "global.json"), "{}");
+
                 if (!Directory.Exists(SdkWithNoWorkloadInstalledPath))
                     throw new LogAsErrorException($"Cannot find {nameof(SdkWithNoWorkloadInstalledPath)}={SdkWithNoWorkloadInstalledPath}");
 

--- a/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
+++ b/src/tasks/WorkloadBuildTasks/InstallWorkloadFromArtifacts.cs
@@ -65,6 +65,13 @@ namespace Microsoft.Workload.Build.Tasks
             if (Directory.Exists(_tempDir))
                 Directory.Delete(_tempDir, recursive: true);
             Directory.CreateDirectory(_tempDir);
+
+            // Create an empty global.json so the SDK resolver doesn't walk up to a
+            // parent global.json that may contain relative "paths" entries (e.g. ".dotnet").
+            // Without this, the workload install invokes dotnet from a different SDK directory
+            // but the resolver picks up the wrong SDK from the repo-local .dotnet directory.
+            File.WriteAllText(Path.Combine(_tempDir, "global.json"), "{}");
+
             _nugetCachePath = Path.Combine(_tempDir, "nuget-cache");
             if (SkipTempDirectoryCleanup)
             {


### PR DESCRIPTION
As C# Dev Kit improves their experience, the fact that we don't have this makes it incresingly frustrating to work with in the runtime repo. Let's use the feature we built for this specific case.