### PR TITLE
Skip Start_Disposed_ThrowsObjectDisposedException on Apple mobile platforms

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -1792,6 +1792,7 @@ namespace System.Diagnostics.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "Process.Start() is not supported on iOS, tvOS, and MacCatalyst.")]
         public void Start_Disposed_ThrowsObjectDisposedException()
         {
             var process = new Process();


### PR DESCRIPTION
## Fix

Adds `[SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]` to `Start_Disposed_ThrowsObjectDisposedException`.

## Why

`Process.Start()` on iOS/tvOS/MacCatalyst throws `PlatformNotSupportedException` (process launching is unsupported) **before** checking disposal state. The test expects `ObjectDisposedException` which never fires, causing a deterministic failure across **7 legs** in every `runtime-extra-platforms` rolling build.

This follows the same `[SkipOnPlatform]` pattern used by 20+ other tests in the same file.

Fixes #126654