### PR TITLE
[Wasm RyuJit] fix funclet prolog and epilog codegen

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -608,7 +608,7 @@ protected:
     void genReserveFuncletProlog(BasicBlock* block);
     void genReserveFuncletEpilog(BasicBlock* block);
     void genFuncletProlog(BasicBlock* block);
-    void genFuncletEpilog();
+    void genFuncletEpilog(BasicBlock* block);
     void genCaptureFuncletPrologEpilogInfo();
 
     void genUpdateCurrentFunclet(BasicBlock* block);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -2371,7 +2371,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  Generates code for an EH funclet epilog.
  */
 
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -1495,7 +1495,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  See the description of frame shapes at genFuncletProlog().
  */
 
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2012,18 +2012,20 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
         JITDUMPEXEC(JitR2RUnsupportedRange.Dump());
         implReadyToRunUnsupported();
     }
+#endif // defined(TARGET_WASM)
+#endif // DEBUG
 
+#if defined(TARGET_WASM)
     // Also fail at this point for any method with funclets, since the Wasm we produce
     // for such methods requires post-processing by the host before it can be validated.
-    // Remove this once the host can do the processing.
+    // TODO-WASM: Remove this once the host can do the processing.
     //
     if ((JitConfig.JitWasmFunclets() == 0) && (m_compiler->compFuncCount() > 1))
     {
-        JITDUMP("Failing R2R codegen because method has funclets.\n", m_compiler->compFuncCount());
+        JITDUMP("Failing R2R codegen because method has funclets.\n");
         implReadyToRunUnsupported();
     }
-#endif // defined(TARGET_WASM)
-#endif // DEBUG
+#endif
 }
 
 //----------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2012,6 +2012,16 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
         JITDUMPEXEC(JitR2RUnsupportedRange.Dump());
         implReadyToRunUnsupported();
     }
+
+    // Also fail at this point for any method with funclets, since the Wasm we produce
+    // for such methods requires post-processing by the host before it can be validated.
+    // Remove this once the host can do the processing.
+    //
+    if ((JitConfig.JitWasmFunclets() == 0) && (m_compiler->compFuncCount() > 1))
+    {
+        JITDUMP("Failing R2R codegen because method has funclets.\n", m_compiler->compFuncCount());
+        implReadyToRunUnsupported();
+    }
 #endif // defined(TARGET_WASM)
 #endif // DEBUG
 }

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -420,8 +420,6 @@ void CodeGen::genCodeForBlock(BasicBlock* block)
         GetEmitter()->emitSetFirstColdIGCookie(block->bbEmitCookie);
     }
 
-    genEmitStartBlock(block);
-
     // Both stacks are always empty on entry to a basic block.
     assert(genStackLevel == 0);
     genAdjustStackLevel(block);
@@ -443,6 +441,8 @@ void CodeGen::genCodeForBlock(BasicBlock* block)
         genUpdateCurrentFunclet(block);
         genReserveFuncletProlog(block);
     }
+
+    genEmitStartBlock(block);
 
     // Clear compCurStmt and compCurLifeTree.
     m_compiler->compCurStmt     = nullptr;

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -475,7 +475,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  Generates code for an EH funclet epilog.
  */
 
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -463,7 +463,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *
  *  See the description of frame shapes at genFuncletProlog().
  */
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -311,10 +311,19 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 //------------------------------------------------------------------------
 // genFuncletEpilog: codegen for funclet epilogs.
 //
-// For Wasm, funclet epilogs are empty
+// Arguments:
+//   block - funclet epilog block
 //
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* block)
 {
+    if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
+    {
+        instGen(INS_end);
+    }
+    else
+    {
+        instGen(INS_return);
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -316,6 +316,8 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 //
 void CodeGen::genFuncletEpilog(BasicBlock* block)
 {
+    ScopedSetVariable<bool> _setGeneratingEpilog(&m_compiler->compGeneratingEpilog, true);
+
     if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
     {
         instGen(INS_end);

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10865,7 +10865,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  Note that we don't do anything with unwind codes, because AMD64 only cares about unwind codes for the prolog.
  */
 
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* block)
 {
 #ifdef DEBUG
     if (verbose)
@@ -10992,7 +10992,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  Generates code for an EH funclet epilog.
  */
 
-void CodeGen::genFuncletEpilog()
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10865,7 +10865,7 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
  *  Note that we don't do anything with unwind codes, because AMD64 only cares about unwind codes for the prolog.
  */
 
-void CodeGen::genFuncletEpilog(BasicBlock* block)
+void CodeGen::genFuncletEpilog(BasicBlock* /* block */)
 {
 #ifdef DEBUG
     if (verbose)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -2226,7 +2226,7 @@ void emitter::emitGeneratePrologEpilog()
             case IGPT_FUNCLET_EPILOG:
                 INDEBUG(++funcletEpilogCnt);
                 emitBegFuncletEpilog(igPh);
-                codeGen->genFuncletEpilog();
+                codeGen->genFuncletEpilog(igPhBB);
                 emitEndFuncletEpilog();
                 break;
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -883,7 +883,7 @@ CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
 // Useful for bypassing methods that compile cleanly but have invalid Wasm codegen.
 CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange")
 // Enable processing methods with funclets.
-CONFIG_INTEGER(JitWasmFunclets, "JitWasmFunclets", 0)
+RELEASE_CONFIG_INTEGER(JitWasmFunclets, "JitWasmFunclets", 0)
 #endif // defined(TARGET_WASM)
 
 // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -882,6 +882,8 @@ CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
 // Specify methods that will fail with R2R unsupported after codegen.
 // Useful for bypassing methods that compile cleanly but have invalid Wasm codegen.
 CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange")
+// Enable processing methods with funclets.
+CONFIG_INTEGER(JitWasmFunclets, "JitWasmFunclets", 0)
 #endif // defined(TARGET_WASM)
 
 // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -44,6 +44,7 @@ public:
 #ifdef TARGET_WASM
             MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
                                  // a dedicated register (WASM local), for multiple uses.
+            Collected = 0x10,    // Set by the RA on nodes that have had their references collected.
 #endif                           // TARGET_WASM
         };
     };

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -44,7 +44,6 @@ public:
 #ifdef TARGET_WASM
             MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
                                  // a dedicated register (WASM local), for multiple uses.
-            Collected = 0x10,    // Set by the RA on nodes that have had their references collected.
 #endif                           // TARGET_WASM
         };
     };

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -716,11 +716,14 @@ void WasmRegAlloc::CollectReference(GenTree* node)
     // We may make multiple collection calls for the same node.
     // We only want to collect it once.
     //
-    if ((node->gtLIRFlags & LIR::Flags::Collected) != 0)
+    if (data->m_lastVirtualRegRefsCount > 0)
     {
-        return;
+        assert(refs != nullptr);
+        if (node == refs->Nodes[data->m_lastVirtualRegRefsCount - 1])
+        {
+            return;
+        }
     }
-    node->gtLIRFlags |= LIR::Flags::Collected;
 
     if (refs == nullptr)
     {
@@ -774,6 +777,8 @@ void WasmRegAlloc::RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node)
     regNumber reg = AllocateTemporaryRegister(node->TypeGet());
     assert((node->GetRegNum() == REG_NA) && "Trying to double-assign a temporary register");
     node->SetRegNum(reg);
+
+    CollectReference(node);
 }
 
 //------------------------------------------------------------------------
@@ -796,7 +801,6 @@ void WasmRegAlloc::ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const
 
     regNumber reg = ReleaseTemporaryRegister(genActualType(operand));
     assert((reg == operand->GetRegNum()) && "Temporary reg being consumed out of order");
-    CollectReference(operand);
 
     operand->gtLIRFlags &= ~LIR::Flags::MultiplyUsed;
     JITDUMP("Consumed a temporary reg for [%06u]: %s\n", Compiler::dspTreeID(operand), reason);

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -713,17 +713,14 @@ void WasmRegAlloc::CollectReference(GenTree* node)
     PerFuncletData* const data = m_perFuncletData[m_currentFunclet];
     VirtualRegReferences* refs = data->m_virtualRegRefs;
 
-    // We may make multiple consecutive collection calls for the same node.
+    // We may make multiple collection calls for the same node.
     // We only want to collect it once.
     //
-    if (data->m_lastVirtualRegRefsCount > 0)
+    if ((node->gtLIRFlags & LIR::Flags::Collected) != 0)
     {
-        assert(refs != nullptr);
-        if (node == refs->Nodes[data->m_lastVirtualRegRefsCount - 1])
-        {
-            return;
-        }
+        return;
     }
+    node->gtLIRFlags |= LIR::Flags::Collected;
 
     if (refs == nullptr)
     {
@@ -819,6 +816,8 @@ void WasmRegAlloc::ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const
 //
 regNumber WasmRegAlloc::RequestInternalRegister(GenTree* node, var_types type)
 {
+    JITDUMP("Requesting internal %s register for [%06u]\n", varTypeName(type), Compiler::dspTreeID(node));
+
     regNumber reg = AllocateTemporaryRegister(type);
     m_codeGen->internalRegisters.Add(node, reg);
     CollectReference(node);


### PR DESCRIPTION
Defer calling genEmitStartBlock until after we've set up the funclet prolog IG. Pass the BasicBlock back from emitter to codegen for the funclet epilog generation since epilog codegen is position dependent.

Also, add an on-by default R2R fail-over at the end of codegen for methods with funclets, since the Wasm for method with funclets can't be validated. We can remove this once the JIT host extracts the funclets as separate functions. You can override this via `JitWasmFunclets=1`.

Also includes a fix for https://github.com/dotnet/runtime/issues/125756#issuecomment-4210126354, which was causing node references to be collected more than once; this would corrupt the node's internal registers.