### PR TITLE
Update THIRD-PARTY-NOTICES.TXT with opentelemetry license

### DIFF
--- a/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
+++ b/src/installer/pkg/THIRD-PARTY-NOTICES.TXT
@@ -1449,3 +1449,20 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+License for opentelemetry-dotnet (https://github.com/open-telemetry/opentelemetry-dotnet)
+--------------------------------------
+
+   Copyright (c) The OpenTelemetry Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
Related: https://github.com/dotnet/sdk/pull/53181

## Summary

In the SDK repo, we've transitioned to [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet) (OTel) for providing telemetry in the dotnet CLI. I was told that we need to make the TPN in the dotnet installer have the information for OTel. I believe this is the right TPN file to update.