### PR TITLE
Add `WASM_MEMORY_ADDR_REL_LEB` Relocation Type

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -928,7 +928,7 @@ enum class CorInfoReloc
                                            // e.g. in R2R scenarios as an offset from __image_base
     WASM_TYPE_INDEX_LEB,                 // Wasm: a type index encoded as a 5-byte varuint32, e.g. the type immediate in a call_indirect.
     WASM_GLOBAL_INDEX_LEB,               // Wasm: a global index encoded as a 5-byte varuint32, e.g. the index immediate in a get_global.
-    WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of a load or store instruction,
+    WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
                                            // e.g. in R2R scenarios as an offset from __image_base
 };
 

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -928,6 +928,8 @@ enum class CorInfoReloc
                                            // e.g. in R2R scenarios as an offset from __image_base
     WASM_TYPE_INDEX_LEB,                 // Wasm: a type index encoded as a 5-byte varuint32, e.g. the type immediate in a call_indirect.
     WASM_GLOBAL_INDEX_LEB,               // Wasm: a global index encoded as a 5-byte varuint32, e.g. the index immediate in a get_global.
+    WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of a load or store instruction,
+                                           // e.g. in R2R scenarios as an offset from __image_base
 };
 
 enum CorInfoGCType

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* d4aa533f-231b-4bd3-9d4e-238f88b337cb */
-    0xd4aa533f,
-    0x231b,
-    0x4bd3,
-    {0x9d, 0x4e, 0x23, 0x8f, 0x88, 0xb3, 0x37, 0xcb}
+constexpr GUID JITEEVersionIdentifier = { /* 5fad64ab-f0ea-4c4d-b67a-b3a47ef0b321 */
+    0x5fad64ab,
+    0xf0ea,
+    0x4c4d,
+    {0xb6, 0x7a, 0xb3, 0xa4, 0x7e, 0xf0, 0xb3, 0x21}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -59,7 +59,7 @@ namespace ILCompiler.DependencyAnalysis
 
         WASM_TABLE_INDEX_I32       = 0x207,  // Wasm: a table index encoded as a 4-byte uint32, e.g. for storing the "address" of a function into linear memory
         WASM_TABLE_INDEX_I64       = 0x208,  // Wasm: a table index encoded as a 8-byte uint64, e.g. for storing the "address" of a function into linear memory
-        WASM_MEMORY_ADDR_REL_LEB   = 0x209,  // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of a load or store instruction,
+        WASM_MEMORY_ADDR_REL_LEB   = 0x209,  // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
                                                        // e.g. in R2R scenarios as an offset from __image_base
 
         //

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -59,6 +59,8 @@ namespace ILCompiler.DependencyAnalysis
 
         WASM_TABLE_INDEX_I32       = 0x207,  // Wasm: a table index encoded as a 4-byte uint32, e.g. for storing the "address" of a function into linear memory
         WASM_TABLE_INDEX_I64       = 0x208,  // Wasm: a table index encoded as a 8-byte uint64, e.g. for storing the "address" of a function into linear memory
+        WASM_MEMORY_ADDR_REL_LEB   = 0x209,  // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of a load or store instruction,
+                                                       // e.g. in R2R scenarios as an offset from __image_base
 
         //
         // Relocation operators related to TLS access
@@ -656,6 +658,7 @@ namespace ILCompiler.DependencyAnalysis
                 case RelocType.WASM_GLOBAL_INDEX_LEB:
                 case RelocType.WASM_FUNCTION_INDEX_LEB:
                 case RelocType.WASM_MEMORY_ADDR_LEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                     DwarfHelper.WritePaddedULEB128(new Span<byte>((byte*)location, WASM_PADDED_RELOC_SIZE_32), checked((ulong)value));
                     return;
 
@@ -710,6 +713,7 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.WASM_GLOBAL_INDEX_LEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_MEMORY_ADDR_LEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_MEMORY_ADDR_SLEB => WASM_PADDED_RELOC_SIZE_32,
+                RelocType.WASM_MEMORY_ADDR_REL_LEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_MEMORY_ADDR_REL_SLEB => WASM_PADDED_RELOC_SIZE_32,
                 RelocType.WASM_TABLE_INDEX_I32 => 4,
                 RelocType.WASM_TABLE_INDEX_I64 => 8,
@@ -783,6 +787,7 @@ namespace ILCompiler.DependencyAnalysis
                     return 0;
 
                 case RelocType.WASM_MEMORY_ADDR_LEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                     return checked((long)DwarfHelper.ReadULEB128(new ReadOnlySpan<byte>(location, WASM_PADDED_RELOC_SIZE_32)));
 
                 case RelocType.WASM_MEMORY_ADDR_SLEB:

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -52,7 +52,7 @@ namespace ILCompiler.DependencyAnalysis
         WASM_MEMORY_ADDR_SLEB      = 0x203,  // Wasm: a linear memory index encoded as a 5-byte varint32. Used for the immediate argument of a i32.const instruction,
                                                        //  e.g. taking the address of a C++ global.
         WASM_MEMORY_ADDR_REL_SLEB  = 0x204,   // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of an i32.const instruction,
-                                                       // e.g. in R2R scenarios, encoding an offset from __image_base
+                                                       // e.g. in R2R scenarios, encoding an offset from $imageBase
         WASM_TYPE_INDEX_LEB        = 0x205,  // Wasm: a type index encoded as a 5-byte varuint32, e.g. the type immediate in a call_indirect.
 
         WASM_GLOBAL_INDEX_LEB      = 0x206,  // Wasm: a global index encoded as a 5-byte varuint32, e.g. the index immediate in a get_global.
@@ -60,7 +60,7 @@ namespace ILCompiler.DependencyAnalysis
         WASM_TABLE_INDEX_I32       = 0x207,  // Wasm: a table index encoded as a 4-byte uint32, e.g. for storing the "address" of a function into linear memory
         WASM_TABLE_INDEX_I64       = 0x208,  // Wasm: a table index encoded as a 8-byte uint64, e.g. for storing the "address" of a function into linear memory
         WASM_MEMORY_ADDR_REL_LEB   = 0x209,  // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
-                                                       // e.g. in R2R scenarios as an offset from __image_base
+                                                       // e.g. in R2R scenarios as an offset from $imageBase
 
         //
         // Relocation operators related to TLS access

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -295,12 +295,81 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         }
     }
 
-    class WasmMemoryArgInstruction : WasmExpr
+    struct WasmEncodableULong : IWasmEncodable
+    {
+        private ulong _value;
+        public WasmEncodableULong(ulong value)
+        {
+            _value = value;
+        }
+        public int EncodeSize()
+        {
+            return (int)DwarfHelper.SizeOfULEB128(_value);
+        }
+        public int Encode(Span<byte> buffer)
+        {
+            return DwarfHelper.WriteULEB128(buffer, _value);
+        }
+        public int EncodeRelocationCount() => 0;
+        public int EncodeRelocations(Span<Relocation> buffer) => 0;
+    }
+
+    struct WasmEncodableSymbol : IWasmEncodable
+    {
+        private ISymbolNode _symbol;
+        private RelocType _relocType;
+
+        public WasmEncodableSymbol(ISymbolNode symbol, RelocType relocType)
+        {
+            _symbol = symbol;
+            _relocType = relocType;
+        }
+
+        public int EncodeSize()
+        {
+            return Relocation.GetSize(_relocType);
+        }
+
+        public int Encode(Span<byte> buffer)
+        {
+            // The actual value is not encoded into the buffer, instead a relocation is emitted for the symbol
+            int relocSize = Relocation.GetSize(_relocType);
+            switch (_relocType)
+            {
+                case RelocType.WASM_FUNCTION_INDEX_LEB:
+                case RelocType.WASM_MEMORY_ADDR_LEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_LEB:
+                case RelocType.WASM_TYPE_INDEX_LEB:
+                case RelocType.WASM_GLOBAL_INDEX_LEB:
+                    DwarfHelper.WritePaddedULEB128(buffer, 0);
+                    break;
+
+                case RelocType.WASM_TABLE_INDEX_SLEB:
+                case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
+                    DwarfHelper.WritePaddedSLEB128(buffer, 0);
+                    break;
+
+                default:
+                    throw new Exception($"Unknown WASM reloc type : {_relocType}");
+            }
+            return relocSize;
+        }
+
+        public int EncodeRelocationCount() => 1;
+
+        public int EncodeRelocations(Span<Relocation> buffer)
+        {
+            buffer[0] = new Relocation(_relocType, 0, _symbol);
+            return 1;
+        }
+    }
+
+    class WasmMemoryArgInstruction<TOffset> : WasmExpr where TOffset : IWasmEncodable
     {
         readonly uint _align;
-        readonly ulong _offset;
+        readonly TOffset _offset;
 
-        public WasmMemoryArgInstruction(WasmExprKind kind, uint align, ulong offset) : base(kind)
+        public WasmMemoryArgInstruction(WasmExprKind kind, uint align, TOffset offset) : base(kind)
         {
             switch (align)
             {
@@ -317,7 +386,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
         public override int EncodeSize()
         {
-            uint valSize = DwarfHelper.SizeOfULEB128(_align) + DwarfHelper.SizeOfULEB128(_offset);
+            int valSize = (int)DwarfHelper.SizeOfULEB128(_align) + _offset.EncodeSize();
             return base.EncodeSize() + (int)valSize;
         }
 
@@ -325,8 +394,16 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         {
             int pos = base.Encode(buffer);
             pos += DwarfHelper.WriteULEB128(buffer.Slice(pos), _align);
-            pos += DwarfHelper.WriteULEB128(buffer.Slice(pos), _offset);
+            pos += _offset.Encode(buffer.Slice(pos));
             return pos;
+        }
+        public override int EncodeRelocationCount() => _offset.EncodeRelocationCount();
+        public override int EncodeRelocations(Span<Relocation> buffer)
+        {
+            int relocsEncoded = _offset.EncodeRelocations(buffer);
+            if (relocsEncoded > 0)
+                WasmExpr.OffsetRelocationsByOffset(buffer.Slice(0, relocsEncoded), base.EncodeSize() + (int)DwarfHelper.SizeOfULEB128(_align));
+            return relocsEncoded;
         }
     }
 
@@ -399,46 +476,27 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
     sealed class WasmLEBConstantReloc : WasmExpr
     {
-        readonly ISymbolNode _symbol;
-        readonly RelocType _relocType;
+        readonly WasmEncodableSymbol _symbol;
 
         public WasmLEBConstantReloc(WasmExprKind kind, ISymbolNode symbol, RelocType relocType) : base(kind)
         {
-            _symbol = symbol;
-            _relocType = relocType;
+            _symbol = new WasmEncodableSymbol(symbol, relocType);
         }
-        public override int EncodeSize() => base.EncodeSize() + Relocation.GetSize(_relocType);
+        public override int EncodeSize() => base.EncodeSize() + _symbol.EncodeSize();
         public override int Encode(Span<byte> buffer)
         {
             int pos = base.Encode(buffer);
-            int relocSize = Relocation.GetSize(_relocType);
-            switch (_relocType)
-            {
-                case RelocType.WASM_FUNCTION_INDEX_LEB:
-                case RelocType.WASM_MEMORY_ADDR_LEB:
-                case RelocType.WASM_TYPE_INDEX_LEB:
-                case RelocType.WASM_GLOBAL_INDEX_LEB:
-                    DwarfHelper.WritePaddedULEB128(buffer.Slice(pos, relocSize), 0);
-                    break;
-
-                case RelocType.WASM_TABLE_INDEX_SLEB:
-                case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
-                    DwarfHelper.WritePaddedSLEB128(buffer.Slice(pos, relocSize), 0);
-                    break;
-
-                default:
-                    throw new Exception($"Unknown WASM reloc type : {_relocType}");
-            }
-
-            pos += relocSize;
+            pos += _symbol.Encode(buffer.Slice(pos));
             return pos;
         }
 
-        public override int EncodeRelocationCount() => 1;
+        public override int EncodeRelocationCount() => _symbol.EncodeRelocationCount();
         public override int EncodeRelocations(Span<Relocation> buffer)
         {
-            buffer[0] = new Relocation(_relocType, base.EncodeSize(), _symbol);
-            return 1;
+            int relocsEncoded = _symbol.EncodeRelocations(buffer);
+            if (relocsEncoded > 0)
+                WasmExpr.OffsetRelocationsByOffset(buffer.Slice(0, relocsEncoded), base.EncodeSize());
+            return relocsEncoded;
         }
     }
 
@@ -694,32 +752,33 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         public static WasmExpr Add => new WasmBinaryExpr(WasmExprKind.I32Add);
         public static WasmExpr Sub => new WasmBinaryExpr(WasmExprKind.I32Sub);
         public static WasmExpr Ge_s => new WasmBinaryExpr(WasmExprKind.I32Ge_s);
-        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.I32Load, 4, offset);
-        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.I32Store, 4, offset);
+        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I32Load, 4, new WasmEncodableULong(offset));
+        public static WasmExpr LoadWithRVAOffset(ISymbolNode symbolNode) => new WasmMemoryArgInstruction<WasmEncodableSymbol>(WasmExprKind.I32Load, 4, new WasmEncodableSymbol(symbolNode, RelocType.WASM_MEMORY_ADDR_REL_LEB));
+        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I32Store, 4, new WasmEncodableULong(offset));
     }
 
     static class I64
     {
-        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.I64Load, 8, offset);
-        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.I64Store, 8, offset);
+        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I64Load, 8, new WasmEncodableULong(offset));
+        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.I64Store, 8, new WasmEncodableULong(offset));
     }
 
     static class F32
     {
-        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.F32Load, 4, offset);
-        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.F32Store, 4, offset);
+        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F32Load, 4, new WasmEncodableULong(offset));
+        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F32Store, 4, new WasmEncodableULong(offset));
     }
 
     static class F64
     {
-        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.F64Load, 8, offset);
-        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.F64Store, 8, offset);
+        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F64Load, 8, new WasmEncodableULong(offset));
+        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.F64Store, 8, new WasmEncodableULong(offset));
     }
 
     static class V128
     {
-        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.V128Load, 16, offset);
-        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction(WasmExprKind.V128Store, 16, offset);
+        public static WasmExpr Load(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.V128Load, 16, new WasmEncodableULong(offset));
+        public static WasmExpr Store(ulong offset) => new WasmMemoryArgInstruction<WasmEncodableULong>(WasmExprKind.V128Store, 16, new WasmEncodableULong(offset));
     }
 
     static class Memory

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -334,6 +334,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
         {
             // The actual value is not encoded into the buffer, instead a relocation is emitted for the symbol
             int relocSize = Relocation.GetSize(_relocType);
+            Debug.Assert(buffer.Length >= relocSize);
             switch (_relocType)
             {
                 case RelocType.WASM_FUNCTION_INDEX_LEB:
@@ -341,12 +342,12 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
                 case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                 case RelocType.WASM_TYPE_INDEX_LEB:
                 case RelocType.WASM_GLOBAL_INDEX_LEB:
-                    DwarfHelper.WritePaddedULEB128(buffer, 0);
+                    DwarfHelper.WritePaddedULEB128(buffer.Slice(0, relocSize), 0);
                     break;
 
                 case RelocType.WASM_TABLE_INDEX_SLEB:
                 case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
-                    DwarfHelper.WritePaddedSLEB128(buffer, 0);
+                    DwarfHelper.WritePaddedSLEB128(buffer.Slice(0, relocSize), 0);
                     break;
 
                 default:
@@ -367,7 +368,7 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
     class WasmMemoryArgInstruction<TOffset> : WasmExpr where TOffset : IWasmEncodable
     {
         readonly uint _align;
-        readonly TOffset _offset;
+        TOffset _offset;
 
         public WasmMemoryArgInstruction(WasmExprKind kind, uint align, TOffset offset) : base(kind)
         {

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -946,7 +946,7 @@ namespace ILCompiler.ObjectWriter
                         case RelocType.WASM_MEMORY_ADDR_REL_SLEB:
                         {
                             // These relocs should be for cases of the form:
-                            //  global.get __image_base
+                            //  global.get $imageBase
                             //  i32.const <reloc>
                             //  i32.add
                             //  i32.load 0
@@ -964,7 +964,7 @@ namespace ILCompiler.ObjectWriter
                         case RelocType.WASM_MEMORY_ADDR_REL_LEB:
                         {
                             // These relocs should be for cases of the form:
-                            //  global.get __image_base
+                            //  global.get $imageBase
                             //  i32.load <reloc>
                             // So, the relocated address value should always represent an offset relative to image base. 
                             // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -961,6 +961,22 @@ namespace ILCompiler.ObjectWriter
                             Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
                             break;
                         }
+                        case RelocType.WASM_MEMORY_ADDR_REL_LEB:
+                        {
+                            // These relocs should be for cases of the form:
+                            //  global.get __image_base
+                            //  i32.load <reloc>
+                            // So, the relocated address value should always represent an offset relative to image base. 
+                            // This offset should ALWAYS be equal to the actual offset from image base at runtime, due to Webcil's
+                            // flag mapping
+                            if (symbolWebcilSection is null)
+                            {
+                                throw new InvalidDataException();
+                            }
+
+                            Relocation.WriteValue(reloc.Type, pData, virtualSymbolImageOffset + addend);
+                            break;
+                        }
                         case RelocType.WASM_TABLE_INDEX_I32:
                         case RelocType.WASM_TABLE_INDEX_I64:
                         case RelocType.WASM_TABLE_INDEX_SLEB:

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -4250,6 +4250,7 @@ namespace Internal.JitInterface
                 CorInfoReloc.WASM_MEMORY_ADDR_LEB => RelocType.WASM_MEMORY_ADDR_LEB,
                 CorInfoReloc.WASM_MEMORY_ADDR_SLEB => RelocType.WASM_MEMORY_ADDR_SLEB,
                 CorInfoReloc.WASM_MEMORY_ADDR_REL_SLEB => RelocType.WASM_MEMORY_ADDR_REL_SLEB,
+                CorInfoReloc.WASM_MEMORY_ADDR_REL_LEB => RelocType.WASM_MEMORY_ADDR_REL_LEB,
                 CorInfoReloc.WASM_TYPE_INDEX_LEB => RelocType.WASM_TYPE_INDEX_LEB,
                 CorInfoReloc.WASM_GLOBAL_INDEX_LEB => RelocType.WASM_GLOBAL_INDEX_LEB,
                 _ => throw new ArgumentException("Unsupported relocation type: " + reloc),

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -515,11 +515,11 @@ namespace Internal.JitInterface
         WASM_MEMORY_ADDR_SLEB,               // Wasm: a linear memory index encoded as a 5-byte varint32. Used for the immediate argument of a i32.const instruction,
                                                //  e.g. taking the address of a C++ global.
         WASM_MEMORY_ADDR_REL_SLEB,           // Wasm: a relative linear memory index encoded as a 5-byte varint32. Used as the immediate argument of an i32.const instruction,
-                                               // e.g. in R2R scenarios, encoding an offset from __image_base
+                                               // e.g. in R2R scenarios, encoding an offset from $imageBase
         WASM_TYPE_INDEX_LEB,                 // Wasm: a type index encoded as a 5-byte varuint32, e.g. the type immediate in a call_indirect.
         WASM_GLOBAL_INDEX_LEB,               // Wasm: a global index encoded as a 5-byte varuint32, e.g. the index immediate in a get_global.
         WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
-                                               // e.g. in R2R scenarios, encoding an offset from __image_base
+                                               // e.g. in R2R scenarios, encoding an offset from $imageBase
     }
 
     public enum CorInfoGCType

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -518,6 +518,8 @@ namespace Internal.JitInterface
                                                // e.g. in R2R scenarios, encoding an offset from __image_base
         WASM_TYPE_INDEX_LEB,                 // Wasm: a type index encoded as a 5-byte varuint32, e.g. the type immediate in a call_indirect.
         WASM_GLOBAL_INDEX_LEB,               // Wasm: a global index encoded as a 5-byte varuint32, e.g. the index immediate in a get_global.
+        WASM_MEMORY_ADDR_REL_LEB,            // Wasm: a relative linear memory index encoded as a 5-byte varuint32. Used as the immediate argument of a load or store instruction,
+                                               // e.g. in R2R scenarios, encoding an offset from __image_base
     }
 
     public enum CorInfoGCType


### PR DESCRIPTION
This PR contains one of @davidwrighton's commits extracted from #126662 to reduce the PR size and complexity. It adds a relocation type that is essentially `R_WASM_MEMORY_ADDR_REL_LEB`, so that a relocation corresponding to a relative offset from r2r `imageBase` can be used directly as the `offset` in a load, like:
```wasm
global.get $imageBase
i32.load align=... offset=<reloc>
```

The functionality isn't used yet, but will be in #126662.