### PR TITLE
Optimize IndexOfAnyAsciiSearcher on Arm64

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.Numerics.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.Numerics.cs
@@ -183,78 +183,62 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector4.Count(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Count(Vector2 vector, float value) => BitOperations.PopCount(Equals(vector.AsVector128(), Create(value, value, -1, -1)).ExtractMostSignificantBits());
+        internal static int Count(Vector2 vector, float value) => CountMatches(Equals(vector.AsVector128(), Create(value, value, -1, -1)));
 
         /// <inheritdoc cref="Vector4.Count(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int Count(Vector3 vector, float value) => BitOperations.PopCount(Equals(vector.AsVector128(), Create(value, value, value, -1)).ExtractMostSignificantBits());
+        internal static int Count(Vector3 vector, float value) => CountMatches(Equals(vector.AsVector128(), Create(value, value, value, -1)));
 
         /// <inheritdoc cref="Vector4.CountWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int CountWhereAllBitsSet(Vector2 vector) => BitOperations.PopCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
+        internal static int CountWhereAllBitsSet(Vector2 vector) => CountWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.CountWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int CountWhereAllBitsSet(Vector3 vector) => BitOperations.PopCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
+        internal static int CountWhereAllBitsSet(Vector3 vector) => CountWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.IndexOf(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOf(Vector2 vector, float value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector.AsVector128(), Create(value, value, -1, -1)).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        internal static int IndexOf(Vector2 vector, float value) => IndexOfFirstMatch(Equals(vector.AsVector128(), Create(value, value, -1, -1)));
 
         /// <inheritdoc cref="Vector4.IndexOf(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOf(Vector3 vector, float value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector.AsVector128(), Create(value, value, value, -1)).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        internal static int IndexOf(Vector3 vector, float value) => IndexOfFirstMatch(Equals(vector.AsVector128(), Create(value, value, value, -1)));
 
         /// <inheritdoc cref="Vector4.IndexOfWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOfWhereAllBitsSet(Vector2 vector)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        internal static int IndexOfWhereAllBitsSet(Vector2 vector) => IndexOfWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.IndexOfWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOfWhereAllBitsSet(Vector3 vector)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        internal static int IndexOfWhereAllBitsSet(Vector3 vector) => IndexOfWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.LastIndexOf(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LastIndexOf(Vector2 vector, float value) => 31 - BitOperations.LeadingZeroCount(Equals(vector.AsVector128(), Create(value, value, -1, -1)).ExtractMostSignificantBits());
+        internal static int LastIndexOf(Vector2 vector, float value) => IndexOfLastMatch(Equals(vector.AsVector128(), Create(value, value, -1, -1)));
 
         /// <inheritdoc cref="Vector4.LastIndexOf(Vector4, float)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LastIndexOf(Vector3 vector, float value) => 31 - BitOperations.LeadingZeroCount(Equals(vector.AsVector128(), Create(value, value, value, -1)).ExtractMostSignificantBits());
+        internal static int LastIndexOf(Vector3 vector, float value) => IndexOfLastMatch(Equals(vector.AsVector128(), Create(value, value, value, -1)));
 
         /// <inheritdoc cref="Vector4.LastIndexOfWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LastIndexOfWhereAllBitsSet(Vector2 vector) => 31 - BitOperations.LeadingZeroCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
+        internal static int LastIndexOfWhereAllBitsSet(Vector2 vector) => LastIndexOfWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.LastIndexOfWhereAllBitsSet(Vector4)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int LastIndexOfWhereAllBitsSet(Vector3 vector) => 31 - BitOperations.LeadingZeroCount(Equals(vector.AsVector128().AsInt32(), Vector128<int>.AllBitsSet).ExtractMostSignificantBits());
+        internal static int LastIndexOfWhereAllBitsSet(Vector3 vector) => LastIndexOfWhereAllBitsSet(vector.AsVector128());
 
         /// <inheritdoc cref="Vector4.None(Vector4, float)" />
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -4521,7 +4521,7 @@ namespace System.Runtime.Intrinsics
             // * 0xFF_00 - 0xF0
             // * 0xFF_FF - 0xFF
             //
-            // This allows us to extract the full metadata as a 64-bit scalar which can be then
+            // This allows us to extract the full metadata as a 64-bit scalar which can then
             // be consumed by bit-counting APIs, such as PopCount, LeadingZeroCount, or TrailingZeroCount,
             // and then adjusted by AdvSimdFixupBitCount to get the actual count of elements
             // that were masked.
@@ -4539,7 +4539,7 @@ namespace System.Runtime.Intrinsics
             }
 
             // This API is meant to be consumed alongside AdvSimdExtractBitMask and will
-            // not produce correct results for arbitary inputs. It adjusts the bit count
+            // not produce correct results for arbitrary inputs. It adjusts the bit count
             // assuming that sequences of 1 or 0 were in groups of 4 bits per byte.
 
             unsafe

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -898,7 +898,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector64.Count{T}(Vector64{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Count<T>(Vector128<T> vector, T value) => BitOperations.PopCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int Count<T>(Vector128<T> vector, T value) => CountMatches(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector64.CountWhereAllBitsSet{T}(Vector64{T})" />
         [Intrinsic]
@@ -1978,11 +1978,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector64.IndexOf{T}(Vector64{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf<T>(Vector128<T> vector, T value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        public static int IndexOf<T>(Vector128<T> vector, T value) => IndexOfFirstMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector64.IndexOfWhereAllBitsSet{T}(Vector64{T})" />
         [Intrinsic]
@@ -2213,7 +2209,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector64.LastIndexOf{T}(Vector64{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LastIndexOf<T>(Vector128<T> vector, T value) => 31 - BitOperations.LeadingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int LastIndexOf<T>(Vector128<T> vector, T value) => IndexOfLastMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector64.LastIndexOfWhereAllBitsSet{T}(Vector64{T})" />
         [Intrinsic]
@@ -4506,11 +4502,99 @@ namespace System.Runtime.Intrinsics
         public static Vector128<T> Xor<T>(Vector128<T> left, Vector128<T> right) => left ^ right;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        internal static ulong AdvSimdExtractBitMask<T>(Vector128<T> vector)
+        {
+            if (!AdvSimd.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+
+            // This expects vector to have each element be one of Zero or AllBitsSet
+            // and will not produce correct results otherwise.
+            //
+            // Given this, we can treat it as ushort and do a logical-right-shift by 4 to
+            // compact the mask into half the space, giving us the following possibilities for
+            // each pair of bytes:
+            // * 0x00_00 - 0x00
+            // * 0x00_FF - 0x0F
+            // * 0xFF_00 - 0xF0
+            // * 0xFF_FF - 0xFF
+            //
+            // This allows us to extract the full metadata as a 64-bit scalar which can be then
+            // be consumed by bit-counting APIs, such as PopCount, LeadingZeroCount, or TrailingZeroCount,
+            // and then adjusted by AdvSimdFixupBitCount to get the actual count of elements
+            // that were masked.
+
+            return AdvSimd.ShiftRightLogicalNarrowingLower(vector.AsUInt16(), 4).AsUInt64().ToScalar();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        internal static int AdvSimdFixupBitCount<T>(int bitCount)
+        {
+            if (!AdvSimd.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+
+            // This API is meant to be consumed alongside AdvSimdExtractBitMask and will
+            // not produce correct results for arbitary inputs. It adjusts the bit count
+            // assuming that sequences of 1 or 0 were in groups of 4 bits per byte.
+
+            unsafe
+            {
+                return bitCount >>> (2 + int.Log2(sizeof(T)));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountMatches<T>(Vector128<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimdFixupBitCount<T>(BitOperations.PopCount(AdvSimdExtractBitMask(vector)));
+            }
+            else
+            {
+                return BitOperations.PopCount(vector.ExtractMostSignificantBits());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T GetElementUnsafe<T>(in this Vector128<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector128<T>.Count));
             ref T address = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in vector));
             return Unsafe.Add(ref address, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfFirstMatch<T>(Vector128<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                int result = AdvSimdFixupBitCount<T>(BitOperations.TrailingZeroCount(AdvSimdExtractBitMask(vector)));
+                return (result != Vector128<T>.Count) ? result : -1;
+            }
+            else
+            {
+                int result = BitOperations.TrailingZeroCount(vector.ExtractMostSignificantBits());
+                return (result != 32) ? result : -1;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfLastMatch<T>(Vector128<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                return (Vector128<T>.Count - 1) - AdvSimdFixupBitCount<T>(BitOperations.LeadingZeroCount(AdvSimdExtractBitMask(vector)));
+            }
+            else
+            {
+                return 31 - BitOperations.LeadingZeroCount(vector.ExtractMostSignificantBits());
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -899,7 +899,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector128.Count{T}(Vector128{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Count<T>(Vector256<T> vector, T value) => BitOperations.PopCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int Count<T>(Vector256<T> vector, T value) => CountMatches(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector128.CountWhereAllBitsSet{T}(Vector128{T})" />
         [Intrinsic]
@@ -2056,11 +2056,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector128.IndexOf{T}(Vector128{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf<T>(Vector256<T> vector, T value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        public static int IndexOf<T>(Vector256<T> vector, T value) => IndexOfFirstMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector128.IndexOfWhereAllBitsSet{T}(Vector128{T})" />
         [Intrinsic]
@@ -2291,7 +2287,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector128.LastIndexOf{T}(Vector128{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LastIndexOf<T>(Vector256<T> vector, T value) => 31 - BitOperations.LeadingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int LastIndexOf<T>(Vector256<T> vector, T value) => IndexOfLastMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector128.LastIndexOfWhereAllBitsSet{T}(Vector128{T})" />
         [Intrinsic]
@@ -4453,11 +4449,66 @@ namespace System.Runtime.Intrinsics
         public static Vector256<T> Xor<T>(Vector256<T> left, Vector256<T> right) => left ^ right;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountMatches<T>(Vector256<T> vector)
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                return BitOperations.PopCount(vector.ExtractMostSignificantBits());
+            }
+            else
+            {
+                return Vector128.CountMatches(vector._lower)
+                     + Vector128.CountMatches(vector._upper);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T GetElementUnsafe<T>(in this Vector256<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector256<T>.Count));
             ref T address = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in vector));
             return Unsafe.Add(ref address, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfFirstMatch<T>(Vector256<T> vector)
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                int result = BitOperations.TrailingZeroCount(vector.ExtractMostSignificantBits());
+                return (result != 32) ? result : -1;
+            }
+            else
+            {
+                int result = Vector128.IndexOfFirstMatch(vector._lower);
+
+                if (result >= 0)
+                {
+                    return result;
+                }
+
+                result = Vector128.IndexOfFirstMatch(vector._upper);
+                return result + ((result >= 0) ? Vector128<T>.Count : 0);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfLastMatch<T>(Vector256<T> vector)
+        {
+            if (Vector256.IsHardwareAccelerated)
+            {
+                return 31 - BitOperations.LeadingZeroCount(vector.ExtractMostSignificantBits());
+            }
+            else
+            {
+                int result = Vector128.IndexOfLastMatch(vector._upper);
+
+                if (result >= 0)
+                {
+                    return result + Vector128<T>.Count;
+                }
+                return Vector128.IndexOfLastMatch(vector._lower);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -795,7 +795,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector256.Count{T}(Vector256{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Count<T>(Vector512<T> vector, T value) => BitOperations.PopCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int Count<T>(Vector512<T> vector, T value) => CountMatches(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector256.CountWhereAllBitsSet{T}(Vector256{T})" />
         [Intrinsic]
@@ -2075,11 +2075,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector256.IndexOf{T}(Vector256{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf<T>(Vector512<T> vector, T value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
-            return (result != 64) ? result : -1;
-        }
+        public static int IndexOf<T>(Vector512<T> vector, T value) => IndexOfFirstMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector256.IndexOfWhereAllBitsSet{T}(Vector256{T})" />
         [Intrinsic]
@@ -2310,7 +2306,7 @@ namespace System.Runtime.Intrinsics
         /// <inheritdoc cref="Vector256.LastIndexOf{T}(Vector256{T}, T)" />
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LastIndexOf<T>(Vector512<T> vector, T value) => 63 - BitOperations.LeadingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int LastIndexOf<T>(Vector512<T> vector, T value) => IndexOfLastMatch(Equals(vector, Create(value)));
 
         /// <inheritdoc cref="Vector256.LastIndexOfWhereAllBitsSet{T}(Vector256{T})" />
         [Intrinsic]
@@ -4423,11 +4419,66 @@ namespace System.Runtime.Intrinsics
         public static Vector512<T> Xor<T>(Vector512<T> left, Vector512<T> right) => left ^ right;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountMatches<T>(Vector512<T> vector)
+        {
+            if (Vector512.IsHardwareAccelerated)
+            {
+                return BitOperations.PopCount(vector.ExtractMostSignificantBits());
+            }
+            else
+            {
+                return Vector256.CountMatches(vector._lower)
+                     + Vector256.CountMatches(vector._upper);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T GetElementUnsafe<T>(in this Vector512<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector512<T>.Count));
             ref T address = ref Unsafe.As<Vector512<T>, T>(ref Unsafe.AsRef(in vector));
             return Unsafe.Add(ref address, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfFirstMatch<T>(Vector512<T> vector)
+        {
+            if (Vector512.IsHardwareAccelerated)
+            {
+                int result = BitOperations.TrailingZeroCount(vector.ExtractMostSignificantBits());
+                return (result != 64) ? result : -1;
+            }
+            else
+            {
+                int result = Vector256.IndexOfFirstMatch(vector._lower);
+
+                if (result >= 0)
+                {
+                    return result;
+                }
+
+                result = Vector256.IndexOfFirstMatch(vector._upper);
+                return result + ((result >= 0) ? Vector256<T>.Count : 0);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfLastMatch<T>(Vector512<T> vector)
+        {
+            if (Vector512.IsHardwareAccelerated)
+            {
+                return 63 - BitOperations.LeadingZeroCount(vector.ExtractMostSignificantBits());
+            }
+            else
+            {
+                int result = Vector256.IndexOfLastMatch(vector._upper);
+
+                if (result >= 0)
+                {
+                    return result + Vector256<T>.Count;
+                }
+                return Vector256.IndexOfLastMatch(vector._lower);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
 
 namespace System.Runtime.Intrinsics
 {
@@ -866,7 +867,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="vector" /> and <paramref name="value" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int Count<T>(Vector64<T> vector, T value) => BitOperations.PopCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int Count<T>(Vector64<T> vector, T value) => CountMatches(Equals(vector, Create(value)));
 
         /// <summary>Determines the number of elements in a vector that have all their bits set.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -1888,11 +1889,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="vector" /> and <paramref name="value" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf<T>(Vector64<T> vector, T value)
-        {
-            int result = BitOperations.TrailingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
-            return (result != 32) ? result : -1;
-        }
+        public static int IndexOf<T>(Vector64<T> vector, T value) => IndexOfFirstMatch(Equals(vector, Create(value)));
 
         /// <summary>Determines the index of the first element in a vector that has all bits set.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -2132,7 +2129,7 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="vector" /> and <paramref name="value" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int LastIndexOf<T>(Vector64<T> vector, T value) => 31 - BitOperations.LeadingZeroCount(Equals(vector, Create(value)).ExtractMostSignificantBits());
+        public static int LastIndexOf<T>(Vector64<T> vector, T value) => IndexOfLastMatch(Equals(vector, Create(value)));
 
         /// <summary>Determines the index of the last element in a vector that has all bits set.</summary>
         /// <typeparam name="T">The type of the elements in the vector.</typeparam>
@@ -4401,11 +4398,99 @@ namespace System.Runtime.Intrinsics
         public static Vector64<T> Xor<T>(Vector64<T> left, Vector64<T> right) => left ^ right;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        internal static uint AdvSimdExtractBitMask<T>(Vector64<T> vector)
+        {
+            if (!AdvSimd.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+
+            // This expects vector to have each element be one of Zero or AllBitsSet
+            // and will not produce correct results otherwise.
+            //
+            // Given this, we can treat it as ushort and do a logical-right-shift by 4 to
+            // compact the mask into half the space, giving us the following possibilities for
+            // each pair of bytes:
+            // * 0x00_00 - 0x00
+            // * 0x00_FF - 0x0F
+            // * 0xFF_00 - 0xF0
+            // * 0xFF_FF - 0xFF
+            //
+            // This allows us to extract the full metadata as a 32-bit scalar which can be then
+            // be consumed by bit-counting APIs, such as PopCount, LeadingZeroCount, or TrailingZeroCount,
+            // and then adjusted by AdvSimdFixupBitCount to get the actual count of elements
+            // that were masked.
+
+            return AdvSimd.ShiftRightLogicalNarrowingLower(vector.ToVector128().AsUInt16(), 4).AsUInt32().ToScalar();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [CompExactlyDependsOn(typeof(AdvSimd))]
+        internal static int AdvSimdFixupBitCount<T>(int bitCount)
+        {
+            if (!AdvSimd.IsSupported)
+            {
+                ThrowHelper.ThrowNotSupportedException();
+            }
+
+            // This API is meant to be consumed alongside AdvSimdExtractBitMask and will
+            // not produce correct results for arbitary inputs. It adjusts the bit count
+            // assuming that sequences of 1 or 0 were in groups of 4 bits per byte.
+
+            unsafe
+            {
+                return bitCount >>> (2 + int.Log2(sizeof(T)));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int CountMatches<T>(Vector64<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                return AdvSimdFixupBitCount<T>(BitOperations.PopCount(AdvSimdExtractBitMask(vector)));
+            }
+            else
+            {
+                return BitOperations.PopCount(vector.ExtractMostSignificantBits());
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static T GetElementUnsafe<T>(in this Vector64<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector64<T>.Count));
             ref T address = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in vector));
             return Unsafe.Add(ref address, index);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfFirstMatch<T>(Vector64<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                int result = AdvSimdFixupBitCount<T>(BitOperations.TrailingZeroCount(AdvSimdExtractBitMask(vector)));
+                return (result != Vector64<T>.Count) ? result : -1;
+            }
+            else
+            {
+                int result = BitOperations.TrailingZeroCount(vector.ExtractMostSignificantBits());
+                return (result != 32) ? result : -1;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int IndexOfLastMatch<T>(Vector64<T> vector)
+        {
+            if (AdvSimd.IsSupported)
+            {
+                return (Vector64<T>.Count - 1) - AdvSimdFixupBitCount<T>(BitOperations.LeadingZeroCount(AdvSimdExtractBitMask(vector)));
+            }
+            else
+            {
+                return 31 - BitOperations.LeadingZeroCount(vector.ExtractMostSignificantBits());
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -4417,7 +4417,7 @@ namespace System.Runtime.Intrinsics
             // * 0xFF_00 - 0xF0
             // * 0xFF_FF - 0xFF
             //
-            // This allows us to extract the full metadata as a 32-bit scalar which can be then
+            // This allows us to extract the full metadata as a 32-bit scalar which can then
             // be consumed by bit-counting APIs, such as PopCount, LeadingZeroCount, or TrailingZeroCount,
             // and then adjusted by AdvSimdFixupBitCount to get the actual count of elements
             // that were masked.
@@ -4435,7 +4435,7 @@ namespace System.Runtime.Intrinsics
             }
 
             // This API is meant to be consumed alongside AdvSimdExtractBitMask and will
-            // not produce correct results for arbitary inputs. It adjusts the bit count
+            // not produce correct results for arbitrary inputs. It adjusts the bit count
             // assuming that sequences of 1 or 0 were in groups of 4 bits per byte.
 
             unsafe

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -1255,8 +1255,7 @@ namespace System.Buffers
         private static unsafe int ComputeLastIndex<T, TNegator>(ref T searchSpace, ref T current, Vector128<byte> result)
             where TNegator : struct, INegator
         {
-            uint mask = TNegator.ExtractMask(result) & 0xFFFF;
-            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            int offsetInVector = TNegator.IndexOfLastMatch(result);
             return offsetInVector + (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref current) / (nuint)sizeof(T));
         }
 
@@ -1264,8 +1263,8 @@ namespace System.Buffers
         private static unsafe int ComputeLastIndexOverlapped<T, TNegator>(ref T searchSpace, ref T secondVector, Vector128<byte> result)
             where TNegator : struct, INegator
         {
-            uint mask = TNegator.ExtractMask(result) & 0xFFFF;
-            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            int offsetInVector = TNegator.IndexOfLastMatch(result);
+
             if (offsetInVector < Vector128<short>.Count)
             {
                 return offsetInVector;
@@ -1285,9 +1284,7 @@ namespace System.Buffers
                 result = PackedSpanHelpers.FixUpPackedVector256Result(result);
             }
 
-            uint mask = TNegator.ExtractMask(result);
-
-            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
+            int offsetInVector = TNegator.IndexOfLastMatch(result);
             return offsetInVector + (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref current) / (nuint)sizeof(T));
         }
 
@@ -1301,9 +1298,8 @@ namespace System.Buffers
                 result = PackedSpanHelpers.FixUpPackedVector256Result(result);
             }
 
-            uint mask = TNegator.ExtractMask(result);
+            int offsetInVector = TNegator.IndexOfLastMatch(result);
 
-            int offsetInVector = 31 - BitOperations.LeadingZeroCount(mask);
             if (offsetInVector < Vector256<short>.Count)
             {
                 return offsetInVector;
@@ -1318,8 +1314,10 @@ namespace System.Buffers
             static abstract bool NegateIfNeeded(bool result);
             static abstract Vector128<byte> NegateIfNeeded(Vector128<byte> result);
             static abstract Vector256<byte> NegateIfNeeded(Vector256<byte> result);
-            static abstract uint ExtractMask(Vector128<byte> result);
-            static abstract uint ExtractMask(Vector256<byte> result);
+            static abstract int IndexOfFirstMatch(Vector128<byte> result);
+            static abstract int IndexOfFirstMatch(Vector256<byte> result);
+            static abstract int IndexOfLastMatch(Vector128<byte> result);
+            static abstract int IndexOfLastMatch(Vector256<byte> result);
         }
 
         internal readonly struct DontNegate : INegator
@@ -1328,13 +1326,21 @@ namespace System.Buffers
             public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => result;
             public static Vector256<byte> NegateIfNeeded(Vector256<byte> result) => result;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static uint ExtractMask(Vector128<byte> result) => ~Vector128.Equals(result, Vector128<byte>.Zero).ExtractMostSignificantBits();
+            public static int IndexOfFirstMatch(Vector128<byte> result) => Vector128.IndexOfFirstMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static uint ExtractMask(Vector256<byte> result) => ~Vector256.Equals(result, Vector256<byte>.Zero).ExtractMostSignificantBits();
+            public static int IndexOfFirstMatch(Vector256<byte> result) => Vector256.IndexOfFirstMatch(~Vector256.Equals(result, Vector256<byte>.Zero));
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int IndexOfLastMatch(Vector128<byte> result) => Vector128.IndexOfLastMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int IndexOfLastMatch(Vector256<byte> result) => Vector256.IndexOfLastMatch(~Vector256.Equals(result, Vector256<byte>.Zero));
         }
 
         internal readonly struct Negate : INegator
         {
+            // AdvSimd expects that a given element is strictly Zero or AllBitsSet
+            // so we need to ensure that we normalize the input prior to calling
+            // IndexOfFirstMatch or IndexOfLastMatch
+
             public static bool NegateIfNeeded(bool result) => !result;
             // This is intentionally testing for equality with 0 instead of "~result".
             // We want to know if any character didn't match, as that means it should be treated as a match for the -Except method.
@@ -1343,9 +1349,27 @@ namespace System.Buffers
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static Vector256<byte> NegateIfNeeded(Vector256<byte> result) => Vector256.Equals(result, Vector256<byte>.Zero);
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static uint ExtractMask(Vector128<byte> result) => result.ExtractMostSignificantBits();
+            public static int IndexOfFirstMatch(Vector128<byte> result)
+            {
+                if (AdvSimd.IsSupported)
+                {
+                    result = (result.AsSByte() >> 7).AsByte();
+                }
+                return Vector128.IndexOfFirstMatch(result);
+            }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static uint ExtractMask(Vector256<byte> result) => result.ExtractMostSignificantBits();
+            public static int IndexOfFirstMatch(Vector256<byte> result) => Vector256.IndexOfFirstMatch(result);
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int IndexOfLastMatch(Vector128<byte> result)
+            {
+                if (AdvSimd.IsSupported)
+                {
+                    result = (result.AsSByte() >> 7).AsByte();
+                }
+                return Vector128.IndexOfLastMatch(result);
+            }
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static int IndexOfLastMatch(Vector256<byte> result) => Vector256.IndexOfLastMatch(result);
         }
 
         internal interface IOptimizations
@@ -1470,8 +1494,7 @@ namespace System.Buffers
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int FirstIndex<TNegator>(ref T searchSpace, ref T current, Vector128<byte> result) where TNegator : struct, INegator
             {
-                uint mask = TNegator.ExtractMask(result);
-                int offsetInVector = BitOperations.TrailingZeroCount(mask);
+                int offsetInVector = TNegator.IndexOfFirstMatch(result);
                 return offsetInVector + (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref current) / (nuint)sizeof(T));
             }
 
@@ -1484,17 +1507,15 @@ namespace System.Buffers
                     result = PackedSpanHelpers.FixUpPackedVector256Result(result);
                 }
 
-                uint mask = TNegator.ExtractMask(result);
-
-                int offsetInVector = BitOperations.TrailingZeroCount(mask);
+                int offsetInVector = TNegator.IndexOfFirstMatch(result);
                 return offsetInVector + (int)((nuint)Unsafe.ByteOffset(ref searchSpace, ref current) / (nuint)sizeof(T));
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int FirstIndexOverlapped<TNegator>(ref T searchSpace, ref T current0, ref T current1, Vector128<byte> result) where TNegator : struct, INegator
             {
-                uint mask = TNegator.ExtractMask(result);
-                int offsetInVector = BitOperations.TrailingZeroCount(mask);
+                int offsetInVector = TNegator.IndexOfFirstMatch(result);
+
                 if (offsetInVector >= Vector128<short>.Count)
                 {
                     // We matched within the second vector
@@ -1513,9 +1534,8 @@ namespace System.Buffers
                     result = PackedSpanHelpers.FixUpPackedVector256Result(result);
                 }
 
-                uint mask = TNegator.ExtractMask(result);
+                int offsetInVector = TNegator.IndexOfFirstMatch(result);
 
-                int offsetInVector = BitOperations.TrailingZeroCount(mask);
                 if (offsetInVector >= Vector256<short>.Count)
                 {
                     // We matched within the second vector


### PR DESCRIPTION
This improves the codegen of the dedicated `Count`, `IndexOf`, and `LastIndexOf` APIs on Arm64 and correspondingly updates `IndexOfAnyAsciiSearcher` to consume them instead of `ExtractMostSignificantBits`

This is notably not strictly the "ideal" codegen as it still does an extra comparison, but that is something we can address in the JIT and should still provide a 5-50% performance increase in workloads using this API as part of their core loop.