### PR TITLE
Work around Schannel TLS resume disable race on older Windows

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -220,7 +220,7 @@ namespace System.Net.Security
                     // ensures the new ClientHello is generated without a stale session ID.
                     // We can reuse inputBuffers since this only runs on the very first ISC call
                     // (newContext == true) where the input is empty.
-                    context.Dispose();
+                    context?.Dispose();
                     context = null;
                     token.ReleasePayload();
                     token = default;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -220,7 +220,7 @@ namespace System.Net.Security
                     // ensures the new ClientHello is generated without a stale session ID.
                     // We can reuse inputBuffers since this only runs on the very first ISC call
                     // (newContext == true) where the input is empty.
-                    context?.Dispose();
+                    context.Dispose();
                     context = null;
                     token.ReleasePayload();
                     token = default;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -197,13 +197,6 @@ namespace System.Net.Security
 
             token.Status = SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
 
-            consumed = inputBuffer.Length;
-            if (inputBuffers._item1.Type == SecurityBufferType.SECBUFFER_EXTRA)
-            {
-                // not all data were consumed
-                consumed -= inputBuffers._item1.Token.Length;
-            }
-
             bool allowTlsResume = sslAuthenticationOptions.AllowTlsResume && !LocalAppContextSwitches.DisableTlsResume;
 
             if (!allowTlsResume && newContext && context != null)
@@ -225,20 +218,13 @@ namespace System.Net.Security
                     // resumable entry and embeds the session ID in the ClientHello before
                     // ApplyControlToken can expire it. Deleting the context and retrying ISC
                     // ensures the new ClientHello is generated without a stale session ID.
+                    // We can reuse inputBuffers since this only runs on the very first ISC call
+                    // (newContext == true) where the input is empty.
                     context?.Dispose();
                     context = null;
                     token.ReleasePayload();
                     token = default;
                     token.RentBuffer = true;
-
-                    scoped InputSecurityBuffers retryInputBuffers = default;
-                    retryInputBuffers.SetNextBuffer(new InputSecurityBuffer(inputBuffer, SecurityBufferType.SECBUFFER_TOKEN));
-                    retryInputBuffers.SetNextBuffer(new InputSecurityBuffer(default, SecurityBufferType.SECBUFFER_EMPTY));
-                    if (sslAuthenticationOptions.ApplicationProtocols is { Count: > 0 })
-                    {
-                        Span<byte> retryLocalBuffer = stackalloc byte[64];
-                        SetAlpn(ref retryInputBuffers, sslAuthenticationOptions.ApplicationProtocols, retryLocalBuffer);
-                    }
 
                     errorCode = SSPIWrapper.InitializeSecurityContext(
                                     GlobalSSPI.SSPISecureChannel,
@@ -247,18 +233,19 @@ namespace System.Net.Security
                                     targetName,
                                     RequiredFlags | Interop.SspiCli.ContextFlags.InitManualCredValidation,
                                     Interop.SspiCli.Endianness.SECURITY_NATIVE_DREP,
-                                    ref retryInputBuffers,
+                                    ref inputBuffers,
                                     ref token,
                                     ref unusedAttributes);
 
                     token.Status = SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
-
-                    consumed = inputBuffer.Length;
-                    if (retryInputBuffers._item1.Type == SecurityBufferType.SECBUFFER_EXTRA)
-                    {
-                        consumed -= retryInputBuffers._item1.Token.Length;
-                    }
                 }
+            }
+
+            consumed = inputBuffer.Length;
+            if (inputBuffers._item1.Type == SecurityBufferType.SECBUFFER_EXTRA)
+            {
+                // not all data were consumed
+                consumed -= inputBuffers._item1.Token.Length;
             }
 
             return token;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Windows.cs
@@ -26,6 +26,15 @@ namespace System.Net.Security
             // API is supported since Windows 10 1809 (17763) but there is no reason to use at the moment.
             Environment.OSVersion.Version.Major >= 10 && Environment.OSVersion.Version.Build >= 18836;
 
+        // On Windows Server 2022 (build 20348) and older, Schannel has a race condition where
+        // ApplyControlToken(SSL_SESSION_DISABLE_RECONNECTS) doesn't reliably prevent the session
+        // cache from being repopulated. The workaround is to delete the context and retry
+        // InitializeSecurityContext after ApplyControlToken. This follows the same pattern used by
+        // Schannel's own webcli.c test and http.sys. The issue was fixed in newer Schannel builds
+        // shipping with Windows 11+ (build 22000+).
+        private static readonly bool NeedsDisableTlsResumeWorkaround =
+            Environment.OSVersion.Version.Build < 22000;
+
         private const string SecurityPackage = "Microsoft Unified Security Protocol Provider";
 
         private const Interop.SspiCli.ContextFlags RequiredFlags =
@@ -206,10 +215,49 @@ namespace System.Net.Security
                     ref context,
                     in securityBuffer));
 
-
                 if (result.ErrorCode != SecurityStatusPalErrorCode.OK)
                 {
                     token.Status = result;
+                }
+                else if (NeedsDisableTlsResumeWorkaround)
+                {
+                    // On affected builds, Schannel's internal LookupCacheByName finds a fresh
+                    // resumable entry and embeds the session ID in the ClientHello before
+                    // ApplyControlToken can expire it. Deleting the context and retrying ISC
+                    // ensures the new ClientHello is generated without a stale session ID.
+                    context?.Dispose();
+                    context = null;
+                    token.ReleasePayload();
+                    token = default;
+                    token.RentBuffer = true;
+
+                    scoped InputSecurityBuffers retryInputBuffers = default;
+                    retryInputBuffers.SetNextBuffer(new InputSecurityBuffer(inputBuffer, SecurityBufferType.SECBUFFER_TOKEN));
+                    retryInputBuffers.SetNextBuffer(new InputSecurityBuffer(default, SecurityBufferType.SECBUFFER_EMPTY));
+                    if (sslAuthenticationOptions.ApplicationProtocols is { Count: > 0 })
+                    {
+                        Span<byte> retryLocalBuffer = stackalloc byte[64];
+                        SetAlpn(ref retryInputBuffers, sslAuthenticationOptions.ApplicationProtocols, retryLocalBuffer);
+                    }
+
+                    errorCode = SSPIWrapper.InitializeSecurityContext(
+                                    GlobalSSPI.SSPISecureChannel,
+                                    ref credentialsHandle,
+                                    ref context,
+                                    targetName,
+                                    RequiredFlags | Interop.SspiCli.ContextFlags.InitManualCredValidation,
+                                    Interop.SspiCli.Endianness.SECURITY_NATIVE_DREP,
+                                    ref retryInputBuffers,
+                                    ref token,
+                                    ref unusedAttributes);
+
+                    token.Status = SecurityStatusAdapterPal.GetSecurityStatusPalFromNativeInt(errorCode);
+
+                    consumed = inputBuffer.Length;
+                    if (retryInputBuffers._item1.Type == SecurityBufferType.SECBUFFER_EXTRA)
+                    {
+                        consumed -= retryInputBuffers._item1.Token.Length;
+                    }
                 }
             }
 

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAllowTlsResumeTests.cs
@@ -34,7 +34,6 @@ namespace System.Net.Security.Tests
         [ConditionalTheory]
         [InlineData(true)]
         [InlineData(false)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/103449", TestPlatforms.Windows)]
         public async Task ClientDisableTlsResume_Succeeds(bool testClient)
         {
             SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions


### PR DESCRIPTION
## Summary

On Windows Server 2022 (build 20348) and older, `ApplyControlToken(SSL_SESSION_DISABLE_RECONNECTS)` races with Schannel's internal session cache — `InitializeSecurityContext`'s internal `LookupCacheByName` finds a fresh resumable entry and embeds the session ID in the `ClientHello` before `ApplyControlToken` can expire it.

## Workaround

After `ApplyControlToken`, delete the security context and retry `InitializeSecurityContext` with a null context so the new `ClientHello` is generated without a stale session ID. This follows the same pattern used by Schannel's own `webcli.c` test and `http.sys`.

The workaround is conditioned on `Environment.OSVersion.Version.Build < 22000` (pre-Windows 11), since newer Schannel builds correctly prevent cache population when `ApplyControlToken` is used.

Also re-enables the `ClientDisableTlsResume_Succeeds` test that was disabled due to this issue.

Fixes #103449