### PR TITLE
[wasm][coreclr] Fix browser-wasm library tests broken by webcil V1 version bump

### DIFF
--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilConverter.cs
@@ -117,7 +117,7 @@ public class WebcilConverter
         var sections = headers.SectionHeaders;
         WebcilHeader header = default;
         header.Id = WebcilConstants.WEBCIL_MAGIC;
-        header.VersionMajor = WebcilConstants.WC_VERSION_MAJOR;
+        header.VersionMajor = 0; // WASM-TODO: add webcil V1 support
         header.VersionMinor = WebcilConstants.WC_VERSION_MINOR;
         header.CoffSections = (ushort)coffHeader.NumberOfSections;
         header.Reserved0 = 0;

--- a/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilReader.cs
+++ b/src/tasks/Microsoft.NET.WebAssembly.Webcil/WebcilReader.cs
@@ -79,7 +79,7 @@ public sealed partial class WebcilReader : IDisposable
             header.PeDebugSize = BinaryPrimitives.ReverseEndianness(header.PeDebugSize);
         }
         if (header.Id != WebcilConstants.WEBCIL_MAGIC
-            || header.VersionMajor != WebcilConstants.WC_VERSION_MAJOR
+            || header.VersionMajor != 0 // WASM-TODO: add webcil V1 support
             || header.VersionMinor != WebcilConstants.WC_VERSION_MINOR)
         {
             return false;


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

PR #126388 bumped `WC_VERSION_MAJOR` from 0 to 1 in `Webcil.cs`. That constant is shared by both the crossgen2 R2R path (fully updated for V1) and the `WebcilConverter` build task (still writes V0 28-byte headers). The mismatch caused the C++ `webcildecoder` to misparse section headers at offset 32 instead of 28, breaking all browser-wasm library tests with `COR_E_ASSEMBLYEXPECTED`.

Pin `WebcilConverter` and `WebcilReader` to V0 until full V1 support is added to the managed converter and wasm wrapper.