### PR TITLE
CoreCLR: Add missing null guard

### DIFF
--- a/src/coreclr/gc/unix/cgroup.cpp
+++ b/src/coreclr/gc/unix/cgroup.cpp
@@ -510,6 +510,9 @@ private:
 
     static bool GetCGroupMemoryUsage(size_t *val, const char *filename, const char *inactiveFileFieldName)
     {
+        if (s_memory_cgroup_path == nullptr)
+            return false;
+
         // Use the same way to calculate memory load as popular container tools (Docker, Kubernetes, Containerd etc.)
         // For cgroup v1: value of 'memory.usage_in_bytes' minus 'total_inactive_file' value of 'memory.stat'
         // For cgroup v2: value of 'memory.current' minus 'inactive_file' value of 'memory.stat'
@@ -533,9 +536,6 @@ private:
 
         if (!result)
             return result;
-
-        if (s_memory_cgroup_path == nullptr)
-            return false;
 
         uint64_t inactiveFileValue = 0;
         if (GetCGroupMemoryStatField(inactiveFileFieldName, &inactiveFileValue))

--- a/src/mono/mono/utils/mono-cgroup.c
+++ b/src/mono/mono/utils/mono-cgroup.c
@@ -535,6 +535,9 @@ getCGroupMemoryLimit(size_t *val, const char *filename)
 static gboolean 
 getCGroupMemoryUsage(size_t *val, const char *filename, const char *inactiveFileFieldName)
 {
+	if (s_memory_cgroup_path == NULL)
+		return FALSE;
+
 	/* 
 	 * Use the same way to calculate memory load as popular container tools (Docker, Kubernetes, Containerd etc.)
 	 * For cgroup v1: value of 'memory.usage_in_bytes' minus 'total_inactive_file' value of 'memory.stat'
@@ -560,9 +563,6 @@ getCGroupMemoryUsage(size_t *val, const char *filename, const char *inactiveFile
 
 	if (!result)
 		return result;
-
-	if (s_memory_cgroup_path == NULL)
-		return FALSE;
 
 	char *stat_filename = NULL;
 	if (asprintf (&stat_filename, "%s%s", s_memory_cgroup_path, CGROUP_MEMORY_STAT_FILENAME) < 0)


### PR DESCRIPTION
This fixes Release builds using GCC.

Without this patch, these builds fail with:

```
  /home/runner/dotnet-runtime/src/coreclr/gc/unix/cgroup.cpp:518:21: error: '%s' directive argument is null [-Werror=format-overflow=]
    518 |         if (asprintf(&mem_usage_filename, "%s%s", s_memory_cgroup_path, filename) < 0)
        |             ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Part of https://github.com/dotnet/runtime/issues/55803.