### PR TITLE
Update .gitignore to include cache and dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -221,6 +221,13 @@ browse.VC.db
 **/.vscode/**
 !**/.vscode/c_cpp_properties.json
 
+# C# Dev Kit language server caches
+*.lscache
+
+# Dump files
+*.dmp
+*.dump
+
 ### MonoDevelop ###
 *.userprefs
 


### PR DESCRIPTION
Add patterns to ignore C# Dev Kit caches and dump files.

The Dev Kit extension now creates .lscache files for each csproj loaded by the lsp. We should tell git to ignore them

Also ignore dump files because I imagine people often have them in the directory but never want to commit them.