### PR TITLE
Fix GC write barrier when writing async method return into continuation object

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1064,9 +1064,15 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
         // We had a normal return, so copy out the return value
         if (returnValueSize > 0)
         {
-            if (pSuspendData->asyncMethodReturnType != NULL && pSuspendData->asyncMethodReturnType->ContainsGCPointers())
+            if (pSuspendData->asyncMethodReturnType != NULL && !pSuspendData->asyncMethodReturnType->IsValueType())
             {
-                // GC refs need to be written with write barriers
+                // asyncMethodReturnType is set only for CORINFO_TYPE_VALUECLASS/STRING/CLASS
+                // so we can make the assumption that the return is an object reference if not valuetype
+                SetObjectReference((OBJECTREF*)resultStorage, ObjectToOBJECTREF(*(Object**)returnValueLocation));
+            }
+            else if (pSuspendData->asyncMethodReturnType != NULL && pSuspendData->asyncMethodReturnType->ContainsGCPointers())
+            {
+                // ValueType containing gc refs, needs to be written with write barriers
                 memmoveGCRefs(resultStorage, returnValueLocation, returnValueSize);
             }
             else


### PR DESCRIPTION
Previous code was only checking if the type contains GC refs, which means it would fail to add a write barrier if the method returns an object without refs.

Fixes System.Text.Json.Tests random GC crashes