### PR TITLE
Replace SHash of call counting managers with linked list.

### DIFF
--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -381,32 +381,9 @@ CallCountingManager::MethodDescForwarderStubHashTraits::Hash(const key_t &k)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// CallCountingManager::CallCountingManagerHashTraits
-
-CallCountingManager::CallCountingManagerHashTraits::key_t
-CallCountingManager::CallCountingManagerHashTraits::GetKey(const element_t &e)
-{
-    WRAPPER_NO_CONTRACT;
-    return e;
-}
-
-BOOL CallCountingManager::CallCountingManagerHashTraits::Equals(const key_t &k1, const key_t &k2)
-{
-    WRAPPER_NO_CONTRACT;
-    return k1 == k2;
-}
-
-CallCountingManager::CallCountingManagerHashTraits::count_t
-CallCountingManager::CallCountingManagerHashTraits::Hash(const key_t &k)
-{
-    WRAPPER_NO_CONTRACT;
-    return (count_t)dac_cast<TADDR>(k);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // CallCountingManager
 
-CallCountingManager::PTR_CallCountingManagerHash CallCountingManager::s_callCountingManagers = PTR_NULL;
+CallCountingManager* CallCountingManager::s_callCountingManagers = nullptr;
 COUNT_T CallCountingManager::s_callCountingStubCount = 0;
 COUNT_T CallCountingManager::s_activeCallCountingStubCount = 0;
 COUNT_T CallCountingManager::s_completedCallCountingStubCount = 0;
@@ -423,7 +400,13 @@ CallCountingManager::CallCountingManager()
 
 #ifndef DACCESS_COMPILE
     CodeVersionManager::LockHolder codeVersioningLockHolder;
-    s_callCountingManagers->Add(this);
+    m_nextManager = s_callCountingManagers;
+    m_pPreviousManager = &s_callCountingManagers;
+    if (s_callCountingManagers != nullptr)
+    {
+        s_callCountingManagers->m_pPreviousManager = &m_nextManager;
+    }
+    s_callCountingManagers = this;
 #endif
 }
 
@@ -448,19 +431,13 @@ CallCountingManager::~CallCountingManager()
         delete callCountingInfo;
     }
 
-    s_callCountingManagers->Remove(this);
+    *m_pPreviousManager = m_nextManager;
+    if (m_nextManager != nullptr)
+    {
+        m_nextManager->m_pPreviousManager = m_pPreviousManager;
+    }
 #endif
 }
-
-#ifndef DACCESS_COMPILE
-
-void CallCountingManager::StaticInitialize()
-{
-    WRAPPER_NO_CONTRACT;
-    s_callCountingManagers = PTR_CallCountingManagerHash(new CallCountingManagerHash());
-    CallCountingStub::StaticInitialize();
-}
-#endif
 
 #ifndef DACCESS_COMPILE
 
@@ -762,9 +739,8 @@ COUNT_T CallCountingManager::GetCountOfCodeVersionsPendingCompletion()
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
     {
-        CallCountingManager *callCountingManager = *it;
         count += callCountingManager->m_callCountingInfosPendingCompletion.GetCount();
     }
 
@@ -790,9 +766,8 @@ void CallCountingManager::CompleteCallCounting()
     MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
     {
-        CallCountingManager *callCountingManager = *it;
         SArray<CallCountingInfo *> &callCountingInfosPendingCompletion =
             callCountingManager->m_callCountingInfosPendingCompletion;
         COUNT_T callCountingInfoCount = callCountingInfosPendingCompletion.GetCount();
@@ -951,10 +926,8 @@ void CallCountingManager::StopAllCallCounting(TieredCompilationManager *tieredCo
     _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
     _ASSERTE(tieredCompilationManager != nullptr);
 
-    for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
     {
-        CallCountingManager *callCountingManager = *it;
-
         CallCountingInfoByCodeVersionHash &callCountingInfoByCodeVersionHash =
             callCountingManager->m_callCountingInfoByCodeVersionHash;
         for (auto itEnd = callCountingInfoByCodeVersionHash.End(), it = callCountingInfoByCodeVersionHash.Begin();
@@ -1039,9 +1012,8 @@ void CallCountingManager::DeleteAllCallCountingStubs()
     s_callCountingStubCount = 0;
     s_completedCallCountingStubCount = 0;
 
-    for (auto itEnd = s_callCountingManagers->End(), it = s_callCountingManagers->Begin(); it != itEnd; ++it)
+    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
     {
-        CallCountingManager *callCountingManager = *it;
         _ASSERTE(callCountingManager->m_callCountingInfosPendingCompletion.IsEmpty());
 
         // Clear the call counting stub from call counting infos and delete completed infos

--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -383,7 +383,7 @@ CallCountingManager::MethodDescForwarderStubHashTraits::Hash(const key_t &k)
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // CallCountingManager
 
-CallCountingManager* CallCountingManager::s_callCountingManagers = nullptr;
+SList<CallCountingManager> CallCountingManager::s_callCountingManagers;
 COUNT_T CallCountingManager::s_callCountingStubCount = 0;
 COUNT_T CallCountingManager::s_activeCallCountingStubCount = 0;
 COUNT_T CallCountingManager::s_completedCallCountingStubCount = 0;
@@ -400,13 +400,7 @@ CallCountingManager::CallCountingManager()
 
 #ifndef DACCESS_COMPILE
     CodeVersionManager::LockHolder codeVersioningLockHolder;
-    m_nextManager = s_callCountingManagers;
-    m_pPreviousManager = &s_callCountingManagers;
-    if (s_callCountingManagers != nullptr)
-    {
-        s_callCountingManagers->m_pPreviousManager = &m_nextManager;
-    }
-    s_callCountingManagers = this;
+    s_callCountingManagers.InsertTail(this);
 #endif
 }
 
@@ -431,11 +425,7 @@ CallCountingManager::~CallCountingManager()
         delete callCountingInfo;
     }
 
-    *m_pPreviousManager = m_nextManager;
-    if (m_nextManager != nullptr)
-    {
-        m_nextManager->m_pPreviousManager = m_pPreviousManager;
-    }
+    s_callCountingManagers.FindAndRemove(this);
 #endif
 }
 
@@ -739,7 +729,7 @@ COUNT_T CallCountingManager::GetCountOfCodeVersionsPendingCompletion()
 
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
+    for (CallCountingManager *callCountingManager = s_callCountingManagers.GetHead(); callCountingManager != nullptr; callCountingManager = SList<CallCountingManager>::GetNext(callCountingManager))
     {
         count += callCountingManager->m_callCountingInfosPendingCompletion.GetCount();
     }
@@ -766,7 +756,7 @@ void CallCountingManager::CompleteCallCounting()
     MethodDescBackpatchInfoTracker::ConditionalLockHolder slotBackpatchLockHolder;
     CodeVersionManager::LockHolder codeVersioningLockHolder;
 
-    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
+    for (CallCountingManager *callCountingManager = s_callCountingManagers.GetHead(); callCountingManager != nullptr; callCountingManager = SList<CallCountingManager>::GetNext(callCountingManager))
     {
         SArray<CallCountingInfo *> &callCountingInfosPendingCompletion =
             callCountingManager->m_callCountingInfosPendingCompletion;
@@ -926,7 +916,7 @@ void CallCountingManager::StopAllCallCounting(TieredCompilationManager *tieredCo
     _ASSERTE(CodeVersionManager::IsLockOwnedByCurrentThread());
     _ASSERTE(tieredCompilationManager != nullptr);
 
-    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
+    for (CallCountingManager *callCountingManager = s_callCountingManagers.GetHead(); callCountingManager != nullptr; callCountingManager = SList<CallCountingManager>::GetNext(callCountingManager))
     {
         CallCountingInfoByCodeVersionHash &callCountingInfoByCodeVersionHash =
             callCountingManager->m_callCountingInfoByCodeVersionHash;
@@ -1012,7 +1002,7 @@ void CallCountingManager::DeleteAllCallCountingStubs()
     s_callCountingStubCount = 0;
     s_completedCallCountingStubCount = 0;
 
-    for (auto* callCountingManager = s_callCountingManagers; callCountingManager != nullptr; callCountingManager = callCountingManager->m_nextManager)
+    for (CallCountingManager *callCountingManager = s_callCountingManagers.GetHead(); callCountingManager != nullptr; callCountingManager = SList<CallCountingManager>::GetNext(callCountingManager))
     {
         _ASSERTE(callCountingManager->m_callCountingInfosPendingCompletion.IsEmpty());
 

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -299,8 +299,11 @@ private:
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // CallCountingManager members
 
+public:
+    SLink m_Link;
+
 private:
-    static CallCountingManager *s_callCountingManagers;
+    static SList<CallCountingManager> s_callCountingManagers;
     static COUNT_T s_callCountingStubCount;
     static COUNT_T s_activeCallCountingStubCount;
     static COUNT_T s_completedCallCountingStubCount;
@@ -310,9 +313,6 @@ private:
     CallCountingStubAllocator m_callCountingStubAllocator;
     MethodDescForwarderStubHash m_methodDescForwarderStubHash;
     SArray<CallCountingInfo *> m_callCountingInfosPendingCompletion;
-
-    CallCountingManager **m_pPreviousManager = nullptr;
-    CallCountingManager *m_nextManager = nullptr;
 
 public:
     CallCountingManager();

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -297,32 +297,10 @@ private:
     typedef SHash<MethodDescForwarderStubHashTraits> MethodDescForwarderStubHash;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // CallCountingManager::CallCountingManagerHashTraits
-
-private:
-    class CallCountingManagerHashTraits : public DefaultSHashTraits<PTR_CallCountingManager>
-    {
-    private:
-        typedef DefaultSHashTraits<PTR_CallCountingManager> Base;
-    public:
-        typedef Base::element_t element_t;
-        typedef Base::count_t count_t;
-        typedef PTR_CallCountingManager key_t;
-
-    public:
-        static key_t GetKey(const element_t &e);
-        static BOOL Equals(const key_t &k1, const key_t &k2);
-        static count_t Hash(const key_t &k);
-    };
-
-    typedef SHash<CallCountingManagerHashTraits> CallCountingManagerHash;
-    typedef DPTR(CallCountingManagerHash) PTR_CallCountingManagerHash;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // CallCountingManager members
 
 private:
-    static PTR_CallCountingManagerHash s_callCountingManagers;
+    static CallCountingManager *s_callCountingManagers;
     static COUNT_T s_callCountingStubCount;
     static COUNT_T s_activeCallCountingStubCount;
     static COUNT_T s_completedCallCountingStubCount;
@@ -333,14 +311,12 @@ private:
     MethodDescForwarderStubHash m_methodDescForwarderStubHash;
     SArray<CallCountingInfo *> m_callCountingInfosPendingCompletion;
 
+    CallCountingManager **m_pPreviousManager = nullptr;
+    CallCountingManager *m_nextManager = nullptr;
+
 public:
     CallCountingManager();
     ~CallCountingManager();
-
-#ifndef DACCESS_COMPILE
-public:
-    static void StaticInitialize();
-#endif // !DACCESS_COMPILE
 
 #ifndef DACCESS_COMPILE
 public:

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -668,7 +668,7 @@ void EEStartupHelper()
 
 #ifdef FEATURE_TIERED_COMPILATION
         TieredCompilationManager::StaticInitialize();
-        CallCountingManager::StaticInitialize();
+        CallCountingStub::StaticInitialize();
 #endif // FEATURE_TIERED_COMPILATION
 
         OnStackReplacementManager::StaticInitialize();


### PR DESCRIPTION
We only add, remove, and iterate through all here - we never make use of the hashing behavior. So, it is more appropriate to have this as a linked list as opposed to an SHash.