### PR TITLE
Simple RuntimeTypeSystem DacDbi APIs

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -80,6 +80,7 @@ partial interface IRuntimeTypeSystem : IContract
     public virtual bool IsGenericTypeDefinition(TypeHandle typeHandle);
 
     public virtual bool IsCollectible(TypeHandle typeHandle);
+    public virtual bool ContainsGenericVariables(TypeHandle typeHandle);
     public virtual bool HasTypeParam(TypeHandle typeHandle);
 
     // Element type of the type. NOTE: this drops the CorElementType.GenericInst, and CorElementType.String is returned as CorElementType.Class.
@@ -226,6 +227,8 @@ bool IsFieldDescThreadStatic(TargetPointer fieldDescPointer);
 bool IsFieldDescStatic(TargetPointer fieldDescPointer);
 uint GetFieldDescType(TargetPointer fieldDescPointer);
 uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition fieldDef);
+TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer);
+TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread);
 ```
 
 ### Other APIs
@@ -675,6 +678,14 @@ Contracts used:
             return false;
         MethodTable typeHandle = _methodTables[typeHandle.Address];
         return typeHandle.Flags.IsCollectible;
+    }
+
+    public bool ContainsGenericVariables(TypeHandle typeHandle)
+    {
+        if (typeHandle.IsMethodTable())
+            return _methodTables[typeHandle.Address].Flags.ContainsGenericVariables;
+        // For TypeDescs: Var/MVar are generic variables; for parameterized types (Ptr, ByRef),
+        // recurse through GetTypeParam; for FnPtr, check each signature type argument.
     }
 
     public bool HasTypeParam(TypeHandle typeHandle)
@@ -1812,6 +1823,19 @@ uint GetFieldDescOffset(TargetPointer fieldDescPointer)
         return (uint)fieldDef.GetRelativeVirtualAddress();
     }
     return DWord2 & (uint)FieldDescFlags2.OffsetMask;
+}
+
+TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer)
+{
+    // Resolves the base pointer (GC or non-GC statics) for the enclosing type,
+    // then applies the field's metadata-based offset within that region.
+    // Uses GetGCStaticsBasePointer / GetNonGCStaticsBasePointer depending on the field's CorElementType.
+}
+
+TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread)
+{
+    // Like GetFieldDescStaticAddress, but resolves thread-local base pointers instead.
+    // Uses GetGCThreadStaticsBasePointer / GetNonGCThreadStaticsBasePointer.
 }
 ```
 

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -274,6 +274,7 @@ internal partial struct RuntimeTypeSystem_1
         Category_Interface = 0x000C0000,
         Collectible = 0x00200000,
         ContainsGCPointers = 0x01000000,
+        ContainsGenericVariables = 0x20000000,
         HasComponentSize = 0x80000000, // This is set if lower 16 bits is used for the component size,
                                        // otherwise the lower bits are used for WFLAGS_LOW
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -143,6 +143,7 @@ public interface IRuntimeTypeSystem : IContract
     public bool IsClassInited(TypeHandle typeHandle) => throw new NotImplementedException();
     public bool IsInitError(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsGenericTypeDefinition(TypeHandle typeHandle) => throw new NotImplementedException();
+    bool ContainsGenericVariables(TypeHandle typeHandle) => throw new NotImplementedException();
     bool IsCollectible(TypeHandle typeHandle) => throw new NotImplementedException();
 
     bool HasTypeParam(TypeHandle typeHandle) => throw new NotImplementedException();
@@ -232,6 +233,7 @@ public interface IRuntimeTypeSystem : IContract
     uint GetFieldDescOffset(TargetPointer fieldDescPointer, FieldDefinition fieldDef) => throw new NotImplementedException();
     TargetPointer GetFieldDescByName(TypeHandle typeHandle, string fieldName) => throw new NotImplementedException();
     TargetPointer GetFieldDescStaticAddress(TargetPointer fieldDescPointer) => throw new NotImplementedException();
+    TargetPointer GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread) => throw new NotImplementedException();
     #endregion FieldDesc inspection APIs
     #region Other APIs
     void GetCoreLibFieldDescAndDef(string typeNamespace, string typeName, string fieldName, out TargetPointer fieldDescAddr, out FieldDefinition fieldDef) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
@@ -8,5 +8,5 @@ public static class CorDbgHResults
     public const int CORDBG_E_NOTREADY = unchecked((int)0x80131c10);
     public const int CORDBG_E_READVIRTUAL_FAILURE = unchecked((int)0x80131c49);
     public const int ERROR_BUFFER_OVERFLOW = unchecked((int)0x8007006F); // HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW)
-    public const int CLASS_NOT_LOADED = unchecked((int)0x80131303);
+    public const int CORDBG_E_CLASS_NOT_LOADED = unchecked((int)0x80131303);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
@@ -8,4 +8,5 @@ public static class CorDbgHResults
     public const int CORDBG_E_NOTREADY = unchecked((int)0x80131c10);
     public const int CORDBG_E_READVIRTUAL_FAILURE = unchecked((int)0x80131c49);
     public const int ERROR_BUFFER_OVERFLOW = unchecked((int)0x8007006F); // HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW)
+    public const int CLASS_NOT_LOADED = unchecked((int)0x80131303);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1892,6 +1892,9 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             }
         }
 
+        if (@base == TargetPointer.Null)
+            return TargetPointer.Null;
+
         MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
         uint token = ((IRuntimeTypeSystem)this).GetFieldDescMemberDef(fieldDescPointer);
         FieldDefinitionHandle fieldHandle = (FieldDefinitionHandle)MetadataTokens.Handle((int)token);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -693,6 +693,34 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     }
 
     public bool IsGenericTypeDefinition(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.IsGenericTypeDefinition;
+    public bool ContainsGenericVariables(TypeHandle typeHandle)
+    {
+        if (typeHandle.IsTypeDesc())
+        {
+            CorElementType type = GetSignatureCorElementType(typeHandle);
+            if (type == CorElementType.Var || type == CorElementType.MVar)
+                return true;
+
+            else if (HasTypeParam(typeHandle))
+            {
+                return ContainsGenericVariables(GetRootTypeParam(typeHandle));
+            }
+
+            else if (type == CorElementType.FnPtr)
+            {
+                _ = IsFunctionPointer(typeHandle, out ReadOnlySpan<TypeHandle> signatureTypeArgs, out _);
+                foreach (TypeHandle sigTypeArg in signatureTypeArgs)
+                {
+                    if (ContainsGenericVariables(sigTypeArg))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+        return _methodTables[typeHandle.Address].Flags.ContainsGenericVariables;
+    }
+
     public bool IsCollectible(TypeHandle typeHandle) => !typeHandle.IsMethodTable() ? false : _methodTables[typeHandle.Address].Flags.IsCollectible;
     public bool HasTypeParam(TypeHandle typeHandle)
     {
@@ -813,6 +841,16 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             }
         }
         throw new ArgumentException(nameof(typeHandle));
+    }
+
+    private TypeHandle GetRootTypeParam(TypeHandle typeHandle)
+    {
+        TypeHandle current = typeHandle;
+        while (HasTypeParam(current))
+        {
+            current = GetTypeParam(current);
+        }
+        return current;
     }
 
     private bool GenericInstantiationMatch(TypeHandle genericType, TypeHandle potentialMatch, ImmutableArray<TypeHandle> typeArguments)
@@ -1822,7 +1860,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return new TargetPointer(@base + offset);
     }
 
-    TargetPointer IRuntimeTypeSystem.GetFieldDescStaticAddress(TargetPointer fieldDescPointer)
+    private TargetPointer GetFieldDescStaticOrThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer? thread = null)
     {
         TargetPointer enclosingMT = ((IRuntimeTypeSystem)this).GetMTOfEnclosingClass(fieldDescPointer);
         TypeHandle ctx = GetTypeHandle(enclosingMT);
@@ -1833,11 +1871,25 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         TargetPointer @base;
         if (type == CorElementType.Class || type == CorElementType.ValueType)
         {
-            @base = GetGCStaticsBasePointer(ctx);
+            if (thread.HasValue)
+            {
+                @base = GetGCThreadStaticsBasePointer(ctx, thread.Value);
+            }
+            else
+            {
+                @base = GetGCStaticsBasePointer(ctx);
+            }
         }
         else
         {
-            @base = GetNonGCStaticsBasePointer(ctx);
+            if (thread.HasValue)
+            {
+                @base = GetNonGCThreadStaticsBasePointer(ctx, thread.Value);
+            }
+            else
+            {
+                @base = GetNonGCStaticsBasePointer(ctx);
+            }
         }
 
         MetadataReader mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
@@ -1856,6 +1908,10 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         }
         return handleAddr;
     }
+
+    TargetPointer IRuntimeTypeSystem.GetFieldDescStaticAddress(TargetPointer fieldDescPointer) => GetFieldDescStaticOrThreadStaticAddress(fieldDescPointer);
+
+    TargetPointer IRuntimeTypeSystem.GetFieldDescThreadStaticAddress(TargetPointer fieldDescPointer, TargetPointer thread) => GetFieldDescStaticOrThreadStaticAddress(fieldDescPointer, thread);
 
     void IRuntimeTypeSystem.GetCoreLibFieldDescAndDef(string @namespace, string typeName, string fieldName, out TargetPointer fieldDescAddr, out FieldDefinition fieldDef)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
@@ -5,7 +5,7 @@ using System.Diagnostics;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
-internal static class EcmaMetadataUtils
+public static class EcmaMetadataUtils
 {
     internal const int RowIdBitCount = 24;
     internal const uint RIDMask = (1 << RowIdBitCount) - 1;
@@ -24,7 +24,7 @@ internal static class EcmaMetadataUtils
         mdtMethodDef = 0x06 << 24,
     }
 
-    internal const uint TokenTypeMask = 0xff000000;
+    public const uint TokenTypeMask = 0xff000000;
 
     public static uint CreateMethodDef(uint tokenParts)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodTableFlags_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/MethodTableFlags_1.cs
@@ -47,6 +47,7 @@ internal struct MethodTableFlags_1
         Collectible = 0x00200000, // GC depends on this bit.
 
         ContainsGCPointers = 0x01000000,
+        ContainsGenericVariables = 0x20000000,
         HasComponentSize = 0x80000000, // This is set if lower 16 bits is used for the component size,
                                         // otherwise the lower bits are used for WFLAGS_LOW
     }
@@ -101,6 +102,7 @@ internal struct MethodTableFlags_1
     public bool IsCollectible => GetFlag(WFLAGS_HIGH.Collectible) != 0;
     public bool IsDynamicStatics => GetFlag(WFLAGS2_ENUM.DynamicStatics) != 0;
     public bool IsGenericTypeDefinition => TestFlagWithMask(WFLAGS_LOW.GenericsMask, WFLAGS_LOW.GenericsMask_TypicalInstantiation);
+    public bool ContainsGenericVariables => GetFlag(WFLAGS_HIGH.ContainsGenericVariables) != 0;
 
     internal static EEClassOrCanonMTBits GetEEClassOrCanonMTBits(TargetPointer eeClassOrCanonMTPtr)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -681,7 +681,31 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     }
 
     public int HasTypeParams(ulong vmTypeHandle, Interop.BOOL* pResult)
-        => _legacy is not null ? _legacy.HasTypeParams(vmTypeHandle, pResult) : HResults.E_NOTIMPL;
+    {
+        *pResult = Interop.BOOL.FALSE;
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            TypeHandle typeHandle = rts.GetTypeHandle(new TargetPointer(vmTypeHandle));
+            *pResult = rts.ContainsGenericVariables(typeHandle) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL resultLocal;
+            int hrLocal = _legacy.HasTypeParams(vmTypeHandle, &resultLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pResult == resultLocal, $"cDAC: {*pResult}, DAC: {resultLocal}");
+        }
+#endif
+        return hr;
+    }
 
     public int GetClassInfo(ulong vmAppDomain, ulong thExact, nint pData)
         => _legacy is not null ? _legacy.GetClassInfo(vmAppDomain, thExact, pData) : HResults.E_NOTIMPL;
@@ -699,7 +723,43 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         => _legacy is not null ? _legacy.GetObjectExpandedTypeInfoFromID(boxed, vmAppDomain, id, pTypeInfo) : HResults.E_NOTIMPL;
 
     public int GetTypeHandle(ulong vmModule, uint metadataToken, ulong* pRetVal)
-        => _legacy is not null ? _legacy.GetTypeHandle(vmModule, metadataToken, pRetVal) : HResults.E_NOTIMPL;
+    {
+        *pRetVal = 0;
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.ILoader loader = _target.Contracts.Loader;
+            TargetPointer module = new TargetPointer(vmModule);
+            Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(module);
+            Contracts.ModuleLookupTables lookupTables = loader.GetLookupTables(moduleHandle);
+            switch ((EcmaMetadataUtils.TokenType)(metadataToken & EcmaMetadataUtils.TokenTypeMask))
+            {
+                case EcmaMetadataUtils.TokenType.mdtTypeDef:
+                    *pRetVal = loader.GetModuleLookupMapElement(lookupTables.TypeDefToMethodTable, metadataToken, out var _).Value;
+                    break;
+                case EcmaMetadataUtils.TokenType.mdtTypeRef:
+                    *pRetVal = loader.GetModuleLookupMapElement(lookupTables.TypeRefToMethodTable, metadataToken, out var _).Value;
+                    break;
+                default:
+                    throw Marshal.GetExceptionForHR(CorDbgHResults.CLASS_NOT_LOADED)!;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            ulong retValLocal;
+            int hrLocal = _legacy.GetTypeHandle(vmModule, metadataToken, &retValLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pRetVal == retValLocal, $"cDAC: {*pRetVal}, DAC: {retValLocal}");
+        }
+#endif
+        return hr;
+    }
 
     public int GetApproxTypeHandle(nint pTypeData, ulong* pRetVal)
         => _legacy is not null ? _legacy.GetApproxTypeHandle(pTypeData, pRetVal) : HResults.E_NOTIMPL;
@@ -711,7 +771,37 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         => _legacy is not null ? _legacy.GetMethodDescParams(vmAppDomain, vmMethodDesc, genericsToken, pcGenericClassTypeParams, pGenericTypeParams) : HResults.E_NOTIMPL;
 
     public int GetThreadStaticAddress(ulong vmField, ulong vmRuntimeThread, ulong* pRetVal)
-        => _legacy is not null ? _legacy.GetThreadStaticAddress(vmField, vmRuntimeThread, pRetVal) : HResults.E_NOTIMPL;
+    {
+        *pRetVal = 0;
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            TargetPointer fd = new TargetPointer(vmField);
+            if (vmRuntimeThread == 0)
+                throw new ArgumentException("vmRuntimeThread cannot be null for thread static fields");
+            if (!rts.IsFieldDescThreadStatic(fd))
+            {
+                throw new NotImplementedException();
+            }
+            *pRetVal = rts.GetFieldDescThreadStaticAddress(fd, new TargetPointer(vmRuntimeThread)).Value;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            ulong retValLocal;
+            int hrLocal = _legacy.GetThreadStaticAddress(vmField, vmRuntimeThread, &retValLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pRetVal == retValLocal, $"cDAC: {*pRetVal}, DAC: {retValLocal}");
+        }
+#endif
+        return hr;
+    }
 
     public int GetCollectibleTypeStaticAddress(ulong vmField, ulong vmAppDomain, ulong* pRetVal)
         => _legacy is not null ? _legacy.GetCollectibleTypeStaticAddress(vmField, vmAppDomain, pRetVal) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -741,7 +741,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                     *pRetVal = loader.GetModuleLookupMapElement(lookupTables.TypeRefToMethodTable, metadataToken, out var _).Value;
                     break;
                 default:
-                    throw Marshal.GetExceptionForHR(CorDbgHResults.CLASS_NOT_LOADED)!;
+                    throw Marshal.GetExceptionForHR(CorDbgHResults.CORDBG_E_CLASS_NOT_LOADED)!;
             }
         }
         catch (System.Exception ex)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices.Marshalling;
 using System.Text;
 
+using Microsoft.Diagnostics.DataContractReader;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Contracts.Extensions;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
@@ -62,15 +63,6 @@ public sealed unsafe partial class SOSDacImpl
     private readonly IXCLRDataProcess? _legacyProcess;
     private readonly IXCLRDataProcess2? _legacyProcess2;
     private readonly ICLRDataEnumMemoryRegions? _legacyEnumMemory;
-
-    private enum CorTokenType : uint
-    {
-        mdtTypeRef = 0x01000000,
-        mdtTypeDef = 0x02000000,
-        mdtFieldDef = 0x04000000,
-        mdtMethodDef = 0x06000000,
-        typeMask = 0xff000000,
-    }
 
     public SOSDacImpl(Target target, object? legacyObj)
     {
@@ -1155,7 +1147,7 @@ public sealed unsafe partial class SOSDacImpl
             else
             {
                 // otherwise we have not found the token here, but we can encode the underlying type in sigType
-                data->TokenOfType = (uint)CorTokenType.mdtTypeDef;
+                data->TokenOfType = (uint)EcmaMetadataUtils.TokenType.mdtTypeDef;
                 if (data->MTOfType == 0)
                     data->sigType = typeCode;
             }
@@ -2572,18 +2564,18 @@ public sealed unsafe partial class SOSDacImpl
             TargetPointer module = moduleAddr.ToTargetPointer(_target);
             Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(module);
             Contracts.ModuleLookupTables lookupTables = loader.GetLookupTables(moduleHandle);
-            switch ((CorTokenType)token & CorTokenType.typeMask)
+            switch ((EcmaMetadataUtils.TokenType)(token & EcmaMetadataUtils.TokenTypeMask))
             {
-                case CorTokenType.mdtFieldDef:
+                case EcmaMetadataUtils.TokenType.mdtFieldDef:
                     *methodDesc = loader.GetModuleLookupMapElement(lookupTables.FieldDefToDesc, token, out var _).ToClrDataAddress(_target);
                     break;
-                case CorTokenType.mdtMethodDef:
+                case EcmaMetadataUtils.TokenType.mdtMethodDef:
                     *methodDesc = loader.GetModuleLookupMapElement(lookupTables.MethodDefToDesc, token, out var _).ToClrDataAddress(_target);
                     break;
-                case CorTokenType.mdtTypeDef:
+                case EcmaMetadataUtils.TokenType.mdtTypeDef:
                     *methodDesc = loader.GetModuleLookupMapElement(lookupTables.TypeDefToMethodTable, token, out var _).ToClrDataAddress(_target);
                     break;
-                case CorTokenType.mdtTypeRef:
+                case EcmaMetadataUtils.TokenType.mdtTypeRef:
                     *methodDesc = loader.GetModuleLookupMapElement(lookupTables.TypeRefToMethodTable, token, out var _).ToClrDataAddress(_target);
                     break;
                 default:

--- a/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiLoaderDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiLoaderDumpTests.cs
@@ -33,4 +33,31 @@ public class DacDbiLoaderDumpTests : DumpTestBase
         Assert.Equal(System.HResults.S_OK, hr);
         Assert.False(string.IsNullOrEmpty(holder.Value), "AppDomain name should not be empty");
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    public unsafe void GetTypeHandle_ReturnsMethodTableForTypeDef(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        DacDbiImpl dbi = CreateDacDbi();
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+
+        // Get the well-known System.Object MethodTable
+        TargetPointer objectMTGlobal = Target.ReadGlobalPointer("ObjectMethodTable");
+        TargetPointer objectMT = Target.ReadPointer(objectMTGlobal);
+        TypeHandle objectHandle = rts.GetTypeHandle(objectMT);
+
+        // Get its TypeDef token and module pointer
+        uint token = rts.GetTypeDefToken(objectHandle);
+        Assert.Equal(0x02000000u, token & 0xFF000000u);
+
+        TargetPointer modulePtr = rts.GetModule(objectHandle);
+        Assert.NotEqual(TargetPointer.Null, modulePtr);
+
+        // DacDbi GetTypeHandle should resolve the same token back to the same MethodTable
+        ulong result;
+        int hr = dbi.GetTypeHandle(modulePtr.Value, token, &result);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(objectMT.Value, result);
+    }
 }

--- a/src/native/managed/cdac/tests/DumpTests/RuntimeTypeSystemDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/RuntimeTypeSystemDumpTests.cs
@@ -316,13 +316,14 @@ public class RuntimeTypeSystemDumpTests : DumpTestBase
     [MemberData(nameof(TestConfigurations))]
     public void RuntimeTypeSystem_GenericTypeDefinitionContainsGenericVariables(TestConfiguration config)
     {
-        InitializeDumpTest(config);
+        // TODO: use default debuggee as soon as heap dumps are fixed
+        InitializeDumpTest(config, "LocalVariables", "full");
         IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
         ILoader loader = Target.Contracts.Loader;
 
         // Look up the generic type definition List<> in System.Private.CoreLib.
-        // The debuggee instantiates List<Animal>, so the runtime has loaded
-        // both the closed List<Animal> MT and the open List<T> type definition MT.
+        // The debuggee instantiates List<int>, so the runtime has loaded
+        // both the closed List<int> MT and the open List<T> type definition MT.
         TargetPointer systemAssembly = loader.GetSystemAssembly();
         ModuleHandle coreLibModule = loader.GetModuleHandleFromAssemblyPtr(systemAssembly);
         TypeHandle listTypeDef = rts.GetTypeByNameAndModule(

--- a/src/native/managed/cdac/tests/DumpTests/RuntimeTypeSystemDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/RuntimeTypeSystemDumpTests.cs
@@ -293,4 +293,46 @@ public class RuntimeTypeSystemDumpTests : DumpTestBase
         bool isLoaded = loader.TryGetLoadedImageContents(moduleHandle, out _, out _, out _);
         Assert.True(isLoaded, "System.String's module should have loaded image contents");
     }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    public void RuntimeTypeSystem_ConcreteTypesDoNotContainGenericVariables(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+
+        string[] globalNames = ["ObjectMethodTable", "StringMethodTable", "FreeObjectMethodTable"];
+        foreach (string globalName in globalNames)
+        {
+            TargetPointer mtGlobal = Target.ReadGlobalPointer(globalName);
+            TargetPointer mt = Target.ReadPointer(mtGlobal);
+            TypeHandle handle = rts.GetTypeHandle(mt);
+            Assert.False(rts.ContainsGenericVariables(handle),
+                $"{globalName} should not contain generic variables");
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    public void RuntimeTypeSystem_GenericTypeDefinitionContainsGenericVariables(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+        ILoader loader = Target.Contracts.Loader;
+
+        // Look up the generic type definition List<> in System.Private.CoreLib.
+        // The debuggee instantiates List<Animal>, so the runtime has loaded
+        // both the closed List<Animal> MT and the open List<T> type definition MT.
+        TargetPointer systemAssembly = loader.GetSystemAssembly();
+        ModuleHandle coreLibModule = loader.GetModuleHandleFromAssemblyPtr(systemAssembly);
+        TypeHandle listTypeDef = rts.GetTypeByNameAndModule(
+            "List`1",
+            "System.Collections.Generic",
+            coreLibModule);
+        Assert.True(listTypeDef.Address != 0, "Could not find List<> type definition in CoreLib");
+
+        Assert.True(rts.IsGenericTypeDefinition(listTypeDef));
+        Assert.True(rts.ContainsGenericVariables(listTypeDef),
+            "List<> generic type definition should contain generic variables");
+    }
 }


### PR DESCRIPTION
Implementing DacDbi APIs `HasTypeParams`, `GetTypeHandle` and `GetThreadStaticAddress` that use and require minimal modifications to the RuntimeTypeSystem cDAC contract.