### PR TITLE
Arm64 jitstress outerloop

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2652,7 +2652,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                     GetEmitter()->emitIns_R_R_R(INS_orr, scalarSize, op2Reg, op2Reg, op3Reg);
 
                     // Generate the table using the combined immediate.
-                    HWIntrinsicImmOpHelper helper(this, op2Reg, 0, 511, node);
+                    int                    numInstrs = (targetReg != op1Reg) ? 2 : 1;
+                    HWIntrinsicImmOpHelper helper(this, op2Reg, 0, 511, node, numInstrs);
                     for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
                     {
                         // Extract scale and pattern from the immediate
@@ -2712,7 +2713,8 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
             {
                 assert(isRMW);
 
-                HWIntrinsicImmOpHelper helper(this, intrin.op3, node);
+                int                    numInstrs = (targetReg != op1Reg) ? 2 : 1;
+                HWIntrinsicImmOpHelper helper(this, intrin.op3, node, numInstrs);
 
                 for (helper.EmitBegin(); !helper.Done(); helper.EmitCaseEnd())
                 {


### PR DESCRIPTION
Original fix here missed some cases, as msbuild or helix cuts off the failure list after 300:

https://github.com/dotnet/runtime/commit/95f94b62378e2ac3e74b42bebfb91327a4d8708d

This is applying the same fix to other locations we needed this.

I grabbed this codechange from @ylpoonlg (thanks in advance)

Ran jitstress, arm64 is green