### PR TITLE
JIT: Disable instrument_if_optimizing in libraries-pgo

### DIFF
--- a/eng/pipelines/coreclr/libraries-pgo.yml
+++ b/eng/pipelines/coreclr/libraries-pgo.yml
@@ -72,4 +72,3 @@ extends:
                     - syntheticpgo
                     - syntheticpgo_blend
                     - jitrlcse
-                    - instrument_if_optimizing


### PR DESCRIPTION
Remove the instrument_if_optimizing scenario from the libraries-pgo pipeline so the very slow JIT instrumentation mode no longer runs for libraries tests. The shared scenario definition remains available for coreclr tests.

Fixes #120902