### PR TITLE
Support hardware with more than 1024 CPUs

### DIFF
--- a/src/coreclr/gc/allocation.cpp
+++ b/src/coreclr/gc/allocation.cpp
@@ -4118,8 +4118,8 @@ void gc_heap::balance_heaps (alloc_context* acontext)
         if (set_home_heap)
         {
             /*
-                        // Since we are balancing up to MAX_SUPPORTED_CPUS, no need for this.
-                        if (n_heaps > MAX_SUPPORTED_CPUS)
+                        // Since we are balancing up to MAX_SUPPORTED_HEAPS, no need for this.
+                        if (n_heaps > MAX_SUPPORTED_HEAPS)
                         {
                             // on machines with many processors cache affinity is really king, so don't even try
                             // to balance on these.

--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -170,8 +170,16 @@ class AffinitySet
 
 public:
 
+    // Delete default copy and move constructors and assignment operators since this class manages a raw pointer.
+    AffinitySet(const AffinitySet&) = delete;
+    AffinitySet& operator=(const AffinitySet&) = delete;
+    AffinitySet(AffinitySet&&) = delete;
+    AffinitySet& operator=(AffinitySet&&) = delete;
+
     bool Initialize(int cpuCount)
     {
+        assert(m_bitset == nullptr);
+
         m_bitsetDataSize = (cpuCount + BitsPerBitsetEntry - 1) / BitsPerBitsetEntry;
         m_bitset = new (nothrow) uintptr_t[m_bitsetDataSize];
         if (m_bitset == nullptr)

--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -6,6 +6,9 @@
 #ifndef __GCENV_OS_H__
 #define __GCENV_OS_H__
 
+#include <new>
+using std::nothrow;
+
 #include <minipal/mutex.h>
 
 #define NUMA_NODE_UNDEFINED UINT16_MAX
@@ -138,12 +141,12 @@ public:
 typedef void (*GCThreadFunction)(void* param);
 
 #ifdef HOST_64BIT
-// Right now we support maximum 1024 procs - meaning that we will create at most
+// Right now we support maximum 1024 heaps - meaning that we will create at most
 // that many GC threads and GC heaps.
-#define MAX_SUPPORTED_CPUS 1024
+#define MAX_SUPPORTED_HEAPS 1024
 #define MAX_SUPPORTED_NODES 64
 #else
-#define MAX_SUPPORTED_CPUS 64
+#define MAX_SUPPORTED_HEAPS 64
 #define MAX_SUPPORTED_NODES 16
 #endif // HOST_64BIT
 
@@ -152,7 +155,8 @@ class AffinitySet
 {
     static const size_t BitsPerBitsetEntry = 8 * sizeof(uintptr_t);
 
-    uintptr_t m_bitset[MAX_SUPPORTED_CPUS / BitsPerBitsetEntry];
+    uintptr_t *m_bitset = nullptr;
+    size_t m_bitsetDataSize = 0;
 
     static uintptr_t GetBitsetEntryMask(size_t cpuIndex)
     {
@@ -166,11 +170,22 @@ class AffinitySet
 
 public:
 
-    static const size_t BitsetDataSize = MAX_SUPPORTED_CPUS / BitsPerBitsetEntry;
-
-    AffinitySet()
+    bool Initialize(int cpuCount)
     {
-        memset(m_bitset, 0, sizeof(m_bitset));
+        m_bitsetDataSize = (cpuCount + BitsPerBitsetEntry - 1) / BitsPerBitsetEntry;
+        m_bitset = new (nothrow) uintptr_t[m_bitsetDataSize];
+        if (m_bitset == nullptr)
+        {
+            return false;
+        }
+
+        memset(m_bitset, 0, sizeof(uintptr_t) * m_bitsetDataSize);
+        return true;
+    }
+
+    ~AffinitySet()
+    {
+        delete[] m_bitset;
     }
 
     uintptr_t* GetBitsetData()
@@ -181,25 +196,28 @@ public:
     // Check if the set contains a processor
     bool Contains(size_t cpuIndex) const
     {
+        assert(GetBitsetEntryIndex(cpuIndex) < m_bitsetDataSize);
         return (m_bitset[GetBitsetEntryIndex(cpuIndex)] & GetBitsetEntryMask(cpuIndex)) != 0;
     }
 
     // Add a processor to the set
     void Add(size_t cpuIndex)
     {
+        assert(GetBitsetEntryIndex(cpuIndex) < m_bitsetDataSize);
         m_bitset[GetBitsetEntryIndex(cpuIndex)] |= GetBitsetEntryMask(cpuIndex);
     }
 
     // Remove a processor from the set
     void Remove(size_t cpuIndex)
     {
+        assert(GetBitsetEntryIndex(cpuIndex) < m_bitsetDataSize);
         m_bitset[GetBitsetEntryIndex(cpuIndex)] &= ~GetBitsetEntryMask(cpuIndex);
     }
 
     // Check if the set is empty
     bool IsEmpty() const
     {
-        for (size_t i = 0; i < MAX_SUPPORTED_CPUS / BitsPerBitsetEntry; i++)
+        for (size_t i = 0; i < m_bitsetDataSize; i++)
         {
             if (m_bitset[i] != 0)
             {
@@ -210,11 +228,17 @@ public:
         return true;
     }
 
+    // Return the capacity of the affinity set (maximum number of processor indices it can hold)
+    size_t MaxCpuCount() const
+    {
+        return m_bitsetDataSize * BitsPerBitsetEntry;
+    }
+
     // Return number of processors in the affinity set
     size_t Count() const
     {
         size_t count = 0;
-        for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
+        for (size_t i = 0; i < m_bitsetDataSize * BitsPerBitsetEntry; i++)
         {
             if (Contains(i))
             {
@@ -478,6 +502,13 @@ public:
     // Return:
     //  Number of processors on the machine
     static uint32_t GetTotalProcessorCount();
+
+    // Gets the maximum number of processors that could potentially exist on
+    // the machine (including offlined ones). Processor indices returned by
+    // GetCurrentProcessorNumber are guaranteed to be less than this value.
+    // Return:
+    //  Maximum number of processors
+    static uint32_t GetMaxProcessorCount();
 
     // Is NUMA support available
     static bool CanEnableGCNumaAware();

--- a/src/coreclr/gc/env/gcenv.os.h
+++ b/src/coreclr/gc/env/gcenv.os.h
@@ -170,7 +170,8 @@ class AffinitySet
 
 public:
 
-    // Delete default copy and move constructors and assignment operators since this class manages a raw pointer.
+    // Delete copy and move constructors and assignment operators since this class manages a raw pointer.
+    AffinitySet() = default;
     AffinitySet(const AffinitySet&) = delete;
     AffinitySet& operator=(const AffinitySet&) = delete;
     AffinitySet(AffinitySet&&) = delete;

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -650,7 +650,7 @@ class t_join
     gc_join_flavor flavor;
 
 #ifdef JOIN_STATS
-    uint64_t start[MAX_SUPPORTED_CPUS], end[MAX_SUPPORTED_CPUS], start_seq;
+    uint64_t start[MAX_SUPPORTED_HEAPS], end[MAX_SUPPORTED_HEAPS], start_seq;
     // remember join id and last thread to arrive so restart can use these
     int thd;
     // we want to print statistics every 10 seconds - this is to remember the start of the 10 sec interval
@@ -4502,10 +4502,10 @@ public:
     static unsigned n_sniff_buffers;
     static unsigned cur_sniff_index;
 
-    static uint16_t proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
-    static uint16_t heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
-    static uint16_t heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
-    static uint16_t numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
+    static uint16_t *proc_no_to_heap_no;
+    static uint16_t heap_no_to_proc_no[MAX_SUPPORTED_HEAPS];
+    static uint16_t heap_no_to_numa_node[MAX_SUPPORTED_HEAPS];
+    static uint16_t *numa_node_to_heap_map;
 
 #ifdef HEAP_BALANCE_INSTRUMENTATION
     // Note this is the total numa nodes GC heaps are on. There might be
@@ -4529,6 +4529,16 @@ public:
     static BOOL init(int n_heaps)
     {
         assert (sniff_buffer == NULL && n_sniff_buffers == 0);
+
+        uint32_t maxCpuCount = GCToOSInterface::GetMaxProcessorCount();
+        proc_no_to_heap_no = new (nothrow) uint16_t[maxCpuCount];
+        if (proc_no_to_heap_no == NULL)
+        {
+            return FALSE;
+        }
+
+        memset(proc_no_to_heap_no, 0, maxCpuCount*sizeof(uint16_t));
+
         if (!GCToOSInterface::CanGetCurrentProcessorNumber())
         {
             n_sniff_buffers = n_heaps*2+1;
@@ -4555,15 +4565,15 @@ public:
         // 2. assign heap numbers for each numa node
 
         // Pass 1: gather processor numbers and numa node numbers
-        uint16_t proc_no[MAX_SUPPORTED_CPUS];
-        uint16_t node_no[MAX_SUPPORTED_CPUS];
+        uint16_t proc_no[MAX_SUPPORTED_HEAPS];
+        uint16_t node_no[MAX_SUPPORTED_HEAPS];
         uint16_t max_node_no = 0;
         uint16_t heap_num;
         for (heap_num = 0; heap_num < n_heaps; heap_num++)
         {
             if (!GCToOSInterface::GetProcessorForHeap (heap_num, &proc_no[heap_num], &node_no[heap_num]))
                 break;
-            assert(proc_no[heap_num] < MAX_SUPPORTED_CPUS);
+            assert(proc_no[heap_num] < GCToOSInterface::GetMaxProcessorCount());
             if (!do_numa || node_no[heap_num] == NUMA_NODE_UNDEFINED)
                 node_no[heap_num] = 0;
             max_node_no = max(max_node_no, node_no[heap_num]);
@@ -4594,11 +4604,7 @@ public:
         if (GCToOSInterface::CanGetCurrentProcessorNumber())
         {
             uint32_t proc_no = GCToOSInterface::GetCurrentProcessorNumber();
-            // For a 32-bit process running on a machine with > 64 procs,
-            // even though the process can only use up to 32 procs, the processor
-            // index can be >= 64; or in the cpu group case, if the process is not running in cpu group #0,
-            // the GetCurrentProcessorNumber will return a number that's >= 64.
-            proc_no_to_heap_no[proc_no % MAX_SUPPORTED_CPUS] = (uint16_t)heap_number;
+            proc_no_to_heap_no[proc_no] = (uint16_t)heap_number;
         }
     }
 
@@ -4620,11 +4626,7 @@ public:
         if (GCToOSInterface::CanGetCurrentProcessorNumber())
         {
             uint32_t proc_no = GCToOSInterface::GetCurrentProcessorNumber();
-            // For a 32-bit process running on a machine with > 64 procs,
-            // even though the process can only use up to 32 procs, the processor
-            // index can be >= 64; or in the cpu group case, if the process is not running in cpu group #0,
-            // the GetCurrentProcessorNumber will return a number that's >= 64.
-            int adjusted_heap = proc_no_to_heap_no[proc_no % MAX_SUPPORTED_CPUS];
+            int adjusted_heap = proc_no_to_heap_no[proc_no];
             // with dynamic heap count, need to make sure the value is in range.
             if (adjusted_heap >= gc_heap::n_heaps)
             {
@@ -4686,9 +4688,21 @@ public:
         return heap_no_to_numa_node[heap_number];
     }
 
-    static void init_numa_node_to_heap_map(int nheaps)
+    static bool init_numa_node_to_heap_map(int nheaps)
     {
         // Called right after GCHeap::Init() for each heap
+
+        uint32_t maxCpuCount = GCToOSInterface::GetMaxProcessorCount();
+        // The upper limit of the numa node numbers is maxCpuCount - 1 since in the worst case each processor could be on a different NUMA node. 
+        // We add +1 here to make it easier to calculate the heap number range for the last NUMA node.
+        numa_node_to_heap_map = new (nothrow) uint16_t[maxCpuCount + 1];
+        if (numa_node_to_heap_map == nullptr)
+        {
+            return false;
+        }
+
+        memset(numa_node_to_heap_map, 0, (maxCpuCount + 1)*sizeof(uint16_t));
+
         // For each NUMA node used by the heaps, the
         // numa_node_to_heap_map[numa_node] is set to the first heap number on that node and
         // numa_node_to_heap_map[numa_node + 1] is set to the first heap number not on that node
@@ -4709,7 +4723,8 @@ public:
                 total_numa_nodes++;
                 heaps_on_node[total_numa_nodes].node_no = heap_no_to_numa_node[i];
 #endif
-
+                assert(heap_no_to_numa_node[i-1] < maxCpuCount);
+                assert(heap_no_to_numa_node[i] < maxCpuCount);
                 // Set the end of the heap number range for the previous NUMA node
                 numa_node_to_heap_map[heap_no_to_numa_node[i-1] + 1] =
                 // Set the start of the heap number range for the current NUMA node
@@ -4720,12 +4735,14 @@ public:
 #endif
         }
 
+        assert(heap_no_to_numa_node[nheaps-1] < maxCpuCount);
         // Set the end of the heap range for the last NUMA node
         numa_node_to_heap_map[heap_no_to_numa_node[nheaps-1] + 1] = (uint16_t)nheaps; //mark the end with nheaps
 
 #ifdef HEAP_BALANCE_INSTRUMENTATION
         total_numa_nodes++;
 #endif
+        return true;
     }
 
     static bool get_info_proc (int index, uint16_t* proc_no, uint16_t* node_no, int* start_heap, int* end_heap)
@@ -4749,7 +4766,7 @@ public:
 
         if (distribute_all_p)
         {
-            uint16_t current_heap_no_on_node[MAX_SUPPORTED_CPUS];
+            uint16_t current_heap_no_on_node[MAX_SUPPORTED_HEAPS];
             memset (current_heap_no_on_node, 0, sizeof (current_heap_no_on_node));
             uint16_t current_heap_no = 0;
 
@@ -4831,10 +4848,10 @@ public:
 uint8_t* heap_select::sniff_buffer;
 unsigned heap_select::n_sniff_buffers;
 unsigned heap_select::cur_sniff_index;
-uint16_t heap_select::proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
-uint16_t heap_select::heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
-uint16_t heap_select::heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
-uint16_t heap_select::numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
+uint16_t* heap_select::proc_no_to_heap_no;
+uint16_t heap_select::heap_no_to_proc_no[MAX_SUPPORTED_HEAPS];
+uint16_t heap_select::heap_no_to_numa_node[MAX_SUPPORTED_HEAPS];
+uint16_t* heap_select::numa_node_to_heap_map;
 #ifdef HEAP_BALANCE_INSTRUMENTATION
 uint16_t  heap_select::total_numa_nodes;
 node_heap_count heap_select::heaps_on_node[MAX_SUPPORTED_NODES];

--- a/src/coreclr/gc/gcconfig.cpp
+++ b/src/coreclr/gc/gcconfig.cpp
@@ -175,7 +175,8 @@ bool ParseGCHeapAffinitizeRanges(const char* cpu_index_ranges, AffinitySet* conf
                     break;
                 }
 
-                if ((start_index >= MAX_SUPPORTED_CPUS) || (end_index >= MAX_SUPPORTED_CPUS) || (end_index < start_index))
+                size_t maxCpuCount = GCToOSInterface::GetMaxProcessorCount();
+                if ((start_index >= maxCpuCount) || (end_index >= maxCpuCount) || (end_index < start_index))
                 {
                     // Invalid CPU index values or range
                     break;

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -1755,7 +1755,7 @@ private:
     PER_HEAP_ISOLATED_METHOD void move_aged_regions(region_free_list dest[count_free_region_kinds], region_free_list& src, free_region_kind kind, bool joined_last_gc_before_oom);
     PER_HEAP_ISOLATED_METHOD bool aged_region_p(heap_segment* region, free_region_kind kind);
     PER_HEAP_ISOLATED_METHOD void move_regions_to_decommit(region_free_list oregions[count_free_region_kinds]);
-    PER_HEAP_ISOLATED_METHOD size_t compute_basic_region_budgets(size_t heap_basic_budget_in_region_units[MAX_SUPPORTED_CPUS], size_t min_heap_basic_budget_in_region_units[MAX_SUPPORTED_CPUS], size_t total_basic_free_regions);
+    PER_HEAP_ISOLATED_METHOD size_t compute_basic_region_budgets(size_t heap_basic_budget_in_region_units[MAX_SUPPORTED_HEAPS], size_t min_heap_basic_budget_in_region_units[MAX_SUPPORTED_HEAPS], size_t total_basic_free_regions);
     PER_HEAP_ISOLATED_METHOD bool near_heap_hard_limit_p();
     PER_HEAP_ISOLATED_METHOD bool distribute_surplus_p(ptrdiff_t balance, int kind, bool aggressive_decommit_large_p);
     PER_HEAP_ISOLATED_METHOD void decide_on_decommit_strategy(bool joined_last_gc_before_oom);

--- a/src/coreclr/gc/interface.cpp
+++ b/src/coreclr/gc/interface.cpp
@@ -198,6 +198,12 @@ HRESULT GCHeap::Initialize()
 #else //!MULTIPLE_HEAPS
     GCConfig::SetServerGC(true);
     AffinitySet config_affinity_set;
+    if (!config_affinity_set.Initialize(GCToOSInterface::GetMaxProcessorCount()))
+    {
+        log_init_error_to_host ("Failed to initialize affinity set for GC heap affinity configuration");
+        return E_OUTOFMEMORY;
+    }
+
     GCConfigStringHolder cpu_index_ranges_holder(GCConfig::GetGCHeapAffinitizeRanges());
 
     uintptr_t config_affinity_mask = static_cast<uintptr_t>(GCConfig::GetGCHeapAffinitizeMask());
@@ -240,7 +246,7 @@ HRESULT GCHeap::Initialize()
 
     nhp = ((nhp_from_config == 0) ? g_num_active_processors : nhp_from_config);
 
-    nhp = min (nhp, (uint32_t)MAX_SUPPORTED_CPUS);
+    nhp = min (nhp, (uint32_t)MAX_SUPPORTED_HEAPS);
 
     gc_heap::gc_thread_no_affinitize_p = (gc_heap::heap_hard_limit ?
         !affinity_config_specified_p : (GCConfig::GetNoAffinitize() != 0));
@@ -532,7 +538,11 @@ HRESULT GCHeap::Initialize()
         }
     }
 
-    heap_select::init_numa_node_to_heap_map (nhp);
+    if (!heap_select::init_numa_node_to_heap_map (nhp))
+    {
+        log_init_error_to_host ("Initialization of NUMA node to heap map failed");
+        return E_OUTOFMEMORY;
+    }
 
     // If we have more active processors than heaps we still want to initialize some of the
     // mapping for the rest of the active processors because user threads can still run on

--- a/src/coreclr/gc/mark_phase.cpp
+++ b/src/coreclr/gc/mark_phase.cpp
@@ -273,7 +273,7 @@ static size_t target_mark_count_for_heap (size_t total_mark_count, int heap_coun
 NOINLINE
 uint8_t** gc_heap::equalize_mark_lists (size_t total_mark_list_size)
 {
-    size_t local_mark_count[MAX_SUPPORTED_CPUS];
+    size_t local_mark_count[MAX_SUPPORTED_HEAPS];
     size_t total_mark_count = 0;
 
     // compute mark count per heap into a local array
@@ -674,9 +674,9 @@ void gc_heap::merge_mark_lists (size_t total_mark_list_size)
     int source_number = (size_t)heap_number;
 #endif //USE_REGIONS
 
-    uint8_t** source[MAX_SUPPORTED_CPUS];
-    uint8_t** source_end[MAX_SUPPORTED_CPUS];
-    int source_heap[MAX_SUPPORTED_CPUS];
+    uint8_t** source[MAX_SUPPORTED_HEAPS];
+    uint8_t** source_end[MAX_SUPPORTED_HEAPS];
+    int source_heap[MAX_SUPPORTED_HEAPS];
     int source_count = 0;
 
     for (int i = 0; i < n_heaps; i++)
@@ -687,7 +687,7 @@ void gc_heap::merge_mark_lists (size_t total_mark_list_size)
             source[source_count] = heap->mark_list_piece_start[source_number];
             source_end[source_count] = heap->mark_list_piece_end[source_number];
             source_heap[source_count] = i;
-            if (source_count < MAX_SUPPORTED_CPUS)
+            if (source_count < MAX_SUPPORTED_HEAPS)
                 source_count++;
         }
     }
@@ -1141,7 +1141,7 @@ void gc_heap::equalize_promoted_bytes(int condemned_gen_number)
         //  compute total promoted bytes per gen
         size_t total_surv = 0;
         size_t max_surv_per_heap = 0;
-        size_t surv_per_heap[MAX_SUPPORTED_CPUS];
+        size_t surv_per_heap[MAX_SUPPORTED_HEAPS];
         for (int i = 0; i < n_heaps; i++)
         {
             surv_per_heap[i] = 0;
@@ -1282,7 +1282,7 @@ void gc_heap::equalize_promoted_bytes(int condemned_gen_number)
             surplus_regions_by_size_class[size_class] = region;
         }
 
-        int next_heap_in_size_class[MAX_SUPPORTED_CPUS];
+        int next_heap_in_size_class[MAX_SUPPORTED_HEAPS];
         int heaps_by_deficit_size_class[NUM_SIZE_CLASSES];
         for (int i = 0; i < NUM_SIZE_CLASSES; i++)
         {

--- a/src/coreclr/gc/regions_segments.cpp
+++ b/src/coreclr/gc/regions_segments.cpp
@@ -219,7 +219,7 @@ BOOL gc_heap::reserve_initial_memory (size_t normal_size, size_t large_size, siz
             highest_numa_node = max (highest_numa_node, heap_numa_node);
         }
 
-        assert (highest_numa_node < MAX_SUPPORTED_CPUS);
+        assert (highest_numa_node < MAX_SUPPORTED_HEAPS);
 
         numa_node_count = highest_numa_node + 1;
         memory_details.numa_reserved_block_count = numa_node_count * (1 + separated_poh_p);
@@ -1855,8 +1855,8 @@ void gc_heap::distribute_free_regions()
     size_t total_num_free_regions[count_distributed_free_region_kinds] = { 0, 0 };
     size_t total_budget_in_region_units[count_distributed_free_region_kinds] = { 0, 0 };
 
-    size_t heap_budget_in_region_units[count_distributed_free_region_kinds][MAX_SUPPORTED_CPUS] = {};
-    size_t min_heap_budget_in_region_units[count_distributed_free_region_kinds][MAX_SUPPORTED_CPUS] = {};
+    size_t heap_budget_in_region_units[count_distributed_free_region_kinds][MAX_SUPPORTED_HEAPS] = {};
+    size_t min_heap_budget_in_region_units[count_distributed_free_region_kinds][MAX_SUPPORTED_HEAPS] = {};
     region_free_list aged_regions[count_free_region_kinds];
     region_free_list surplus_regions[count_distributed_free_region_kinds];
 
@@ -2152,8 +2152,8 @@ void gc_heap::move_regions_to_decommit(region_free_list regions[count_free_regio
 }
 
 size_t gc_heap::compute_basic_region_budgets(
-    size_t heap_basic_budget_in_region_units[MAX_SUPPORTED_CPUS],
-    size_t min_heap_basic_budget_in_region_units[MAX_SUPPORTED_CPUS],
+    size_t heap_basic_budget_in_region_units[MAX_SUPPORTED_HEAPS],
+    size_t min_heap_basic_budget_in_region_units[MAX_SUPPORTED_HEAPS],
     size_t total_basic_free_regions)
 {
     const size_t region_size = global_region_allocator.get_region_alignment();

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -188,7 +188,7 @@ bool GCToOSInterface::Initialize()
 
         if (st == 0)
         {
-            for (size_t i = 0; i < configuredCpuCount; i++)
+            for (size_t i = 0; i < (size_t)configuredCpuCount; i++)
             {
                 if (CPU_ISSET_S(i, cpuSetSize, pCpuSet))
                 {

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -151,7 +151,18 @@ bool GCToOSInterface::Initialize()
         return false;
     }
 
+    int configuredCpuCount = sysconf(_SC_NPROCESSORS_CONF);
+    if (configuredCpuCount == -1)
+    {
+        return false;
+    }
+
     g_totalCpuCount = cpuCount;
+
+    if (!g_processAffinitySet.Initialize(configuredCpuCount))
+    {
+        return false;
+    }
 
     if (!minipal_initialize_memory_barrier_process_wide())
     {
@@ -162,29 +173,42 @@ bool GCToOSInterface::Initialize()
 
 #if HAVE_SCHED_GETAFFINITY
 
-    cpu_set_t cpuSet;
-    int st = sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuSet);
-
-    if (st == 0)
     {
-        for (size_t i = 0; i < CPU_SETSIZE; i++)
+        // Use a dynamically allocated cpu_set_t to support systems with more than CPU_SETSIZE (typically 1024) CPUs.
+        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        if (pCpuSet == nullptr)
         {
-            if (CPU_ISSET(i, &cpuSet))
+            return false;
+        }
+
+        size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+        CPU_ZERO_S(cpuSetSize, pCpuSet);
+
+        int st = sched_getaffinity(getpid(), cpuSetSize, pCpuSet);
+
+        if (st == 0)
+        {
+            for (size_t i = 0; i < configuredCpuCount; i++)
             {
-                g_processAffinitySet.Add(i);
+                if (CPU_ISSET_S(i, cpuSetSize, pCpuSet))
+                {
+                    g_processAffinitySet.Add(i);
+                }
             }
         }
-    }
-    else
-    {
-        // We should not get any of the errors that the sched_getaffinity can return since none
-        // of them applies for the current thread, so this is an unexpected kind of failure.
-        assert(false);
+        else
+        {
+            // We should not get any of the errors that the sched_getaffinity can return since none
+            // of them applies for the current thread, so this is an unexpected kind of failure.
+            assert(false);
+        }
+
+        CPU_FREE(pCpuSet);
     }
 
 #else // HAVE_SCHED_GETAFFINITY
 
-    for (size_t i = 0; i < g_totalCpuCount; i++)
+    for (size_t i = 0; i < configuredCpuCount; i++)
     {
         g_processAffinitySet.Add(i);
     }
@@ -941,7 +965,7 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
     if (!configAffinitySet->IsEmpty())
     {
         // Update the process affinity set using the configured set
-        for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
+        for (size_t i = 0; i < g_totalCpuCount; i++)
         {
             if (g_processAffinitySet.Contains(i) && !configAffinitySet->Contains(i))
             {
@@ -1296,6 +1320,11 @@ uint32_t GCToOSInterface::GetTotalProcessorCount()
     return g_totalCpuCount;
 }
 
+uint32_t GCToOSInterface::GetMaxProcessorCount()
+{
+    return (uint32_t)g_processAffinitySet.MaxCpuCount();
+}
+
 bool GCToOSInterface::CanEnableGCNumaAware()
 {
     return g_numaAvailable;
@@ -1318,7 +1347,9 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
     bool success = false;
 
     uint16_t availableProcNumber = 0;
-    for (size_t procNumber = 0; procNumber < MAX_SUPPORTED_CPUS; procNumber++)
+
+    size_t maxCpuCount = g_processAffinitySet.MaxCpuCount();
+    for (size_t procNumber = 0; procNumber < maxCpuCount; procNumber++)
     {
         if (g_processAffinitySet.Contains(procNumber))
         {

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -515,6 +515,11 @@ bool GCToOSInterface::Initialize()
     InitNumaNodeInfo();
     InitCPUGroupInfo();
 
+    if (!g_processAffinitySet.Initialize(GCToOSInterface::GetTotalProcessorCount()))
+    {
+        return false;
+    }
+
     if (CanEnableGCCPUGroups())
     {
         // When CPU groups are enabled, then the process is not bound by the process affinity set at process launch.
@@ -913,7 +918,7 @@ const AffinitySet* GCToOSInterface::SetGCThreadsAffinitySet(uintptr_t configAffi
         if (!configAffinitySet->IsEmpty())
         {
             // Update the process affinity set using the configured set
-            for (size_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
+            for (size_t i = 0; i < g_totalCpuCount; i++)
             {
                 if (g_processAffinitySet.Contains(i) && !configAffinitySet->Contains(i))
                 {
@@ -1130,6 +1135,11 @@ uint32_t GCToOSInterface::GetTotalProcessorCount()
     return g_totalCpuCount;
 }
 
+uint32_t GCToOSInterface::GetMaxProcessorCount()
+{
+    return (uint32_t)g_processAffinitySet.MaxCpuCount();
+}
+
 bool GCToOSInterface::CanEnableGCNumaAware()
 {
     return g_fEnableGCNumaAware;
@@ -1200,7 +1210,7 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
     // Locate heap_number-th available processor
     uint16_t procIndex = 0;
     size_t cnt = heap_number;
-    for (uint16_t i = 0; i < MAX_SUPPORTED_CPUS; i++)
+    for (uint16_t i = 0; i < g_totalCpuCount; i++)
     {
         if (g_processAffinitySet.Contains(i))
         {

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -1210,13 +1210,13 @@ bool GCToOSInterface::GetProcessorForHeap(uint16_t heap_number, uint16_t* proc_n
     // Locate heap_number-th available processor
     uint16_t procIndex = 0;
     size_t cnt = heap_number;
-    for (uint16_t i = 0; i < g_totalCpuCount; i++)
+    for (uint32_t i = 0; i < g_totalCpuCount; i++)
     {
         if (g_processAffinitySet.Contains(i))
         {
             if (cnt == 0)
             {
-                procIndex = i;
+                procIndex = (uint16_t)i;
                 success = true;
                 break;
             }

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -439,7 +439,7 @@ void ConfigureSignals()
 
 void InitializeCurrentProcessCpuCount()
 {
-    uint32_t count;
+    uint32_t count = 0;
 
     // If the configuration value has been set, it takes precedence. Otherwise, take into account
     // process affinity and CPU quota limit.
@@ -464,24 +464,32 @@ void InitializeCurrentProcessCpuCount()
         }
 
         cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
-        if (pCpuSet == nullptr)
-        {
-            _ASSERTE(!"CPU_ALLOC failed");
-            count = 1;
-        }
-        else
+        if (pCpuSet != nullptr)
         {
             size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
             CPU_ZERO_S(cpuSetSize, pCpuSet);
 
             int st = sched_getaffinity(getpid(), cpuSetSize, pCpuSet);
-            if (st != 0)
+            if (st == 0)
+            {
+                count = (uint32_t)CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            }
+            else
             {
                 _ASSERTE(!"sched_getaffinity failed");
             }
 
-            count = (uint32_t)CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
             CPU_FREE(pCpuSet);
+        }
+        else
+        {
+            ASSERT("CPU_ALLOC failed!\n");
+        }
+
+        if (count == 0)
+        {
+            // If we failed to get the number of CPUs from sched_getaffinity, fall back to getting the total number of CPUs in the system.
+            count = GCToOSInterface::GetTotalProcessorCount();
         }
 #else // HAVE_SCHED_GETAFFINITY
         count = GCToOSInterface::GetTotalProcessorCount();

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -456,14 +456,33 @@ void InitializeCurrentProcessCpuCount()
     {
 #if HAVE_SCHED_GETAFFINITY
 
-        cpu_set_t cpuSet;
-        int st = sched_getaffinity(getpid(), sizeof(cpu_set_t), &cpuSet);
-        if (st != 0)
+        int configuredCpuCount = sysconf(_SC_NPROCESSORS_CONF);
+        if (configuredCpuCount == -1)
         {
-            _ASSERTE(!"sched_getaffinity failed");
+            // In the unlikely event that sysconf(_SC_NPROCESSORS_CONF) fails, just assume a reasonable default maximum number of CPUs to avoid failing.
+            configuredCpuCount = CPU_SETSIZE;
         }
 
-        count = CPU_COUNT(&cpuSet);
+        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        if (pCpuSet == nullptr)
+        {
+            _ASSERTE(!"CPU_ALLOC failed");
+            count = 1;
+        }
+        else
+        {
+            size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+            CPU_ZERO_S(cpuSetSize, pCpuSet);
+
+            int st = sched_getaffinity(getpid(), cpuSetSize, pCpuSet);
+            if (st != 0)
+            {
+                _ASSERTE(!"sched_getaffinity failed");
+            }
+
+            count = (uint32_t)CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            CPU_FREE(pCpuSet);
+        }
 #else // HAVE_SCHED_GETAFFINITY
         count = GCToOSInterface::GetTotalProcessorCount();
 #endif // HAVE_SCHED_GETAFFINITY

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -163,24 +163,32 @@ PAL_GetLogicalCpuCountFromOS()
         }
 
         cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
-        if (pCpuSet == nullptr)
-        {
-            ASSERT("CPU_ALLOC failed\n");
-            nrcpus = 1;
-        }
-        else
+        if (pCpuSet != nullptr)
         {
             size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
             CPU_ZERO_S(cpuSetSize, pCpuSet);
 
             int st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
-            if (st != 0)
+            if (st == 0)
+            {
+                nrcpus = CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            }
+            else
             {
                 ASSERT("sched_getaffinity failed (%d)\n", errno);
             }
 
-            nrcpus = CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
             CPU_FREE(pCpuSet);
+        }
+        else
+        {
+            ASSERT("CPU_ALLOC failed!\n");
+        }
+
+        if (nrcpus < 1)
+        {
+            // If we failed to get the number of CPUs from sched_getaffinity, fall back to getting the total number of CPUs in the system.
+            nrcpus = PAL_GetTotalCpuCount();
         }
 #else // HAVE_SCHED_GETAFFINITY
         nrcpus = PAL_GetTotalCpuCount();

--- a/src/coreclr/pal/src/misc/sysinfo.cpp
+++ b/src/coreclr/pal/src/misc/sysinfo.cpp
@@ -110,7 +110,7 @@ PAL_GetTotalCpuCount()
 
 #if HAVE_SYSCONF
 
-#if defined(HOST_ARM) || defined(HOST_ARM64)
+#if defined(HOST_ARM) || defined(HOST_ARM64) || defined(HOST_LOONGARCH64) || defined(HOST_RISCV64)
 #define SYSCONF_GET_NUMPROCS       _SC_NPROCESSORS_CONF
 #define SYSCONF_GET_NUMPROCS_NAME "_SC_NPROCESSORS_CONF"
 #else
@@ -136,6 +136,12 @@ PAL_GetTotalCpuCount()
 #error "Don't know how to get total CPU count on this platform"
 #endif // HAVE_SYSCONF
 
+    if (nrcpus < 1)
+    {
+        // Default to 1 if we failed to get the number of CPUs or if the value is invalid.
+        nrcpus = 1;
+    }
+
     return nrcpus;
 }
 
@@ -149,14 +155,33 @@ PAL_GetLogicalCpuCountFromOS()
     {
 #if HAVE_SCHED_GETAFFINITY
 
-        cpu_set_t cpuSet;
-        int st = sched_getaffinity(gPID, sizeof(cpu_set_t), &cpuSet);
-        if (st != 0)
+        int configuredCpuCount = sysconf(_SC_NPROCESSORS_CONF);
+        if (configuredCpuCount == -1)
         {
-            ASSERT("sched_getaffinity failed (%d)\n", errno);
+            // In the unlikely event that sysconf(_SC_NPROCESSORS_CONF) fails, just assume a reasonable default maximum number of CPUs to avoid failing.
+            configuredCpuCount = CPU_SETSIZE;
         }
 
-        nrcpus = CPU_COUNT(&cpuSet);
+        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        if (pCpuSet == nullptr)
+        {
+            ASSERT("CPU_ALLOC failed\n");
+            nrcpus = 1;
+        }
+        else
+        {
+            size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+            CPU_ZERO_S(cpuSetSize, pCpuSet);
+
+            int st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
+            if (st != 0)
+            {
+                ASSERT("sched_getaffinity failed (%d)\n", errno);
+            }
+
+            nrcpus = CPU_COUNT_S(CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            CPU_FREE(pCpuSet);
+        }
 #else // HAVE_SCHED_GETAFFINITY
         nrcpus = PAL_GetTotalCpuCount();
 #endif // HAVE_SCHED_GETAFFINITY

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1415,36 +1415,34 @@ CPalThread::ThreadEntry(
         CPU_ZERO_S(cpuSetSize, pCpuSet);
 
         st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
-        if (st != 0)
+        if (st == 0)
         {
+            st = sched_setaffinity(0, CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+            if (st != 0)
+            {
+                if (errno == EPERM || errno == EACCES)
+                {
+                    // Some sandboxed or restricted environments (snap strict confinement,
+                    // vendor-modified Android kernels with strict SELinux policy) block
+                    // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
+                    // Treat this as non-fatal — the thread will continue running on any
+                    // available CPU rather than the originally affinitized one. 
+                    WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
+                }
+                else
+                {
+                    ASSERT("sched_setaffinity failed!\n");
+                    CPU_FREE(pCpuSet);
+                    palError = ERROR_INTERNAL_ERROR;
+                    goto fail;
+                }
+            }
+        }
+        else
+        {
+            // Treat failure to get the affinity mask in release build as non-fatal.
             ASSERT("sched_getaffinity failed!\n");
-            CPU_FREE(pCpuSet);
-            // The sched_getaffinity should never fail for getting affinity of the current process
-            palError = ERROR_INTERNAL_ERROR;
-            goto fail;
         }
-
-        st = sched_setaffinity(0, CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
-        if (st != 0)
-        {
-            if (errno == EPERM || errno == EACCES)
-            {
-                // Some sandboxed or restricted environments (snap strict confinement,
-                // vendor-modified Android kernels with strict SELinux policy) block
-                // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
-                // Treat this as non-fatal — the thread will continue running on any
-                // available CPU rather than the originally affinitized one. 
-                WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
-            }
-            else
-            {
-                ASSERT("sched_setaffinity failed!\n");
-                CPU_FREE(pCpuSet);
-                palError = ERROR_INTERNAL_ERROR;
-                goto fail;
-            }
-        }
-
         CPU_FREE(pCpuSet);
     }
 #endif // HAVE_SCHED_GETAFFINITY && HAVE_SCHED_SETAFFINITY

--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1369,7 +1369,6 @@ CPalThread::ThreadEntry(
     LPVOID pvPar;
     DWORD retValue;
 #if HAVE_SCHED_GETAFFINITY && HAVE_SCHED_SETAFFINITY
-    cpu_set_t cpuSet;
     int st;
 #endif
 
@@ -1396,35 +1395,57 @@ CPalThread::ThreadEntry(
     // - https://github.com/dotnet/runtime/issues/1634
     // - https://forum.snapcraft.io/t/requesting-autoconnect-for-interfaces-in-pigmeat-process-control-home/17987/13
 
-    CPU_ZERO(&cpuSet);
-
-    st = sched_getaffinity(gPID, sizeof(cpu_set_t), &cpuSet);
-    if (st != 0)
     {
-        ASSERT("sched_getaffinity failed!\n");
-        // The sched_getaffinity should never fail for getting affinity of the current process
-        palError = ERROR_INTERNAL_ERROR;
-        goto fail;
-    }
-
-    st = sched_setaffinity(0, sizeof(cpu_set_t), &cpuSet);
-    if (st != 0)
-    {
-        if (errno == EPERM || errno == EACCES)
+        int configuredCpuCount = sysconf(_SC_NPROCESSORS_CONF);
+        if (configuredCpuCount == -1)
         {
-            // Some sandboxed or restricted environments (snap strict confinement,
-            // vendor-modified Android kernels with strict SELinux policy) block
-            // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
-            // Treat this as non-fatal — the thread will continue running on any
-            // available CPU rather than the originally affinitized one. 
-            WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
+            // In the unlikely event that sysconf(_SC_NPROCESSORS_CONF) fails, just assume a reasonable default maximum number of CPUs to avoid failing thread creation.
+            configuredCpuCount = CPU_SETSIZE;
         }
-        else
+
+        cpu_set_t* pCpuSet = CPU_ALLOC(configuredCpuCount);
+        if (pCpuSet == nullptr)
         {
-            ASSERT("sched_setaffinity failed!\n");
+            ASSERT("CPU_ALLOC failed!\n");
+            palError = ERROR_OUTOFMEMORY;
+            goto fail;
+        }
+
+        size_t cpuSetSize = CPU_ALLOC_SIZE(configuredCpuCount);
+        CPU_ZERO_S(cpuSetSize, pCpuSet);
+
+        st = sched_getaffinity(gPID, cpuSetSize, pCpuSet);
+        if (st != 0)
+        {
+            ASSERT("sched_getaffinity failed!\n");
+            CPU_FREE(pCpuSet);
+            // The sched_getaffinity should never fail for getting affinity of the current process
             palError = ERROR_INTERNAL_ERROR;
             goto fail;
         }
+
+        st = sched_setaffinity(0, CPU_ALLOC_SIZE(configuredCpuCount), pCpuSet);
+        if (st != 0)
+        {
+            if (errno == EPERM || errno == EACCES)
+            {
+                // Some sandboxed or restricted environments (snap strict confinement,
+                // vendor-modified Android kernels with strict SELinux policy) block
+                // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
+                // Treat this as non-fatal — the thread will continue running on any
+                // available CPU rather than the originally affinitized one. 
+                WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
+            }
+            else
+            {
+                ASSERT("sched_setaffinity failed!\n");
+                CPU_FREE(pCpuSet);
+                palError = ERROR_INTERNAL_ERROR;
+                goto fail;
+            }
+        }
+
+        CPU_FREE(pCpuSet);
     }
 #endif // HAVE_SCHED_GETAFFINITY && HAVE_SCHED_SETAFFINITY
 


### PR DESCRIPTION
A customer has reported that .NET runtime fails to initialize on machines that have more than 1024 CPUs due to `sched_getaffinity` being passed the default instance of `cpu_set_t` that supports max 1024 CPUs and fails if there are more CPUs on the current machine.

This change fixes `sched_getaffinity` calls to use a dynamically allocated CPU set data structure so that it can support any number of CPUs.

In the GC code, we keep the limit of max 1024 heaps, but the CPU limit is now dynamic. The arrays `proc_no_to_heap_no` and `﻿numa_node_to_heap_map` are now dynamically allocated based on the real number of processors configured on the system. Also the `AffinitySet` was modified to be able to contain affinities for a dynamic number of CPUs.

Several other arrays were originally sized by `MAX_SUPPORTED_CPUS`, but that was misleading as they are really indexed by heaps. So I've renamed the constant to `MAX_SUPPORTED_HEAPS` to make it clear that the number of supported CPUs is not limited.

Close #126747