### PR TITLE
Implement XmlSerializer end element handling workaround and tests

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/LocalAppContextSwitches.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/LocalAppContextSwitches.cs
@@ -39,6 +39,16 @@ namespace System.Xml
             }
         }
 
+        private static int s_useXmlSerializerReadEndElementWorkaround;
+        public static bool UseXmlSerializerReadEndElementWorkaround
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                return SwitchesHelpers.GetCachedSwitchValue("Switch.System.Xml.UseXmlSerializerReadEndElementWorkaround", ref s_useXmlSerializerReadEndElementWorkaround, defaultValue: true);
+            }
+        }
+
         private static int s_allowXsdTimeToTimeOnlyWithOffsetLoss;
         public static bool AllowXsdTimeToTimeOnlyWithOffsetLoss
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -1892,8 +1892,24 @@ namespace System.Xml.Serialization
         protected void ReadEndElement()
         {
             while (_r.NodeType == XmlNodeType.Whitespace) _r.Skip();
-            if (_r.NodeType == XmlNodeType.None) _r.Skip();
-            else _r.ReadEndElement();
+
+            if (LocalAppContextSwitches.UseXmlSerializerReadEndElementWorkaround)
+            {
+                if (_r.NodeType == XmlNodeType.None)
+                    return;
+
+                // Avoid forcing the reader to pull one more token after completing a top-level element.
+                // In fragment scenarios over streaming transports, additional data may not be immediately
+                // available even though deserialization of the current element is already complete.
+                if (_r.NodeType == XmlNodeType.EndElement && _r.Depth == 0)
+                    return;
+            }
+            else if (_r.NodeType == XmlNodeType.None)
+            {
+                _r.Skip();
+            }
+
+            _r.ReadEndElement();
         }
 
         private object ReadXmlNodes(bool elementCanBeType)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -486,6 +486,8 @@ namespace System.Xml.Serialization
             events.sender = this;
             try
             {
+                AdvancePastTopLevelEndElementIfNeeded(xmlReader);
+
                 if (_primitiveType != null)
                 {
                     if (encodingStyle != null && encodingStyle.Length > 0)
@@ -542,6 +544,8 @@ namespace System.Xml.Serialization
 
         public virtual bool CanDeserialize(XmlReader xmlReader)
         {
+            AdvancePastTopLevelEndElementIfNeeded(xmlReader);
+
             if (_primitiveType != null)
             {
                 TypeDesc typeDesc = (TypeDesc)TypeScope.PrimtiveTypes[_primitiveType]!;
@@ -837,6 +841,16 @@ namespace System.Xml.Serialization
             _tempAssembly = tempAssembly;
             _mapping = mapping;
             _typedSerializer = true;
+        }
+
+        private static void AdvancePastTopLevelEndElementIfNeeded(XmlReader xmlReader)
+        {
+            if (LocalAppContextSwitches.UseXmlSerializerReadEndElementWorkaround &&
+                xmlReader.NodeType == XmlNodeType.EndElement &&
+                xmlReader.Depth == 0)
+            {
+                xmlReader.Read();
+            }
         }
 
         private static XmlTypeMapping? GetKnownMapping(Type type, string? ns)

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -919,9 +919,7 @@ public static partial class XmlSerializerTests
         XmlSerializer serializer = new XmlSerializer(typeof(SimpleType));
         byte[] data = Encoding.UTF8.GetBytes(payload);
 
-        // Default should be true
-        //const string switchName = "Switch.System.Xml.UseXmlSerializerReadEndElementWorkaround";
-        //using var switchScope = new XmlSerializerAppContextSwitchScope(switchName, true);
+        // "Switch.System.Xml.UseXmlSerializerReadEndElementWorkaround" default should be true
         using var stream = new BlockingAfterBufferStream(data);
         using var reader = XmlReader.Create(stream, new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment });
 

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -913,6 +913,54 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
+    public static void Xml_DeserializeFragmentsFromXmlReader()
+    {
+        const string payload = "<SimpleType><P1>one</P1><P2>1</P2></SimpleType><SimpleType><P1>two</P1><P2>2</P2></SimpleType>";
+        XmlSerializer serializer = new XmlSerializer(typeof(SimpleType));
+        byte[] data = Encoding.UTF8.GetBytes(payload);
+
+        // Default should be true
+        //const string switchName = "Switch.System.Xml.UseXmlSerializerReadEndElementWorkaround";
+        //using var switchScope = new XmlSerializerAppContextSwitchScope(switchName, true);
+        using var stream = new BlockingAfterBufferStream(data);
+        using var reader = XmlReader.Create(stream, new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment });
+
+        Assert.True(serializer.CanDeserialize(reader));
+
+        SimpleType first = (SimpleType)serializer.Deserialize(reader);
+        Assert.Equal("one", first.P1);
+        Assert.Equal(1, first.P2);
+
+        Assert.True(serializer.CanDeserialize(reader));
+
+        SimpleType second = (SimpleType)serializer.Deserialize(reader);
+        Assert.Equal("two", second.P1);
+        Assert.Equal(2, second.P2);
+    }
+ 
+    [Fact]
+    public static void Xml_DeserializeFragmentsFromXmlReader_CanDisableWorkaround()
+    {
+        const string switchName = "Switch.System.Xml.UseXmlSerializerReadEndElementWorkaround";
+        const string payload = "<SimpleType><P1>one</P1><P2>1</P2></SimpleType><SimpleType><P1>two</P1><P2>2</P2></SimpleType>";
+        XmlSerializer serializer = new XmlSerializer(typeof(SimpleType));
+        byte[] data = Encoding.UTF8.GetBytes(payload);
+
+        using var compatSwitch = new XmlSerializerAppContextSwitchScope(switchName, false);
+        Assert.False(compatSwitch.CurrentValue);
+
+        using var stream = new BlockingAfterBufferStream(data);
+        using var reader = XmlReader.Create(stream, new XmlReaderSettings { ConformanceLevel = ConformanceLevel.Fragment });
+
+        SimpleType first = (SimpleType)serializer.Deserialize(reader);
+        Assert.Equal("one", first.P1);
+        Assert.Equal(1, first.P2);
+
+        InvalidOperationException exception = Assert.Throws<InvalidOperationException>(() => serializer.Deserialize(reader));
+        Assert.IsType<TimeoutException>(exception.InnerException);
+    }
+
+    [Fact]
     public static void Xml_TypeWithTimeSpanProperty()
     {
         var obj = new TypeWithTimeSpanProperty { TimeSpanProperty = TimeSpan.FromMilliseconds(1) };
@@ -3041,6 +3089,45 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         => time.ToString($"HH:mm:ss.fffffff{(!ignoreUtc && time.Kind == DateTimeKind.Utc ? "Z" : "zzzzzz")}", CultureInfo.InvariantCulture);
 }
 
+internal sealed class BlockingAfterBufferStream : Stream
+{
+    private readonly byte[] _buffer;
+    private int _position;
+
+    public BlockingAfterBufferStream(byte[] buffer)
+    {
+        _buffer = buffer;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => _buffer.Length;
+    public override long Position
+    {
+        get => _position;
+        set => throw new NotSupportedException();
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (_position < _buffer.Length)
+        {
+            int toCopy = Math.Min(count, _buffer.Length - _position);
+            Array.Copy(_buffer, _position, buffer, offset, toCopy);
+            _position += toCopy;
+            return toCopy;
+        }
+
+        throw new TimeoutException("Simulated Exception - No additional data is available.");
+    }
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    public override void Flush() { }
+}
+
 internal sealed class XmlSerializerAppContextSwitchScope : IDisposable
 {
     private readonly string _name;
@@ -3065,11 +3152,31 @@ internal sealed class XmlSerializerAppContextSwitchScope : IDisposable
         if (_hadValue)
             AppContext.SetSwitch(_name, _originalValue);
         else
-            // There's no "unset", so pick a default or false
-            AppContext.SetSwitch(_name, false);
+            UnsetSwitch(_name);
+
         ClearCachedSwitch(_cachedName);
     }
 
+    private static void UnsetSwitch(string name)
+    {
+        const BindingFlags Flags = BindingFlags.NonPublic | BindingFlags.Static;
+
+        if (typeof(AppContext).GetField("s_switches", Flags)?.GetValue(null) is IDictionary switches)
+        {
+            lock (switches)
+            {
+                switches.Remove(name);
+            }
+        }
+
+        if (typeof(AppContext).GetField("s_dataStore", Flags)?.GetValue(null) is IDictionary dataStore)
+        {
+            lock (dataStore)
+            {
+                dataStore.Remove(name);
+            }
+        }
+    }
     private static void ClearCachedSwitch(string name)
     {
         Type t = Type.GetType("System.Xml.LocalAppContextSwitches, System.Private.Xml");


### PR DESCRIPTION
This pull request improves handling of XML fragments over streaming transports, particularly when deserializing multiple root elements. The changes add a workaround (enabled by default) to avoid unnecessary reads after a top-level end element, preventing timeouts or exceptions when more data is not immediately available. An AppContext opt-out is also included. The PR also adds comprehensive tests and supporting infrastructure to validate and control this behavior.

**XML Serializer Compatibility and Behavior Improvements:**

* Added a new `UseXmlSerializerReadEndElementWorkaround` switch (default: true) to `LocalAppContextSwitches` to control workaround behavior for reading end elements in XML fragments.
* Updated `XmlSerializationReader.ReadEndElement()` to respect the new switch, avoiding extra reads after a top-level end element when enabled, which prevents blocking or timeouts in streaming/fragment scenarios.
* Introduced `AdvancePastTopLevelEndElementIfNeeded(XmlReader)` utility and invoked it in `XmlSerializer` methods (`GetMapping`, `CanDeserialize`) to ensure correct reader advancement when the workaround is enabled. [[1]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR489-R490) [[2]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR547-R548) [[3]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR846-R855)

**Testing and Infrastructure Enhancements:**

* Added new tests to `XmlSerializerTests.cs` to verify deserialization of XML fragments with and without the workaround, including a test that disables the switch and expects a timeout exception.
* Implemented `BlockingAfterBufferStream`, a custom `Stream` that simulates blocking behavior after buffer exhaustion, to facilitate robust testing of streaming scenarios.
* Improved `XmlSerializerAppContextSwitchScope` to properly unset AppContext switches and clear cached values, ensuring test isolation and reliability.

Fixes: #47371