### PR TITLE
Fix result assignment after action execution

### DIFF
--- a/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Lifetime/Program.cs
@@ -148,13 +148,13 @@ namespace NetClient
                 try
                 {
                     action();
+                    result = TestPassed;
                 }
                 catch (Exception e)
                 {
                     Console.WriteLine($"Test Failure: {e}");
                     result = TestFailed;
                 }
-                result = TestPassed;
             });
 
             staThread.SetApartmentState(ApartmentState.STA);


### PR DESCRIPTION
Ensure result is set to TestPassed only after action execution.