### PR TITLE
JIT: fix bug in loop cloning with down-counting loops

### DIFF
--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1334,17 +1334,17 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
     // GT_LE loop test: (start <= end) ==> (end < arrLen)
     //
     // Decreasing loops
-    // GT_GT loop test: (end > start) ==> (end <= arrLen)
-    // GT_GE loop test: (end >= start) ==> (end < arrLen)
+    // Always check if iter var is less than array length.
     genTreeOps opLimitCondition;
     switch (iterInfo->TestOper())
     {
         case GT_LT:
-        case GT_GT:
+
             opLimitCondition = GT_LE;
             break;
         case GT_LE:
         case GT_GE:
+        case GT_GT:
             opLimitCondition = GT_LT;
             break;
         default:

--- a/src/tests/JIT/opt/Cloning/DownCounted.cs
+++ b/src/tests/JIT/opt/Cloning/DownCounted.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class DownCounted
+{
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static bool ArrayProblem(int[] a, int n)
+    {
+        bool result = false;
+        for (int i = n; i > 0; i--)
+        {
+            a[i] = 44;
+            result |= (i == n);
+        }
+        return result;
+    }
+
+    [Fact]
+    public static int ArrayTest()
+    {
+        int[] a = new int[100];
+        int result = -1;
+        try
+        {
+            bool hasProblem = ArrayProblem(a, 100);
+            Console.WriteLine($"failed, has problem={hasProblem}");
+        }
+        catch (IndexOutOfRangeException e)
+        {
+            Console.WriteLine("passed");
+            result = 100;
+        }
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    static bool SpanProblem(Span<int> a, int n)
+    {
+        bool result = false;
+        for (int i = n; i > 0; i--)
+        {
+            a[i] = 44;
+            result |= (i == n);
+        }
+        return result;
+    }
+
+    [Fact]
+    public static int SpanTest()
+    {
+        int[] a = new int[100];
+        int result = -1;
+        try
+        {
+            bool hasProblem = SpanProblem(a, 100);
+            Console.WriteLine($"failed, has problem={hasProblem}");
+        }
+        catch (IndexOutOfRangeException e)
+        {
+            Console.WriteLine("passed");
+            result = 100;
+        }
+        return result;
+    }
+
+
+}
+    

--- a/src/tests/JIT/opt/Cloning/DownCounted.csproj
+++ b/src/tests/JIT/opt/Cloning/DownCounted.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
We were not creating proper cloning conditions, so the fast path might execute in cases where it shouldn't.

We need to always verify for down counting that the initial value is strictly less than the array length(s).