### PR TITLE
[RyuJIT] Make the mis-sized struct return logic only apply to return values that are structs

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5955,8 +5955,7 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                     // We have a non-struct return value that needs to be widened, but we can't widen the
                     // indirection safely since that could cause the read to overrun the end of a buffer.
                     // Instead, wrap the indirection in a cast to zero extend it.
-                    GenTreeCast* cast =
-                        m_compiler->gtNewCastNode(nativeReturnType, retVal, true, TypeGet(retVal));
+                    GenTreeCast* cast = m_compiler->gtNewCastNode(nativeReturnType, retVal, true, TypeGet(retVal));
                     assert(cast->IsZeroExtending());
                     BlockRange().InsertBefore(ret, cast);
                     ContainCheckCast(cast);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5955,7 +5955,8 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                     // We have a non-struct return value that needs to be widened, but we can't widen the
                     // indirection safely since that could cause the read to overrun the end of a buffer.
                     // Instead, wrap the indirection in a cast to zero extend it.
-                    GenTreeCast* cast = m_compiler->gtNewCastNode(nativeReturnType, retVal, true, varTypeToUnsigned(nativeReturnType));
+                    GenTreeCast* cast =
+                        m_compiler->gtNewCastNode(nativeReturnType, retVal, true, varTypeToUnsigned(nativeReturnType));
                     BlockRange().InsertBefore(ret, cast);
                     ContainCheckCast(cast);
                     retValUse.ReplaceWith(cast);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5956,7 +5956,8 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
                     // indirection safely since that could cause the read to overrun the end of a buffer.
                     // Instead, wrap the indirection in a cast to zero extend it.
                     GenTreeCast* cast =
-                        m_compiler->gtNewCastNode(nativeReturnType, retVal, true, varTypeToUnsigned(nativeReturnType));
+                        m_compiler->gtNewCastNode(nativeReturnType, retVal, true, TypeGet(retVal));
+                    assert(cast->IsZeroExtending());
                     BlockRange().InsertBefore(ret, cast);
                     ContainCheckCast(cast);
                     retValUse.ReplaceWith(cast);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5936,7 +5936,12 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
         {
             // Spill to a local if sizes don't match so we can avoid the "load more than requested"
             // problem, e.g. struct size is 5 and we emit "ldr x0, [x1]"
-            if (genTypeSize(nativeReturnType) > retVal->AsIndir()->Size())
+            if (
+                (genTypeSize(nativeReturnType) > retVal->AsIndir()->Size()) &&
+                // Ensure that the retval is actually a struct - otherwise the ReplaceWithLclVar below
+                // will fail due to assigning a non-struct to a struct local
+                (retVal->TypeGet() == TYP_STRUCT)
+            )
             {
                 LIR::Use retValUse(BlockRange(), &ret->gtOp1, ret);
                 unsigned tmpNum = m_compiler->lvaGrabTemp(true DEBUGARG("mis-sized struct return"));

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5936,19 +5936,30 @@ void Lowering::LowerRetStruct(GenTreeUnOp* ret)
         {
             // Spill to a local if sizes don't match so we can avoid the "load more than requested"
             // problem, e.g. struct size is 5 and we emit "ldr x0, [x1]"
-            if (
-                (genTypeSize(nativeReturnType) > retVal->AsIndir()->Size()) &&
-                // Ensure that the retval is actually a struct - otherwise the ReplaceWithLclVar below
-                // will fail due to assigning a non-struct to a struct local
-                (retVal->TypeGet() == TYP_STRUCT)
-            )
+            if (genTypeSize(nativeReturnType) > retVal->AsIndir()->Size())
             {
                 LIR::Use retValUse(BlockRange(), &ret->gtOp1, ret);
-                unsigned tmpNum = m_compiler->lvaGrabTemp(true DEBUGARG("mis-sized struct return"));
-                m_compiler->lvaSetStruct(tmpNum, m_compiler->info.compMethodInfo->args.retTypeClass, false);
 
-                ReplaceWithLclVar(retValUse, tmpNum);
-                LowerRetSingleRegStructLclVar(ret);
+                // Ensure that the retval is actually a struct - otherwise the ReplaceWithLclVar below
+                // will fail due to assigning a non-struct to a struct local
+                if (retVal->TypeGet() == TYP_STRUCT)
+                {
+                    unsigned tmpNum = m_compiler->lvaGrabTemp(true DEBUGARG("mis-sized struct return"));
+                    m_compiler->lvaSetStruct(tmpNum, m_compiler->info.compMethodInfo->args.retTypeClass, false);
+
+                    ReplaceWithLclVar(retValUse, tmpNum);
+                    LowerRetSingleRegStructLclVar(ret);
+                }
+                else
+                {
+                    // We have a non-struct return value that needs to be widened, but we can't widen the
+                    // indirection safely since that could cause the read to overrun the end of a buffer.
+                    // Instead, wrap the indirection in a cast to zero extend it.
+                    GenTreeCast* cast = m_compiler->gtNewCastNode(nativeReturnType, retVal, true, varTypeToUnsigned(nativeReturnType));
+                    BlockRange().InsertBefore(ret, cast);
+                    ContainCheckCast(cast);
+                    retValUse.ReplaceWith(cast);
+                }
                 break;
             }
 


### PR DESCRIPTION
This addresses an assert in wasm codegen with a release SPC, i.e.:

```
--targetos:browser
--targetarch:wasm
--obj-format=wasm
--parallelism:1
--print-repro-instructions
--codegenopt:JitWasmNyiToR2RUnsupported=1
--codegenopt:JitDump=System.Nullable`1[System.Reflection.Metadata.TypeNameParseOptions]:op_Explicit
-r:"Z:\runtime\artifacts\tests\coreclr\browser.wasm.Release\Tests\Core_Root\*.dll"
"Z:\runtime\artifacts\tests\coreclr\browser.wasm.Release\Tests\Core_Root\System.Private.CoreLib.dll"
--out:"Z:\runtime\artifacts\spc.wasm"
--singlemethodtypename:"System.Nullable`1[[System.Reflection.Metadata.TypeNameParseOptions]]"
--singlemethodname:"op_Explicit"
--singlemethodindex:1
```

Would produce:
```
Single method repro args:--singlemethodtypename "System.Nullable`1[[System.Reflection.Metadata.TypeNameParseOptions]]" --singlemethodname "op_Explicit" --singlemethodindex 1
N004 (  7,  7) [000020] n---G+-----                         *  IND       ubyte  <l:$141, c:$181>
N003 (  3,  4) [000019] -----+-----                         \--*  ADD       byref  $200
N001 (  1,  1) [000012] -----+-----                            +--*  LCL_VAR   byref  V01 arg0         u:1 (last use) $c0
N002 (  1,  2) [000018] -----+-----                            \--*  CNS_INT   int    1 $41
Z:\runtime\src\coreclr\jit\gentree.cpp:16961
Assertion failed '!"Incompatible types for gtNewTempStore"' in 'System.Nullable`1[System.Reflection.Metadata.TypeNameParseOptions]:op_Explicit(System.Nullable`1[System.Reflection.Metadata.TypeNameParseOptions]):System.Reflection.Metadata.TypeNameParseOptions' during 'Lowering nodeinfo' (IL size 8; hash 0xbc4e1b69; FullOpts)
```

The problem is that we are creating a temporary local of struct type using the `retTypeClass`, but the type of the return value was erased, so we try to turn a `GT_IND` of type `TYP_UBYTE` into a temp of `TYP_STRUCT` which can't possibly work the way `ReplaceWithLclVar` is constructed.

EDIT:
In this scenario what we need to do is zero-extend the mis-sized return value (a byte or short, most likely) to match the native return type's size. So I wrap the return value in a CAST.