### PR TITLE
Skip covariant-return test when running crossgen tests

### DIFF
--- a/src/tests/async/covariant-return/covariant-returns.csproj
+++ b/src/tests/async/covariant-return/covariant-returns.csproj
@@ -2,10 +2,10 @@
   <PropertyGroup>
     <!-- https://github.com/dotnet/runtime/issues/126685 -->
     <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot'">true</DisableProjectBuild>
-  </PropertyGroup>
-  <ItemGroup>
     <!-- https://github.com/dotnet/runtime/issues/126755 -->
     <CrossGenTest>false</CrossGenTest>
+  </PropertyGroup>
+  <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/async/covariant-return/covariant-returns.csproj
+++ b/src/tests/async/covariant-return/covariant-returns.csproj
@@ -4,6 +4,8 @@
     <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
+    <!-- https://github.com/dotnet/runtime/issues/126755 -->
+    <CrossGenTest>false</CrossGenTest>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To make the outerloops green until https://github.com/dotnet/runtime/issues/126755 is fixed