### PR TITLE
cDAC test cleanup - Allocator adds HeapFragments by default

### DIFF
--- a/src/native/managed/cdac/tests/AuxiliarySymbolsTests.cs
+++ b/src/native/managed/cdac/tests/AuxiliarySymbolsTests.cs
@@ -73,18 +73,15 @@ public class AuxiliarySymbolsTests
                 byte[] nameBytes = Encoding.UTF8.GetBytes(helpers[i].Name + '\0');
                 MockMemorySpace.HeapFragment nameFragment = allocator.Allocate((ulong)nameBytes.Length, $"Name_{helpers[i].Name}");
                 nameBytes.CopyTo(nameFragment.Data.AsSpan());
-                builder.AddHeapFragment(nameFragment);
                 entry.Name = nameFragment.Address;
             }
 
-            builder.AddHeapFragment(arrayFragment);
             arrayAddress = arrayFragment.Address;
         }
 
         // Allocate global for the count
         MockMemorySpace.HeapFragment countFragment = allocator.Allocate(sizeof(uint), "HelperCount");
         targetTestHelpers.Write(countFragment.Data, (uint)helpers.Length);
-        builder.AddHeapFragment(countFragment);
 
         return targetBuilder
             .AddTypes(types)

--- a/src/native/managed/cdac/tests/ClrDataExceptionStateTests.cs
+++ b/src/native/managed/cdac/tests/ClrDataExceptionStateTests.cs
@@ -23,7 +23,6 @@ public unsafe class ExceptionStateTests
 
         MockMemorySpace.HeapFragment handleFragment = allocator.Allocate((ulong)helpers.PointerSize, "ThrownObjectHandle");
         helpers.WritePointer(handleFragment.Data, exceptionObjectAddr);
-        targetBuilder.MemoryBuilder.AddHeapFragment(handleFragment);
 
         TargetPointer thrownObjectHandle = new TargetPointer(handleFragment.Address);
 
@@ -450,7 +449,6 @@ public unsafe class ExceptionStateTests
 
         MockMemorySpace.HeapFragment handleFragment = allocator.Allocate((ulong)helpers.PointerSize, "LastThrownObjectHandle");
         helpers.WritePointer(handleFragment.Data, exceptionObjectAddr);
-        targetBuilder.MemoryBuilder.AddHeapFragment(handleFragment);
         TargetPointer lastThrownObjectHandle = new TargetPointer(handleFragment.Address);
 
         var mockThread = new Mock<IThread>();

--- a/src/native/managed/cdac/tests/DebuggerTests.cs
+++ b/src/native/managed/cdac/tests/DebuggerTests.cs
@@ -40,20 +40,17 @@ public class DebuggerTests
         helpers.Write(debuggerFrag.Data.AsSpan(debuggerLayout.Fields[nameof(Data.Debugger.LeftSideInitialized)].Offset, sizeof(int)), leftSideInitialized);
         helpers.Write(debuggerFrag.Data.AsSpan(debuggerLayout.Fields[nameof(Data.Debugger.Defines)].Offset, sizeof(uint)), defines);
         helpers.Write(debuggerFrag.Data.AsSpan(debuggerLayout.Fields[nameof(Data.Debugger.MDStructuresVersion)].Offset, sizeof(uint)), mdStructuresVersion);
-        memBuilder.AddHeapFragment(debuggerFrag);
 
         // g_pDebugger is a pointer-to-Debugger. The global stores the address of g_pDebugger,
         // so ReadGlobalPointer returns the location, and ReadPointer dereferences it.
         MockMemorySpace.HeapFragment debuggerPtrFrag = allocator.Allocate((ulong)helpers.PointerSize, "g_pDebugger");
         helpers.WritePointer(debuggerPtrFrag.Data, debuggerFrag.Address);
-        memBuilder.AddHeapFragment(debuggerPtrFrag);
         builder.AddGlobals((Constants.Globals.Debugger, debuggerPtrFrag.Address));
 
         if (attachStateFlags.HasValue)
         {
             MockMemorySpace.HeapFragment attachFrag = allocator.Allocate(sizeof(uint), "CLRJitAttachState");
             helpers.Write(attachFrag.Data.AsSpan(0, sizeof(uint)), (uint)attachStateFlags.Value);
-            memBuilder.AddHeapFragment(attachFrag);
             builder.AddGlobals((Constants.Globals.CLRJitAttachState, attachFrag.Address));
         }
 
@@ -61,7 +58,6 @@ public class DebuggerTests
         {
             MockMemorySpace.HeapFragment metadataFrag = allocator.Allocate(1, "MetadataUpdatesApplied");
             helpers.Write(metadataFrag.Data.AsSpan(0, 1), metadataUpdatesApplied.Value);
-            memBuilder.AddHeapFragment(metadataFrag);
             builder.AddGlobals((Constants.Globals.MetadataUpdatesApplied, metadataFrag.Address));
         }
 
@@ -80,7 +76,6 @@ public class DebuggerTests
         // g_pDebugger is a pointer-to-Debugger that contains null.
         MockMemorySpace.HeapFragment debuggerPtrFrag = allocator.Allocate((ulong)helpers.PointerSize, "g_pDebugger");
         helpers.WritePointer(debuggerPtrFrag.Data, 0);
-        memBuilder.AddHeapFragment(debuggerPtrFrag);
         builder.AddGlobals((Constants.Globals.Debugger, debuggerPtrFrag.Address));
         builder.AddContract<IDebugger>(version: 1);
 

--- a/src/native/managed/cdac/tests/GCMemoryRegionTests.cs
+++ b/src/native/managed/cdac/tests/GCMemoryRegionTests.cs
@@ -88,33 +88,27 @@ public class GCMemoryRegionTests
         };
 
         var segFragment = allocator.Allocate(HandleSegmentSize, "Segment");
-        builder.AddHeapFragment(segFragment);
         Span<byte> segSpan = builder.BorrowAddressRange(segFragment.Address, segFragment.Data.Length);
         helpers.WritePointer(segSpan.Slice(0, ptrSize), TargetPointer.Null);
 
         var htFragment = allocator.Allocate((ulong)ptrSize, "HandleTable");
-        builder.AddHeapFragment(htFragment);
         Span<byte> htSpan = builder.BorrowAddressRange(htFragment.Address, htFragment.Data.Length);
         helpers.WritePointer(htSpan.Slice(0, ptrSize), segFragment.Address);
 
         var bucketTableFragment = allocator.Allocate((ulong)ptrSize, "BucketTable");
-        builder.AddHeapFragment(bucketTableFragment);
         Span<byte> btSpan = builder.BorrowAddressRange(bucketTableFragment.Address, bucketTableFragment.Data.Length);
         helpers.WritePointer(btSpan.Slice(0, ptrSize), htFragment.Address);
 
         var bucketFragment = allocator.Allocate((ulong)ptrSize, "Bucket");
-        builder.AddHeapFragment(bucketFragment);
         Span<byte> bSpan = builder.BorrowAddressRange(bucketFragment.Address, bucketFragment.Data.Length);
         helpers.WritePointer(bSpan.Slice(0, ptrSize), bucketTableFragment.Address);
 
         var bucketsArrayFragment = allocator.Allocate((ulong)(InitialHandleTableArraySize * ptrSize), "BucketsArray");
-        builder.AddHeapFragment(bucketsArrayFragment);
         Span<byte> baSpan = builder.BorrowAddressRange(bucketsArrayFragment.Address, bucketsArrayFragment.Data.Length);
         helpers.WritePointer(baSpan.Slice(0, ptrSize), bucketFragment.Address);
         helpers.WritePointer(baSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
 
         var mapFragment = allocator.Allocate((ulong)(2 * ptrSize), "Map");
-        builder.AddHeapFragment(mapFragment);
         Span<byte> mapSpan = builder.BorrowAddressRange(mapFragment.Address, mapFragment.Data.Length);
         helpers.WritePointer(mapSpan.Slice(0, ptrSize), bucketsArrayFragment.Address);
         helpers.WritePointer(mapSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
@@ -153,13 +147,11 @@ public class GCMemoryRegionTests
         };
 
         var bucketsArrayFragment = allocator.Allocate((ulong)(InitialHandleTableArraySize * ptrSize), "BucketsArray");
-        builder.AddHeapFragment(bucketsArrayFragment);
         Span<byte> baSpan = builder.BorrowAddressRange(bucketsArrayFragment.Address, bucketsArrayFragment.Data.Length);
         helpers.WritePointer(baSpan.Slice(0, ptrSize), TargetPointer.Null);
         helpers.WritePointer(baSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
 
         var mapFragment = allocator.Allocate((ulong)(2 * ptrSize), "Map");
-        builder.AddHeapFragment(mapFragment);
         Span<byte> mapSpan = builder.BorrowAddressRange(mapFragment.Address, mapFragment.Data.Length);
         helpers.WritePointer(mapSpan.Slice(0, ptrSize), bucketsArrayFragment.Address);
         helpers.WritePointer(mapSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
@@ -199,38 +191,31 @@ public class GCMemoryRegionTests
         };
 
         var seg2Fragment = allocator.Allocate(HandleSegmentSize, "Seg2");
-        builder.AddHeapFragment(seg2Fragment);
         Span<byte> seg2Span = builder.BorrowAddressRange(seg2Fragment.Address, seg2Fragment.Data.Length);
         helpers.WritePointer(seg2Span.Slice(0, ptrSize), TargetPointer.Null);
 
         var seg1Fragment = allocator.Allocate(HandleSegmentSize, "Seg1");
-        builder.AddHeapFragment(seg1Fragment);
         Span<byte> seg1Span = builder.BorrowAddressRange(seg1Fragment.Address, seg1Fragment.Data.Length);
         helpers.WritePointer(seg1Span.Slice(0, ptrSize), seg2Fragment.Address);
 
         var htFragment = allocator.Allocate((ulong)ptrSize, "HT");
-        builder.AddHeapFragment(htFragment);
         Span<byte> htSpan = builder.BorrowAddressRange(htFragment.Address, htFragment.Data.Length);
         helpers.WritePointer(htSpan.Slice(0, ptrSize), seg1Fragment.Address);
 
         var btFragment = allocator.Allocate((ulong)ptrSize, "BT");
-        builder.AddHeapFragment(btFragment);
         Span<byte> btSpan = builder.BorrowAddressRange(btFragment.Address, btFragment.Data.Length);
         helpers.WritePointer(btSpan.Slice(0, ptrSize), htFragment.Address);
 
         var bucketFragment = allocator.Allocate((ulong)ptrSize, "Bucket");
-        builder.AddHeapFragment(bucketFragment);
         Span<byte> bucketSpan = builder.BorrowAddressRange(bucketFragment.Address, bucketFragment.Data.Length);
         helpers.WritePointer(bucketSpan.Slice(0, ptrSize), btFragment.Address);
 
         var baFragment = allocator.Allocate((ulong)(InitialHandleTableArraySize * ptrSize), "BA");
-        builder.AddHeapFragment(baFragment);
         Span<byte> baSpan = builder.BorrowAddressRange(baFragment.Address, baFragment.Data.Length);
         helpers.WritePointer(baSpan.Slice(0, ptrSize), bucketFragment.Address);
         helpers.WritePointer(baSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
 
         var mapFragment = allocator.Allocate((ulong)(2 * ptrSize), "Map");
-        builder.AddHeapFragment(mapFragment);
         Span<byte> mapSpan = builder.BorrowAddressRange(mapFragment.Address, mapFragment.Data.Length);
         helpers.WritePointer(mapSpan.Slice(0, ptrSize), baFragment.Address);
         helpers.WritePointer(mapSpan.Slice(ptrSize, ptrSize), TargetPointer.Null);
@@ -270,7 +255,6 @@ public class GCMemoryRegionTests
         };
 
         var ctiFragment = allocator.Allocate(cardTableTypeSize, "CTI");
-        builder.AddHeapFragment(ctiFragment);
         Span<byte> ctiSpan = builder.BorrowAddressRange(ctiFragment.Address, ctiFragment.Data.Length);
         helpers.Write(ctiSpan.Slice(0, sizeof(uint)), (uint)1);
         if (ptrSize == 8)
@@ -280,7 +264,6 @@ public class GCMemoryRegionTests
         helpers.WritePointer(ctiSpan.Slice(4 + ptrSize, ptrSize), TargetPointer.Null);
 
         var bkFragment = allocator.Allocate((ulong)ptrSize, "BK");
-        builder.AddHeapFragment(bkFragment);
         Span<byte> bkSpan = builder.BorrowAddressRange(bkFragment.Address, bkFragment.Data.Length);
         helpers.WritePointer(bkSpan.Slice(0, ptrSize), ctiFragment.Address);
 
@@ -313,7 +296,6 @@ public class GCMemoryRegionTests
 
         // BookkeepingStart global pointer exists but the value at that address is null
         var bkFragment = allocator.Allocate((ulong)ptrSize, "BK");
-        builder.AddHeapFragment(bkFragment);
         Span<byte> bkSpan = builder.BorrowAddressRange(bkFragment.Address, bkFragment.Data.Length);
         helpers.WritePointer(bkSpan.Slice(0, ptrSize), TargetPointer.Null);
 
@@ -360,14 +342,12 @@ public class GCMemoryRegionTests
         TargetPointer committedAddr = new(0x1000_2000);
 
         var segFragment = allocator.Allocate(heapSegmentSize, "Seg");
-        builder.AddHeapFragment(segFragment);
         Span<byte> segSpan = builder.BorrowAddressRange(segFragment.Address, segFragment.Data.Length);
         helpers.WritePointer(segSpan.Slice(ptrSize, ptrSize), committedAddr);
         helpers.WritePointer(segSpan.Slice(4 * ptrSize, ptrSize), memAddr);
         helpers.WritePointer(segSpan.Slice(6 * ptrSize, ptrSize), TargetPointer.Null);
 
         var flFragment = allocator.Allocate(regionFreeListSize, "FL");
-        builder.AddHeapFragment(flFragment);
         Span<byte> flSpan = builder.BorrowAddressRange(flFragment.Address, flFragment.Data.Length);
         helpers.WritePointer(flSpan.Slice(5 * ptrSize, ptrSize), segFragment.Address);
 
@@ -405,7 +385,6 @@ public class GCMemoryRegionTests
         };
 
         var flFragment = allocator.Allocate(regionFreeListSize, "FL");
-        builder.AddHeapFragment(flFragment);
         Span<byte> flSpan = builder.BorrowAddressRange(flFragment.Address, flFragment.Data.Length);
         helpers.WritePointer(flSpan.Slice(5 * ptrSize, ptrSize), TargetPointer.Null);
 
@@ -449,21 +428,18 @@ public class GCMemoryRegionTests
         };
 
         var seg2Fragment = allocator.Allocate(heapSegmentSize, "Seg2");
-        builder.AddHeapFragment(seg2Fragment);
         Span<byte> seg2Span = builder.BorrowAddressRange(seg2Fragment.Address, seg2Fragment.Data.Length);
         helpers.WritePointer(seg2Span.Slice(ptrSize, ptrSize), new TargetPointer(0x2000_4000));
         helpers.WritePointer(seg2Span.Slice(4 * ptrSize, ptrSize), new TargetPointer(0x2000_0000));
         helpers.WritePointer(seg2Span.Slice(6 * ptrSize, ptrSize), TargetPointer.Null);
 
         var seg1Fragment = allocator.Allocate(heapSegmentSize, "Seg1");
-        builder.AddHeapFragment(seg1Fragment);
         Span<byte> seg1Span = builder.BorrowAddressRange(seg1Fragment.Address, seg1Fragment.Data.Length);
         helpers.WritePointer(seg1Span.Slice(ptrSize, ptrSize), new TargetPointer(0x1000_2000));
         helpers.WritePointer(seg1Span.Slice(4 * ptrSize, ptrSize), new TargetPointer(0x1000_0000));
         helpers.WritePointer(seg1Span.Slice(6 * ptrSize, ptrSize), seg2Fragment.Address);
 
         var flFragment = allocator.Allocate(regionFreeListSize, "FL");
-        builder.AddHeapFragment(flFragment);
         Span<byte> flSpan = builder.BorrowAddressRange(flFragment.Address, flFragment.Data.Length);
         helpers.WritePointer(flSpan.Slice(5 * ptrSize, ptrSize), seg1Fragment.Address);
 

--- a/src/native/managed/cdac/tests/LoaderTests.cs
+++ b/src/native/managed/cdac/tests/LoaderTests.cs
@@ -406,22 +406,17 @@ public unsafe class LoaderTests
             helpers.Write(webcilImage.Data.AsSpan().Slice(baseOffset + sf[nameof(Data.WebcilSectionHeader.PointerToRawData)].Offset, sizeof(uint)), sections[i].PointerToRawData);
         }
 
-        builder.AddHeapFragment(webcilImage);
-
         var layoutFrag = allocator.Allocate(imageLayoutLayout.Stride, "PEImageLayout");
         helpers.WritePointer(layoutFrag.Data.AsSpan().Slice(imageLayoutLayout.Fields[nameof(Data.PEImageLayout.Base)].Offset, helpers.PointerSize), webcilImage.Address);
         helpers.Write(layoutFrag.Data.AsSpan().Slice(imageLayoutLayout.Fields[nameof(Data.PEImageLayout.Size)].Offset, sizeof(uint)), webcilImageSize);
         helpers.Write(layoutFrag.Data.AsSpan().Slice(imageLayoutLayout.Fields[nameof(Data.PEImageLayout.Flags)].Offset, sizeof(uint)), 0u);
         helpers.Write(layoutFrag.Data.AsSpan().Slice(imageLayoutLayout.Fields[nameof(Data.PEImageLayout.Format)].Offset, sizeof(uint)), 1u);
-        builder.AddHeapFragment(layoutFrag);
 
         var peImageFrag = allocator.Allocate(peImageLayout.Stride, "PEImage");
         helpers.WritePointer(peImageFrag.Data.AsSpan().Slice(peImageLayout.Fields[nameof(Data.PEImage.LoadedImageLayout)].Offset, helpers.PointerSize), layoutFrag.Address);
-        builder.AddHeapFragment(peImageFrag);
 
         var peAssemblyFrag = allocator.Allocate(peAssemblyLayout.Stride, "PEAssembly");
         helpers.WritePointer(peAssemblyFrag.Data.AsSpan().Slice(peAssemblyLayout.Fields[nameof(Data.PEAssembly.PEImage)].Offset, helpers.PointerSize), peImageFrag.Address);
-        builder.AddHeapFragment(peAssemblyFrag);
 
         var target = targetBuilder
             .AddTypes(types)

--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -278,7 +278,6 @@ public class MethodTableTests
                 MockMemorySpace.HeapFragment tinyEEClass = rtsBuilder.TypeSystemAllocator.Allocate(
                     (ulong)pointerSize, "Tiny EEClass (MethodTable field only)");
                 helpers.WritePointer(tinyEEClass.Data, methodTablePtr);
-                rtsBuilder.Builder.AddHeapFragment(tinyEEClass);
                 methodTable.EEClassOrCanonMT = tinyEEClass.Address;
             });
 
@@ -357,7 +356,6 @@ public class MethodTableTests
             helpers.Write(dest.Slice(mtTypeInfo.Fields[nameof(Data.MethodTable.MTFlags2)].Offset), (uint)0);
             helpers.WritePointer(dest.Slice(eeClassOrCanonMTOffset), eeClassPtr);
 
-            rtsBuilder.Builder.AddHeapFragment(tinyMT);
             tinyMethodTableAddr = tinyMT.Address;
 
             // Point the EEClass back at the tiny MethodTable to pass validation

--- a/src/native/managed/cdac/tests/MockDescriptors/MockBuiltInComBuilder.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockBuiltInComBuilder.cs
@@ -464,10 +464,10 @@ internal sealed class MockBuiltInComBuilder
     internal Layout<MockRCW> RCWLayout { get; }
 
     public MockSimpleComCallWrapper AddSimpleComCallWrapper()
-        => SimpleComCallWrapperLayout.Create(AllocateAndAdd((ulong)SimpleComCallWrapperLayout.Size, "SimpleComCallWrapper"));
+        => SimpleComCallWrapperLayout.Create(_allocator.Allocate((ulong)SimpleComCallWrapperLayout.Size, "SimpleComCallWrapper"));
 
     public MockComCallWrapper AddComCallWrapper()
-        => ComCallWrapperLayout.Create(AllocateAndAdd((ulong)ComCallWrapperLayout.Size, "ComCallWrapper"));
+        => ComCallWrapperLayout.Create(_allocator.Allocate((ulong)ComCallWrapperLayout.Size, "ComCallWrapper"));
 
     public MockComMethodTable AddComMethodTable(int vtableSlots = 0)
     {
@@ -475,7 +475,7 @@ internal sealed class MockBuiltInComBuilder
 
         int pointerSize = ComMethodTableLayout.Architecture.Is64Bit ? sizeof(ulong) : sizeof(uint);
         int totalSize = checked(ComMethodTableLayout.Size + (vtableSlots * pointerSize));
-        return ComMethodTableLayout.Create(AllocateAndAdd((ulong)totalSize, "ComMethodTable"));
+        return ComMethodTableLayout.Create(_allocator.Allocate((ulong)totalSize, "ComMethodTable"));
     }
 
     public MockStdInterfaceDesc AddStdInterfaceDesc(int vtableSlots = 0)
@@ -484,15 +484,15 @@ internal sealed class MockBuiltInComBuilder
 
         int pointerSize = StdInterfaceDescLayout.Architecture.Is64Bit ? sizeof(ulong) : sizeof(uint);
         int totalSize = checked(StdInterfaceDescLayout.Size + (vtableSlots * pointerSize));
-        return StdInterfaceDescLayout.Create(AllocateAndAdd((ulong)totalSize, "StdInterfaceDesc"));
+        return StdInterfaceDescLayout.Create(_allocator.Allocate((ulong)totalSize, "StdInterfaceDesc"));
     }
 
     public MockRCW AddRCW()
-        => RCWLayout.Create(AllocateAndAdd((ulong)RCWLayout.Size, "Full RCW"));
+        => RCWLayout.Create(_allocator.Allocate((ulong)RCWLayout.Size, "Full RCW"));
 
     public ulong AddCtxEntry(ulong staThread = 0, ulong ctxCookie = 0)
     {
-        MockCtxEntry entry = CtxEntryLayout.Create(AllocateAndAdd((ulong)CtxEntryLayout.Size, "CtxEntry"));
+        MockCtxEntry entry = CtxEntryLayout.Create(_allocator.Allocate((ulong)CtxEntryLayout.Size, "CtxEntry"));
         entry.STAThread = staThread;
         entry.CtxCookie = ctxCookie;
         return entry.Address;
@@ -506,14 +506,6 @@ internal sealed class MockBuiltInComBuilder
         int pointerSize = _architecture.Is64Bit ? sizeof(ulong) : sizeof(uint);
         MockMemorySpace.HeapFragment global = _allocator.Allocate((ulong)pointerSize, $"[global pointer] {name}");
         _builder.TargetTestHelpers.WritePointer(global.Data.AsSpan(), value);
-        _builder.AddHeapFragment(global);
         return global.Address;
-    }
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        _builder.AddHeapFragment(fragment);
-        return fragment;
     }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.CodeVersions.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.CodeVersions.cs
@@ -240,12 +240,12 @@ internal sealed class MockCodeVersionsBuilder
 
     public MockMethodDescVersioningState AddMethodDescVersioningState()
         => MethodDescVersioningStateLayout.Create(
-            AllocateAndAdd((ulong)MethodDescVersioningStateLayout.Size, "MethodDescVersioningState"));
+            _codeVersionsAllocator.Allocate((ulong)MethodDescVersioningStateLayout.Size, "MethodDescVersioningState"));
 
     public MockNativeCodeVersionNode AddNativeCodeVersionNode()
     {
         MockNativeCodeVersionNode node = NativeCodeVersionNodeLayout.Create(
-            AllocateAndAdd((ulong)NativeCodeVersionNodeLayout.Size, "NativeCodeVersionNode"));
+            _codeVersionsAllocator.Allocate((ulong)NativeCodeVersionNodeLayout.Size, "NativeCodeVersionNode"));
         node.OptimizationTier = 0xFFFFFFFFu;
         return node;
     }
@@ -303,23 +303,16 @@ internal sealed class MockCodeVersionsBuilder
 
     public MockILCodeVersioningState AddILCodeVersioningState()
         => ILCodeVersioningStateLayout.Create(
-            AllocateAndAdd((ulong)ILCodeVersioningStateLayout.Size, "ILCodeVersioningState"));
+            _codeVersionsAllocator.Allocate((ulong)ILCodeVersioningStateLayout.Size, "ILCodeVersioningState"));
 
     public MockILCodeVersionNode AddILCodeVersionNode(ulong versionId, uint rejitFlags)
     {
         MockILCodeVersionNode node = ILCodeVersionNodeLayout.Create(
-            AllocateAndAdd((ulong)ILCodeVersionNodeLayout.Size, "ILCodeVersionNode"));
+            _codeVersionsAllocator.Allocate((ulong)ILCodeVersionNodeLayout.Size, "ILCodeVersionNode"));
         node.VersionId = versionId;
         node.RejitState = rejitFlags;
         node.Next = 0;
 
         return node;
-    }
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _codeVersionsAllocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
     }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ExecutionManager.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ExecutionManager.cs
@@ -540,7 +540,6 @@ internal sealed class MockExecutionManagerBuilder
         _rangeSectionMapLevelsCount = architecture.Is64Bit ? 5 : 2;
         _rangeSectionMapMaxSetBit = architecture.Is64Bit ? 56 : 31;
         MockMemorySpace.HeapFragment topRangeSectionMapLevel = _rangeSectionMapAllocator.Allocate((ulong)_rangeSectionMapLevelLayout.Size, $"Map Level {_rangeSectionMapLevelsCount}");
-        Builder.AddHeapFragment(topRangeSectionMapLevel);
         _rangeSectionMapTopLevelAddress = topRangeSectionMapLevel.Address;
         _rangeSectionMapLevels[_rangeSectionMapTopLevelAddress] = _rangeSectionMapLevelLayout.Create(topRangeSectionMapLevel);
 
@@ -585,7 +584,6 @@ internal sealed class MockExecutionManagerBuilder
             _ => throw new InvalidOperationException("Unknown version"),
         };
 
-        Builder.AddHeapFragment(nibBuilder.NibbleMapFragment);
         return nibBuilder;
     }
 
@@ -649,7 +647,7 @@ internal sealed class MockExecutionManagerBuilder
     public MockLoaderCodeHeap AddLoaderCodeHeap()
     {
         ulong allocationSize = (ulong)Math.Max(CodeHeapLayout.Size, LoaderCodeHeapLayout.Size);
-        MockMemorySpace.HeapFragment heapFragment = AllocateAndAdd(allocationSize, "LoaderCodeHeap");
+        MockMemorySpace.HeapFragment heapFragment = _allocator.Allocate(allocationSize, "LoaderCodeHeap");
         MockLoaderCodeHeap loaderCodeHeap = LoaderCodeHeapLayout.Create(heapFragment);
         MockCodeHeap codeHeap = CodeHeapLayout.Create(
             heapFragment.Data.AsMemory(0, CodeHeapLayout.Size),
@@ -661,7 +659,7 @@ internal sealed class MockExecutionManagerBuilder
     public MockHostCodeHeap AddHostCodeHeap(ulong baseAddress, ulong currentAddress)
     {
         ulong allocationSize = (ulong)Math.Max(CodeHeapLayout.Size, HostCodeHeapLayout.Size);
-        MockMemorySpace.HeapFragment heapFragment = AllocateAndAdd(allocationSize, "HostCodeHeap");
+        MockMemorySpace.HeapFragment heapFragment = _allocator.Allocate(allocationSize, "HostCodeHeap");
         MockHostCodeHeap hostCodeHeap = HostCodeHeapLayout.Create(heapFragment);
         MockCodeHeap codeHeap = CodeHeapLayout.Create(
             heapFragment.Data.AsMemory(0, CodeHeapLayout.Size),
@@ -694,7 +692,7 @@ internal sealed class MockExecutionManagerBuilder
         ulong hotColdMapAddress = 0;
         if (hotColdMap.Length > 0)
         {
-            MockMemorySpace.HeapFragment hotColdMapFragment = AllocateAndAdd((ulong)hotColdMap.Length * sizeof(uint), $"HotColdMap[{hotColdMap.Length}]");
+            MockMemorySpace.HeapFragment hotColdMapFragment = _allocator.Allocate((ulong)hotColdMap.Length * sizeof(uint), $"HotColdMap[{hotColdMap.Length}]");
             hotColdMapAddress = hotColdMapFragment.Address;
             for (uint i = 0; i < hotColdMap.Length; i++)
             {
@@ -758,27 +756,19 @@ internal sealed class MockExecutionManagerBuilder
     {
         Layout<MockJittedMethod> jittedMethodLayout = MockJittedMethod.CreateLayout(Builder.TargetTestHelpers.Arch, checked((int)codeSize));
         MockMemorySpace.HeapFragment methodFragment = jittedCodeRange.Allocator.Allocate((ulong)jittedMethodLayout.Size, name);
-        Builder.AddHeapFragment(methodFragment);
         return jittedMethodLayout.Create(methodFragment);
     }
 
     private ulong AddPointerGlobal(ulong value, string name)
     {
-        MockMemorySpace.HeapFragment fragment = AllocateAndAdd((ulong)Builder.TargetTestHelpers.PointerSize, name);
+        MockMemorySpace.HeapFragment fragment = _allocator.Allocate((ulong)Builder.TargetTestHelpers.PointerSize, name);
         Builder.TargetTestHelpers.WritePointer(fragment.Data, value);
         return fragment.Address;
     }
 
     private TView AllocateAndCreate<TView>(Layout<TView> layout, string name, MockMemorySpace.BumpAllocator? allocator = null)
         where TView : TypedView, new()
-        => layout.Create(AllocateAndAdd((ulong)layout.Size, name, allocator));
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name, MockMemorySpace.BumpAllocator? allocator = null)
-    {
-        MockMemorySpace.HeapFragment fragment = (allocator ?? _allocator).Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
-    }
+        => layout.Create((allocator ?? _allocator).Allocate((ulong)layout.Size, name));
 
     private int RangeSectionMapBitsAtLastLevel => _rangeSectionMapMaxSetBit - RangeSectionMapBitsPerLevel * _rangeSectionMapLevelsCount + 1;
 
@@ -807,7 +797,6 @@ internal sealed class MockExecutionManagerBuilder
     private MockRangeSectionMapLevel AllocateRangeSectionMapLevel(int level)
     {
         MockMemorySpace.HeapFragment mapLevel = _rangeSectionMapAllocator.Allocate((ulong)_rangeSectionMapLevelLayout.Size, $"Map Level {level}");
-        Builder.AddHeapFragment(mapLevel);
         _rangeSectionMapLevels[mapLevel.Address] = _rangeSectionMapLevelLayout.Create(mapLevel);
         return _rangeSectionMapLevels[mapLevel.Address];
     }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.GC.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.GC.cs
@@ -302,7 +302,6 @@ internal sealed class MockGCBuilder
             generation.AllocationStart = generations[i].AllocationStart;
         }
 
-        Builder.AddHeapFragment(generationTable);
         return generationTable.Address;
     }
 
@@ -357,7 +356,6 @@ internal sealed class MockGCBuilder
             (ulong)Builder.TargetTestHelpers.PointerSize,
             $"[global pointer] {name}");
         Builder.TargetTestHelpers.WritePointer(fragment.Data, pointsTo);
-        Builder.AddHeapFragment(fragment);
         return fragment.Address;
     }
 
@@ -367,7 +365,6 @@ internal sealed class MockGCBuilder
             (ulong)Builder.TargetTestHelpers.PointerSize,
             $"[{name}]");
         Builder.TargetTestHelpers.Write(fragment.Data.AsSpan(0, sizeof(int)), value);
-        Builder.AddHeapFragment(fragment);
         return fragment.Address;
     }
 
@@ -377,7 +374,6 @@ internal sealed class MockGCBuilder
             (ulong)Builder.TargetTestHelpers.PointerSize,
             $"[{name}]");
         Builder.TargetTestHelpers.Write(fragment.Data.AsSpan(0, sizeof(uint)), value);
-        Builder.AddHeapFragment(fragment);
         return fragment.Address;
     }
 
@@ -402,7 +398,6 @@ internal sealed class MockGCBuilder
     private ulong AddDataRegion(ulong size, string name)
     {
         MockMemorySpace.HeapFragment fragment = GCAllocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
         return fragment.Address;
     }
 
@@ -414,7 +409,6 @@ internal sealed class MockGCBuilder
         where TView : TypedView, new()
     {
         MockMemorySpace.HeapFragment fragment = GCAllocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
         return layout.Create(fragment.Data.AsMemory(), fragment.Address);
     }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.HashMap.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.HashMap.cs
@@ -94,7 +94,7 @@ internal sealed class MockHashMapBuilder
     {
         ArgumentNullException.ThrowIfNull(entries);
 
-        MockHashMap map = HashMapLayout.Create(AllocateAndAdd((ulong)HashMapLayout.Size, "HashMap"));
+        MockHashMap map = HashMapLayout.Create(_allocator.Allocate((ulong)HashMapLayout.Size, "HashMap"));
         PopulateMap(map.Address, entries);
         return map.Address;
     }
@@ -112,7 +112,7 @@ internal sealed class MockHashMapBuilder
         // First bucket is the number of buckets
         uint numBuckets = size + 1;
         uint totalBucketsSize = checked(bucketSize * numBuckets);
-        MockMemorySpace.HeapFragment buckets = AllocateAndAdd(totalBucketsSize, $"Buckets[{numBuckets}]");
+        MockMemorySpace.HeapFragment buckets = _allocator.Allocate(totalBucketsSize, $"Buckets[{numBuckets}]");
         Builder.TargetTestHelpers.Write(buckets.Data.AsSpan().Slice(0, sizeof(uint)), size);
 
         const int MaxRetry = 8;
@@ -186,10 +186,4 @@ internal sealed class MockHashMapBuilder
         return false;
     }
 
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
-    }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Loader.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Loader.cs
@@ -146,7 +146,7 @@ internal sealed class MockLoaderBuilder
         string? simpleName = null,
         byte[]? simpleNameBytes = null)
     {
-        MockLoaderModule module = ModuleLayout.Create(AllocateAndAdd((ulong)ModuleLayout.Size, "Module"));
+        MockLoaderModule module = ModuleLayout.Create(_allocator.Allocate((ulong)ModuleLayout.Size, "Module"));
 
         byte[]? rawSimpleName = simpleName is not null ? Encoding.UTF8.GetBytes(simpleName) : simpleNameBytes;
         if (rawSimpleName is not null)
@@ -164,7 +164,7 @@ internal sealed class MockLoaderBuilder
             module.FileName = AddUtf16String(fileName, $"Module file name = {fileName}");
         }
 
-        MockLoaderAssembly assembly = AssemblyLayout.Create(AllocateAndAdd((ulong)AssemblyLayout.Size, "Assembly"));
+        MockLoaderAssembly assembly = AssemblyLayout.Create(_allocator.Allocate((ulong)AssemblyLayout.Size, "Assembly"));
         assembly.Module = module.Address;
         module.Assembly = assembly.Address;
         return module;
@@ -172,7 +172,7 @@ internal sealed class MockLoaderBuilder
 
     private ulong AddNullTerminatedUtf8(ReadOnlySpan<byte> bytes, string name)
     {
-        MockMemorySpace.HeapFragment fragment = AllocateAndAdd((ulong)bytes.Length + 1, name);
+        MockMemorySpace.HeapFragment fragment = _allocator.Allocate((ulong)bytes.Length + 1, name);
         bytes.CopyTo(fragment.Data);
         fragment.Data[^1] = 0;
         return fragment.Address;
@@ -182,15 +182,8 @@ internal sealed class MockLoaderBuilder
     {
         TargetTestHelpers helpers = Builder.TargetTestHelpers;
         Encoding encoding = helpers.Arch.IsLittleEndian ? Encoding.Unicode : Encoding.BigEndianUnicode;
-        MockMemorySpace.HeapFragment fragment = AllocateAndAdd((ulong)encoding.GetByteCount(value) + sizeof(char), name);
+        MockMemorySpace.HeapFragment fragment = _allocator.Allocate((ulong)encoding.GetByteCount(value) + sizeof(char), name);
         helpers.WriteUtf16String(fragment.Data, value);
         return fragment.Address;
-    }
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
     }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.MethodDescriptors.cs
@@ -296,7 +296,6 @@ internal partial class MockDescriptors
             totalAllocSize += (uint)(size * MethodDescAlignment);
 
             MockMemorySpace.HeapFragment fragment = _allocator.Allocate(totalAllocSize, $"MethodDescChunk {name}");
-            Builder.AddHeapFragment(fragment);
 
             MockMethodDescChunk chunk = MethodDescChunkLayout.Create(fragment.Data.AsMemory(), fragment.Address);
             return chunk;
@@ -307,7 +306,6 @@ internal partial class MockDescriptors
             ArgumentNullException.ThrowIfNull(typeArgs);
 
             MockMemorySpace.HeapFragment fragment = _allocator.Allocate((ulong)(typeArgs.Length * TargetTestHelpers.PointerSize), "PerInstInfo");
-            Builder.AddHeapFragment(fragment);
 
             MockPerInstInfo perInstInfo = PerInstInfoLayout.Create(fragment.Data.AsMemory(), fragment.Address);
             for (int i = 0; i < typeArgs.Length; i++)

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Object.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Object.cs
@@ -200,7 +200,6 @@ internal partial class MockDescriptors
             MockMemorySpace.HeapFragment fragment = ManagedObjectAllocator.Allocate((uint)(ObjectLayout.Size + prefixSize), $"Object : MT = '{methodTable}'");
             MockObjectData mockObject = ObjectLayout.Create(fragment.Data.AsMemory((int)prefixSize, ObjectLayout.Size), fragment.Address + prefixSize);
             mockObject.MethodTable = methodTable;
-            Builder.AddHeapFragment(fragment);
             return mockObject.Address;
         }
 
@@ -233,7 +232,6 @@ internal partial class MockDescriptors
             mockString.MethodTable = TestStringMethodTableAddress;
             mockString.StringLength = (uint)value.Length;
             MemoryMarshal.Cast<char, byte>(value).CopyTo(fragment.Data.AsSpan((int)(mockString.FirstCharAddress - fragment.Address)));
-            Builder.AddHeapFragment(fragment);
             return fragment.Address;
         }
 
@@ -273,7 +271,6 @@ internal partial class MockDescriptors
             MockArrayObjectData arrayObject = ArrayLayout.Create(fragment);
             arrayObject.MethodTable = methodTable.Address;
             arrayObject.NumComponents = (uint)array.Length;
-            Builder.AddHeapFragment(fragment);
             return fragment.Address;
         }
 

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ReJIT.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ReJIT.cs
@@ -83,7 +83,6 @@ internal sealed class MockReJITBuilder
     private ulong AddProfControlBlock(bool rejitOnAttachEnabled)
     {
         MockMemorySpace.HeapFragment fragment = _rejitAllocator.Allocate((ulong)ProfControlBlockLayout.Size, "ProfControlBlock");
-        Builder.AddHeapFragment(fragment);
         MockProfControlBlock profControlBlock = ProfControlBlockLayout.Create(fragment);
         profControlBlock.GlobalEventMask = 0;
         profControlBlock.RejitOnAttachEnabled = rejitOnAttachEnabled ? (byte)1 : (byte)0;

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeFunctions.cs
@@ -105,7 +105,7 @@ internal sealed class MockRuntimeFunctionsBuilder
 
         uint numRuntimeFunctions = checked((uint)runtimeFunctions.Length);
         uint runtimeFunctionSize = checked((uint)RuntimeFunctionLayout.Size);
-        MockMemorySpace.HeapFragment runtimeFunctionsFragment = AllocateAndAdd(
+        MockMemorySpace.HeapFragment runtimeFunctionsFragment = _allocator.Allocate(
             checked((numRuntimeFunctions + 1) * runtimeFunctionSize),
             $"RuntimeFunctions[{numRuntimeFunctions}]");
 
@@ -127,7 +127,7 @@ internal sealed class MockRuntimeFunctionsBuilder
             }
 
             MockUnwindInfo unwindInfo = UnwindInfoLayout.Create(
-                AllocateAndAdd((ulong)UnwindInfoLayout.Size, $"UnwindInfo for RuntimeFunction {runtimeFunctions[i]}"));
+                _allocator.Allocate((ulong)UnwindInfoLayout.Size, $"UnwindInfo for RuntimeFunction {runtimeFunctions[i]}"));
 
             if (HasFunctionLength())
             {
@@ -162,10 +162,4 @@ internal sealed class MockRuntimeFunctionsBuilder
     private bool HasFunctionLength()
         => Array.Exists(UnwindInfoLayout.Fields, static field => field.Name == "FunctionLength");
 
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
-    }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
@@ -445,7 +445,6 @@ internal partial class MockDescriptors
             where TView : TypedView, new()
         {
             MockMemorySpace.HeapFragment fragment = TypeSystemAllocator.Allocate(size, name);
-            Builder.AddHeapFragment(fragment);
             return layout.Create(fragment.Data.AsMemory(), fragment.Address);
         }
     }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.SyncBlock.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.SyncBlock.cs
@@ -139,7 +139,7 @@ internal sealed class MockSyncBlockBuilder
 
         if (initializeCacheAndGlobals)
         {
-            MockMemorySpace.HeapFragment syncBlockCacheFragment = AllocateAndAdd((ulong)SyncBlockCacheLayout.Size, "SyncBlockCache");
+            MockMemorySpace.HeapFragment syncBlockCacheFragment = _allocator.Allocate((ulong)SyncBlockCacheLayout.Size, "SyncBlockCache");
             _syncBlockCache = SyncBlockCacheLayout.Create(syncBlockCacheFragment);
             _syncBlockCache.FreeSyncTableIndex = 1;
 
@@ -156,7 +156,7 @@ internal sealed class MockSyncBlockBuilder
         string name = "SyncBlock")
     {
         int totalSize = SyncBlockLayout.Size + (hasInteropInfo ? InteropSyncBlockInfoLayout.Size : 0);
-        MockMemorySpace.HeapFragment fragment = AllocateAndAdd((ulong)totalSize, name);
+        MockMemorySpace.HeapFragment fragment = _allocator.Allocate((ulong)totalSize, name);
         MockSyncBlock syncBlock = SyncBlockLayout.Create(
             fragment.Data.AsMemory(0, SyncBlockLayout.Size),
             fragment.Address);
@@ -201,15 +201,8 @@ internal sealed class MockSyncBlockBuilder
     private ulong AddPointerGlobal(string name, ulong value)
     {
         TargetTestHelpers helpers = Builder.TargetTestHelpers;
-        MockMemorySpace.HeapFragment global = AllocateAndAdd((ulong)helpers.PointerSize, $"[global pointer] {name}");
+        MockMemorySpace.HeapFragment global = _allocator.Allocate((ulong)helpers.PointerSize, $"[global pointer] {name}");
         helpers.WritePointer(global.Data, value);
         return global.Address;
-    }
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
     }
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
@@ -308,7 +308,6 @@ internal sealed class MockThreadBuilder
         MockMemorySpace.HeapFragment threadStoreGlobal = _allocator.Allocate((ulong)helpers.PointerSize, "[global pointer] ThreadStore");
         MockMemorySpace.HeapFragment threadStore = _allocator.Allocate((ulong)ThreadStoreLayout.Size, "ThreadStore");
         helpers.WritePointer(threadStoreGlobal.Data, threadStore.Address);
-        Builder.AddHeapFragments([threadStoreGlobal, threadStore]);
         ThreadStoreGlobalAddress = threadStoreGlobal.Address;
         ThreadStoreAddress = threadStore.Address;
         _threadStore = ThreadStoreLayout.Create(threadStore);
@@ -325,14 +324,14 @@ internal sealed class MockThreadBuilder
 
     internal MockThread AddThread(uint id, ulong osId, long allocBytes, long allocBytesLoh)
     {
-        MockExceptionInfo exceptionInfo = ExceptionInfoLayout.Create(AllocateAndAdd((ulong)ExceptionInfoLayout.Size, "ExceptionInfo"));
-        MockRuntimeThreadLocals runtimeThreadLocals = RuntimeThreadLocalsLayout.Create(AllocateAndAdd((ulong)RuntimeThreadLocalsLayout.Size, "RuntimeThreadLocals"));
+        MockExceptionInfo exceptionInfo = ExceptionInfoLayout.Create(_allocator.Allocate((ulong)ExceptionInfoLayout.Size, "ExceptionInfo"));
+        MockRuntimeThreadLocals runtimeThreadLocals = RuntimeThreadLocalsLayout.Create(_allocator.Allocate((ulong)RuntimeThreadLocalsLayout.Size, "RuntimeThreadLocals"));
         runtimeThreadLocals.SetGCAllocContextLayout(GCAllocContextLayout);
         MockGCAllocContext gcAllocContext = runtimeThreadLocals.GCAllocContext;
         gcAllocContext.AllocBytes = allocBytes;
         gcAllocContext.AllocBytesLoh = allocBytesLoh;
 
-        MockThread thread = ThreadLayout.Create(AllocateAndAdd((ulong)ThreadLayout.Size, "Thread"));
+        MockThread thread = ThreadLayout.Create(_allocator.Allocate((ulong)ThreadLayout.Size, "Thread"));
         thread.Id = id;
         thread.OSId = osId;
         thread.ExceptionTracker = exceptionInfo.Address;
@@ -367,16 +366,8 @@ internal sealed class MockThreadBuilder
         MockMemorySpace.HeapFragment global = _allocator.Allocate((ulong)helpers.PointerSize, $"[global pointer] {name}");
         MockMemorySpace.HeapFragment pointee = _allocator.Allocate(pointeeSize, pointeeName);
         helpers.WritePointer(global.Data, pointee.Address);
-        Builder.AddHeapFragments([global, pointee]);
         value = pointee.Address;
         return global.Address;
-    }
-
-    private MockMemorySpace.HeapFragment AllocateAndAdd(ulong size, string name)
-    {
-        MockMemorySpace.HeapFragment fragment = _allocator.Allocate(size, name);
-        Builder.AddHeapFragment(fragment);
-        return fragment;
     }
 
     private Memory<byte> BorrowMemory(ulong address, int length)

--- a/src/native/managed/cdac/tests/MockMemorySpace.BumpAllocator.cs
+++ b/src/native/managed/cdac/tests/MockMemorySpace.BumpAllocator.cs
@@ -22,13 +22,15 @@ internal unsafe static partial class MockMemorySpace
 {
     internal class BumpAllocator
     {
+        private readonly Builder _builder;
         private readonly ulong _blockStart;
         private readonly ulong _blockEnd; // exclusive
         ulong _current;
 
         public int MinAlign { get; init; } = 16; // by default align to 16 bytes
-        public BumpAllocator(ulong blockStart, ulong blockEnd)
+        public BumpAllocator(Builder builder, ulong blockStart, ulong blockEnd)
         {
+            _builder = builder;
             _blockStart = blockStart;
             _blockEnd = blockEnd;
             _current = blockStart;
@@ -49,11 +51,13 @@ internal unsafe static partial class MockMemorySpace
             Debug.Assert((current % (ulong)MinAlign) == 0);
             if (current + size <= _blockEnd)
             {
-                fragment = new HeapFragment {
+                fragment = new HeapFragment
+                {
                     Address = current,
                     Data = new byte[size],
                     Name = name,
                 };
+                _builder.AddHeapFragment(fragment.Value);
                 current += size;
                 _current = current;
                 return true;

--- a/src/native/managed/cdac/tests/MockMemorySpace.cs
+++ b/src/native/managed/cdac/tests/MockMemorySpace.cs
@@ -119,10 +119,11 @@ internal unsafe static partial class MockMemorySpace
             return true;
         }
 
-        // Get an allocator for a range of addresses to simplify creating heap fragments
+        // Get an allocator for a range of addresses to simplify creating heap fragments.
+        // Fragments allocated from the returned allocator are registered with this builder automatically.
         public BumpAllocator CreateAllocator(ulong start, ulong end, int minAlign = 16)
         {
-            BumpAllocator allocator = new BumpAllocator(start, end) { MinAlign = minAlign };
+            BumpAllocator allocator = new BumpAllocator(this, start, end) { MinAlign = minAlign };
             foreach (var a in _allocators)
             {
                 if (allocator.Overlaps(a))

--- a/src/native/managed/cdac/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdac/tests/PrecodeStubsTests.cs
@@ -276,7 +276,6 @@ public class PrecodeStubsTests
             SetCodePointerFlags(descriptor);
             var typeInfo = Types[DataType.PrecodeMachineDescriptor];
             var fragment = PrecodeAllocator.Allocate((ulong)typeInfo.Size, $"{descriptor.Name} Precode Machine Descriptor");
-            Builder.AddHeapFragment(fragment);
             MachineDescriptorAddress = fragment.Address;
             Span<byte> desc = Builder.BorrowAddressRange(fragment.Address, (int)typeInfo.Size);
             Builder.TargetTestHelpers.Write(desc.Slice(typeInfo.Fields[nameof(Data.PrecodeMachineDescriptor.ReadWidthOfPrecodeType)].Offset, sizeof(byte)), (byte)descriptor.ReadWidthOfPrecodeType);
@@ -293,7 +292,6 @@ public class PrecodeStubsTests
             ulong stubCodeSize = (ulong)test.StubPrecodeSize;
             var stubDataTypeInfo  = Types[DataType.StubPrecodeData];
             MockMemorySpace.HeapFragment stubDataFragment = StubDataPageAllocator.Allocate(Math.Max((ulong)stubDataTypeInfo.Size, (ulong)stubCodeSize), $"Stub data for {name} on {test.Name}");
-            Builder.AddHeapFragment(stubDataFragment);
             // allocate the code one page before the stub data
             ulong stubCodeStart = stubDataFragment.Address - test.StubCodePageSize;
             MockMemorySpace.HeapFragment stubCodeFragment = new MockMemorySpace.HeapFragment {
@@ -323,11 +321,9 @@ public class PrecodeStubsTests
             ulong stubCodeSize = (ulong)test.StubPrecodeSize;
             var stubDataTypeInfo  = Types[DataType.StubPrecodeData];
             MockMemorySpace.HeapFragment stubDataFragment = StubDataPageAllocator.Allocate(Math.Max((ulong)stubDataTypeInfo.Size, (ulong)stubCodeSize), $"Stub data for {name} on {test.Name}");
-            Builder.AddHeapFragment(stubDataFragment);
 
             var thisPtrRetBufDataTypeInfo  = Types[DataType.ThisPtrRetBufPrecodeData];
             MockMemorySpace.HeapFragment thisPtrRetBufStubDataFragment = StubDataPageAllocator.Allocate((ulong)thisPtrRetBufDataTypeInfo.Size, $"ThisPtrRetBufData stub data for {name} on {test.Name}");
-            Builder.AddHeapFragment(thisPtrRetBufStubDataFragment);
 
             // allocate the code one page before the stub data
             ulong stubCodeStart = stubDataFragment.Address - test.StubCodePageSize;

--- a/src/native/managed/cdac/tests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/ThreadTests.cs
@@ -226,7 +226,6 @@ public unsafe class ThreadTests
                 MockMemorySpace.BumpAllocator allocator = threadBuilder.Builder.CreateAllocator(0x1_0000, 0x2_0000);
                 MockMemorySpace.HeapFragment handleFragment = allocator.Allocate((ulong)helpers.PointerSize, "ThrownObjectHandle");
                 helpers.WritePointer(handleFragment.Data, expectedObject);
-                threadBuilder.Builder.AddHeapFragment(handleFragment);
                 exceptionInfo!.ThrownObjectHandle = handleFragment.Address;
             });
 
@@ -271,7 +270,6 @@ public unsafe class ThreadTests
                 MockMemorySpace.BumpAllocator allocator = threadBuilder.Builder.CreateAllocator(0x1_0000, 0x2_0000);
                 MockMemorySpace.HeapFragment handleFragment = allocator.Allocate((ulong)helpers.PointerSize, "ThrownObjectHandle");
                 helpers.WritePointer(handleFragment.Data, TargetPointer.Null);
-                threadBuilder.Builder.AddHeapFragment(handleFragment);
                 exceptionInfo!.ThrownObjectHandle = handleFragment.Address;
             });
 


### PR DESCRIPTION
Previously the tests used a two step process of first using BumpAllocator to calculate a simulated address for a new HeapFragment, then separately calling Builder.AddHeapFragment() to store it. Now the allocator automatically stores all allocations eliminating the need for a 2nd call.

This is follow up from the recent PR feedback asking to consolidate the AllocateAndAdd() helper. Removing the need for it entirely seemed cleaner. https://github.com/dotnet/runtime/pull/126466#discussion_r3040470101