### PR TITLE
Fix bug with XmlSerializer and generic type handling wrt collectible ALCs

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/Compilation.cs
@@ -141,7 +141,7 @@ namespace System.Xml.Serialization
             contract = null;
             string? serializerName;
 
-            using (AssemblyLoadContext.EnterContextualReflection(type.Assembly))
+            using (AssemblyLoadContext.EnterContextualReflection(LoadContextAwareTypeResolver.GetLoadContextAssembly(type)))
             {
                 // check to see if we loading explicit pre-generated assembly
                 object[] attrs = type.GetCustomAttributes(typeof(System.Xml.Serialization.XmlSerializerAssemblyAttribute), false);
@@ -437,8 +437,8 @@ namespace System.Xml.Serialization
         [RequiresDynamicCode(XmlSerializer.AotSerializationWarning)]
         internal static Assembly GenerateRefEmitAssembly(XmlMapping[] xmlMappings, Type?[] types)
         {
-            var mainType = (types.Length > 0) ? types[0] : null;
-            Assembly? mainAssembly = mainType?.Assembly;
+            Type? mainType = LoadContextAwareTypeResolver.GetRepresentativeType(types);
+            Assembly? mainAssembly = LoadContextAwareTypeResolver.GetLoadContextAssembly(types) ?? mainType?.Assembly;
             var scopeTable = new Dictionary<TypeScope, XmlMapping>();
             foreach (XmlMapping mapping in xmlMappings)
                 scopeTable[mapping.Scope!] = mapping;
@@ -451,8 +451,13 @@ namespace System.Xml.Serialization
                 // they are compatible with the current ALC
                 for (int i = 0; i < types.Length; i++)
                     VerifyLoadContext(types[i], mainAssembly);
-                foreach (var mapping in xmlMappings)
-                    VerifyLoadContext(mapping.Accessor.Mapping?.TypeDesc?.Type, mainAssembly);
+                foreach (TypeScope scope in scopes)
+                {
+                    foreach (Type scopeType in scope.Types)
+                    {
+                        VerifyLoadContext(scopeType, mainAssembly);
+                    }
+                }
 
                 string assemblyName = "Microsoft.GeneratedCode";
                 AssemblyBuilder assemblyBuilder = CodeGenerator.CreateAssemblyBuilder(assemblyName);
@@ -593,7 +598,7 @@ namespace System.Xml.Serialization
                 return;
 
             // No worries if the type is not collectible
-            var typeALC = AssemblyLoadContext.GetLoadContext(t.Assembly);
+            var typeALC = LoadContextAwareTypeResolver.GetLoadContext(t);
             if (typeALC == null || !typeALC.IsCollectible)
                 return;
 
@@ -702,7 +707,8 @@ namespace System.Xml.Serialization
                 if (_fastCache.TryGetValue(key, out tempAssembly))
                     return tempAssembly;
 
-                if (_collectibleCaches.TryGetValue(t.Assembly, out var cCache))
+                Assembly contextAssembly = LoadContextAwareTypeResolver.GetLoadContextAssembly(t)!;
+                if (_collectibleCaches.TryGetValue(contextAssembly, out var cCache))
                     cCache.TryGetValue(key, out tempAssembly);
 
                 return tempAssembly;
@@ -717,17 +723,18 @@ namespace System.Xml.Serialization
                 if (tempAssembly == assembly)
                     return;
 
-                AssemblyLoadContext? alc = AssemblyLoadContext.GetLoadContext(t.Assembly);
+                AssemblyLoadContext? alc = LoadContextAwareTypeResolver.GetLoadContext(t);
+                Assembly contextAssembly = LoadContextAwareTypeResolver.GetLoadContextAssembly(t)!;
                 TempAssemblyCacheKey key = new TempAssemblyCacheKey(ns, t);
                 Dictionary<TempAssemblyCacheKey, TempAssembly>? cache;
 
                 if (alc != null && alc.IsCollectible)
                 {
-                    cache = _collectibleCaches.TryGetValue(t.Assembly, out var c)   // Clone or create
+                    cache = _collectibleCaches.TryGetValue(contextAssembly, out var c)   // Clone or create
                         ? new Dictionary<TempAssemblyCacheKey, TempAssembly>(c)
                         : new Dictionary<TempAssemblyCacheKey, TempAssembly>();
                     cache[key] = assembly;
-                    _collectibleCaches.AddOrUpdate(t.Assembly, cache);
+                    _collectibleCaches.AddOrUpdate(contextAssembly, cache);
                 }
                 else
                 {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ContextAwareTables.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ContextAwareTables.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
 
@@ -32,7 +33,7 @@ namespace System.Xml.Serialization
                 return ret;
 
             // Not found. Do the slower work of creating the value in the correct collection.
-            AssemblyLoadContext? alc = AssemblyLoadContext.GetLoadContext(t.Assembly);
+            AssemblyLoadContext? alc = LoadContextAwareTypeResolver.GetLoadContext(t);
 
             // Null and non-collectible load contexts use the default table
             if (alc == null || !alc.IsCollectible)
@@ -61,6 +62,88 @@ namespace System.Xml.Serialization
             }
 
             return ret;
+        }
+    }
+
+    internal static class LoadContextAwareTypeResolver
+    {
+        internal static Assembly? GetLoadContextAssembly(Type? type)
+        {
+            if (type is null)
+            {
+                return null;
+            }
+
+            Assembly assembly = type.Assembly;
+            if (IsNonDefaultLoadContext(assembly))
+            {
+                return assembly;
+            }
+
+            if (type.HasElementType)
+            {
+                Assembly? elementAssembly = GetLoadContextAssembly(type.GetElementType());
+                if (IsNonDefaultLoadContext(elementAssembly))
+                {
+                    return elementAssembly;
+                }
+            }
+
+            if (type.IsConstructedGenericType)
+            {
+                foreach (Type genericArgument in type.GetGenericArguments())
+                {
+                    Assembly? argumentAssembly = GetLoadContextAssembly(genericArgument);
+                    if (IsNonDefaultLoadContext(argumentAssembly))
+                    {
+                        return argumentAssembly;
+                    }
+                }
+            }
+
+            return assembly;
+        }
+
+        internal static AssemblyLoadContext? GetLoadContext(Type? type) =>
+            GetLoadContext(GetLoadContextAssembly(type));
+
+        internal static Type? GetRepresentativeType(Type?[]? types)
+        {
+            Type? fallback = null;
+            if (types is null)
+            {
+                return null;
+            }
+
+            foreach (Type? type in types)
+            {
+                if (type is null)
+                {
+                    continue;
+                }
+
+                fallback ??= type;
+                if (IsNonDefaultLoadContext(GetLoadContextAssembly(type)))
+                {
+                    return type;
+                }
+            }
+
+            return fallback;
+        }
+
+        internal static Assembly? GetLoadContextAssembly(Type?[]? types) =>
+            GetLoadContextAssembly(GetRepresentativeType(types));
+
+        private static AssemblyLoadContext? GetLoadContext(Assembly? assembly) =>
+            assembly is null ? null : AssemblyLoadContext.GetLoadContext(assembly);
+
+        // Constructed wrapper types like List<T> are defined in CoreLib even when a generic
+        // argument loaded in a custom ALC determines the effective load context.
+        private static bool IsNonDefaultLoadContext(Assembly? assembly)
+        {
+            AssemblyLoadContext? alc = GetLoadContext(assembly);
+            return alc != null && alc != AssemblyLoadContext.Default;
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -612,7 +612,7 @@ namespace System.Xml.Serialization
                 {
                     if (type == null)
                     {
-                        tempAssembly = new TempAssembly(mappings, new Type?[] { type }, null, null);
+                        tempAssembly = new TempAssembly(mappings, GetTypesFromMappings(mappings, type), null, null);
                         XmlSerializer[] serializers = new XmlSerializer[mappings.Length];
 
                         contract = tempAssembly.Contract;
@@ -705,10 +705,8 @@ namespace System.Xml.Serialization
         private static XmlSerializer[] GetSerializersFromCache(XmlMapping[] mappings, Type type)
         {
             XmlSerializer?[] serializers = new XmlSerializer?[mappings.Length];
-            Dictionary<XmlSerializerMappingKey, XmlSerializer>? typedMappingTable = null;
-            AssemblyLoadContext? alc = AssemblyLoadContext.GetLoadContext(type.Assembly);
-
-            typedMappingTable = s_xmlSerializerTable.GetOrCreateValue(type, _ => new Dictionary<XmlSerializerMappingKey, XmlSerializer>());
+            Dictionary<XmlSerializerMappingKey, XmlSerializer> typedMappingTable =
+                s_xmlSerializerTable.GetOrCreateValue(type, _ => new Dictionary<XmlSerializerMappingKey, XmlSerializer>());
 
             lock (typedMappingTable)
             {
@@ -731,7 +729,7 @@ namespace System.Xml.Serialization
                         pendingMappings[index++] = mappingKey.Mapping;
                     }
 
-                    TempAssembly tempAssembly = new TempAssembly(pendingMappings, new Type[] { type }, null, null);
+                    TempAssembly tempAssembly = new TempAssembly(pendingMappings, GetTypesFromMappings(pendingMappings, type), null, null);
                     XmlSerializerImplementation contract = tempAssembly.Contract;
 
                     foreach (XmlSerializerMappingKey mappingKey in pendingKeys.Keys)
@@ -748,6 +746,41 @@ namespace System.Xml.Serialization
             return serializers!;
         }
 
+        private static Type?[] GetTypesFromMappings(XmlMapping[] mappings, Type? type)
+        {
+            var types = new List<Type?>(mappings.Length + (type is null ? 0 : 1));
+            var uniqueTypes = new HashSet<Type>();
+
+            if (type is not null)
+            {
+                types.Add(type);
+                uniqueTypes.Add(type);
+            }
+
+            foreach (XmlMapping mapping in mappings)
+            {
+                if (mapping.Scope is null)
+                {
+                    Type? mappingType = mapping.Accessor.Mapping?.TypeDesc?.Type;
+                    if (mappingType is not null && uniqueTypes.Add(mappingType))
+                    {
+                        types.Add(mappingType);
+                    }
+                    continue;
+                }
+
+                foreach (Type scopeType in mapping.Scope.Types)
+                {
+                    if (uniqueTypes.Add(scopeType))
+                    {
+                        types.Add(scopeType);
+                    }
+                }
+            }
+
+            return types.ToArray();
+        }
+
         [RequiresUnreferencedCode(TrimSerializationWarning)]
         [RequiresDynamicCode(XmlSerializer.AotSerializationWarning)]
         public static XmlSerializer?[] FromTypes(Type[]? types)
@@ -761,7 +794,7 @@ namespace System.Xml.Serialization
             {
                 mappings[i] = importer.ImportTypeMapping(types[i]);
             }
-            return FromMappings(mappings);
+            return FromMappings(mappings, types.Length == 1 ? types[0] : null);
         }
 
         public static string GetXmlSerializerAssemblyName(Type type)

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -2561,7 +2561,7 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         Assert.Equal(x.Name, y.Name);
     }
 
-    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
+    [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
 #if XMLSERIALIZERGENERATORTESTS
     // Lack of AssemblyDependencyResolver results in assemblies that are not loaded by path to get
     // loaded in the default ALC, which causes problems for this test.
@@ -2570,9 +2570,11 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34072", TestRuntimes.Mono)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/95928", typeof(PlatformDetection), nameof(PlatformDetection.IsReadyToRunCompiled))]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-    public static void Xml_TypeInCollectibleALC()
+    [InlineData(false)]
+    [InlineData(true)]
+    public static void Xml_TypeInCollectibleALC(bool useCollectionRoot)
     {
-        ExecuteAndUnload("SerializableAssembly.dll", "SerializationTypes.SimpleType", out var weakRef);
+        ExecuteAndUnload("SerializableAssembly.dll", "SerializationTypes.SimpleType", useCollectionRoot, out var weakRef);
 
         for (int i = 0; weakRef.IsAlive && i < 10; i++)
         {
@@ -2734,7 +2736,7 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
 #endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]
-    private static void ExecuteAndUnload(string assemblyfile, string typename, out WeakReference wref)
+    private static void ExecuteAndUnload(string assemblyfile, string typename, bool useCollectionRoot, out WeakReference wref)
     {
         var fullPath = Path.GetFullPath(assemblyfile);
         var alc = new TestAssemblyLoadContext("XmlSerializerTests", true, fullPath);
@@ -2744,18 +2746,63 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
         var asm = alc.LoadFromAssemblyPath(fullPath);
 
         // Ensure the type loaded in the intended non-Default ALC
-        var type = asm.GetType(typename);
+        Type type = asm.GetType(typename)!;
         Assert.Equal(AssemblyLoadContext.GetLoadContext(type.Assembly), alc);
         Assert.NotEqual(alc, AssemblyLoadContext.Default);
 
+        object obj;
+        Type rootType = type;
+
+        if (useCollectionRoot)
+        {
+            rootType = typeof(List<>).MakeGenericType(type);
+            Assert.True(rootType.IsCollectible);
+            Assert.Equal(AssemblyLoadContext.Default, AssemblyLoadContext.GetLoadContext(rootType.Assembly));
+
+            IList list = Assert.IsAssignableFrom<IList>(Activator.CreateInstance(rootType));
+            list.Add(Activator.CreateInstance(type));
+            obj = list;
+        }
+        else
+        {
+            obj = Activator.CreateInstance(rootType)!;
+        }
+
         // Round-Trip the instance
-        XmlSerializer serializer = new XmlSerializer(type);
-        var obj = Activator.CreateInstance(type);
+        XmlSerializer serializer = new XmlSerializer(rootType);
         var rtobj = SerializeAndDeserialize(obj, null, () => serializer, true);
         Assert.NotNull(rtobj);
-        Assert.True(rtobj.Equals(obj));
+        AssertEqual(obj, rtobj, useCollectionRoot);
+
+        XmlSerializer cachedSerializer = Assert.Single(XmlSerializer.FromTypes(new[] { rootType }))!;
+        var cachedRtobj = SerializeAndDeserialize(obj, null, () => cachedSerializer, true);
+        Assert.NotNull(cachedRtobj);
+        AssertEqual(obj, cachedRtobj, useCollectionRoot);
+
+        var importer = new XmlReflectionImporter();
+        var member = new XmlReflectionMember { MemberName = "Value", MemberType = rootType };
+        XmlMembersMapping membersMapping = importer.ImportMembersMapping("Root", null, new[] { member }, true);
+        XmlSerializer fromMappingsSerializer = Assert.Single(XmlSerializer.FromMappings(new XmlMapping[] { membersMapping }))!;
+        var fromMappingsRtobj = Assert.IsType<object[]>(SerializeAndDeserialize(new object[] { obj }, null, () => fromMappingsSerializer, true));
+        Assert.Single(fromMappingsRtobj);
+        AssertEqual(obj, fromMappingsRtobj[0], useCollectionRoot);
 
         alc.Unload();
+
+        static void AssertEqual(object expected, object actual, bool isCollectionRoot)
+        {
+            if (isCollectionRoot)
+            {
+                IList expectedList = Assert.IsAssignableFrom<IList>(expected);
+                IList actualList = Assert.IsAssignableFrom<IList>(actual);
+                Assert.Equal(expectedList.Count, actualList.Count);
+                Assert.Equal(expectedList[0], actualList[0]);
+            }
+            else
+            {
+                Assert.True(actual.Equals(expected));
+            }
+        }
     }
 
 


### PR DESCRIPTION
This pull request refactors the XML serialization code to improve handling of types loaded in custom AssemblyLoadContexts (ALCs), especially for scenarios involving collectible ALCs and generic types. The changes centralize and enhance logic for determining the appropriate assembly and load context for types, and expand test coverage to ensure correct serializer behavior with types in custom and collectible ALCs.

Key improvements include:

**AssemblyLoadContext and Type Resolution Enhancements:**
* Introduced the `LoadContextAwareTypeResolver` utility to consistently determine the correct assembly and load context for a given `Type` or array of types, handling generic and array types, and preferring non-default ALCs when present.
* Updated usages throughout the serialization codebase to use `LoadContextAwareTypeResolver` instead of directly accessing `Type.Assembly` or `AssemblyLoadContext.GetLoadContext`, ensuring correctness in complex ALC scenarios. [[1]](diffhunk://#diff-e4d354039ba8ec739e290407b136c6af32d4d38e07fa9420078f662590ea0da2L144-R144) [[2]](diffhunk://#diff-e4d354039ba8ec739e290407b136c6af32d4d38e07fa9420078f662590ea0da2L440-R441) [[3]](diffhunk://#diff-e4d354039ba8ec739e290407b136c6af32d4d38e07fa9420078f662590ea0da2L596-R601) [[4]](diffhunk://#diff-e4d354039ba8ec739e290407b136c6af32d4d38e07fa9420078f662590ea0da2L705-R711) [[5]](diffhunk://#diff-e4d354039ba8ec739e290407b136c6af32d4d38e07fa9420078f662590ea0da2L720-R737) [[6]](diffhunk://#diff-ddd028dcb1c03a409ec83ec7247b1c4793ebbee56e379a0dab16696fedf1503dL35-R36)

**Serializer Caching and Mapping Improvements:**
* Enhanced methods that construct or cache serializers to use all relevant types from mappings, not just a single root type, reducing cache misses and ensuring correct serializer lookup in multi-type scenarios. [[1]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bL615-R615) [[2]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bL734-R732) [[3]](diffhunk://#diff-fa07acc29a1aed946fd7f4fca4b198bc71c7bb4204019cd407b9447882af374bR749-R783)
* Added a helper method `GetTypesFromMappings` to extract all unique types from mappings and the root type for consistent use in serializer construction and caching.

**Test Coverage Expansion:**
* Extended the existing test for types in collectible ALCs (`Xml_TypeInCollectibleALC`) to run with both standalone and collection root types, verifying correct serialization/deserialization and cache behavior for these scenarios. [[1]](diffhunk://#diff-cb25d8cca02e9c7959514c29f15823cfbdcae1b51cd148ddc69e2a8a6fb780e4L2564-R2564) [[2]](diffhunk://#diff-cb25d8cca02e9c7959514c29f15823cfbdcae1b51cd148ddc69e2a8a6fb780e4L2573-R2577)
* Refactored the test harness to support collection roots, and added assertions to ensure correct serializer behavior and object equality for both single objects and collections. [[1]](diffhunk://#diff-cb25d8cca02e9c7959514c29f15823cfbdcae1b51cd148ddc69e2a8a6fb780e4L2737-R2739) [[2]](diffhunk://#diff-cb25d8cca02e9c7959514c29f15823cfbdcae1b51cd148ddc69e2a8a6fb780e4L2747-R2805)

These changes make the XML serialization infrastructure more robust and reliable in advanced loading scenarios, such as dynamic plugin systems or environments using collectible assemblies.

Fixes: #100518