### PR TITLE
Haiku: Apply .NET-specific llvm-libunwind patches

### DIFF
--- a/src/native/external/llvm-libunwind-version.txt
+++ b/src/native/external/llvm-libunwind-version.txt
@@ -2,3 +2,4 @@ v22.1.1
 https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.1
 
 Apply https://github.com/dotnet/runtime/commit/35b7d59fa1075ab0fefb921393409806a821d8ed
+Apply https://github.com/dotnet/runtime/commit/be5f98fb6702704afbaf705dce0b54d55479c6f1

--- a/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
+++ b/src/native/external/llvm-libunwind/src/UnwindCursor.hpp
@@ -3258,23 +3258,23 @@ int UnwindCursor<A, R>::stepThroughSigReturn() {
   pint_t bp = this->getReg(UNW_X86_64_RBP);
   vregs *regs = (vregs *)(bp + 0x70);
 
-  _registers.setRegister(UNW_REG_IP, regs->rip);
-  _registers.setRegister(UNW_REG_SP, regs->rsp);
-  _registers.setRegister(UNW_X86_64_RAX, regs->rax);
-  _registers.setRegister(UNW_X86_64_RDX, regs->rdx);
-  _registers.setRegister(UNW_X86_64_RCX, regs->rcx);
-  _registers.setRegister(UNW_X86_64_RBX, regs->rbx);
-  _registers.setRegister(UNW_X86_64_RSI, regs->rsi);
-  _registers.setRegister(UNW_X86_64_RDI, regs->rdi);
-  _registers.setRegister(UNW_X86_64_RBP, regs->rbp);
-  _registers.setRegister(UNW_X86_64_R8, regs->r8);
-  _registers.setRegister(UNW_X86_64_R9, regs->r9);
-  _registers.setRegister(UNW_X86_64_R10, regs->r10);
-  _registers.setRegister(UNW_X86_64_R11, regs->r11);
-  _registers.setRegister(UNW_X86_64_R12, regs->r12);
-  _registers.setRegister(UNW_X86_64_R13, regs->r13);
-  _registers.setRegister(UNW_X86_64_R14, regs->r14);
-  _registers.setRegister(UNW_X86_64_R15, regs->r15);
+  _registers.setRegister(UNW_REG_IP, regs->rip, 0);
+  _registers.setRegister(UNW_REG_SP, regs->rsp, 0);
+  _registers.setRegister(UNW_X86_64_RAX, regs->rax, 0);
+  _registers.setRegister(UNW_X86_64_RDX, regs->rdx, 0);
+  _registers.setRegister(UNW_X86_64_RCX, regs->rcx, 0);
+  _registers.setRegister(UNW_X86_64_RBX, regs->rbx, 0);
+  _registers.setRegister(UNW_X86_64_RSI, regs->rsi, 0);
+  _registers.setRegister(UNW_X86_64_RDI, regs->rdi, 0);
+  _registers.setRegister(UNW_X86_64_RBP, regs->rbp, 0);
+  _registers.setRegister(UNW_X86_64_R8, regs->r8, 0);
+  _registers.setRegister(UNW_X86_64_R9, regs->r9, 0);
+  _registers.setRegister(UNW_X86_64_R10, regs->r10, 0);
+  _registers.setRegister(UNW_X86_64_R11, regs->r11, 0);
+  _registers.setRegister(UNW_X86_64_R12, regs->r12, 0);
+  _registers.setRegister(UNW_X86_64_R13, regs->r13, 0);
+  _registers.setRegister(UNW_X86_64_R14, regs->r14, 0);
+  _registers.setRegister(UNW_X86_64_R15, regs->r15, 0);
   // TODO: XMM
 #endif // defined(_LIBUNWIND_TARGET_X86_64)
 


### PR DESCRIPTION
.NET uses `setRegister` with 3 arguments, the last being a "location" for the register.

For calls without a known location, `0` is passed.

This updates the recent Haiku-specific call sites to `setRegister` to match what .NET uses.

Part of #55803.