### PR TITLE
Set MSBUILDDEBUGPATH in build scripts for reliable crash diagnostics

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -382,7 +382,7 @@ $env:DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
 
 # Set up the directory for MSBuild debug logs, so that if MSBuild crashes (MSB4166)
 # the failure.txt diagnostics are written to a known location under artifacts/log
-# where they'll be captured as build artifacts. See https://github.com/dotnet/runtime/issues/92290
+# where they'll be captured as build artifacts.
 $msbuildDebugLogsDir = "$PSScriptRoot/../artifacts/log/$((Get-Culture).TextInfo.ToTitleCase($configuration[0]))/MsbuildDebugLogs"
 New-Item -ItemType Directory -Force -Path $msbuildDebugLogsDir | Out-Null
 $env:MSBUILDDEBUGPATH = $msbuildDebugLogsDir

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -448,8 +448,9 @@ foreach ($config in $configuration) {
   $msbuildDebugLogsDir = "$PSScriptRoot/../artifacts/log/$titleCaseConfig/MsbuildDebugLogs"
   New-Item -ItemType Directory -Force -Path $msbuildDebugLogsDir | Out-Null
   $env:MSBUILDDEBUGPATH = $msbuildDebugLogsDir
+  Write-Host "MSBUILDDEBUGPATH=$msbuildDebugLogsDir"
 
-  $argumentsWithConfig = $arguments + " -configuration $titleCaseConfig";
+  $argumentsWithConfig= $arguments + " -configuration $titleCaseConfig";
   foreach ($singleArch in $arch) {
     $argumentsWithArch =  "/p:TargetArchitecture=$singleArch " + $argumentsWithConfig
     Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $argumentsWithArch"

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -380,6 +380,14 @@ $arguments += " /clp:ForceNoAlign"
 # The later changes are ignored when using the cache.
 $env:DOTNETSDK_ALLOW_TARGETING_PACK_CACHING=0
 
+# Set up the directory for MSBuild debug logs, so that if MSBuild crashes (MSB4166)
+# the failure.txt diagnostics are written to a known location under artifacts/log
+# where they'll be captured as build artifacts. See https://github.com/dotnet/runtime/issues/92290
+$msbuildDebugLogsDir = "$PSScriptRoot/../artifacts/log/$((Get-Culture).TextInfo.ToTitleCase($configuration[0]))/MsbuildDebugLogs"
+New-Item -ItemType Directory -Force -Path $msbuildDebugLogsDir | Out-Null
+$env:MSBUILDDEBUGPATH = $msbuildDebugLogsDir
+Write-Host "MSBUILDDEBUGPATH=$msbuildDebugLogsDir"
+
 if ($bootstrap -eq $True) {
 
   if ($actionPassedIn) {
@@ -434,7 +442,14 @@ if ($bootstrap -eq $True) {
 $failedBuilds = @()
 
 foreach ($config in $configuration) {
-  $argumentsWithConfig = $arguments + " -configuration $((Get-Culture).TextInfo.ToTitleCase($config))";
+  $titleCaseConfig = $((Get-Culture).TextInfo.ToTitleCase($config))
+
+  # Update MSBuild debug logs directory for this configuration.
+  $msbuildDebugLogsDir = "$PSScriptRoot/../artifacts/log/$titleCaseConfig/MsbuildDebugLogs"
+  New-Item -ItemType Directory -Force -Path $msbuildDebugLogsDir | Out-Null
+  $env:MSBUILDDEBUGPATH = $msbuildDebugLogsDir
+
+  $argumentsWithConfig = $arguments + " -configuration $titleCaseConfig";
   foreach ($singleArch in $arch) {
     $argumentsWithArch =  "/p:TargetArchitecture=$singleArch " + $argumentsWithConfig
     Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" $argumentsWithArch"

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -635,6 +635,14 @@ cmakeargs="${cmakeargs// /%20}"
 arguments+=("/p:TargetArchitecture=$arch" "/p:BuildArchitecture=$hostArch")
 arguments+=("/p:CMakeArgs=\"$cmakeargs\"" ${extraargs[@]+"${extraargs[@]}"})
 
+# Set up the directory for MSBuild debug logs, so that if MSBuild crashes (MSB4166)
+# the failure.txt diagnostics are written to a known location under artifacts/log
+# where they'll be captured as build artifacts. See https://github.com/dotnet/runtime/issues/92290
+MSBUILDDEBUGPATH="$scriptroot/../artifacts/log/${bootstrapConfig:-Debug}/MsbuildDebugLogs"
+mkdir -p "$MSBUILDDEBUGPATH"
+export MSBUILDDEBUGPATH
+echo "MSBUILDDEBUGPATH=$MSBUILDDEBUGPATH"
+
 if [[ "$bootstrap" == "1" ]]; then
   # Strip build actions other than -restore and -build from the arguments for the bootstrap build.
   bootstrapArguments=()

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -637,7 +637,7 @@ arguments+=("/p:CMakeArgs=\"$cmakeargs\"" ${extraargs[@]+"${extraargs[@]}"})
 
 # Set up the directory for MSBuild debug logs, so that if MSBuild crashes (MSB4166)
 # the failure.txt diagnostics are written to a known location under artifacts/log
-# where they'll be captured as build artifacts. See https://github.com/dotnet/runtime/issues/92290
+# where they'll be captured as build artifacts.
 MSBUILDDEBUGPATH="$scriptroot/../artifacts/log/${bootstrapConfig:-Debug}/MsbuildDebugLogs"
 mkdir -p "$MSBUILDDEBUGPATH"
 export MSBUILDDEBUGPATH


### PR DESCRIPTION
Set MSBUILDDEBUGPATH directly in eng/build.sh for reliable crash diagnostics

PR #126012 added `MSBUILDDEBUGPATH` as an AzDO pipeline variable in `global-build-job.yml` so that MSBuild crash diagnostics (`MSBuild_*.failure.txt`) would be written to `artifacts/log/` instead of the system temp directory. However, recent builds that hit the MSB4166 crash (e.g., build 1370423) still show MSBuild writing to the default temp path, indicating the pipeline variable is not reaching the MSBuild process.

Other build scripts (`src/coreclr/build-runtime.sh`, `src/tests/build.sh`) already set and export `MSBUILDDEBUGPATH` independently, which is why "Build Tests" steps work. The "Build product" step calls `eng/build.sh`, which did not set it.

This PR sets `MSBUILDDEBUGPATH` directly in `eng/build.sh` and `eng/build.ps1` before any `common/build.sh`/`common/build.ps1` invocations, matching the pattern used by the other scripts. This also:

- Creates the directory with `mkdir -p` before MSBuild starts (MSBuild's `EnsureDirectoryExists` has no try/catch in its static constructor, so a failed directory creation would silently fall back to the temp dir)
- Echoes the path for diagnostic visibility in build logs
- Covers both the bootstrap and product build invocations

The existing pipeline variable in `global-build-job.yml` is left in place as defense-in-depth.

Relates to getting data to fix #92290
