### PR TITLE
Add skill-validator structural checks for skills and agents

### DIFF
--- a/.github/agents/agentic-workflows.agent.md
+++ b/.github/agents/agentic-workflows.agent.md
@@ -1,4 +1,5 @@
 ---
+name: agentic-workflows
 description: GitHub Agentic Workflows (gh-aw) - Create, debug, and upgrade AI-powered workflows with intelligent prompt routing
 disable-model-invocation: true
 ---

--- a/.github/skills/api-proposal/SKILL.md
+++ b/.github/skills/api-proposal/SKILL.md
@@ -133,7 +133,7 @@ The skill contains baked-in examples and guidelines for writing good proposals (
 
 #### Prototype Validation (all steps required)
 
-> **Prerequisite:** Follow the build and test workflow in [`copilot-instructions.md`](/.github/copilot-instructions.md) — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
+> **Prerequisite:** Follow the build and test workflow in `.github/copilot-instructions.md` — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
 
 **Step 1: Build and test**
 

--- a/.github/skills/issue-triage/SKILL.md
+++ b/.github/skills/issue-triage/SKILL.md
@@ -145,7 +145,7 @@ languishing unnoticed.
 #### 2a: Check the `area-*` label
 
 1. Read the issue content carefully -- what namespace, type, or component does it concern?
-2. Cross-reference with [`docs/area-owners.md`](../../../docs/area-owners.md) which maps
+2. Cross-reference with `docs/area-owners.md` which maps
    `area-*` labels to specific assemblies, namespaces, and teams.
 3. If the current `area-*` label doesn't match the issue's actual subject, flag it
    and suggest the correct label with a rationale.

--- a/.github/skills/issue-triage/SKILL.md
+++ b/.github/skills/issue-triage/SKILL.md
@@ -145,7 +145,7 @@ languishing unnoticed.
 #### 2a: Check the `area-*` label
 
 1. Read the issue content carefully -- what namespace, type, or component does it concern?
-2. Cross-reference with `docs/area-owners.md` which maps
+2. Cross-reference with `docs/area-owners.md`, which maps
    `area-*` labels to specific assemblies, namespaces, and teams.
 3. If the current `area-*` label doesn't match the issue's actual subject, flag it
    and suggest the correct label with a rationale.

--- a/.github/skills/issue-triage/SKILL.md
+++ b/.github/skills/issue-triage/SKILL.md
@@ -442,39 +442,17 @@ includes status markers (`[ok]`, `[x]`, `[!]`, `[i]`), section-by-section
 guidance, conditional section rules, and formatting requirements for suggested
 responses.
 
-Key points:
-- Each section has multiple outcome variants -- pick the one that matches
-- Some sections are conditional (Reproduction only for bugs, Answer only for
-  questions) -- see the conditional sections table in the reference file
-- Suggested responses MUST be in fenced code blocks (not blockquotes) for
-  copy-paste safety
+Key points: each section has multiple outcome variants (pick the one that matches); some sections are conditional (Reproduction for bugs, Answer for questions -- see the conditional sections table); suggested responses MUST be in fenced code blocks (not blockquotes) for copy-paste safety.
 
 ## Anti-Patterns
 
-- **NEVER take autonomous action.** During triage (before the user picks an
-  outcome), do not post comments, change labels, close issues, or modify
-  anything in the repository. You only output a recommendation.
+- **NEVER take autonomous action.** During triage (before the user picks an outcome), do not post comments, change labels, close issues, or modify anything. You only output a recommendation. After the user picks an outcome and a finalized response has been produced, the user may **explicitly instruct** you to take actions -- post the comment, apply label changes, close the issue, etc. Comply with these explicit instructions; the constraint prevents *autonomous* actions before the human decision, not user-directed actions after it.
 
-  After the user picks an outcome (KEEP, CLOSE, or NEEDS INFO) and a finalized
-  response has been produced, the user may **explicitly instruct** you to take
-  actions -- post the comment, apply label changes, close the issue, etc. Comply
-  with these explicit instructions; the constraint above prevents *autonomous*
-  actions before the human decision, not user-directed actions after it.
+  When posting any content to GitHub under a user's credentials (not a dedicated bot account), you **MUST** include a concise, visible note (e.g. a `> [!NOTE]` alert) indicating the content was AI/Copilot-generated. Skip this if the user explicitly asks you to omit it.
 
-  When posting any content to GitHub (issue comments, label changes with explanations)
-  under a user's credentials -- i.e., the account is **not** a dedicated "copilot"
-  or "bot" account/app -- you **MUST** include a concise, visible note (e.g. a
-  `> [!NOTE]` alert) indicating the content was AI/Copilot-generated. Skip this if
-  the user explicitly asks you to omit it.
+- **NEVER** use `gh issue close`, `gh issue edit`, `gh issue comment`, or `gh pr review --approve`/`--request-changes` **unless the user explicitly asks you to** after picking an outcome.
 
-- **NEVER** use `gh issue close`, `gh issue edit`, `gh issue comment`, or
-  `gh pr review --approve`/`--request-changes` **unless the user explicitly
-  asks you to** after picking an outcome.
-
-- **Security concerns are out of scope.** This skill does not assess, discuss, or
-  make recommendations about potential security implications of issues. If you
-  believe an issue may have security implications, do not mention this in the
-  triage report. Security assessment is handled through separate processes.
+- **Security concerns are out of scope.** Do not assess, discuss, or make recommendations about potential security implications. Security assessment is handled through separate processes.
 
 - **Do not guess area labels.** Always cross-reference with `docs/area-owners.md`.
 
@@ -488,38 +466,22 @@ Key points:
 
 ## Tips
 
-1. **Check +1 reactions** on the issue -- high reaction counts indicate community demand.
-2. **Read the full comment thread**, not just the first post. Maintainers may have
-   already partially triaged the issue.
-3. **Look for `backlog-cleanup-candidate`** label -- this means the issue was flagged
-   for potential auto-closure. If the issue is still valid, recommend KEEP.
-4. **For API proposals**, see the
-   [API proposal triage](references/api-proposal-triage.md) guide for the full
-   evaluation framework. Optionally, suggest that the user invoke the
-   **api-proposal** Copilot skill to help refine a proposal with merit.
-5. **For bug reports**, check whether the issue mentions "regression" -- regressions are
-   higher priority and may warrant faster triage.
-6. **Use `[ActiveIssue]` search** in the codebase to see if the bug is already tracked
-   in test infrastructure.
-7. **The `Future` milestone** means "triaged but not committed to a specific release."
-   This is the most common outcome for valid KEEP issues.
-8. When writing the suggested response for CLOSE/duplicate, always link to the
-   canonical issue: "Closing as duplicate of #{number}."
-9. When writing the suggested response for wrong-repo issues, provide the correct
-   repo URL: "This issue would be better tracked in {repo}. Please file it there."
-10. **Triage rules of thumb** (from `docs/project/issue-guide.md`):
-    - Each issue should have exactly one `area-*` label
-    - Don't be afraid to say no -- just explain why and be polite
-    - Don't be afraid to be wrong -- just be flexible when new information appears
+1. **Check +1 reactions** -- high reaction counts indicate community demand.
+2. **Read the full comment thread**, not just the first post. Maintainers may have already partially triaged.
+3. **Look for `backlog-cleanup-candidate`** label -- if the issue is still valid, recommend KEEP.
+4. **For API proposals**, see [API proposal triage](references/api-proposal-triage.md). Optionally suggest the **api-proposal** Copilot skill.
+5. **For bug reports**, check for "regression" mentions -- regressions are higher priority.
+6. **Use `[ActiveIssue]` search** in the codebase to see if the bug is already tracked in test infrastructure.
+7. **The `Future` milestone** means "triaged but not committed to a specific release" -- the most common outcome for valid KEEP issues.
+8. For CLOSE/duplicate responses, always link to the canonical issue: "Closing as duplicate of #{number}."
+9. For wrong-repo issues, provide the correct repo URL: "This issue would be better tracked in {repo}."
+10. **Triage rules of thumb** (from `docs/project/issue-guide.md`): each issue should have exactly one `area-*` label; don't be afraid to say no (just be polite); don't be afraid to be wrong (just be flexible when new info appears).
 
 ## Related Skills
 
-After triage is complete, the following skills can help with next steps
-depending on the outcome:
+After triage, these skills can help with next steps:
 
-| Condition | Skill | When to suggest |
-|-----------|-------|-----------------|
-| API proposal recommended as KEEP | **api-proposal** | Offer to draft a formal API proposal with working prototype |
-| Bug report with root cause identified | **jit-regression-test** | If the bug is JIT-related, offer to create a regression test |
-| Performance regression confirmed | **performance-benchmark** | Offer to validate the regression with ad hoc benchmarks |
-| Fix PR linked to the issue | **code-review** | Offer to review the fix PR for correctness and consistency |
+- **api-proposal** -- if an API proposal is recommended as KEEP, offer to draft a formal proposal with working prototype.
+- **jit-regression-test** -- if a bug with root cause is JIT-related, offer to create a regression test.
+- **performance-benchmark** -- if a performance regression is confirmed, offer to validate with ad hoc benchmarks.
+- **code-review** -- if a fix PR is linked, offer to review for correctness and consistency.

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,7 +15,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## Prerequisites
 
-> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from [`copilot-instructions.md`](/.github/copilot-instructions.md) unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
+> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from `.github/copilot-instructions.md` unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
 
 ## When to use
 
@@ -49,7 +49,7 @@ OS version references appear in these pipeline files:
 | `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
 | `docs/workflow/using-docker.md` | Documents the official build/test Docker images — update only when build image versions change (cross-compilation images, not Helix test images) |
 
-The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
+The OS onboarding guide (`docs/project/os-onboarding.md`) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
 
 ### helix-platforms.yml structure
 
@@ -297,7 +297,7 @@ When asked to audit all OS coverage:
 
 ## Reference
 
-- [OS onboarding guide](/docs/project/os-onboarding.md)
+- OS onboarding guide: `docs/project/os-onboarding.md`
 - [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
 - [Prereq container image lifecycle](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/lifecycle.md)
 - [Container image registry (image-info)](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -1,0 +1,93 @@
+name: Skill Validation
+
+on:
+  pull_request:
+    paths:
+      - '.github/skills/**'
+      - '.github/agents/**'
+      - '.github/workflows/skill-validation.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/skills/**'
+      - '.github/agents/**'
+      - '.github/workflows/skill-validation.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: skill-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate skills and agents
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/skills
+            .github/agents
+          persist-credentials: false
+
+      - name: Download skill-validator
+        shell: bash
+        run: |
+          curl -fsSL --retry 3 --retry-all-errors -o skill-validator.tar.gz \
+            https://github.com/dotnet/skills/releases/download/skill-validator-nightly/skill-validator-linux-x64.tar.gz
+          mkdir -p skill-validator-bin
+          tar -xzf skill-validator.tar.gz -C skill-validator-bin
+          chmod +x skill-validator-bin/skill-validator
+          if [ ! -x skill-validator-bin/skill-validator ]; then
+            echo "::error::skill-validator binary not found after extraction"
+            exit 1
+          fi
+
+      - name: Run skill-validator check
+        shell: bash
+        run: |
+          rc=0
+
+          if [ -d .github/skills ]; then
+            echo "::group::Validate skills"
+            set +e
+            skill-validator-bin/skill-validator check --skills .github/skills --verbose 2>&1 | tee skill-check-skills.txt
+            skills_rc=${PIPESTATUS[0]}
+            set -e
+            echo "::endgroup::"
+            if [ "$skills_rc" -ne 0 ]; then rc=1; fi
+          fi
+
+          if [ -d .github/agents ]; then
+            echo "::group::Validate agents"
+            set +e
+            skill-validator-bin/skill-validator check --agents .github/agents --verbose 2>&1 | tee skill-check-agents.txt
+            agents_rc=${PIPESTATUS[0]}
+            set -e
+            echo "::endgroup::"
+            if [ "$agents_rc" -ne 0 ]; then rc=1; fi
+          fi
+
+          # Write to step summary
+          {
+            echo "## skill-validator check"
+            echo ""
+            if [ "$rc" -eq 0 ]; then
+              echo "All checks passed."
+            else
+              for f in skill-check-skills.txt skill-check-agents.txt; do
+                if [ -f "$f" ]; then
+                  echo "### ${f}"
+                  echo '```'
+                  head -n 200 "$f"
+                  echo '```'
+                  echo ""
+                fi
+              done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit "$rc"

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -41,11 +41,11 @@ jobs:
             https://github.com/dotnet/skills/releases/download/skill-validator-nightly/skill-validator-linux-x64.tar.gz
           mkdir -p skill-validator-bin
           tar -xzf skill-validator.tar.gz -C skill-validator-bin
-          chmod +x skill-validator-bin/skill-validator
-          if [ ! -x skill-validator-bin/skill-validator ]; then
+          if [ ! -f skill-validator-bin/skill-validator ]; then
             echo "::error::skill-validator binary not found after extraction"
             exit 1
           fi
+          chmod +x skill-validator-bin/skill-validator
 
       - name: Run skill-validator check
         shell: bash


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow that runs `skill-validator check` (from [dotnet/skills](https://github.com/dotnet/skills) nightly release) on PRs that touch `.github/skills/` or `.github/agents/`. The validator is an AOT-compiled binary that performs structural static analysis -- no .NET runtime or secrets required.

dotnet/runtime currently has 11 skills and 2 agents with no validation. This catches structural issues (malformed frontmatter, missing fields, skill size warnings) before merge.

## Design choices

- **Path-filtered triggers** -- only fires on changes to `.github/skills/**`, `.github/agents/**`, or the workflow itself. With runtime's high PR volume, 99%+ of PRs won't trigger this.
- **Sparse checkout** -- only checks out the skill/agent directories, not the full repo.
- **Separate invocations** for skills and agents -- `skill-validator check` requires exactly one of `--plugin`, `--skills`, or `--agents` per call. Both run regardless of individual failures to give complete diagnostics.
- **Concurrency group** with cancel-in-progress to avoid wasting runners on stale pushes.
- **Nightly binary** (not pinned) so validation improvements from dotnet/skills are picked up automatically. Both repos are in the dotnet org. Can pin later if stability is a concern.
- **Step summary** with truncated output (200 lines) for easy diagnosis from the Actions UI.

## Relation to dotnet/arcade-skills#19

This is the runtime equivalent of https://github.com/dotnet/arcade-skills/pull/19, adapted for runtime's `.github/skills/` layout (repo-local skills) rather than arcade-skills' `plugins/` layout (marketplace format). Key learnings from that PR were applied: curl retries, extraction verification, PIPESTATUS for exit code through tee, and step summary output.

## Testing

This workflow won't fire in this PR's CI because the workflow doesn't exist on `main` yet. After merge, any PR touching `.github/skills/**` or `.github/agents/**` will trigger it. Can also be tested via `workflow_dispatch`.

cc @lewing @ViktorHofer