### PR TITLE
Fix race condition in EvictionCount_NotOvercounted_WhenEntryAlreadyRemoved test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 {
                     TrackStatistics = true,
                     Clock = clock,
-                    ExpirationScanFrequency = TimeSpan.Zero
+                    ExpirationScanFrequency = TimeSpan.MaxValue
                 },
                 loggerFactory: null,
                 meterFactory: meterFactory);


### PR DESCRIPTION
Use `TimeSpan.MaxValue` for `ExpirationScanFrequency` to prevent background `ScanForExpiredItems` tasks from racing with the test's explicit `TryGetValue` and Compact operations. The race caused under-counting because a background scan could remove an entry from the `ConcurrentDictionary` but not yet increment `_accumulatedEvictions` when `GetCurrentStatistics` was called.

Fixes #126818