### PR TITLE
Set commit message for image pinning from Renovate

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -36,7 +36,8 @@
         "eng/pipelines/installer/helix-queues-setup.yml",
         "eng/pipelines/libraries/helix-queues-setup.yml"
       ],
-      "pinDigests": true
+      "pinDigests": true,
+      "commitMessageTopic": "container image dependencies"
     }
   ]
 }


### PR DESCRIPTION
This will cause the Renovate PRs like https://github.com/dotnet/runtime/pull/126827 to use a title of "Pin container image dependencies" instead of "Pin dependencies".