### PR TITLE
Add early long path validation to Windows build script

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -136,48 +136,26 @@ function Get-Help() {
 }
 
 function Check-LongPathSupport() {
-  $repoRoot = Split-Path $PSScriptRoot -Parent
-  $artifactsDir = Join-Path $repoRoot "artifacts"
-  $stampFile = Join-Path $artifactsDir ".long-path-validated"
+  $regValue = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -ErrorAction SilentlyContinue
 
-  if (Test-Path $stampFile) {
+  if ($regValue -and $regValue.LongPathsEnabled -eq 1) {
     return
   }
 
-  $testDir = Join-Path $artifactsDir "tmp"
-  if (-not (Test-Path $testDir)) {
-    New-Item -ItemType Directory -Path $testDir -Force | Out-Null
-  }
-
-  # Build a unique file path that exceeds the 260-character MAX_PATH limit.
-  $uniqueSuffix = "{0}_{1}" -f $PID, ([Guid]::NewGuid().ToString("N"))
-  $basePath = Join-Path $testDir ("longpath_test_{0}_" -f $uniqueSuffix)
-  $padLength = [Math]::Max(32, 270 - $basePath.Length)
-  $testPath = $basePath + ("a" * $padLength) + ".tmp"
-
-  try {
-    [System.IO.File]::WriteAllText($testPath, "test")
-    Remove-Item $testPath -Force -ErrorAction SilentlyContinue
-  }
-  catch {
-    Write-Host ""
-    Write-Host "ERROR: Long file paths are not enabled on this system." -ForegroundColor Red
-    Write-Host "The dotnet/runtime repository requires long path support to build successfully." -ForegroundColor Red
-    Write-Host ""
-    Write-Host "Please follow the instructions at:" -ForegroundColor Yellow
-    Write-Host "  docs\workflow\requirements\windows-requirements.md#enable-long-paths" -ForegroundColor Yellow
-    Write-Host ""
-    Write-Host "Quick fix:" -ForegroundColor Yellow
-    Write-Host "  1. Enable long paths in Windows (requires admin):" -ForegroundColor White
-    Write-Host "     https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation" -ForegroundColor White
-    Write-Host "  2. Enable long paths in Git:" -ForegroundColor White
-    Write-Host "     git config --system core.longpaths true" -ForegroundColor White
-    Write-Host ""
-    exit 1
-  }
-
-  # Validation passed - stamp so we skip this check on subsequent builds.
-  [System.IO.File]::WriteAllText($stampFile, "Long path support validated on $(Get-Date)")
+  Write-Host ""
+  Write-Host "ERROR: Long file paths are not enabled on this system." -ForegroundColor Red
+  Write-Host "The dotnet/runtime repository requires long path support to build successfully." -ForegroundColor Red
+  Write-Host ""
+  Write-Host "Please follow the instructions at:" -ForegroundColor Yellow
+  Write-Host "  docs\workflow\requirements\windows-requirements.md#enable-long-paths" -ForegroundColor Yellow
+  Write-Host ""
+  Write-Host "Quick fix:" -ForegroundColor Yellow
+  Write-Host "  1. Enable long paths in Windows (requires admin):" -ForegroundColor White
+  Write-Host "     https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation" -ForegroundColor White
+  Write-Host "  2. Enable long paths in Git:" -ForegroundColor White
+  Write-Host "     git config --system core.longpaths true" -ForegroundColor White
+  Write-Host ""
+  exit 1
 }
 
 if ($help) {

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -149,8 +149,9 @@ function Check-LongPathSupport() {
     New-Item -ItemType Directory -Path $testDir -Force | Out-Null
   }
 
-  # Build a file path that exceeds the 260-character MAX_PATH limit.
-  $basePath = Join-Path $testDir "longpath_test_"
+  # Build a unique file path that exceeds the 260-character MAX_PATH limit.
+  $uniqueSuffix = "{0}_{1}" -f $PID, ([Guid]::NewGuid().ToString("N"))
+  $basePath = Join-Path $testDir ("longpath_test_{0}_" -f $uniqueSuffix)
   $padLength = [Math]::Max(32, 270 - $basePath.Length)
   $testPath = $basePath + ("a" * $padLength) + ".tmp"
 

--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -135,6 +135,50 @@ function Get-Help() {
   Write-Host "For more information, check out https://github.com/dotnet/runtime/blob/main/docs/workflow/README.md"
 }
 
+function Check-LongPathSupport() {
+  $repoRoot = Split-Path $PSScriptRoot -Parent
+  $artifactsDir = Join-Path $repoRoot "artifacts"
+  $stampFile = Join-Path $artifactsDir ".long-path-validated"
+
+  if (Test-Path $stampFile) {
+    return
+  }
+
+  $testDir = Join-Path $artifactsDir "tmp"
+  if (-not (Test-Path $testDir)) {
+    New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+  }
+
+  # Build a file path that exceeds the 260-character MAX_PATH limit.
+  $basePath = Join-Path $testDir "longpath_test_"
+  $padLength = [Math]::Max(32, 270 - $basePath.Length)
+  $testPath = $basePath + ("a" * $padLength) + ".tmp"
+
+  try {
+    [System.IO.File]::WriteAllText($testPath, "test")
+    Remove-Item $testPath -Force -ErrorAction SilentlyContinue
+  }
+  catch {
+    Write-Host ""
+    Write-Host "ERROR: Long file paths are not enabled on this system." -ForegroundColor Red
+    Write-Host "The dotnet/runtime repository requires long path support to build successfully." -ForegroundColor Red
+    Write-Host ""
+    Write-Host "Please follow the instructions at:" -ForegroundColor Yellow
+    Write-Host "  docs\workflow\requirements\windows-requirements.md#enable-long-paths" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Quick fix:" -ForegroundColor Yellow
+    Write-Host "  1. Enable long paths in Windows (requires admin):" -ForegroundColor White
+    Write-Host "     https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation" -ForegroundColor White
+    Write-Host "  2. Enable long paths in Git:" -ForegroundColor White
+    Write-Host "     git config --system core.longpaths true" -ForegroundColor White
+    Write-Host ""
+    exit 1
+  }
+
+  # Validation passed - stamp so we skip this check on subsequent builds.
+  [System.IO.File]::WriteAllText($stampFile, "Long path support validated on $(Get-Date)")
+}
+
 if ($help) {
   Get-Help
   exit 0
@@ -151,6 +195,8 @@ if ($subset -eq 'help') {
   Invoke-Expression "& `"$PSScriptRoot/common/build.ps1`" -restore -build /p:subset=help /clp:nosummary /tl:false"
   exit 0
 }
+
+Check-LongPathSupport
 
 # Lower-case the passed in OS string.
 if ($os) {


### PR DESCRIPTION
On Windows machines without long path support enabled, the build fails in hard-to-diagnose ways deep in the build process.

Checks `HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem` and prints advisory.

The check runs after `-help` and `-subset help` exit points so those still work without any filesystem access.

Avoids issues like in https://github.com/dotnet/runtime/issues/125765.