### PR TITLE
Fix COM Event ilstub classification

### DIFF
--- a/src/coreclr/vm/clrtocomcall.cpp
+++ b/src/coreclr/vm/clrtocomcall.cpp
@@ -172,7 +172,7 @@ namespace
         MethodDesc* pStubMD = ILStubCache::CreateAndLinkNewILStubMethodDesc(
             pMD->GetLoaderAllocator(),
             pMD->GetMethodTable(),
-            PINVOKESTUB_FL_COMEVENTCALL,
+            PINVOKESTUB_FL_COM | PINVOKESTUB_FL_COMEVENTCALL,
             pMD->GetModule(),
             szMetaSig,
             cbMetaSigSize,

--- a/src/coreclr/vm/ilstubcache.cpp
+++ b/src/coreclr/vm/ilstubcache.cpp
@@ -124,6 +124,7 @@ namespace
             case DynamicMethodDesc::StubPInvokeVarArg:      return "IL_STUB_PInvoke";
             case DynamicMethodDesc::StubReversePInvoke:     return "IL_STUB_ReversePInvoke";
             case DynamicMethodDesc::StubCLRToCOMInterop:    return "IL_STUB_CLRtoCOM";
+            case DynamicMethodDesc::StubCLRToCOMEvent:      return "IL_STUB_CLRtoCOM_Event";
             case DynamicMethodDesc::StubCOMToCLRInterop:    return "IL_STUB_COMtoCLR";
             case DynamicMethodDesc::StubStructMarshalInterop: return "IL_STUB_StructMarshal";
             case DynamicMethodDesc::StubArrayOp:            return "IL_STUB_Array";


### PR DESCRIPTION
The stub was incorrectly classified as a P/Invoke, and we have special handling for P/Invokes for GCStress. Correctly classify the stubs as their own kind of stub (Com events).

Fixes #126724