### PR TITLE
Filter runtime-diagnostics pipeline to SOS tests only

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -38,6 +38,7 @@ parameters:
   disableComponentGovernance: ''
   liveRuntimeDir: ''
   useCdac: false
+  classFilter: ''
 
 jobs:
 - template: /eng/common/${{ parameters.templatePath }}/job/job.yml
@@ -88,6 +89,7 @@ jobs:
       - _TestArgs: '-test'
       - _Cross: ''
       - _CdacArgs: ''
+      - _ClassFilterArgs: ''
 
       - _buildScript: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
 
@@ -102,6 +104,9 @@ jobs:
 
       - ${{ if eq(parameters.useCdac, 'true') }}:
         - _CdacArgs: '-useCdac'
+
+      - ${{ if ne(parameters.classFilter, '') }}:
+        - _ClassFilterArgs: '-classfilter ${{ parameters.classFilter }}'
 
       # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
       - _InternalInstallArgs: ''
@@ -200,6 +205,7 @@ jobs:
           $(_TestArgs)
           $(_Cross)
           $(_InternalInstallArgs)
+          $(_ClassFilterArgs)
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       ${{ if eq(parameters.testOnly, 'true') }}:
         displayName: Test

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -104,6 +104,7 @@ extends:
           jobParameters:
             name: cDAC
             useCdac: true
+            classFilter: SOS
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
@@ -156,6 +157,7 @@ extends:
           jobParameters:
             name: DAC
             useCdac: false
+            classFilter: SOS
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360


### PR DESCRIPTION
## Summary

Filter the `runtime-diagnostics` pipeline's cDAC and DAC test legs to only run SOS tests, which are the tests that actually exercise the DAC/cDAC with a locally-built runtime.

### Problem

The `runtime-diagnostics` pipeline runs ALL diagnostics test projects, including EventPipe monitoring, dotnet-counters, DbgShim, and other tests that don't depend on the runtime's DAC implementation. The `Microsoft.Diagnostics.Monitoring.EventPipe.UnitTests` have been consistently failing since April 10, blocking all builds.

These other tests are already covered by the diagnostics repo's own CI (`diagnostics-public-ci`) and don't need to run against a privately-built runtime.

### Changes

- **`runtime-diag-job.yml`**: Add `classFilter` parameter that passes `-classfilter` to the diagnostics `build.ps1`
- **`runtime-diagnostics.yml`**: Set `classFilter: SOS` for both cDAC and DAC legs

This uses the existing `-classfilter` support in the diagnostics `build.ps1`, which translates to xunit's `-class` filter. Only the `SOS` test class (27+ test methods covering DivZero, StackTests, OtherCommands, GCTests, DotnetDumpCommands, etc.) will run.

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.