### PR TITLE
Remove fatal assert from JIT standalone `operator new`

### DIFF
--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -332,7 +332,10 @@ void ArenaAllocator::dumpMaxMemStats(FILE* file)
 
 void* __cdecl operator new(std::size_t size)
 {
-    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
+    // The PAL is statically linked into the JIT and may call operator new
+    // during PAL initialization (e.g. AllocTHREAD). Do not assert here —
+    // the assert is fatal in Checked builds and crashes every Checked
+    // Android build during jitStartup.
 
     if (size == 0)
     {
@@ -350,8 +353,6 @@ void* __cdecl operator new(std::size_t size)
 
 void* __cdecl operator new[](std::size_t size)
 {
-    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
-
     if (size == 0)
     {
         size++;


### PR DESCRIPTION
## Summary

Remove the `assert` in the JIT's global `operator new` override (`alloc.cpp`, under `#ifdef JIT_STANDALONE_BUILD`) that crashes every Checked Android build during `jitStartup`.

## Problem

On Unix platforms, the PAL (`coreclrpal`) is statically linked into the JIT (via `CLR_CMAKE_HOST_UNIX` in `jit/CMakeLists.txt`). On most Unix platforms the JIT itself is built as a **static** library that gets linked into `libcoreclr.so`, so the PAL copy merges with coreclr's and the JIT's `operator new` override is never the process-wide global.

On Android, however, the JIT is built as a **shared** library (`libclrjit.so`) with `FEATURE_DYNAMIC_CODE_COMPILED`. This gives it its own isolated copy of the PAL with an independent `init_count`. When `jitStartup()` calls `PAL_InitializeDLL()`, the PAL runs full initialization (`init_count == 0`), which includes `CreateThreadData() → AllocTHREAD() → new CPalThread()`. This `new` call dispatches to the JIT's global `operator new` override, which asserts:

```
assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
```

In Checked builds the assert is fatal — it calls `assertAbort()` which raises SIGSEGV at `fault addr 0x10`, crashing the process before managed `Main()` can run. In Release builds the assert is compiled out and the function falls through to `malloc` correctly.

## Call chain (symbolicated from Android tombstone)

```
jitStartup (ee_il_dll.cpp:63)
  → PAL_InitializeDLL (pal.cpp)
    → Initialize (pal.cpp)
      → CreateThreadData (thread.cpp)
        → AllocTHREAD (thread.cpp:188)
          → operator new(size_t) (alloc.cpp:335)   ← assert fires here
            → assertAbort (error.cpp:274)
              → SIGSEGV (fault addr 0x10)
```

## Fix

Remove the two `assert` calls from `operator new` and `operator new[]`. The functions already fall through to `malloc`, which is the correct behavior for PAL allocations. The assert was a development guardrail to nudge JIT developers toward `HostAllocator`, but it inadvertently makes Checked Android builds unusable.

## Impact

- **Android Checked builds**: Fixes a 100% deterministic crash on startup.
- **Other platforms**: No behavioral change — on non-Android Unix the JIT is statically linked into coreclr so this `operator new` is not the process-wide global. On Windows the code is behind `#ifdef JIT_STANDALONE_BUILD` which uses a different linkage model.
- **Release builds**: No change — the assert was already compiled out.
