### PR TITLE
[wasm][CoreCLR] Enable passing System.Runtime.Tests on wasm

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DecimalTests.cs
@@ -135,7 +135,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_IntArray_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void Ctor_IntArray(int[] value, decimal expected)
         {
             Assert.Equal(expected, new decimal(value));
@@ -143,7 +142,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_IntArray_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void Ctor_IntSpan(int[] value, decimal expected)
         {
             Assert.Equal(expected, new decimal(value.AsSpan()));
@@ -249,7 +247,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Ctor_Int_Int_Int_Bool_Byte_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void Ctor_Int_Int_Int_Bool_Byte(int lo, int mid, int hi, bool isNegative, byte scale, decimal expected)
         {
             Assert.Equal(expected, new decimal(lo, mid, hi, isNegative, scale));
@@ -333,7 +330,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Add_Overflows_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void Add_Overflows_ThrowsOverflowException(decimal d1, decimal d2)
         {
             Assert.Throws<OverflowException>(() => d1 + d2);
@@ -1121,7 +1117,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Remainder_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Remainder(decimal d1, decimal d2, decimal expected)
         {
             Assert.Equal(expected, d1 % d2);
@@ -1203,7 +1198,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Round_Digit_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Round_Digits_ReturnsExpected(decimal d, int digits, decimal expected)
         {
             Assert.Equal(expected, decimal.Round(d, digits));
@@ -1237,7 +1231,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Round_Digit_Mid_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Round_DigitsMode_ReturnsExpected(decimal d, int digits, MidpointRounding mode, decimal expected)
         {
             Assert.Equal(expected, decimal.Round(d, digits, mode));
@@ -1308,7 +1301,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Subtract_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Subtract(decimal d1, decimal d2, decimal expected)
         {
             Assert.Equal(expected, d1 - d2);
@@ -1327,7 +1319,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Subtract_Invalid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Subtract_Invalid(decimal d1, decimal d2)
         {
             Assert.Throws<OverflowException>(() => decimal.Subtract(d1, d2));
@@ -1714,7 +1705,6 @@ namespace System.Tests
             Assert.Equal(expected, --d);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))] // too slow
         public static class BigIntegerCompare
         {
             [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DelegateTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DelegateTests.cs
@@ -315,7 +315,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_ValueTypeParameterWithExplicitValue()
         {
             Assert.Equal(
@@ -324,7 +323,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DateTimeParameterWithMissingValue()
         {
             Assert.Equal(
@@ -333,7 +331,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DateTimeAndCustomConstantAttribute_DateTimeParameterWithMissingValue()
         {
             Assert.Equal(
@@ -342,7 +339,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_CustomConstantAndDateTimeAttribute_DateTimeParameterWithMissingValue()
         {
             Assert.Equal(
@@ -351,7 +347,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_CustomConstantAttribute_DateTimeParameterWithMissingValue()
         {
             Assert.Equal(
@@ -360,7 +355,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DateTimeParameterWithExplicitValue()
         {
             Assert.Equal(
@@ -369,7 +363,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DecimalParameterWithAttributeAndMissingValue()
         {
             Assert.Equal(
@@ -378,7 +371,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DecimalAndCustomConstantAttribute_DecimalParameterWithAttributeAndMissingValue()
         {
             Assert.Equal(
@@ -387,7 +379,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_CustomConstantAndDecimalAttribute_DecimalParameterWithAttributeAndMissingValue()
         {
             Assert.Equal(
@@ -396,7 +387,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_CustomConstantAttribute_DecimalParameterWithAttributeAndMissingValue()
         {
             Assert.Equal(
@@ -405,7 +395,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DecimalParameterWithAttributeAndExplicitValue()
         {
             Assert.Equal(
@@ -414,7 +403,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DecimalParameterWithMissingValue()
         {
             Assert.Equal(
@@ -423,7 +411,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_DecimalParameterWithExplicitValue()
         {
             Assert.Equal(
@@ -438,7 +425,6 @@ namespace System.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void DynamicInvoke_DefaultParameter_NullableIntWithExplicitValue()
         {
             Assert.Equal(

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
@@ -399,7 +399,6 @@ namespace System.Tests
         [Fact]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/100368")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsX64Process), nameof(PlatformDetection.IsCoreCLR))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void ConvertToIntegerNativeTest()
         {
             // Signed Values

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/GCTests.cs
@@ -1097,7 +1097,6 @@ namespace System.Tests
 
         [Theory]
         [InlineData(-1)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         private static void AllocateArrayNegativeSize(int negValue)
         {
             Assert.Throws<OverflowException>(() => GC.AllocateUninitializedArray<byte>(-1));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.GenericMath.cs
@@ -2454,7 +2454,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(HalfTests.Parse_Valid_TestData), MemberType = typeof(HalfTests))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void ParseValidStringTest(string value, NumberStyles style, IFormatProvider provider, Half expected)
         {
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;
@@ -2529,7 +2528,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(HalfTests.Parse_ValidWithOffsetCount_TestData), MemberType = typeof(HalfTests))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void ParseValidSpanTest(string value, int offset, int count, NumberStyles style, IFormatProvider provider, Half expected)
         {
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/HalfTests.cs
@@ -972,7 +972,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Utf8Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, float expectedFloat)
         {
             bool isDefaultProvider = provider == null || provider == NumberFormatInfo.CurrentInfo;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Int128Tests.cs
@@ -324,7 +324,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Valid(string value, NumberStyles style, IFormatProvider provider, Int128 expected)
         {
             Int128 result;
@@ -446,7 +445,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, Int128 expected)
         {
             Int128 result;
@@ -488,7 +486,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Utf8Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, Int128 expected)
         {
             Int128 result;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Numerics/TotalOrderIeee754ComparerTests.cs
@@ -137,7 +137,6 @@ namespace System.Runtime.Tests
         [Theory]
         [InlineData(-1)]
         [InlineData(int.MinValue)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void TotalOrderTestInvalidSignificand(int significandByteCount)
         {
             var comparer = new TotalOrderIeee754Comparer<StubFloatingPointIeee754>();

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/InvokeWithRefLikeArgs.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/InvokeWithRefLikeArgs.cs
@@ -53,7 +53,6 @@ namespace System.Reflection.Tests
 
         [Fact]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/40738")]
-        [SkipOnPlatform(TestPlatforms.Browser, "https://github.com/dotnet/runtime/issues/40738")]
         public static void MethodTakesOutToRefStructAsArg_ThrowsNSE()
         {
             MethodInfo mi = GetMethod(nameof(TestClass.TakesOutToRefStructAsArg));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ControlledExecutionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ControlledExecutionTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace System.Runtime.Tests
 {
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
     public sealed class ControlledExecutionTests
     {
         private volatile bool _readyForCancellation;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/JitInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/JitInfoTests.cs
@@ -114,9 +114,8 @@ namespace System.Runtime.Tests
             Assert.True(afterCompiledMethodCount == 0, $"After Compiled method count not equal to 0! ({afterCompiledMethodCount})");
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsMultithreadingSupported))]
         [SkipOnMono("Mono does not track thread specific JIT information")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void JitInfoCurrentThreadIsPopulated()
         {
             TimeSpan t1_beforeCompilationTime = TimeSpan.Zero;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.GenericMath.cs
@@ -399,7 +399,6 @@ namespace System.Tests
         [Fact]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/100368")]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsX64Process), nameof(PlatformDetection.IsCoreCLR))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void ConvertToIntegerNativeTest()
         {
             // Signed Values

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -1235,7 +1235,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(GetHashCode_NoSuchStringComparison_ThrowsArgumentException_Data))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void GetHashCode_NoSuchStringComparison_ThrowsArgumentException(StringComparison comparisonType)
         {
             AssertExtensions.Throws<ArgumentException>("comparisonType", () => "abc".GetHashCode(comparisonType));

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Threading/PeriodicTimerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Threading/PeriodicTimerTests.cs
@@ -65,7 +65,6 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public async Task Dispose_Idempotent()
         {
             var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
@@ -119,7 +118,6 @@ namespace System.Threading.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public async Task WaitForNextTickAsync_ConcurrentDisposeAfterTicks_EventuallyReturnsFalse()
         {
             using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(1));
@@ -139,7 +137,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public void PeriodicTimer_NoActiveOperations_TimerNotRooted()
         {
             WeakReference<PeriodicTimer> timer = Create();
@@ -152,7 +149,6 @@ namespace System.Threading.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsPreciseGcSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public async Task PeriodicTimer_ActiveOperations_TimerRooted()
         {
             // Step 1: Verify that if we have an active wait the timer does not get collected.

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/UInt128Tests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/UInt128Tests.cs
@@ -253,7 +253,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_Valid_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Valid(string value, NumberStyles style, IFormatProvider provider, UInt128 expected)
         {
             UInt128 result;
@@ -388,7 +387,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, UInt128 expected)
         {
             UInt128 result;
@@ -430,7 +428,6 @@ namespace System.Tests
 
         [Theory]
         [MemberData(nameof(Parse_ValidWithOffsetCount_TestData))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123011", typeof(PlatformDetection), nameof(PlatformDetection.IsBrowser), nameof(PlatformDetection.IsCoreCLR))]
         public static void Parse_Utf8Span_Valid(string value, int offset, int count, NumberStyles style, IFormatProvider provider, UInt128 expected)
         {
             UInt128 result;


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Summary

Enable 44 previously-disabled `System.Runtime.Tests` on browser/wasm CoreCLR interpreter by removing unnecessary `[ActiveIssue]` and `[SkipOnPlatform]` attributes added in #122980.

## Changes

**Removed 44 attributes** across 15 test  these tests pass on the wasm interpreter without issues.files 

**Replaced `[ActiveIssue]` with proper platform detection** for tests that require multithreading:
 `[ConditionalClass(...,  uses `Task.Run()` + infinite loop that deadlocks on single-threaded wasmIsMultithreadingSupported)]` 
 added `IsMultithreadingSupported` to ` uses `Thread.Start()`ConditionalFact` 

**10 `[ActiveIssue]` attributes remain** for tests with genuine failures on wasm:
- **GC finalizer tests ( no finalizer thread on single-threaded wasm4)** 
int saturation bug
- **ModuleTests ( `Module.FullyQualifiedName`/`Name` returns `<Unknown>`2)** 
- **DateTimeTests ( `System.Runtime.Serialization.Formatters` not available1)** 
- **RuntimeFeatureTests ( `IsDynamicCodeSupported` is false (no JIT)1)** 

## Validation

Full test suite runs locally in ~7 minutes with 68,025 tests, 0 failures, 94 skipped.

## Triage

See `libraries-tests-triage.md` in the test directory for detailed analysis of remaining disabled tests.
