### PR TITLE
Remove quic.tech from HTTP/3 interop test URIs

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1930,7 +1930,6 @@ namespace System.Net.Http.Functional.Tests
             new TheoryData<string>
             {
                 { "https://www.litespeedtech.com/" }, // LiteSpeed
-                { "https://quic.tech:8443/" }, // Cloudflare
                 { "https://quic.aiortc.org:443/" }, // aioquic
                 { "https://h2o.examp1e.net/" } // h2o/quicly
             };


### PR DESCRIPTION
The \quic.tech:8443\ server is consistently timing out from CI machines, causing 100% failure rate for:
- \Public_Interop_ExactVersion_Success\
- \Public_Interop_Upgrade_Request2OrHigher_Success\
- \Public_Interop_Upgrade_Request3OrLower_Success\

Failures observed across 7 builds across multiple platforms (AzureLinux, Windows 11, Windows Server 2022/2025) over the past week with error:
\\\
System.Net.Http.HttpRequestException : Connection handshake was canceled due to the configured timeout of 00:00:10 seconds elapsing. (quic.tech:8443)
\\\

This follows the same pattern used to remove \quic.nginx.org\ in PR #124743.