### PR TITLE
Fix FileVersionInfo test failure on Apple mobile with trimming

### DIFF
--- a/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/FileVersionInfoTest.cs
@@ -11,7 +11,7 @@ namespace System.Diagnostics.Tests
     {
         private const string TestAssemblyFileName = "System.Diagnostics.FileVersionInfo.TestAssembly.dll";
         // On Unix the internal name's extension is .exe if OutputType is exe even though the TargetExt is .dll.
-        private readonly string OriginalTestAssemblyInternalName = PlatformDetection.IsWindows ?
+        private readonly string OriginalTestAssemblyInternalName = OperatingSystem.IsWindows() ?
             "System.Diagnostics.FileVersionInfo.TestAssembly.dll" :
             "System.Diagnostics.FileVersionInfo.TestAssembly.exe";
         private const string TestCsFileName = "Assembly1.cs";


### PR DESCRIPTION
> [!NOTE]
> PR description was AI/Copilot-generated.

## Summary

Fixes `FileVersionInfo_CustomManagedAssembly` test failure on Apple mobile (iOS/tvOS) when running with `EnableAggressiveTrimming=true`.

## Problem

The test expected `InternalName` with `.dll` extension on iOS, but the actual value was `.exe`. The field initializer used `PlatformDetection.IsWindows` to determine the expected extension:

```csharp
private readonly string OriginalTestAssemblyInternalName = PlatformDetection.IsWindows ?
    "System.Diagnostics.FileVersionInfo.TestAssembly.dll" :
    "System.Diagnostics.FileVersionInfo.TestAssembly.exe";
```

`PlatformDetection.IsWindows` chains through `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)`, which appears to be incorrectly evaluated by the IL trimmer during cross-compilation (Windows host → iOS target), causing the field to be initialized with the Windows value (`.dll`) on iOS.

## Fix

Replace `PlatformDetection.IsWindows` with `OperatingSystem.IsWindows()`, which is a compile-time constant (`#if TARGET_WINDOWS`) in the BCL and is immune to trimmer mis-evaluation.

## Test Failure
```
Assert.Equal() Failure: Strings differ
Expected: ···"ystem.Diagnostics.FileVersionInfo.TestAssembly.dll"
Actual:   ···"ystem.Diagnostics.FileVersionInfo.TestAssembly.exe"
```