### PR TITLE
Skip flaky FileConfigurationProvider test on .NET Framework

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration.Test;
 using Microsoft.Extensions.FileProviders;
@@ -150,9 +149,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
             Assert.NotNull(token);
 
             // The token should fire only when the target file is created, not when just the directory appears.
-            var tcs = new TaskCompletionSource<bool>();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            cts.Token.Register(() => tcs.TrySetCanceled());
+            var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             token.RegisterChangeCallback(_ => tcs.TrySetResult(true), null);
 
             Directory.CreateDirectory(missingSubDir);
@@ -161,7 +158,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
 
             File.WriteAllText(configFilePath, "{}");
 
-            Assert.True(await tcs.Task, "Change token did not fire after the target file was created.");
+            await tcs.Task.WaitAsync(TimeSpan.FromSeconds(30));
         }
 
         public class FileInfoImpl : IFileInfo

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
             Assert.Contains(physicalPath, exception.Message);
         }
 
-        // FileSystemWatcher is unreliable under load on .Net Framework, making this test flaky
+        // FileSystemWatcher is unreliable under load on .NET Framework, making this test flaky
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework))]
         public async Task ResolveFileProvider_WithMissingParentDirectory_WatchTokenFiresWhenFileCreated()
         {
@@ -151,7 +151,7 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
 
             // The token should fire only when the target file is created, not when just the directory appears.
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-            token.RegisterChangeCallback(_ => tcs.TrySetResult(true), null);
+            using var changeCallbackRegistration = token.RegisterChangeCallback(_ => tcs.TrySetResult(true), null);
 
             Directory.CreateDirectory(missingSubDir);
             await Task.Delay(500);

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/FileConfigurationProviderTest.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Extensions.Configuration.FileExtensions.Test
             Assert.Contains(physicalPath, exception.Message);
         }
 
-        [Fact]
+        // FileSystemWatcher is unreliable under load on .Net Framework, making this test flaky
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework))]
         public async Task ResolveFileProvider_WithMissingParentDirectory_WatchTokenFiresWhenFileCreated()
         {
             // Verify the fix for https://github.com/dotnet/runtime/issues/116713:

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/tests/Microsoft.Extensions.Configuration.FileExtensions.Tests.csproj
@@ -8,6 +8,8 @@
   <ItemGroup>
     <Compile Include="$(CommonTestPath)Extensions\ConfigurationRootTest.cs" Link="Common\Extensions\ConfigurationRootTest.cs" />
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs" Link="Common\System\IO\TempDirectory.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs"
+             Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
 
     <TrimmerRootDescriptor Include="$(ILLinkDescriptorsPath)ILLink.Descriptors.Castle.xml" />
   </ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

Fixes #126787

## Problem

The `ResolveFileProvider_WithMissingParentDirectory_WatchTokenFiresWhenFileCreated` test introduced in #126411 is flaky on the `net481-windows-Release-x86` CI leg, causing it to time out and block CI.

## Root cause

`FileSystemWatcher` on .NET Framework drops directory creation events under I/O contention. The `PendingCreationWatcher` in `PhysicalFilesWatcher` relies on FSW to detect when a missing root directory is created. When the FSW event is lost, the change token never fires and the test hangs.

This was verified by:
1. **Reproducing locally** — running the test in parallel (4-8 concurrent `dotnet test` processes) reproduces the hang on net481 x86 (~3% failure rate).
2. **Isolating to raw FSW** — a minimal test using only `FileSystemWatcher` (no `PendingCreationWatcher`) also fails under the same conditions on .NET Framework.
3. **Confirming .NET is unaffected** — 504 runs on net11.0 x86 with 8 concurrent threads produced 0 failures.

All 7 CI failures in the issue report are on the same `net481-windows-Release-x86-NET481_Release-Windows.10.Amd64.Client.Open` configuration.

## Changes

- **Skip on .NET Framework**: Changed `[Fact]` to `[ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotNetFramework))]` since the test depends on FSW reliability that .NET Framework cannot guarantee under load.
- **Improved timeout**: Replaced `CancellationTokenSource`-based timeout with `Task.WaitAsync(TimeSpan)` (via `TaskTimeoutExtensions` polyfill) and added `TaskCreationOptions.RunContinuationsAsynchronously` — matching the pattern used by all similar tests in `PhysicalFilesWatcherTests`.