### PR TITLE
Fix ConfigurationBinder suppressor to only suppress intercepted calls

### DIFF
--- a/src/libraries/Common/tests/SourceGenerators/GlobalOptionsOnlyProvider.cs
+++ b/src/libraries/Common/tests/SourceGenerators/GlobalOptionsOnlyProvider.cs
@@ -1,15 +1,10 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Diagnostics;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
-using Microsoft.Interop;
-using Microsoft.Interop.UnitTests;
-using SourceGenerators.Tests;
 
 namespace SourceGenerators.Tests
 {
@@ -28,23 +23,30 @@ namespace SourceGenerators.Tests
 
         public sealed override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
         {
-            return EmptyOptions.Instance;
+            return DictionaryAnalyzerConfigOptions.Empty;
         }
 
         public sealed override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
         {
-            return EmptyOptions.Instance;
+            return DictionaryAnalyzerConfigOptions.Empty;
         }
+    }
 
-        private sealed class EmptyOptions : AnalyzerConfigOptions
+    /// <summary>
+    /// An implementation of <see cref="AnalyzerConfigOptions"/> backed by an <see cref="ImmutableDictionary{TKey, TValue}"/>.
+    /// </summary>
+    internal sealed class DictionaryAnalyzerConfigOptions : AnalyzerConfigOptions
+    {
+        public static readonly DictionaryAnalyzerConfigOptions Empty = new(ImmutableDictionary<string, string>.Empty);
+
+        private readonly ImmutableDictionary<string, string> _options;
+
+        public DictionaryAnalyzerConfigOptions(ImmutableDictionary<string, string> options)
         {
-            public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
-            {
-                value = null;
-                return false;
-            }
-
-            public static AnalyzerConfigOptions Instance = new EmptyOptions();
+            _options = options;
         }
+
+        public override bool TryGetValue(string key, [NotNullWhen(true)] out string? value)
+            => _options.TryGetValue(key, out value);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
@@ -1,11 +1,15 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 {
@@ -35,6 +39,9 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             public override void ReportSuppressions(SuppressionAnalysisContext context)
             {
+                // Lazily built set of locations that were actually intercepted by the generator.
+                HashSet<string>? interceptedLocationKeys = null;
+
                 foreach (Diagnostic diagnostic in context.ReportedDiagnostics)
                 {
                     string diagnosticId = diagnostic.Id;
@@ -54,22 +61,142 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     // Use getInnermostNodeForTie to handle the case where the binding call is an
                     // argument to another method (e.g. Some.Method(config.Get<T>())). In that case,
                     // ArgumentSyntax and the inner InvocationExpressionSyntax can share the same span.
-                    bool shouldSuppressDiagnostic =
-                        location.SourceTree is SyntaxTree sourceTree &&
-                        sourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true) is SyntaxNode syntaxNode &&
-                        (syntaxNode as InvocationExpressionSyntax ?? syntaxNode.Parent as InvocationExpressionSyntax) is InvocationExpressionSyntax invocation &&
-                        BinderInvocation.IsCandidateSyntaxNode(invocation) &&
-                        context.GetSemanticModel(sourceTree)
-                            .GetOperation(invocation, context.CancellationToken) is IInvocationOperation operation &&
-                        BinderInvocation.IsBindingOperation(operation);
-
-                    if (shouldSuppressDiagnostic)
+                    if (location.SourceTree is not SyntaxTree sourceTree)
                     {
-                        SuppressionDescriptor targetSuppression = diagnosticId == RUCDiagnostic.SuppressedDiagnosticId
-                                ? RUCDiagnostic
-                                : RDCDiagnostic;
-                        context.ReportSuppression(Suppression.Create(targetSuppression, diagnostic));
+                        continue;
                     }
+
+                    SyntaxNode syntaxNode = sourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+                    if ((syntaxNode as InvocationExpressionSyntax ?? syntaxNode.Parent as InvocationExpressionSyntax) is not InvocationExpressionSyntax invocation)
+                    {
+                        continue;
+                    }
+
+                    if (!BinderInvocation.IsCandidateSyntaxNode(invocation))
+                    {
+                        continue;
+                    }
+
+                    SemanticModel semanticModel = context.GetSemanticModel(sourceTree);
+                    if (semanticModel.GetOperation(invocation, context.CancellationToken) is not IInvocationOperation operation ||
+                        !BinderInvocation.IsBindingOperation(operation))
+                    {
+                        continue;
+                    }
+
+                    // Only suppress if the generator actually intercepted this call site.
+                    // The generator may skip interception for unsupported types (https://github.com/dotnet/runtime/issues/96643).
+                    interceptedLocationKeys ??= CollectInterceptedLocationKeys(context.Compilation);
+
+                    string? locationKey = GetInvocationLocationKey(invocation, semanticModel);
+                    if (locationKey is null || !interceptedLocationKeys.Contains(locationKey))
+                    {
+                        continue;
+                    }
+
+                    SuppressionDescriptor targetSuppression = diagnosticId == RUCDiagnostic.SuppressedDiagnosticId
+                            ? RUCDiagnostic
+                            : RDCDiagnostic;
+                    context.ReportSuppression(Suppression.Create(targetSuppression, diagnostic));
+                }
+            }
+
+            /// <summary>
+            /// Scans the generated source trees for [InterceptsLocation] attributes and collects
+            /// all intercepted locations. For v0, locations are (filePath, line, column) tuples.
+            /// For v1, locations are the encoded data strings from the attribute.
+            /// </summary>
+            private static HashSet<string> CollectInterceptedLocationKeys(Compilation compilation)
+            {
+                var keys = new HashSet<string>();
+
+                foreach (SyntaxTree tree in compilation.SyntaxTrees)
+                {
+                    if (!tree.FilePath.EndsWith("BindingExtensions.g.cs"))
+                    {
+                        continue;
+                    }
+
+                    SyntaxNode root = tree.GetRoot();
+                    foreach (AttributeSyntax attr in root.DescendantNodes().OfType<AttributeSyntax>())
+                    {
+                        if (attr.Name.ToString() != "InterceptsLocation")
+                        {
+                            continue;
+                        }
+
+                        AttributeArgumentListSyntax? argList = attr.ArgumentList;
+                        if (argList is null)
+                        {
+                            continue;
+                        }
+
+                        SeparatedSyntaxList<AttributeArgumentSyntax> args = argList.Arguments;
+
+                        if (InterceptorVersion == 0)
+                        {
+                            // v0 format: [InterceptsLocation("filePath", line, column)]
+                            if (args.Count == 3 &&
+                                args[0].Expression is LiteralExpressionSyntax filePathLiteral &&
+                                filePathLiteral.IsKind(SyntaxKind.StringLiteralExpression) &&
+                                args[1].Expression is LiteralExpressionSyntax lineLiteral &&
+                                lineLiteral.IsKind(SyntaxKind.NumericLiteralExpression) &&
+                                args[2].Expression is LiteralExpressionSyntax colLiteral &&
+                                colLiteral.IsKind(SyntaxKind.NumericLiteralExpression))
+                            {
+                                keys.Add(MakeV0Key(filePathLiteral.Token.ValueText, (int)lineLiteral.Token.Value!, (int)colLiteral.Token.Value!));
+                            }
+                        }
+                        else
+                        {
+                            // v1 format: [InterceptsLocation(version, "data")]
+                            if (args.Count == 2 &&
+                                args[1].Expression is LiteralExpressionSyntax dataLiteral &&
+                                dataLiteral.IsKind(SyntaxKind.StringLiteralExpression))
+                            {
+                                keys.Add(MakeV1Key(dataLiteral.Token.ValueText));
+                            }
+                        }
+                    }
+                }
+
+                return keys;
+            }
+
+            private static string MakeV0Key(string filePath, int line, int column) => $"{filePath}|{line}|{column}";
+
+            private static string MakeV1Key(string data) => data;
+
+            private static string? GetInvocationLocationKey(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+            {
+                if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+                {
+                    return null;
+                }
+
+                if (InterceptorVersion == 0)
+                {
+                    SyntaxTree syntaxTree = memberAccess.SyntaxTree;
+                    TextSpan nameSpan = memberAccess.Name.Span;
+                    FileLinePositionSpan lineSpan = syntaxTree.GetLineSpan(nameSpan);
+
+                    string filePath;
+                    SourceReferenceResolver? resolver = semanticModel.Compilation.Options.SourceReferenceResolver;
+                    filePath = resolver?.NormalizePath(syntaxTree.FilePath, baseFilePath: null) ?? syntaxTree.FilePath;
+
+                    return MakeV0Key(filePath, lineSpan.StartLinePosition.Line + 1, lineSpan.StartLinePosition.Character + 1);
+                }
+                else
+                {
+                    object? interceptableLocation = GetInterceptableLocationFunc?.Invoke(semanticModel, invocation, default);
+                    if (interceptableLocation is null)
+                    {
+                        return null;
+                    }
+
+                    string data = (string)InterceptableLocationDataGetter!.Invoke(interceptableLocation, parameters: null)!;
+
+                    return MakeV1Key(data);
                 }
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -88,7 +89,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     // The generator may skip interception for unsupported types (https://github.com/dotnet/runtime/issues/96643).
                     interceptedLocationKeys ??= CollectInterceptedLocationKeys(context.Compilation);
 
-                    string? locationKey = GetInvocationLocationKey(invocation, semanticModel);
+                    string? locationKey = GetInvocationLocationKey(invocation, semanticModel, context.CancellationToken);
                     if (locationKey is null || !interceptedLocationKeys.Contains(locationKey))
                     {
                         continue;
@@ -112,7 +113,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                 foreach (SyntaxTree tree in compilation.SyntaxTrees)
                 {
-                    if (!tree.FilePath.EndsWith("BindingExtensions.g.cs"))
+                    if (!tree.FilePath.EndsWith("BindingExtensions.g.cs", System.StringComparison.Ordinal))
                     {
                         continue;
                     }
@@ -167,7 +168,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
             private static string MakeV1Key(string data) => data;
 
-            private static string? GetInvocationLocationKey(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+            private static string? GetInvocationLocationKey(InvocationExpressionSyntax invocation, SemanticModel semanticModel, CancellationToken cancellationToken)
             {
                 if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
                 {
@@ -178,7 +179,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 {
                     SyntaxTree syntaxTree = memberAccess.SyntaxTree;
                     TextSpan nameSpan = memberAccess.Name.Span;
-                    FileLinePositionSpan lineSpan = syntaxTree.GetLineSpan(nameSpan);
+                    FileLinePositionSpan lineSpan = syntaxTree.GetLineSpan(nameSpan, cancellationToken);
 
                     string filePath;
                     SourceReferenceResolver? resolver = semanticModel.Compilation.Options.SourceReferenceResolver;
@@ -188,7 +189,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                 }
                 else
                 {
-                    object? interceptableLocation = GetInterceptableLocationFunc?.Invoke(semanticModel, invocation, default);
+                    object? interceptableLocation = GetInterceptableLocationFunc?.Invoke(semanticModel, invocation, cancellationToken);
                     if (interceptableLocation is null)
                     {
                         return null;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
@@ -51,9 +51,12 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     // The trim analyzer changed from warning on the InvocationExpression to the MemberAccessExpression in https://github.com/dotnet/runtime/pull/110086
                     // In other words, the warning location went from from `{|Method1(arg1, arg2)|}` to `{|Method1|}(arg1, arg2)`
                     // To account for this, we need to check if the location is an InvocationExpression or a child of an InvocationExpression.
+                    // Use getInnermostNodeForTie to handle the case where the binding call is an
+                    // argument to another method (e.g. Some.Method(config.Get<T>())). In that case,
+                    // ArgumentSyntax and the inner InvocationExpressionSyntax can share the same span.
                     bool shouldSuppressDiagnostic =
                         location.SourceTree is SyntaxTree sourceTree &&
-                        sourceTree.GetRoot().FindNode(location.SourceSpan) is SyntaxNode syntaxNode &&
+                        sourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true) is SyntaxNode syntaxNode &&
                         (syntaxNode as InvocationExpressionSyntax ?? syntaxNode.Parent as InvocationExpressionSyntax) is InvocationExpressionSyntax invocation &&
                         BinderInvocation.IsCandidateSyntaxNode(invocation) &&
                         context.GetSemanticModel(sourceTree)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         continue;
                     }
 
-                    SyntaxNode syntaxNode = sourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+                    SyntaxNode syntaxNode = sourceTree.GetRoot(context.CancellationToken).FindNode(location.SourceSpan, getInnermostNodeForTie: true);
                     if ((syntaxNode as InvocationExpressionSyntax ?? syntaxNode.Parent as InvocationExpressionSyntax) is not InvocationExpressionSyntax invocation)
                     {
                         continue;
@@ -87,7 +87,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
 
                     // Only suppress if the generator actually intercepted this call site.
                     // The generator may skip interception for unsupported types (https://github.com/dotnet/runtime/issues/96643).
-                    interceptedLocationKeys ??= CollectInterceptedLocationKeys(context.Compilation);
+                    interceptedLocationKeys ??= CollectInterceptedLocationKeys(context.Compilation, context.CancellationToken);
 
                     string? locationKey = GetInvocationLocationKey(invocation, semanticModel, context.CancellationToken);
                     if (locationKey is null || !interceptedLocationKeys.Contains(locationKey))
@@ -107,7 +107,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             /// all intercepted locations. For v0, locations are (filePath, line, column) tuples.
             /// For v1, locations are the encoded data strings from the attribute.
             /// </summary>
-            private static HashSet<string> CollectInterceptedLocationKeys(Compilation compilation)
+            private static HashSet<string> CollectInterceptedLocationKeys(Compilation compilation, CancellationToken cancellationToken)
             {
                 var keys = new HashSet<string>();
 
@@ -118,7 +118,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                         continue;
                     }
 
-                    SyntaxNode root = tree.GetRoot();
+                    SyntaxNode root = tree.GetRoot(cancellationToken);
                     foreach (AttributeSyntax attr in root.DescendantNodes().OfType<AttributeSyntax>())
                     {
                         if (attr.Name.ToString() != "InterceptsLocation")

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/ConfigurationBindingGenerator.Suppressor.cs
@@ -121,6 +121,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
                     SyntaxNode root = tree.GetRoot(cancellationToken);
                     foreach (AttributeSyntax attr in root.DescendantNodes().OfType<AttributeSyntax>())
                     {
+                        // Matching the name like this is somewhat brittle, but it's okay as long as we match what the generator emits.
                         if (attr.Name.ToString() != "InterceptsLocation")
                         {
                             continue;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/InterceptorInfo.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/gen/Specs/InterceptorInfo.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             Debug.Assert((MethodsToGen.ConfigBinder_Bind & interceptor) is 0);
 
             ImmutableEquatableArray<InvocationLocationInfo>? infoList;
-            if ((MethodsToGen.ConfigBinder_Any ^ MethodsToGen.ConfigBinder_Bind & interceptor) is not 0)
+            if (((MethodsToGen.ConfigBinder_Any & ~MethodsToGen.ConfigBinder_Bind) & interceptor) is not 0)
             {
                 infoList = ConfigBinder;
             }
@@ -92,7 +92,7 @@ namespace Microsoft.Extensions.Configuration.Binder.SourceGeneration
             {
                 Debug.Assert((MethodsToGen.ConfigBinder_Bind & overload) is 0);
 
-                if ((MethodsToGen.ConfigBinder_Any ^ MethodsToGen.ConfigBinder_Bind & overload) is not 0)
+                if (((MethodsToGen.ConfigBinder_Any & ~MethodsToGen.ConfigBinder_Bind) & overload) is not 0)
                 {
                     RegisterInterceptor(ref _interceptors_configBinder);
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigBindingGenTestDriver.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigBindingGenTestDriver.cs
@@ -62,7 +62,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
                 return new ConfigBindingGenRunResult
                 {
-                    InputCompilation = _compilation,
                     OutputCompilation = outputCompilation,
                     Diagnostics = runResult.Diagnostics,
                     GeneratedSource = runResult.Results[0].GeneratedSources is { Length: not 0 } sources ? sources[0] : null,
@@ -97,12 +96,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
     internal struct ConfigBindingGenRunResult
     {
-        /// <summary>
-        /// The compilation before source generation, used for running analyzers/suppressors
-        /// which need to see the original (non-intercepted) method resolution.
-        /// </summary>
-        public Compilation InputCompilation { get; init; }
-
         public Compilation OutputCompilation { get; init; }
 
         public GeneratedSourceResult? GeneratedSource { get; init; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigBindingGenTestDriver.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/ConfigBindingGenTestDriver.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
                 return new ConfigBindingGenRunResult
                 {
+                    InputCompilation = _compilation,
                     OutputCompilation = outputCompilation,
                     Diagnostics = runResult.Diagnostics,
                     GeneratedSource = runResult.Results[0].GeneratedSources is { Length: not 0 } sources ? sources[0] : null,
@@ -96,6 +97,12 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
     internal struct ConfigBindingGenRunResult
     {
+        /// <summary>
+        /// The compilation before source generation, used for running analyzers/suppressors
+        /// which need to see the original (non-intercepted) method resolution.
+        /// </summary>
+        public Compilation InputCompilation { get; init; }
+
         public Compilation OutputCompilation { get; init; }
 
         public GeneratedSourceResult? GeneratedSource { get; init; }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -175,6 +175,8 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
             Assert.True(resultEqualsBaseline, errorMessage);
 
+            await VerifySuppressedCallsMatchInterceptedCalls(result);
+
             return result;
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.Helpers.cs
@@ -99,6 +99,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.NotNull(source);
             Assert.Empty(result.Diagnostics);
             Assert.True(source.Value.SourceText.Lines.Count > 10);
+            await VerifySuppressedCallsMatchInterceptedCalls(result);
         }
 
         private static bool s_initializedInterceptorVersion;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -9,10 +9,12 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using ILLink.RoslynAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Binder.SourceGeneration;
@@ -620,9 +622,10 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         {
             Assert.NotNull(result.GenerationSpec);
 
-            // Collect all intercepted line numbers from the generator spec.
-            HashSet<int> interceptedLines = GetInterceptedLines(result.GenerationSpec);
-            Assert.NotEmpty(interceptedLines);
+            // Collect all intercepted (line, column) locations from the generator spec.
+            // The interceptor targets MemberAccessExpression.Name (e.g. "Get" in "c.Get<T>()").
+            HashSet<(int Line, int Column)> interceptedLocations = GetInterceptedLocations(result.GenerationSpec);
+            Assert.NotEmpty(interceptedLocations);
 
             // Run the ILLink analyzer + suppressor on the output compilation (which includes generated InterceptsLocation attributes).
             ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
@@ -631,26 +634,50 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             // Without this, the assertions below would pass vacuously if the analyzer didn't fire.
             Assert.Contains(diagnostics, d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed);
 
-            // Every suppressed IL2026/IL3050 diagnostic should be on an intercepted line.
+            // Every suppressed IL2026/IL3050 diagnostic should be at an intercepted location.
             foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed))
             {
-                int line = d.Location.GetLineSpan().StartLinePosition.Line + 1;
-                Assert.True(interceptedLines.Contains(line),
-                    $"Suppressed {d.Id} at line {line} but no interceptor was generated for that call site.");
+                (int line, int column) = GetMethodNameLocation(d);
+                Assert.True(interceptedLocations.Contains((line, column)),
+                    $"Suppressed {d.Id} at ({line},{column}) but no interceptor was generated for that call site.");
             }
 
-            // Every intercepted line should have its IL2026/IL3050 diagnostics suppressed.
+            // Every intercepted location should have its IL2026/IL3050 diagnostics suppressed.
             foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed))
             {
-                int line = d.Location.GetLineSpan().StartLinePosition.Line + 1;
-                Assert.False(interceptedLines.Contains(line),
-                    $"Unsuppressed {d.Id} at line {line} but an interceptor was generated for that call site.");
+                (int line, int column) = GetMethodNameLocation(d);
+                Assert.False(interceptedLocations.Contains((line, column)),
+                    $"Unsuppressed {d.Id} at ({line},{column}) but an interceptor was generated for that call site.");
             }
         }
 
-        private static HashSet<int> GetInterceptedLines(SourceGenerationSpec spec)
+        /// <summary>
+        /// Resolves a diagnostic's location to the method name position that the interceptor targets.
+        /// The ILLink analyzer reports on the MemberAccessExpression (e.g. "c.Get&lt;T&gt;"),
+        /// but the interceptor targets just the Name part (e.g. "Get"). This method walks from
+        /// the diagnostic location to the InvocationExpression's MemberAccessExpression.Name
+        /// to get the matching (line, column).
+        /// </summary>
+        private static (int Line, int Column) GetMethodNameLocation(Diagnostic diagnostic)
         {
-            var lines = new HashSet<int>();
+            Location location = diagnostic.AdditionalLocations.Count > 0
+                ? diagnostic.AdditionalLocations[0]
+                : diagnostic.Location;
+            SyntaxTree sourceTree = location.SourceTree!;
+            SyntaxNode node = sourceTree.GetRoot().FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+
+            InvocationExpressionSyntax invocation = (node as InvocationExpressionSyntax
+                ?? node.Parent as InvocationExpressionSyntax)!;
+
+            var memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
+            FileLinePositionSpan nameSpan = sourceTree.GetLineSpan(memberAccess.Name.Span);
+
+            return (nameSpan.StartLinePosition.Line + 1, nameSpan.StartLinePosition.Character + 1);
+        }
+
+        private static HashSet<(int Line, int Column)> GetInterceptedLocations(SourceGenerationSpec spec)
+        {
+            var locations = new HashSet<(int, int)>();
             InterceptorInfo info = spec.InterceptorInfo;
 
             AddLocations(info.ConfigBinder);
@@ -660,7 +687,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             AddTypedLocations(info.ConfigBinder_Bind_instance_BinderOptions);
             AddTypedLocations(info.ConfigBinder_Bind_key_instance);
 
-            return lines;
+            return locations;
 
             void AddLocations(IEnumerable<InvocationLocationInfo>? locationInfos)
             {
@@ -669,7 +696,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
                 foreach (InvocationLocationInfo loc in locationInfos)
                 {
-                    lines.Add(GetLineNumber(loc));
+                    locations.Add(GetLocation(loc));
                 }
             }
 
@@ -685,18 +712,20 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             }
         }
 
-        private static int GetLineNumber(InvocationLocationInfo loc)
+        private static (int Line, int Column) GetLocation(InvocationLocationInfo loc)
         {
             if (loc.LineNumber != 0)
             {
-                return loc.LineNumber;
+                return (loc.LineNumber, loc.CharacterNumber);
             }
 
-            // v1 interceptor: parse line from display location, e.g. "path(line,col)"
+            // v1 interceptor: parse from display location, e.g. "path(line,col)"
             string display = loc.InterceptableLocationGetDisplayLocation();
-            int parenIndex = display.LastIndexOf('(');
-            int commaIndex = display.IndexOf(',', parenIndex);
-            return int.Parse(display.Substring(parenIndex + 1, commaIndex - parenIndex - 1));
+            Match match = Regex.Match(display, @"\((\d+),(\d+)\)$");
+            Assert.True(match.Success, $"Could not parse display location: {display}");
+
+            return (int.Parse(match.Groups[1].Value, CultureInfo.InvariantCulture),
+                    int.Parse(match.Groups[2].Value, CultureInfo.InvariantCulture));
         }
 
         private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithSuppressor(Compilation compilation)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -572,7 +572,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
             Assert.NotNull(result.GeneratedSource);
 
-            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
             Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
             Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
@@ -609,7 +609,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
             Assert.NotNull(result.GeneratedSource);
 
-            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
             Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
             Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
@@ -632,8 +632,8 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             HashSet<int> interceptedLines = GetInterceptedLines(result.GenerationSpec);
             Assert.NotEmpty(interceptedLines);
 
-            // Run the ILLink analyzer + suppressor on the input compilation (pre-interceptor).
-            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+            // Run the ILLink analyzer + suppressor on the output compilation (which includes generated InterceptsLocation attributes).
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
             // Every suppressed IL2026/IL3050 diagnostic should be on an intercepted line.
             foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed))

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Configuration.Binder.SourceGeneration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using SourceGenerators.Tests;
 using Xunit;
 
 namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
@@ -759,15 +760,16 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                 new DynamicallyAccessedMembersAnalyzer(),
                 new ConfigurationBindingGenerator.Suppressor());
 
-            var globalOptions = ImmutableDictionary.CreateRange<string, string>(
-                StringComparer.OrdinalIgnoreCase,
-                [
-                    new("build_property.EnableTrimAnalyzer", "true"),
-                    new("build_property.EnableAotAnalyzer", "true"),
-                ]);
+            var trimAotAnalyzerOptions = new DictionaryAnalyzerConfigOptions(
+                ImmutableDictionary.CreateRange<string, string>(
+                    StringComparer.OrdinalIgnoreCase,
+                    [
+                        new("build_property.EnableTrimAnalyzer", "true"),
+                        new("build_property.EnableAotAnalyzer", "true"),
+                    ]));
             var analyzerOptions = new AnalyzerOptions(
                 ImmutableArray<AdditionalText>.Empty,
-                new SimpleAnalyzerConfigOptionsProvider(globalOptions));
+                new GlobalOptionsOnlyProvider(trimAotAnalyzerOptions));
             var options = new CompilationWithAnalyzersOptions(
                 analyzerOptions,
                 onAnalyzerException: null,
@@ -777,33 +779,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
             return await new CompilationWithAnalyzers(compilation, analyzers, options)
                 .GetAllDiagnosticsAsync();
-        }
-
-        private sealed class SimpleAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
-        {
-            private readonly SimpleOptions _globalOptions;
-
-            public SimpleAnalyzerConfigOptionsProvider(ImmutableDictionary<string, string> globalOptions)
-            {
-                _globalOptions = new SimpleOptions(globalOptions);
-            }
-
-            public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
-
-            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => SimpleOptions.Empty;
-            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => SimpleOptions.Empty;
-
-            private sealed class SimpleOptions : AnalyzerConfigOptions
-            {
-                public static readonly SimpleOptions Empty = new(ImmutableDictionary<string, string>.Empty);
-
-                private readonly ImmutableDictionary<string, string> _dict;
-                public SimpleOptions(ImmutableDictionary<string, string> dict) => _dict = dict;
-
-#pragma warning disable 8765 // Nullability of parameter doesn't match overridden member
-                public override bool TryGetValue(string key, out string? value) => _dict.TryGetValue(key, out value);
-#pragma warning restore 8765
-            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -574,10 +574,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
             ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
-            Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
-            Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
-            Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
-
             await VerifySuppressedCallsMatchInterceptedCalls(result);
         }
 
@@ -611,10 +607,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
             ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
-            Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
-            Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
-            Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
-
             await VerifySuppressedCallsMatchInterceptedCalls(result);
         }
 
@@ -635,6 +627,10 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             // Run the ILLink analyzer + suppressor on the output compilation (which includes generated InterceptsLocation attributes).
             ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
+            // The ILLink analyzer must have produced at least one IL2026 or IL3050 that was suppressed.
+            // Without this, the assertions below would pass vacuously if the analyzer didn't fire.
+            Assert.Contains(diagnostics, d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed);
+
             // Every suppressed IL2026/IL3050 diagnostic should be on an intercepted line.
             foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed))
             {
@@ -644,8 +640,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             }
 
             // Every intercepted line should have its IL2026/IL3050 diagnostics suppressed.
-            var unsuppressed = diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed).ToList();
-            foreach (Diagnostic d in unsuppressed)
+            foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed))
             {
                 int line = d.Location.GetLineSpan().StartLinePosition.Line + 1;
                 Assert.False(interceptedLines.Contains(line),

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -574,8 +574,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
             Assert.NotNull(result.GeneratedSource);
 
-            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
-
             await VerifySuppressedCallsMatchInterceptedCalls(result);
         }
 
@@ -606,8 +604,6 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 
             ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
             Assert.NotNull(result.GeneratedSource);
-
-            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.OutputCompilation);
 
             await VerifySuppressedCallsMatchInterceptedCalls(result);
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -10,10 +10,12 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using ILLink.RoslynAnalyzer;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Binder.SourceGeneration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -534,6 +536,136 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             var effective = CompilationWithAnalyzers.GetEffectiveDiagnostics(result.Diagnostics, result.OutputCompilation);
             Diagnostic diagnostic = Assert.Single(effective, d => d.Id == "SYSLIB1103");
             Assert.False(diagnostic.IsSuppressed);
+        }
+
+        /// <summary>
+        /// Verifies that the suppressor suppresses IL2026/IL3050 when a ConfigurationBinder call
+        /// is passed directly as a method argument (e.g. Some.Method(config.Get&lt;T&gt;())).
+        /// Regression test for https://github.com/dotnet/runtime/issues/94544.
+        /// </summary>
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        public async Task Suppressor_SuppressesWarnings_WhenBindingCallIsMethodArgument()
+        {
+            string source = """
+                using Microsoft.Extensions.Configuration;
+
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        IConfigurationSection c = new ConfigurationBuilder().Build().GetSection("Options");
+                        Some.Method(c.Get<MyOptions>());
+                    }
+                }
+
+                internal static class Some
+                {
+                    public static void Method(MyOptions? options) { }
+                }
+
+                public class MyOptions
+                {
+                    public int MaxRetries { get; set; }
+                }
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
+            Assert.NotNull(result.GeneratedSource);
+
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+
+            Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
+            Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
+            Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
+        }
+
+        /// <summary>
+        /// Verifies that the suppressor also works for the straightforward assignment case,
+        /// ensuring no regression in existing behavior.
+        /// </summary>
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        public async Task Suppressor_SuppressesWarnings_ForSimpleBindingCall()
+        {
+            string source = """
+                using Microsoft.Extensions.Configuration;
+
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        IConfigurationSection c = new ConfigurationBuilder().Build().GetSection("Options");
+                        var options = c.Get<MyOptions>();
+                    }
+                }
+
+                public class MyOptions
+                {
+                    public int MaxRetries { get; set; }
+                }
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
+            Assert.NotNull(result.GeneratedSource);
+
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+
+            Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
+            Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
+            Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
+        }
+
+        private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithSuppressor(Compilation compilation)
+        {
+            var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(
+                new DynamicallyAccessedMembersAnalyzer(),
+                new ConfigurationBindingGenerator.Suppressor());
+
+            var globalOptions = ImmutableDictionary.CreateRange(
+                StringComparer.OrdinalIgnoreCase,
+                new[]
+                {
+                    new KeyValuePair<string, string>("build_property.EnableTrimAnalyzer", "true"),
+                    new KeyValuePair<string, string>("build_property.EnableAotAnalyzer", "true"),
+                });
+            var analyzerOptions = new AnalyzerOptions(
+                ImmutableArray<AdditionalText>.Empty,
+                new SimpleAnalyzerConfigOptionsProvider(globalOptions));
+            var options = new CompilationWithAnalyzersOptions(
+                analyzerOptions,
+                onAnalyzerException: null,
+                concurrentAnalysis: true,
+                logAnalyzerExecutionTime: false,
+                reportSuppressedDiagnostics: true);
+
+            return await new CompilationWithAnalyzers(compilation, analyzers, options)
+                .GetAllDiagnosticsAsync();
+        }
+
+        private sealed class SimpleAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+        {
+            private readonly SimpleOptions _globalOptions;
+
+            public SimpleAnalyzerConfigOptionsProvider(ImmutableDictionary<string, string> globalOptions)
+            {
+                _globalOptions = new SimpleOptions(globalOptions);
+            }
+
+            public override AnalyzerConfigOptions GlobalOptions => _globalOptions;
+
+            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => SimpleOptions.Empty;
+            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => SimpleOptions.Empty;
+
+            private sealed class SimpleOptions : AnalyzerConfigOptions
+            {
+                public static readonly SimpleOptions Empty = new(ImmutableDictionary<string, string>.Empty);
+
+                private readonly ImmutableDictionary<string, string> _dict;
+                public SimpleOptions(ImmutableDictionary<string, string> dict) => _dict = dict;
+
+#pragma warning disable 8765 // Nullability of parameter doesn't match overridden member
+                public override bool TryGetValue(string key, out string? value) => _dict.TryGetValue(key, out value);
+#pragma warning restore 8765
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -659,6 +659,8 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             InterceptorInfo info = spec.InterceptorInfo;
 
             AddLocations(info.ConfigBinder);
+            AddLocations(info.OptionsBuilderExt);
+            AddLocations(info.ServiceCollectionExt);
             AddTypedLocations(info.ConfigBinder_Bind_instance);
             AddTypedLocations(info.ConfigBinder_Bind_instance_BinderOptions);
             AddTypedLocations(info.ConfigBinder_Bind_key_instance);

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -577,6 +577,8 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
             Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
             Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
+
+            await VerifySuppressedCallsMatchInterceptedCalls(result);
         }
 
         /// <summary>
@@ -612,6 +614,92 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
             Assert.Contains(diagnostics, d => d.Id == "IL2026" && d.IsSuppressed);
             Assert.Contains(diagnostics, d => d.Id == "IL3050" && d.IsSuppressed);
             Assert.DoesNotContain(diagnostics, d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed);
+
+            await VerifySuppressedCallsMatchInterceptedCalls(result);
+        }
+
+        /// <summary>
+        /// Verifies that the set of IL2026/IL3050 diagnostics suppressed by the suppressor
+        /// matches exactly the set of calls intercepted by the source generator.
+        /// Catches both under-suppression (https://github.com/dotnet/runtime/issues/94544)
+        /// and over-suppression (https://github.com/dotnet/runtime/issues/96643).
+        /// </summary>
+        private static async Task VerifySuppressedCallsMatchInterceptedCalls(ConfigBindingGenRunResult result)
+        {
+            Assert.NotNull(result.GenerationSpec);
+
+            // Collect all intercepted line numbers from the generator spec.
+            HashSet<int> interceptedLines = GetInterceptedLines(result.GenerationSpec);
+            Assert.NotEmpty(interceptedLines);
+
+            // Run the ILLink analyzer + suppressor on the input compilation (pre-interceptor).
+            ImmutableArray<Diagnostic> diagnostics = await GetDiagnosticsWithSuppressor(result.InputCompilation);
+
+            // Every suppressed IL2026/IL3050 diagnostic should be on an intercepted line.
+            foreach (Diagnostic d in diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && d.IsSuppressed))
+            {
+                int line = d.Location.GetLineSpan().StartLinePosition.Line + 1;
+                Assert.True(interceptedLines.Contains(line),
+                    $"Suppressed {d.Id} at line {line} but no interceptor was generated for that call site.");
+            }
+
+            // Every intercepted line should have its IL2026/IL3050 diagnostics suppressed.
+            var unsuppressed = diagnostics.Where(d => (d.Id is "IL2026" or "IL3050") && !d.IsSuppressed).ToList();
+            foreach (Diagnostic d in unsuppressed)
+            {
+                int line = d.Location.GetLineSpan().StartLinePosition.Line + 1;
+                Assert.False(interceptedLines.Contains(line),
+                    $"Unsuppressed {d.Id} at line {line} but an interceptor was generated for that call site.");
+            }
+        }
+
+        private static HashSet<int> GetInterceptedLines(SourceGenerationSpec spec)
+        {
+            var lines = new HashSet<int>();
+            InterceptorInfo info = spec.InterceptorInfo;
+
+            AddLocations(info.ConfigBinder);
+            AddTypedLocations(info.ConfigBinder_Bind_instance);
+            AddTypedLocations(info.ConfigBinder_Bind_instance_BinderOptions);
+            AddTypedLocations(info.ConfigBinder_Bind_key_instance);
+
+            return lines;
+
+            void AddLocations(IEnumerable<InvocationLocationInfo>? locationInfos)
+            {
+                if (locationInfos is null)
+                    return;
+
+                foreach (InvocationLocationInfo loc in locationInfos)
+                {
+                    lines.Add(GetLineNumber(loc));
+                }
+            }
+
+            void AddTypedLocations(IEnumerable<TypedInterceptorInvocationInfo>? typedInfos)
+            {
+                if (typedInfos is null)
+                    return;
+
+                foreach (TypedInterceptorInvocationInfo typed in typedInfos)
+                {
+                    AddLocations(typed.Locations);
+                }
+            }
+        }
+
+        private static int GetLineNumber(InvocationLocationInfo loc)
+        {
+            if (loc.LineNumber != 0)
+            {
+                return loc.LineNumber;
+            }
+
+            // v1 interceptor: parse line from display location, e.g. "path(line,col)"
+            string display = loc.InterceptableLocationGetDisplayLocation();
+            int parenIndex = display.LastIndexOf('(');
+            int commaIndex = display.IndexOf(',', parenIndex);
+            return int.Parse(display.Substring(parenIndex + 1, commaIndex - parenIndex - 1));
         }
 
         private static async Task<ImmutableArray<Diagnostic>> GetDiagnosticsWithSuppressor(Compilation compilation)

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -545,7 +545,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         /// is passed directly as a method argument (e.g. Some.Method(config.Get&lt;T&gt;())).
         /// Regression test for https://github.com/dotnet/runtime/issues/94544.
         /// </summary>
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        [Fact]
         public async Task Suppressor_SuppressesWarnings_WhenBindingCallIsMethodArgument()
         {
             string source = """
@@ -581,7 +581,7 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
         /// Verifies that the suppressor also works for the straightforward assignment case,
         /// ensuring no regression in existing behavior.
         /// </summary>
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        [Fact]
         public async Task Suppressor_SuppressesWarnings_ForSimpleBindingCall()
         {
             string source = """
@@ -593,6 +593,35 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                     {
                         IConfigurationSection c = new ConfigurationBuilder().Build().GetSection("Options");
                         var options = c.Get<MyOptions>();
+                    }
+                }
+
+                public class MyOptions
+                {
+                    public int MaxRetries { get; set; }
+                }
+                """;
+
+            ConfigBindingGenRunResult result = await RunGeneratorAndUpdateCompilation(source);
+            Assert.NotNull(result.GeneratedSource);
+
+            await VerifySuppressedCallsMatchInterceptedCalls(result);
+        }
+
+        [Fact]
+        public async Task Suppressor_SuppressesWarnings_WithLineDirective()
+        {
+            string source = """
+                using Microsoft.Extensions.Configuration;
+
+                public class Program
+                {
+                    public static void Main()
+                    {
+                        IConfigurationSection c = new ConfigurationBuilder().Build().GetSection("Options");
+                #line 100 "Remapped.cs"
+                        var options = c.Get<MyOptions>();
+                #line default
                     }
                 }
 
@@ -730,13 +759,12 @@ namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
                 new DynamicallyAccessedMembersAnalyzer(),
                 new ConfigurationBindingGenerator.Suppressor());
 
-            var globalOptions = ImmutableDictionary.CreateRange(
+            var globalOptions = ImmutableDictionary.CreateRange<string, string>(
                 StringComparer.OrdinalIgnoreCase,
-                new[]
-                {
-                    new KeyValuePair<string, string>("build_property.EnableTrimAnalyzer", "true"),
-                    new KeyValuePair<string, string>("build_property.EnableAotAnalyzer", "true"),
-                });
+                [
+                    new("build_property.EnableTrimAnalyzer", "true"),
+                    new("build_property.EnableAotAnalyzer", "true"),
+                ]);
             var analyzerOptions = new AnalyzerOptions(
                 ImmutableArray<AdditionalText>.Empty,
                 new SimpleAnalyzerConfigOptionsProvider(globalOptions));

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
@@ -46,6 +46,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Options.ConfigurationExtensions\src\Microsoft.Extensions.Options.ConfigurationExtensions.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\..\src\Microsoft.Extensions.Configuration.Binder.csproj" SkipUseReferenceAssembly="true" />
     <ProjectReference Include="..\..\gen\Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="true" />
+    <ProjectReference Include="$(RepoRoot)src\tools\illink\src\ILLink.RoslynAnalyzer\ILLink.RoslynAnalyzer.csproj" ReferenceOutputAssembly="true" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/Microsoft.Extensions.Configuration.Binder.SourceGeneration.Tests.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <Compile Include="$(CommonPath)..\tests\SourceGenerators\RoslynTestUtils.cs" Link="SourceGenerators\RoslynTestUtils.cs" />
     <Compile Include="$(CommonPath)..\tests\SourceGenerators\GeneratorTestHelpers.cs" Link="SourceGenerators\GeneratorTestHelpers.cs" />
+    <Compile Include="$(CommonPath)..\tests\SourceGenerators\GlobalOptionsOnlyProvider.cs" Link="SourceGenerators\GlobalOptionsOnlyProvider.cs" />
     <Compile Include="$(CoreLibSharedDir)System\Runtime\CompilerServices\IsExternalInit.cs" Link="Common\System\Runtime\CompilerServices\IsExternalInit.cs" />
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\tests\Common\ConfigurationProviderExtensions.cs" Link="Common\ConfigurationProviderExtensions.cs" />
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\tests\Common\TestStreamHelpers.cs" Link="Common\TestStreamHelpers.cs" />

--- a/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ComInterfaceGenerator.Unit.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/ComInterfaceGenerator.Unit.Tests/ComInterfaceGenerator.Unit.Tests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
-    <Compile Include="$(CommonTestPath)SourceGenerators\GlobalOptionsOnlyProvider.cs" Link="Common\SourceGenerators\GlobalOptionsOnlyProvider.cs" />
     <Compile Include="..\Common\TestUtils.cs" Link="Common\TestUtils.cs" />
     <Compile Include="..\Common\CustomCollectionMarshallingCodeSnippets.cs" Link="Common\CustomCollectionMarshallingCodeSnippets.cs" />
     <Compile Include="..\Common\CustomStructMarshallingCodeSnippets.cs" Link="Common\CustomStructMarshallingCodeSnippets.cs" />

--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/LibraryImportGenerator.Unit.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.UnitTests/LibraryImportGenerator.Unit.Tests.csproj
@@ -15,7 +15,6 @@
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)SourceGenerators\LiveReferencePack.cs" Link="Common\SourceGenerators\LiveReferencePack.cs" />
-    <Compile Include="$(CommonTestPath)SourceGenerators\GlobalOptionsOnlyProvider.cs" Link="Common\SourceGenerators\GlobalOptionsOnlyProvider.cs" />
     <Compile Include="..\Common\TestUtils.cs" Link="Common\TestUtils.cs" />
     <Compile Include="..\Common\CustomCollectionMarshallingCodeSnippets.cs" Link="Common\CustomCollectionMarshallingCodeSnippets.cs" />
     <Compile Include="..\Common\CustomStructMarshallingCodeSnippets.cs" Link="Common\CustomStructMarshallingCodeSnippets.cs" />

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ILLink.RoslynAnalyzer.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Compile Include="$(LibrariesProjectRoot)Common\tests\SourceGenerators\LiveReferencePack.cs" />
+    <Compile Include="$(LibrariesProjectRoot)Common\tests\SourceGenerators\GlobalOptionsOnlyProvider.cs" />
     <Compile Remove="$(CompilerGeneratedFilesOutputPath)/**/*" />
   </ItemGroup>
 

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/TestCaseCompilation.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
+using SourceGenerators.Tests;
 
 namespace ILLink.RoslynAnalyzer.Tests
 {
@@ -87,7 +88,7 @@ namespace ILLink.RoslynAnalyzer.Tests
                     }));
             var analyzerOptions = new AnalyzerOptions(
                 additionalFiles: additionalFiles?.ToImmutableArray() ?? ImmutableArray<AdditionalText>.Empty,
-                new SimpleAnalyzerOptions(globalAnalyzerOptions));
+                new GlobalOptionsOnlyProvider(CreateGlobalOptions(globalAnalyzerOptions)));
 
             var exceptionDiagnostics = new List<Diagnostic>();
 
@@ -103,40 +104,16 @@ namespace ILLink.RoslynAnalyzer.Tests
             return (new CompilationWithAnalyzers(comp, SupportedDiagnosticAnalyzers, compWithAnalyzerOptions), comp.GetSemanticModel(src), exceptionDiagnostics);
         }
 
-        sealed class SimpleAnalyzerOptions : AnalyzerConfigOptionsProvider
+        private static DictionaryAnalyzerConfigOptions CreateGlobalOptions((string, string)[]? globalOptions)
         {
-            public SimpleAnalyzerOptions((string, string)[]? globalOptions)
+            if (globalOptions is null or { Length: 0 })
             {
-                globalOptions ??= Array.Empty<(string, string)>();
-                GlobalOptions = new SimpleAnalyzerConfigOptions(ImmutableDictionary.CreateRange(
-                    StringComparer.OrdinalIgnoreCase,
-                    globalOptions.Select(x => new KeyValuePair<string, string>(x.Item1, x.Item2))));
+                return DictionaryAnalyzerConfigOptions.Empty;
             }
 
-            public override AnalyzerConfigOptions GlobalOptions { get; }
-
-            public override AnalyzerConfigOptions GetOptions(SyntaxTree tree)
-                => SimpleAnalyzerConfigOptions.Empty;
-
-            public override AnalyzerConfigOptions GetOptions(AdditionalText textFile)
-                => SimpleAnalyzerConfigOptions.Empty;
-
-            sealed class SimpleAnalyzerConfigOptions : AnalyzerConfigOptions
-            {
-                public static readonly SimpleAnalyzerConfigOptions Empty = new SimpleAnalyzerConfigOptions(ImmutableDictionary<string, string>.Empty);
-
-                private readonly ImmutableDictionary<string, string> _dict;
-                public SimpleAnalyzerConfigOptions(ImmutableDictionary<string, string> dict)
-                {
-                    _dict = dict;
-                }
-
-                // Suppress warning about missing nullable attributes
-#pragma warning disable 8765
-                public override bool TryGetValue(string key, out string? value)
-                    => _dict.TryGetValue(key, out value);
-#pragma warning restore 8765
-            }
+            return new DictionaryAnalyzerConfigOptions(ImmutableDictionary.CreateRange(
+                StringComparer.OrdinalIgnoreCase,
+                globalOptions.Select(x => new KeyValuePair<string, string>(x.Item1, x.Item2))));
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

## Summary

Fixes the ConfigurationBinder source generator's diagnostic suppressor to correctly handle IL2026/IL3050 AOT warnings. Two issues are addressed:

### 1. Defensive fix for method-argument case (#94544)

When `c.Get<MyOptions>()` is passed directly as a method argument (e.g. `Some.Method(c.Get<MyOptions>())`), `FindNode` could return an `ArgumentSyntax` instead of the inner `InvocationExpressionSyntax` when both share the same span. Added `getInnermostNodeForTie: true` to `FindNode` to resolve the tie correctly. Note: this was already inadvertently fixed by #110086 (which changed diagnostic locations from `InvocationExpression` to `MemberAccessExpression`), but the fix is still valuable as defense-in-depth.

### 2. Only suppress warnings for actually intercepted calls (#96643)

The suppressor was suppressing IL2026/IL3050 for *all* ConfigurationBinder calls, even when the generator chose not to intercept them (e.g. unsupported types). Now the suppressor scans the generated `BindingExtensions.g.cs` for `[InterceptsLocation]` attributes and only suppresses warnings for call sites that were actually intercepted. This handles both v0 (file/line/column) and v1 (encoded data) interceptor formats.

### Tests

- Added `Suppressor_SuppressesWarnings_WhenBindingCallIsMethodArgument` and `Suppressor_SuppressesWarnings_ForSimpleBindingCall` tests using the real `DynamicallyAccessedMembersAnalyzer` from ILLink.
- Added `VerifySuppressedCallsMatchInterceptedCalls` helper that verifies suppressed and intercepted locations match exactly. Integrated into `VerifyAgainstBaselineUsingFile` and `VerifyThatSourceIsGenerated` so all baseline tests automatically get this coverage.

Fixes #94544
Fixes #96643