### PR TITLE
Allow repo traversal from runtime skills

### DIFF
--- a/.github/skills/api-proposal/SKILL.md
+++ b/.github/skills/api-proposal/SKILL.md
@@ -133,7 +133,7 @@ The skill contains baked-in examples and guidelines for writing good proposals (
 
 #### Prototype Validation (all steps required)
 
-> **Prerequisite:** Follow the build and test workflow in [`copilot-instructions.md`](/.github/copilot-instructions.md) — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
+> **Prerequisite:** Follow the build and test workflow in [`copilot-instructions.md`](../../copilot-instructions.md) — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
 
 **Step 1: Build and test**
 

--- a/.github/skills/api-proposal/SKILL.md
+++ b/.github/skills/api-proposal/SKILL.md
@@ -133,7 +133,7 @@ The skill contains baked-in examples and guidelines for writing good proposals (
 
 #### Prototype Validation (all steps required)
 
-> **Prerequisite:** Follow the build and test workflow in `.github/copilot-instructions.md` — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
+> **Prerequisite:** Follow the build and test workflow in [`copilot-instructions.md`](/.github/copilot-instructions.md) — complete the baseline build, configure the environment, and use the component-specific workflow for the target library. All build and test steps below assume the baseline build has already succeeded.
 
 **Step 1: Build and test**
 

--- a/.github/skills/issue-triage/SKILL.md
+++ b/.github/skills/issue-triage/SKILL.md
@@ -145,7 +145,7 @@ languishing unnoticed.
 #### 2a: Check the `area-*` label
 
 1. Read the issue content carefully -- what namespace, type, or component does it concern?
-2. Cross-reference with [`docs/area-owners.md`](../../../docs/area-owners.md) which maps
+2. Cross-reference with [`docs/area-owners.md`](../../../docs/area-owners.md), which maps
    `area-*` labels to specific assemblies, namespaces, and teams.
 3. If the current `area-*` label doesn't match the issue's actual subject, flag it
    and suggest the correct label with a rationale.

--- a/.github/skills/issue-triage/SKILL.md
+++ b/.github/skills/issue-triage/SKILL.md
@@ -145,7 +145,7 @@ languishing unnoticed.
 #### 2a: Check the `area-*` label
 
 1. Read the issue content carefully -- what namespace, type, or component does it concern?
-2. Cross-reference with `docs/area-owners.md`, which maps
+2. Cross-reference with [`docs/area-owners.md`](../../../docs/area-owners.md) which maps
    `area-*` labels to specific assemblies, namespaces, and teams.
 3. If the current `area-*` label doesn't match the issue's actual subject, flag it
    and suggest the correct label with a rationale.

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,7 +15,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## Prerequisites
 
-> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from [`copilot-instructions.md`](/.github/copilot-instructions.md) unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
+> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from [`copilot-instructions.md`](../../copilot-instructions.md) unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
 
 ## When to use
 
@@ -49,7 +49,7 @@ OS version references appear in these pipeline files:
 | `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
 | `docs/workflow/using-docker.md` | Documents the official build/test Docker images — update only when build image versions change (cross-compilation images, not Helix test images) |
 
-The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
+The [OS onboarding guide](../../../docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
 
 ### helix-platforms.yml structure
 
@@ -297,7 +297,7 @@ When asked to audit all OS coverage:
 
 ## Reference
 
-- [OS onboarding guide](/docs/project/os-onboarding.md)
+- [OS onboarding guide](../../../docs/project/os-onboarding.md)
 - [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
 - [Prereq container image lifecycle](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/lifecycle.md)
 - [Container image registry (image-info)](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)

--- a/.github/skills/update-os-coverage/SKILL.md
+++ b/.github/skills/update-os-coverage/SKILL.md
@@ -15,7 +15,7 @@ Update OS version references in Helix queue definition files. These files contro
 
 ## Prerequisites
 
-> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from `.github/copilot-instructions.md` unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
+> **Baseline build not required:** This skill is for YAML/docs-style queue and image reference updates, not product code changes. Do **not** start with the repo-wide baseline build workflow from [`copilot-instructions.md`](/.github/copilot-instructions.md) unless the task expands beyond image / queue metadata into code changes that actually need build or test validation.
 
 ## When to use
 
@@ -49,7 +49,7 @@ OS version references appear in these pipeline files:
 | `eng/pipelines/common/templates/pipeline-with-resources.yml` | Build container definitions (not Helix queues, but OS version references for build images) |
 | `docs/workflow/using-docker.md` | Documents the official build/test Docker images — update only when build image versions change (cross-compilation images, not Helix test images) |
 
-The OS onboarding guide (`docs/project/os-onboarding.md`) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
+The [OS onboarding guide](/docs/project/os-onboarding.md) is the authoritative reference for how OS versions are managed in this repo. Read it if more context is needed on our policies.
 
 ### helix-platforms.yml structure
 
@@ -297,7 +297,7 @@ When asked to audit all OS coverage:
 
 ## Reference
 
-- OS onboarding guide: `docs/project/os-onboarding.md`
+- [OS onboarding guide](/docs/project/os-onboarding.md)
 - [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
 - [Prereq container image lifecycle](https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/lifecycle.md)
 - [Container image registry (image-info)](https://github.com/dotnet/versions/blob/main/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json)

--- a/.github/workflows/skill-validation.yml
+++ b/.github/workflows/skill-validation.yml
@@ -55,7 +55,7 @@ jobs:
           if [ -d .github/skills ]; then
             echo "::group::Validate skills"
             set +e
-            skill-validator-bin/skill-validator check --skills .github/skills --verbose 2>&1 | tee skill-check-skills.txt
+            skill-validator-bin/skill-validator check --skills .github/skills --allow-repo-traversal --verbose 2>&1 | tee skill-check-skills.txt
             skills_rc=${PIPESTATUS[0]}
             set -e
             echo "::endgroup::"
@@ -65,7 +65,7 @@ jobs:
           if [ -d .github/agents ]; then
             echo "::group::Validate agents"
             set +e
-            skill-validator-bin/skill-validator check --agents .github/agents --verbose 2>&1 | tee skill-check-agents.txt
+            skill-validator-bin/skill-validator check --agents .github/agents --allow-repo-traversal --verbose 2>&1 | tee skill-check-agents.txt
             agents_rc=${PIPESTATUS[0]}
             set -e
             echo "::endgroup::"


### PR DESCRIPTION
Follow-up of https://github.com/dotnet/runtime/pull/126814

### Motivation
- The repo local skills differ from plugin skills:
    - the later must not traverse outside of their folder, as it would break their isolated acquisition
    - the former are alredy part of the repo. If we prevent them to traverse valuable files outside of their folder (docs, scripts, etc.) - we force the agents to do at least one extra full turn to discover the full path.

**tl;dr;:** reintroducing full relative paths in skills - this is **good** pattern in repo local skills. Also adding flag that is allowing this.

cc: @danmoseley 