### PR TITLE
Use Checked runtime for cDAC dump tests

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -213,7 +213,7 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacDumpTest
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc $(_BuildConfig) -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml
@@ -257,7 +257,7 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacXPlatDumpGen
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc $(_BuildConfig) -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml
@@ -304,7 +304,7 @@ extends:
             shouldContinueOnError: true
             jobParameters:
               nameSuffix: CdacXPlatDumpTest
-              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc $(_BuildConfig) -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
+              buildArgs: -s clr+libs+tools.cdac+tools.cdacdumptests -c $(_BuildConfig) -rc checked -lc $(_BuildConfig) /p:SkipDumpVersions=net10.0
               timeoutInMinutes: 180
               postBuildSteps:
               - template: /eng/pipelines/cdac/prepare-cdac-helix-steps.yml

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -49,7 +49,7 @@ CDAC_TYPE_FIELD(Thread, T_POINTER, DebuggerFilterContext, cdac_data<Thread>::Deb
 CDAC_TYPE_FIELD(Thread, T_POINTER, ProfilerFilterContext, cdac_data<Thread>::ProfilerFilterContext)
 #endif // PROFILING_SUPPORTED
 CDAC_TYPE_FIELD(Thread, TYPE(GCHandle), GCHandle, cdac_data<Thread>::ExposedObject)
-CDAC_TYPE_FIELD(Thread, TYPE(GCHandle), LastThrownObject, cdac_data<Thread>::LastThrownObject)
+CDAC_TYPE_FIELD(Thread, T_POINTER, LastThrownObject, cdac_data<Thread>::LastThrownObject)
 CDAC_TYPE_FIELD(Thread, T_POINTER, LinkNext, cdac_data<Thread>::Link)
 CDAC_TYPE_FIELD(Thread, T_POINTER, ThreadLocalDataPtr, cdac_data<Thread>::ThreadLocalDataPtr)
 #ifndef TARGET_UNIX
@@ -60,7 +60,7 @@ CDAC_TYPE_END(Thread)
 
 CDAC_TYPE_BEGIN(ThreadStore)
 CDAC_TYPE_INDETERMINATE(ThreadStore)
-CDAC_TYPE_FIELD(ThreadStore, TYPE(SLink), FirstThreadLink, cdac_data<ThreadStore>::FirstThreadLink)
+CDAC_TYPE_FIELD(ThreadStore, T_POINTER, FirstThreadLink, cdac_data<ThreadStore>::FirstThreadLink)
 CDAC_TYPE_FIELD(ThreadStore, T_INT32, ThreadCount, cdac_data<ThreadStore>::ThreadCount)
 CDAC_TYPE_FIELD(ThreadStore, T_INT32, UnstartedCount, cdac_data<ThreadStore>::UnstartedCount)
 CDAC_TYPE_FIELD(ThreadStore, T_INT32, BackgroundCount, cdac_data<ThreadStore>::BackgroundCount)
@@ -174,7 +174,7 @@ CDAC_TYPE_END(String)
 
 CDAC_TYPE_BEGIN(Array)
 CDAC_TYPE_SIZE(sizeof(ArrayBase))
-CDAC_TYPE_FIELD(Array, T_POINTER, m_NumComponents, cdac_data<ArrayBase>::m_NumComponents)
+CDAC_TYPE_FIELD(Array, T_UINT32, m_NumComponents, cdac_data<ArrayBase>::m_NumComponents)
 CDAC_TYPE_END(Array)
 
 CDAC_TYPE_BEGIN(InteropSyncBlockInfo)


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

Switch the cDAC dump test builds from Release to Checked runtime configuration (`-rc checked`) while keeping libs as Release (`-lc release`). This enables runtime asserts in the CLR, which helps catch issues in the cDAC data descriptors and contract implementations during dump testing.

**Changes:**
- Single-leg dump tests: `-rc release` → `-rc checked`
- X-plat dump generation: `-rc release` → `-rc checked`
- X-plat dump testing: `-rc release` → `-rc checked`

SOS test stages are unchanged (remain Release).