### PR TITLE
Improve xplat dump test work item naming

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -34,13 +34,14 @@ public abstract class DumpTestBase : IDisposable
     {
         get
         {
+            string? dumpSource = GetDumpSource();
             foreach (string r2rMode in GetR2RModes())
             {
                 if (!IsVersionSkipped("local"))
-                    yield return [new TestConfiguration("local", r2rMode)];
+                    yield return [new TestConfiguration("local", r2rMode, dumpSource)];
 
                 if (!IsVersionSkipped("net10.0"))
-                    yield return [new TestConfiguration("net10.0", r2rMode)];
+                    yield return [new TestConfiguration("net10.0", r2rMode, dumpSource)];
             }
         }
     }
@@ -174,6 +175,28 @@ public abstract class DumpTestBase : IDisposable
             throw new InvalidOperationException("Could not locate the repository root.");
 
         return Path.Combine(repoRoot, "artifacts", "dumps", "cdac");
+    }
+
+    /// <summary>
+    /// Returns the dump source platform from dump-info.json (e.g., "windows/x64"),
+    /// or null for local runs where CDAC_DUMP_ROOT is not set.
+    /// </summary>
+    private static string? GetDumpSource()
+    {
+        string? dumpRoot = Environment.GetEnvironmentVariable("CDAC_DUMP_ROOT");
+        if (string.IsNullOrEmpty(dumpRoot))
+            return null;
+
+        // Try loading dump-info.json from any version directory to get OS/Arch
+        foreach (string versionDir in new[] { "local", "net10.0" })
+        {
+            DumpInfo? info = DumpInfo.TryLoad(Path.Combine(dumpRoot, versionDir));
+            if (info is not null)
+                return $"{info.Os}/{info.Arch}";
+        }
+
+        // Fall back to the directory name if dump-info.json isn't available
+        return Path.GetFileName(dumpRoot.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
     }
 
     /// <summary>

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -178,7 +178,7 @@ public abstract class DumpTestBase : IDisposable
     }
 
     /// <summary>
-    /// Returns the dump source platform from dump-info.json (e.g., "windows/x64"),
+    /// Returns the dump source platform from dump-info.json (e.g., "windows_x64"),
     /// or null for local runs where CDAC_DUMP_ROOT is not set.
     /// </summary>
     private static string? GetDumpSource()
@@ -192,7 +192,7 @@ public abstract class DumpTestBase : IDisposable
         {
             DumpInfo? info = DumpInfo.TryLoad(Path.Combine(dumpRoot, versionDir));
             if (info is not null)
-                return $"{info.Os}/{info.Arch}";
+                return $"{info.Os}_{info.Arch}";
         }
 
         // Fall back to the directory name if dump-info.json isn't available

--- a/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
+++ b/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
@@ -26,25 +26,35 @@ public sealed class TestConfiguration : IXunitSerializable
     /// </summary>
     public string R2RMode { get; set; } = "r2r";
 
+    /// <summary>
+    /// The platform that produced the dump (e.g., "windows/x64", "linux/arm64").
+    /// Null for local runs where the host and dump source are the same.
+    /// </summary>
+    public string? DumpSource { get; set; }
+
     public TestConfiguration() { }
 
-    public TestConfiguration(string runtimeVersion, string r2rMode)
+    public TestConfiguration(string runtimeVersion, string r2rMode, string? dumpSource = null)
     {
         RuntimeVersion = runtimeVersion;
         R2RMode = r2rMode;
+        DumpSource = dumpSource;
     }
 
-    public override string ToString() => $"{RuntimeVersion}/{R2RMode}";
+    public override string ToString() =>
+        DumpSource is not null ? $"{RuntimeVersion}/{R2RMode}, target: {DumpSource}" : $"{RuntimeVersion}/{R2RMode}";
 
     public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(RuntimeVersion), RuntimeVersion);
         info.AddValue(nameof(R2RMode), R2RMode);
+        info.AddValue(nameof(DumpSource), DumpSource);
     }
 
     public void Deserialize(IXunitSerializationInfo info)
     {
         RuntimeVersion = info.GetValue<string>(nameof(RuntimeVersion));
         R2RMode = info.GetValue<string>(nameof(R2RMode));
+        DumpSource = info.GetValue<string>(nameof(DumpSource));
     }
 }

--- a/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
+++ b/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
@@ -27,7 +27,7 @@ public sealed class TestConfiguration : IXunitSerializable
     public string R2RMode { get; set; } = "r2r";
 
     /// <summary>
-    /// The platform that produced the dump (e.g., "windows/x64", "linux/arm64").
+    /// The platform that produced the dump (e.g., "windows_x64", "linux_arm64").
     /// Null for local runs where the host and dump source are the same.
     /// </summary>
     public string? DumpSource { get; set; }
@@ -42,13 +42,13 @@ public sealed class TestConfiguration : IXunitSerializable
     }
 
     public override string ToString() =>
-        DumpSource is not null ? $"{RuntimeVersion}/{R2RMode}, target: {DumpSource}" : $"{RuntimeVersion}/{R2RMode}";
+        DumpSource is not null ? $"{RuntimeVersion}/{R2RMode} ({DumpSource})" : $"{RuntimeVersion}/{R2RMode}";
 
     public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(RuntimeVersion), RuntimeVersion);
         info.AddValue(nameof(R2RMode), R2RMode);
-        info.AddValue(nameof(DumpSource), DumpSource);
+        info.AddValue(nameof(DumpSource), DumpSource, typeof(string));
     }
 
     public void Deserialize(IXunitSerializationInfo info)

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-xplat-test-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-xplat-test-helix.proj
@@ -97,7 +97,7 @@
     <WriteLinesToFile File="$(_HelixCommandFile)" Lines="@(_HelixCommandLines)" Overwrite="true" />
 
     <ItemGroup>
-      <HelixWorkItem Include="CdacXPlatDumpTests_%(_SourcePlatform.Identity)">
+      <HelixWorkItem Include="CdacXPlatDumpTests_host_$(TargetOS)_$(TargetArchitecture)_dumps_%(_SourcePlatform.Identity)">
         <PayloadDirectory>$(DumpTestsPayload)</PayloadDirectory>
         <Command>$([System.IO.File]::ReadAllText('$(_HelixCommandFile)'))</Command>
         <Timeout>$(WorkItemTimeout)</Timeout>

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-xplat-test-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-xplat-test-helix.proj
@@ -18,6 +18,7 @@
       TestHostPayload    — Path to testhost shared framework directory
       DumpTestsPayload   — Path to payload directory (tests/ + dumps/)
       TargetOS           — Target OS (windows, linux, osx)
+      TargetArchitecture — Target architecture (x64, x86, arm64, arm)
       SourcePlatforms    — Semicolon-separated source platform names
                            (e.g. "windows_x64;linux_x64;osx_arm64")
   -->


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with the help of Copilot.

## Summary

Improve xplat cDAC dump test naming so that both the host platform and dump source platform are visible in test results.

### Helix work item names

**Before:** `CdacXPlatDumpTests_windows_x64`

**After:** `CdacXPlatDumpTests_host_linux_arm_dumps_windows_x64`

### Individual xunit test display names

**Before:** `GetModule_Succeeds(config: local/r2r)`

**After:** `GetModule_Succeeds(config: local/r2r, target: windows/x64)`

The dump source platform is read from `dump-info.json` (which records the OS and architecture where dumps were generated). For local runs where `CDAC_DUMP_ROOT` is not set, the display is unchanged.