### PR TITLE
Fix x86 async frame generic type resolution in DBI

### DIFF
--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -11525,8 +11525,14 @@ void CordbAsyncFrame::LoadGenericArgs()
         {
             if (m_asyncVars[i].ilVarNum == genericArgIndex)
             {
-
-                HRESULT hr = GetProcess()->SafeReadStruct(m_continuationAddress + m_asyncVars[i].offset, &genericTypeParam);
+                // Read a target-pointer-sized value. CORDB_ADDRESS is always 8 bytes (ULONG64),
+                // but on x86 targets the generic arg field is only a 4-byte pointer. Using
+                // SIZE_T (which matches the target pointer size) avoids reading adjacent memory.
+                // This mirrors how CordbJITILFrame::LoadGenericArgs reads the token via
+                // GetRegisterOrStackValue (which returns SIZE_T).
+                SIZE_T rawToken = 0;
+                HRESULT hr = GetProcess()->SafeReadStruct(m_continuationAddress + m_asyncVars[i].offset, &rawToken);
+                genericTypeParam = (CORDB_ADDRESS)rawToken;
                 IfFailThrow(hr);
                 break;
             }

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -11527,9 +11527,9 @@ void CordbAsyncFrame::LoadGenericArgs()
             {
                 // Read a target-pointer-sized value. CORDB_ADDRESS is always 8 bytes (ULONG64),
                 // but on x86 targets the generic arg field is only a 4-byte pointer. Using
-                // SIZE_T (which matches the target pointer size) avoids reading adjacent memory.
-                // This mirrors how CordbJITILFrame::LoadGenericArgs reads the token via
-                // GetRegisterOrStackValue (which returns SIZE_T).
+                // SIZE_T (which is pointer-sized for the DBI build, matching the target here)
+                // avoids reading adjacent memory. This mirrors how CordbJITILFrame::Init()
+                // reads the raw token via GetRegisterOrStackValue (which returns SIZE_T).
                 SIZE_T rawToken = 0;
                 HRESULT hr = GetProcess()->SafeReadStruct(m_continuationAddress + m_asyncVars[i].offset, &rawToken);
                 genericTypeParam = (CORDB_ADDRESS)rawToken;


### PR DESCRIPTION
CordbAsyncFrame::LoadGenericArgs was using SafeReadStruct<CORDB_ADDRESS> to read the generic arg token from the continuation object. CORDB_ADDRESS is ULONG64 (always 8 bytes), but on x86 targets the field is a 4-byte pointer. Reading 8 bytes pulled in adjacent memory, producing garbage pointer values that caused EnumerateTypeParameters to return E_INVALIDARG.

Changed to SafeReadStruct<SIZE_T> which matches the target pointer size (4 bytes on x86, 8 bytes on x64), consistent with how CordbJITILFrame::LoadGenericArgs reads tokens via GetRegisterOrStackValue.