### PR TITLE
Improve constant foldings in optAssertionPropGlobal_RelOp

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4267,7 +4267,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             // Retry by obtaining operand ranges individually. This accounts for cases where the
             // relopVN's operands differ from the physical op1 and op2 due to optimization passes.
             VNFuncApp relopFuncApp;
-            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) && 
+            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) &&
                 ((relopFuncApp.m_args[0] != op1VN) || (relopFuncApp.m_args[1] != op2VN)))
             {
                 Range op1Range = RangeCheck::GetRangeFromAssertions(this, op1VN, assertions);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4205,10 +4205,10 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
 
     // Check if we have an assertion that exactly matches the relop.
     ValueNum relopVN = optConservativeNormalVN(tree);
+    ValueNum op1VN   = optConservativeNormalVN(op1);
+    ValueNum op2VN   = optConservativeNormalVN(op2);
     if (!BitVecOps::IsEmpty(apTraits, assertions))
     {
-        ValueNum op1VN   = optConservativeNormalVN(op1);
-        ValueNum op2VN   = optConservativeNormalVN(op2);
         ValueNum falseVN = vnStore->VNZeroForType(TYP_INT);
 
         BitVecOps::Iter iter(apTraits, assertions);
@@ -4266,14 +4266,12 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         {
             // Retry by obtaining operand ranges individually. This accounts for cases where the
             // relopVN's operands differ from the physical op1 and op2 due to optimization passes.
-            ValueNum  actualOp1VN = optConservativeNormalVN(op1);
-            ValueNum  actualOp2VN = optConservativeNormalVN(op2);
             VNFuncApp relopFuncApp;
             if (vnStore->GetVNFunc(relopVN, &relopFuncApp) && 
-                ((relopFuncApp.m_args[0] != actualOp1VN) || (relopFuncApp.m_args[1] != actualOp2VN)))
+                ((relopFuncApp.m_args[0] != op1VN) || (relopFuncApp.m_args[1] != op2VN)))
             {
-                Range op1Range = RangeCheck::GetRangeFromAssertions(this, actualOp1VN, assertions);
-                Range op2Range = RangeCheck::GetRangeFromAssertions(this, optConservativeNormalVN(op2), assertions);
+                Range op1Range = RangeCheck::GetRangeFromAssertions(this, op1VN, assertions);
+                Range op2Range = RangeCheck::GetRangeFromAssertions(this, op2VN, assertions);
                 relopRange     = RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), op1Range, op2Range);
             }
         }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4264,11 +4264,13 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         int relopResult;
         if (!relopRange.IsSingleValueConstant(&relopResult))
         {
-            // Retry by obtaining operand ranges individually. This accounts for cases where the 
+            // Retry by obtaining operand ranges individually. This accounts for cases where the
             // relopVN's operands differ from the physical op1 and op2 due to optimization passes.
             ValueNum  actualOp1VN = optConservativeNormalVN(op1);
+            ValueNum  actualOp2VN = optConservativeNormalVN(op2);
             VNFuncApp relopFuncApp;
-            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) && (relopFuncApp.m_args[0] != actualOp1VN))
+            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) && 
+                ((relopFuncApp.m_args[0] != actualOp1VN) || (relopFuncApp.m_args[1] != actualOp2VN)))
             {
                 Range op1Range = RangeCheck::GetRangeFromAssertions(this, actualOp1VN, assertions);
                 Range op2Range = RangeCheck::GetRangeFromAssertions(this, optConservativeNormalVN(op2), assertions);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4267,8 +4267,13 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             // Retry by obtaining operand ranges individually. This accounts for cases where the
             // relopVN's operands differ from the physical op1 and op2 due to optimization passes.
             VNFuncApp relopFuncApp;
-            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) &&
-                ((relopFuncApp.m_args[0] != op1VN) || (relopFuncApp.m_args[1] != op2VN)))
+            if (vnStore->IsVNRelop(relopVN, &relopFuncApp) &&
+                (((relopFuncApp.m_args[0] == op1VN) && (relopFuncApp.m_args[1] == op2VN)) ||
+                 ((relopFuncApp.m_args[0] == op2VN) && (relopFuncApp.m_args[1] == op1VN))))
+            {
+                // VNs match - we'll find nothing new by looking at individual operand ranges.
+            }
+            else
             {
                 Range op1Range = RangeCheck::GetRangeFromAssertions(this, op1VN, assertions);
                 Range op2Range = RangeCheck::GetRangeFromAssertions(this, op2VN, assertions);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4262,6 +4262,20 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         Range relopRange = RangeCheck::GetRangeFromAssertions(this, relopVN, assertions);
 
         int relopResult;
+        if (!relopRange.IsSingleValueConstant(&relopResult))
+        {
+            // Retry by obtaining operand ranges individually. This accounts for cases where the 
+            // relopVN's operands differ from the physical op1 and op2 due to optimization passes.
+            ValueNum  actualOp1VN = optConservativeNormalVN(op1);
+            VNFuncApp relopFuncApp;
+            if (vnStore->GetVNFunc(relopVN, &relopFuncApp) && (relopFuncApp.m_args[0] != actualOp1VN))
+            {
+                Range op1Range = RangeCheck::GetRangeFromAssertions(this, actualOp1VN, assertions);
+                Range op2Range = RangeCheck::GetRangeFromAssertions(this, optConservativeNormalVN(op2), assertions);
+                relopRange     = RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), op1Range, op2Range);
+            }
+        }
+
         if (relopRange.IsSingleValueConstant(&relopResult))
         {
             assert((relopResult == 0) || (relopResult == 1));

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -685,7 +685,8 @@ struct RangeOps
         const Limit& yUpper = y.UpperLimit();
 
         // For unsigned comparisons, we only support non-negative ranges.
-        if (isUnsigned)
+        // NOTE: it's not applicable for EQ and NE.
+        if (isUnsigned && (relop != GT_EQ) && (relop != GT_NE))
         {
             if (!xLower.IsConstant() || !yLower.IsConstant() || (xLower.GetConstant() < 0) ||
                 (yLower.GetConstant() < 0))

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7016,7 +7016,7 @@ const char* ValueNumStore::VNRelationString(VN_RELATION_KIND vrk)
 }
 #endif
 
-bool ValueNumStore::IsVNRelop(ValueNum vn)
+bool ValueNumStore::IsVNRelop(ValueNum vn, VNFuncApp* pFuncApp)
 {
     VNFuncApp funcAttr;
     if (!GetVNFunc(vn, &funcAttr))
@@ -7039,6 +7039,10 @@ bool ValueNumStore::IsVNRelop(ValueNum vn)
             case VNF_LE_UN:
             case VNF_GE_UN:
             case VNF_GT_UN:
+                if (pFuncApp != nullptr)
+                {
+                    *pFuncApp = funcAttr;
+                }
                 return true;
             default:
                 return false;
@@ -7046,8 +7050,15 @@ bool ValueNumStore::IsVNRelop(ValueNum vn)
     }
     else
     {
-        const genTreeOps op = (genTreeOps)func;
-        return GenTree::OperIsCompare(op);
+        if (GenTree::OperIsCompare(static_cast<genTreeOps>(func)))
+        {
+            if (pFuncApp != nullptr)
+            {
+                *pFuncApp = funcAttr;
+            }
+            return true;
+        }
+        return false;
     }
 }
 

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1133,7 +1133,7 @@ public:
     bool IsVNTypeHandle(ValueNum vn);
 
     // Returns true iff the VN represents a relop
-    bool IsVNRelop(ValueNum vn);
+    bool IsVNRelop(ValueNum vn, VNFuncApp* pFuncApp = nullptr);
 
     enum class VN_RELATION_KIND
     {


### PR DESCRIPTION
Simpler fix for https://github.com/dotnet/runtime/pull/126907/changes#r3082680126

[diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1380092&view=ms.vss-build-web.run-extensions-tab)