### PR TITLE
Clear blob returned by `BlobBuilder.ReserveBytes`.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -589,6 +589,7 @@ namespace System.Reflection.Metadata
             }
 
             int start = ReserveBytesImpl(byteCount);
+            Array.Clear(_buffer, start, byteCount);
             return new Blob(_buffer, start, byteCount);
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
@@ -275,9 +275,8 @@ namespace System.Reflection.PortableExecutable
             builder.WriteUInt32((uint)BitArithmetic.Align(Header.ComputeSizeOfPEHeaders(sections.Length), Header.FileAlignment));
 
             // Checksum:
-            // Shall be zero for strong name signing.
+            // Shall be zero for strong name signing, already zeroed by ReserveBytes.
             _lazyChecksum = builder.ReserveBytes(sizeof(uint));
-            new BlobWriter(_lazyChecksum).WriteUInt32(0);
 
             builder.WriteUInt16((ushort)Header.Subsystem);
             builder.WriteUInt16((ushort)Header.DllCharacteristics);

--- a/src/libraries/System.Reflection.Metadata/tests/Metadata/BlobTests.cs
+++ b/src/libraries/System.Reflection.Metadata/tests/Metadata/BlobTests.cs
@@ -645,6 +645,17 @@ namespace System.Reflection.Metadata.Tests
             }, blobs[0].GetBytes().ToArray());
         }
 
+        [Fact]
+        public void ReserveBytes3()
+        {
+            var builder = new BlobBuilder(16);
+            builder.WriteBytes(0xff, 16);
+            builder.Clear();
+            // Reserved buffers must be zero-initialized.
+            var reserved = builder.ReserveBytes(4);
+            AssertEx.Equal(Enumerable.Repeat((byte)0, 4).ToArray(), reserved.GetBytes().ToArray());
+        }
+
         // TODO:
         // WriteBytes(byte*)
         // WriteBytes(stream)


### PR DESCRIPTION
Fixes #99244