### PR TITLE
Add `MetadataLoadContext.GetLoadContext(Assembly)`.

### DIFF
--- a/src/libraries/System.Reflection.MetadataLoadContext/ref/System.Reflection.MetadataLoadContext.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/ref/System.Reflection.MetadataLoadContext.cs
@@ -17,6 +17,7 @@ namespace System.Reflection
         public System.Reflection.Assembly? CoreAssembly { get { throw null; } }
         public void Dispose() { }
         public System.Collections.Generic.IEnumerable<System.Reflection.Assembly> GetAssemblies() { throw null; }
+        public static System.Reflection.MetadataLoadContext? GetLoadContext(System.Reflection.Assembly assembly) { throw null; }
         public System.Reflection.Assembly LoadFromAssemblyName(System.Reflection.AssemblyName assemblyName) { throw null; }
         public System.Reflection.Assembly LoadFromAssemblyName(string assemblyName) { throw null; }
         public System.Reflection.Assembly LoadFromAssemblyPath(string assemblyPath) { throw null; }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.Apis.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.Apis.cs
@@ -263,6 +263,17 @@ namespace System.Reflection
         }
 
         /// <summary>
+        /// Returns the <see cref="MetadataLoadContext"/> that an <see cref="Assembly"/> was loaded into,
+        /// or <see langword="null"/> if the assembly was not loaded by a <see cref="MetadataLoadContext"/>.
+        /// </summary>
+        /// <param name="assembly">The assembly object to examine.</param>
+        public static MetadataLoadContext? GetLoadContext(Assembly assembly)
+        {
+            ArgumentNullException.ThrowIfNull(assembly);
+            return (assembly as RoAssembly)?.Loader;
+        }
+
+        /// <summary>
         /// Releases any native resources (such as file locks on assembly files.) After disposal, it is not safe to use
         /// any Assembly objects dispensed by the MetadataLoadContext, nor any Reflection objects dispensed by those Assembly objects.
         /// Though objects provided by the MetadataLoadContext strive to throw an ObjectDisposedException, this is not guaranteed.

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Assembly/AssemblyTests.cs
@@ -59,6 +59,21 @@ namespace System.Reflection.Tests
         }
 
         [Fact]
+        public static void AssemblyGetLoadContext()
+        {
+            using (MetadataLoadContext lc = new MetadataLoadContext(new EmptyCoreMetadataAssemblyResolver()))
+            {
+                Assembly a = lc.LoadFromByteArray(TestData.s_SimpleAssemblyImage);
+                MetadataLoadContext? loadContext = MetadataLoadContext.GetLoadContext(a);
+                Assert.Same(lc, loadContext);
+            }
+
+            Assembly coreLib = typeof(object).Assembly;
+            MetadataLoadContext? coreLibLoadContext = MetadataLoadContext.GetLoadContext(coreLib);
+            Assert.Null(coreLibLoadContext);
+        }
+
+        [Fact]
         public static void AssemblyGlobalAssemblyCache()
         {
             using (MetadataLoadContext lc = new MetadataLoadContext(new EmptyCoreMetadataAssemblyResolver()))


### PR DESCRIPTION
Fixes #98756