### PR TITLE
[interp] Fix doubled interpreter frames in DAC/DBI stack walks

### DIFF
--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2106,6 +2106,9 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
         SetIP(pContext, (TADDR)pFrame->ip);
         SetSP(pContext, dac_cast<TADDR>(pFrame));
         SetFP(pContext, (TADDR)pFrame->pStack);
+
+        // Interpreter ip points past the call instruction (like a return address).
+        pContext->ContextFlags = CONTEXT_FULL | CONTEXT_UNWOUND_TO_CALL;
     }
     else
     {
@@ -2118,8 +2121,8 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
         SetIP(pContext, InterpreterFrame::DummyCallerIP);
         TADDR interpreterFrameAddress = GetFirstArgReg(pContext);
         SetSP(pContext, interpreterFrameAddress);
+        pContext->ContextFlags = CONTEXT_FULL;
     }
-    pContext->ContextFlags = CONTEXT_FULL;
 }
 
 bool InterpreterCodeManager::UnwindStackFrame(PREGDISPLAY     pRD,

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2106,9 +2106,6 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
         SetIP(pContext, (TADDR)pFrame->ip);
         SetSP(pContext, dac_cast<TADDR>(pFrame));
         SetFP(pContext, (TADDR)pFrame->pStack);
-
-        // Interpreter ip points past the call instruction (like a return address).
-        pContext->ContextFlags = CONTEXT_FULL | CONTEXT_UNWOUND_TO_CALL;
     }
     else
     {
@@ -2121,8 +2118,8 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
         SetIP(pContext, InterpreterFrame::DummyCallerIP);
         TADDR interpreterFrameAddress = GetFirstArgReg(pContext);
         SetSP(pContext, interpreterFrameAddress);
-        pContext->ContextFlags = CONTEXT_FULL;
     }
+    pContext->ContextFlags = CONTEXT_FULL;
 }
 
 bool InterpreterCodeManager::UnwindStackFrame(PREGDISPLAY     pRD,

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2161,13 +2161,6 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(GetSP(m_crawl.pRD->pCurrentContext));
             pInterpreterFrame->UpdateRegDisplay(m_crawl.pRD, m_flags & UNWIND_FLOATS);
             LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Transitioning from last interpreted frame under InterpreterFrame %p to native frame (IP=%p, SP=%p)\n", pInterpreterFrame, GetControlPC(m_crawl.pRD), GetRegdisplaySP(m_crawl.pRD)));
-
-            // Advance past the InterpreterFrame to prevent re-entering the interpreter chain.
-            while (m_crawl.pFrame != FRAME_TOP &&
-                   dac_cast<TADDR>(m_crawl.pFrame) <= dac_cast<TADDR>(pInterpreterFrame))
-            {
-                m_crawl.GotoNextFrame();
-            }
         }
 #endif // FEATURE_INTERPRETER
 
@@ -2430,6 +2423,19 @@ void StackFrameIterator::ProcessCurrentFrame(void)
         {
             m_frameState = SFITER_INITIAL_NATIVE_CONTEXT;
             fDone = true;
+        }
+        else
+        {
+#ifdef FEATURE_INTERPRETER
+            if (m_crawl.pFrame != FRAME_TOP && m_crawl.pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                // When stack walk starts on an explicit context in interpreted code, we need to skip the related interpreter
+                // frame, because the stack frame iterator assumes that when it is walking interpreted frames, it has
+                // already processed the interpreter frame. Without this skip, the stack walk would end up walking the
+                // interpreted frames twice.
+                m_crawl.GotoNextFrame();
+            }
+#endif // FEATURE_INTERPRETER
         }
     }
     else

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2161,6 +2161,13 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(GetSP(m_crawl.pRD->pCurrentContext));
             pInterpreterFrame->UpdateRegDisplay(m_crawl.pRD, m_flags & UNWIND_FLOATS);
             LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Transitioning from last interpreted frame under InterpreterFrame %p to native frame (IP=%p, SP=%p)\n", pInterpreterFrame, GetControlPC(m_crawl.pRD), GetRegdisplaySP(m_crawl.pRD)));
+
+            // Advance past the InterpreterFrame to prevent re-entering the interpreter chain.
+            while (m_crawl.pFrame != FRAME_TOP &&
+                   dac_cast<TADDR>(m_crawl.pFrame) <= dac_cast<TADDR>(pInterpreterFrame))
+            {
+                m_crawl.GotoNextFrame();
+            }
         }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -70,7 +70,7 @@ PTR_VOID ConvertStackMarkToPointerOnOSStack(PTR_Thread pThread, PTR_VOID stackMa
                     }
                     pCurrent = pCurrent->pParent;
                 } while (pCurrent != NULL);
-                
+
             }
 
             pFrame = pFrame->PtrNextFrame();
@@ -1087,6 +1087,9 @@ BOOL StackFrameIterator::Init(Thread *    pThread,
 
     // process the REGDISPLAY and stop at the first frame
     ProcessIp(GetControlPC(m_crawl.pRD));
+#ifdef FEATURE_INTERPRETER
+    _ASSERTE(!m_crawl.codeInfo.IsInterpretedCode());
+#endif // FEATURE_INTERPRETER
     if (m_crawl.isFrameless && !!(m_crawl.pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE))
     {
         m_crawl.hasFaulted = true;
@@ -1160,6 +1163,45 @@ BOOL StackFrameIterator::ResetRegDisp(PREGDISPLAY pRegDisp,
     PCODE curPc = GetControlPC(pRegDisp);
     ProcessIp(curPc);
 
+#ifdef FEATURE_INTERPRETER
+    if (m_crawl.codeInfo.IsInterpretedCode())
+    {
+        // SP points at an InterpMethodContextFrame on the interpreter stack.
+        // Locate the owning InterpreterFrame and advance past it so the iterator
+        // does not re-enter the same chain via the explicit frame link.
+        TADDR interpSP = GetRegdisplaySP(m_crawl.pRD);
+        PTR_Frame pSearch = m_crawl.pFrame;
+        PTR_Frame pOwningInterpFrame = (PTR_Frame)FRAME_TOP;
+        while (pSearch != FRAME_TOP)
+        {
+            if (pSearch->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                PTR_InterpreterFrame pInterpFrame = dac_cast<PTR_InterpreterFrame>(pSearch);
+                for (PTR_InterpMethodContextFrame pCur = pInterpFrame->GetTopInterpMethodContextFrame();
+                     pCur != NULL;
+                     pCur = pCur->pParent)
+                {
+                    if (dac_cast<TADDR>(pCur) == interpSP)
+                    {
+                        pOwningInterpFrame = pSearch;
+                        break;
+                    }
+                }
+                if (pOwningInterpFrame != FRAME_TOP)
+                {
+                    break;
+                }
+            }
+            pSearch = pSearch->PtrNextFrame();
+        }
+        _ASSERTE(pOwningInterpFrame != FRAME_TOP);
+        if (pOwningInterpFrame != FRAME_TOP)
+        {
+            m_crawl.pFrame = pOwningInterpFrame->PtrNextFrame();
+        }
+    }
+    else
+#endif // FEATURE_INTERPRETER
     // loop the frame chain to find the closet explicit frame which is lower than the specified REGDISPLAY
     // (stack grows up towards lower address)
     if (m_crawl.pFrame != FRAME_TOP)
@@ -2423,19 +2465,6 @@ void StackFrameIterator::ProcessCurrentFrame(void)
         {
             m_frameState = SFITER_INITIAL_NATIVE_CONTEXT;
             fDone = true;
-        }
-        else
-        {
-#ifdef FEATURE_INTERPRETER
-            if (m_crawl.pFrame != FRAME_TOP && m_crawl.pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
-            {
-                // When stack walk starts on an explicit context in interpreted code, we need to skip the related interpreter
-                // frame, because the stack frame iterator assumes that when it is walking interpreted frames, it has
-                // already processed the interpreter frame. Without this skip, the stack walk would end up walking the
-                // interpreted frames twice.
-                m_crawl.GotoNextFrame();
-            }
-#endif // FEATURE_INTERPRETER
         }
     }
     else

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -1166,39 +1166,15 @@ BOOL StackFrameIterator::ResetRegDisp(PREGDISPLAY pRegDisp,
 #ifdef FEATURE_INTERPRETER
     if (m_crawl.codeInfo.IsInterpretedCode())
     {
-        // SP points at an InterpMethodContextFrame on the interpreter stack.
-        // Locate the owning InterpreterFrame and advance past it so the iterator
-        // does not re-enter the same chain via the explicit frame link.
-        TADDR interpSP = GetRegdisplaySP(m_crawl.pRD);
-        PTR_Frame pSearch = m_crawl.pFrame;
-        PTR_Frame pOwningInterpFrame = (PTR_Frame)FRAME_TOP;
-        while (pSearch != FRAME_TOP)
-        {
-            if (pSearch->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
-            {
-                PTR_InterpreterFrame pInterpFrame = dac_cast<PTR_InterpreterFrame>(pSearch);
-                for (PTR_InterpMethodContextFrame pCur = pInterpFrame->GetTopInterpMethodContextFrame();
-                     pCur != NULL;
-                     pCur = pCur->pParent)
-                {
-                    if (dac_cast<TADDR>(pCur) == interpSP)
-                    {
-                        pOwningInterpFrame = pSearch;
-                        break;
-                    }
-                }
-                if (pOwningInterpFrame != FRAME_TOP)
-                {
-                    break;
-                }
-            }
-            pSearch = pSearch->PtrNextFrame();
-        }
-        _ASSERTE(pOwningInterpFrame != FRAME_TOP);
-        if (pOwningInterpFrame != FRAME_TOP)
-        {
-            m_crawl.pFrame = pOwningInterpFrame->PtrNextFrame();
-        }
+        // The CONTEXT carries the owning InterpreterFrame in the first-arg register
+        // (set by InterpreterFrame::SetContextToInterpMethodContextFrame). Advance
+        // m_crawl.pFrame past it so the iterator does not re-enter the same
+        // InterpMethodContextFrame chain via the explicit frame link.
+        PTR_InterpreterFrame pOwningInterpFrame =
+            dac_cast<PTR_InterpreterFrame>((TADDR)GetFirstArgReg(m_crawl.pRD->pCurrentContext));
+        _ASSERTE(pOwningInterpFrame != NULL);
+        _ASSERTE(pOwningInterpFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame);
+        m_crawl.pFrame = pOwningInterpFrame->PtrNextFrame();
     }
     else
 #endif // FEATURE_INTERPRETER


### PR DESCRIPTION
## Description

When DAC/DBI seeds StackFrameIterator from a CONTEXT pointing into interpreted code, m_crawl.pFrame is initialized to the thread's top explicit Frame, which is the InterpreterFrame that owns the executing InterpMethodContextFrame chain.

ResetRegDisp reads the owning InterpreterFrame* from the CONTEXT's first-arg register and advances m_crawl.pFrame past it before ProcessCurrentFrame runs.

## Tests

Fixes the following interpreter debugger test failures:
- `StackWalking.NestedException`
- `StackWalking.ChildParentTest`
