### PR TITLE
Wasm import thunk corrections

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -868,7 +868,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         break;
 
                     case TargetArchitecture.Wasm32:
-                        _wasmOfsStack = numRegistersUsed * _transitionBlock.PointerSize;
+                        _wasmOfsStack = numRegistersUsed * 8;
                         break;
 
                     case TargetArchitecture.ARM:
@@ -1107,8 +1107,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                             break;
                         case WasmValueType.I32:
                         case WasmValueType.F32:
-                            cbArg = 4;
-                            align = 4;
+                            cbArg = 8;
+                            align = 8;
                             break;
                         case WasmValueType.V128:
                             cbArg = 16;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -687,15 +687,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // VaSig cookie is after this and retbuf arguments by default.
                 int ret = _transitionBlock.OffsetOfArgumentRegisters;
+                int slotSize = _transitionBlock.StackElemSize(_transitionBlock.PointerSize);
 
                 if (HasThis)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 if (HasRetBuffArg() && _transitionBlock.IsRetBuffPassedAsFirstArg)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 return ret;
@@ -729,15 +730,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // The hidden arg is after this and retbuf arguments by default.
                 int ret = _transitionBlock.OffsetOfArgumentRegisters;
+                int slotSize = _transitionBlock.StackElemSize(_transitionBlock.PointerSize);
 
                 if (HasThis)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 if (HasRetBuffArg() && _transitionBlock.IsRetBuffPassedAsFirstArg)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 return ret;
@@ -778,20 +780,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // The hidden arg is after this, retbuf and param type arguments by default.
                 int ret = _transitionBlock.OffsetOfArgumentRegisters;
+                int slotSize = _transitionBlock.StackElemSize(_transitionBlock.PointerSize);
 
                 if (HasThis)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 if (HasRetBuffArg() && _transitionBlock.IsRetBuffPassedAsFirstArg)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 if (HasParamType)
                 {
-                    ret += _transitionBlock.PointerSize;
+                    ret += slotSize;
                 }
 
                 return ret;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -871,7 +871,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         break;
 
                     case TargetArchitecture.Wasm32:
-                        _wasmOfsStack = numRegistersUsed * 8;
+                        _wasmOfsStack = numRegistersUsed * _transitionBlock.StackElemSize(_transitionBlock.PointerSize);
                         break;
 
                     case TargetArchitecture.ARM:
@@ -1707,7 +1707,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                         stackElemSize = _transitionBlock.StackElemSize(GetArgSize(), IsValueType(), IsFloatHfa());
 
                         if (IsArgPassedByRef())
-                            stackElemSize = _transitionBlock.PointerSize;
+                            stackElemSize = _transitionBlock.StackElemSize(_transitionBlock.PointerSize);
                     }
 
                     int endOfs = ofs + stackElemSize;
@@ -1739,8 +1739,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
-            // arg stack size is rounded to the pointer size on all platforms.
-            nSizeOfArgStack = ALIGN_UP(nSizeOfArgStack, _transitionBlock.PointerSize);
+            // arg stack size is rounded to the stack slot size on all platforms.
+            nSizeOfArgStack = ALIGN_UP(nSizeOfArgStack, _transitionBlock.StackElemSize(_transitionBlock.PointerSize));
 
             // Cache the result
             _nSizeOfArgStack = nSizeOfArgStack;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/GCRefMapBuilder.cs
@@ -66,16 +66,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             _transitionBlock = TransitionBlock.FromTarget(target);
         }
 
-        public void GetCallRefMap(MethodDesc method, bool isUnboxingStub)
+        internal static (ArgIterator, TransitionBlock) BuildArgIterator(MethodSignature signature, TypeSystemContext context, bool methodRequiresInstArg = false, bool isUnboxingStub = false, bool methodIsArrayAddressMethod = false, bool methodIsStringConstructor = false, bool methodIsAsyncCall = false)
         {
-            TransitionBlock transitionBlock = TransitionBlock.FromTarget(method.Context.Target);
-
-            MethodSignature signature = method.Signature;
+            TransitionBlock transitionBlock = TransitionBlock.FromTarget(context.Target);
 
             bool hasThis = (signature.Flags & MethodSignatureFlags.Static) == 0;
 
             // This pointer is omitted for string constructors
-            bool fCtorOfVariableSizedObject = hasThis && method.OwningType.IsString && method.IsConstructor;
+            bool fCtorOfVariableSizedObject = hasThis && methodIsStringConstructor;
             if (fCtorOfVariableSizedObject)
                 hasThis = false;
 
@@ -87,16 +85,16 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 parameterTypes[parameterIndex] = new TypeHandle(signature[parameterIndex]);
             }
             CallingConventions callingConventions = (hasThis ? CallingConventions.ManagedInstance : CallingConventions.ManagedStatic);
-            bool hasParamType = method.RequiresInstArg() && !isUnboxingStub;
+            bool hasParamType = methodRequiresInstArg && !isUnboxingStub;
 
             // On X86 the Array address method doesn't use IL stubs, and instead has a custom calling convention
-            if ((method.Context.Target.Architecture == TargetArchitecture.X86) &&
-                method.IsArrayAddressMethod())
+            if ((context.Target.Architecture == TargetArchitecture.X86) &&
+                methodIsArrayAddressMethod)
             {
                 hasParamType = true;
             }
 
-            bool hasAsyncContinuation = method.IsAsyncCall();
+            bool hasAsyncContinuation = methodIsAsyncCall;
             // We shouldn't be compiling unboxing stubs for async methods yet.
             Debug.Assert(hasAsyncContinuation ? !isUnboxingStub : true);
 
@@ -107,7 +105,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             ArgIteratorData argIteratorData = new ArgIteratorData(hasThis, isVarArg, parameterTypes, returnType);
 
             ArgIterator argit = new ArgIterator(
-                method.Context,
+                context,
                 argIteratorData,
                 callingConventions,
                 hasParamType,
@@ -116,6 +114,18 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 forcedByRefParams,
                 skipFirstArg,
                 extraObjectFirstArg);
+
+            return (argit, transitionBlock);
+        }
+
+        public void GetCallRefMap(MethodDesc method, bool isUnboxingStub)
+        {
+            (ArgIterator argit, TransitionBlock transitionBlock) = BuildArgIterator(method.Signature, method.Context, 
+                methodRequiresInstArg: method.RequiresInstArg(),
+                isUnboxingStub: isUnboxingStub,
+                methodIsArrayAddressMethod: method.IsArrayAddressMethod(),
+                methodIsStringConstructor: method.OwningType.IsString && method.IsConstructor,
+                methodIsAsyncCall: method.IsAsyncCall());
 
             int nStackBytes = argit.SizeOfFrameArgumentArray();
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -760,9 +760,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public override int NumCalleeSavedRegisters => 0;
 
-            public override int SizeOfTransitionBlock => 0;
+            public override int SizeOfTransitionBlock => 8;
 
-            public override int OffsetOfArgumentRegisters => 0;
+            public override int OffsetOfArgumentRegisters => 8;
 
             public override int OffsetOfFloatArgumentRegisters => 0;
 
@@ -770,7 +770,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public override int EnregisteredReturnTypeIntegerMaxSize => 0;
 
-            public override int GetRetBuffArgOffset(bool hasThis) => hasThis ? 4 : 0;
+            public override int GetRetBuffArgOffset(bool hasThis) => hasThis ? 8 : 0;
 
             public override bool IsArgPassedByRef(TypeHandle th)
             {
@@ -779,7 +779,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public override int StackElemSize(int parmSize, bool isValueType, bool isFloatHfa)
             {
-                int stackSlotSize = 4;
+                int stackSlotSize = 8;
                 return ALIGN_UP(parmSize, stackSlotSize);
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TransitionBlock.cs
@@ -770,7 +770,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             public override int EnregisteredReturnTypeIntegerMaxSize => 0;
 
-            public override int GetRetBuffArgOffset(bool hasThis) => hasThis ? 8 : 0;
+            public override int GetRetBuffArgOffset(bool hasThis) => OffsetOfArgumentRegisters + (hasThis ? StackElemSize(PointerSize, false, false) : 0);
 
             public override bool IsArgPassedByRef(TypeHandle th)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -156,6 +156,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             expressions.Add(Local.Set(0));
 
             // Initialize m_ReturnAddress to 0 at offset 0 of the transition block
+            // The 0 is a marker that the actual return address is to be computed from the m_StackPointer at offset 4.
             expressions.Add(Local.Get(0));
             expressions.Add(I32.Const(0));
             expressions.Add(I32.Store(0));
@@ -221,7 +222,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Load the helper function address and dispatch
             // global.get {module base}
             expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // Module base used to load the helper function address
-            expressions.Add(I32.LoadWithRVAOffset(_helperCell)); // Load the helper call function pointer from the helper cell, using a load with an RVA offset so that the helper cell can be left as a zero in the R2R image and fixed up at runtime without needing a relocation
+            expressions.Add(I32.LoadWithRVAOffset(_helperCell)); // Load the helper call function pointer from the helper cell, using a load with an RVA offset so that the helper cell can be left as a zero in the R2R image and fixed up at runtime. This avoids the need to emit a runtime relocation for the helper cell.
             // call_indirect (i32, i32, i32, i32) -> (i32)
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -11,7 +11,6 @@ using Internal.ReadyToRunConstants;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Reflection.Metadata;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -153,7 +152,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             expressions.Add(I32.Const(sizeOfStoredLocals));
             // i32.sub
             expressions.Add(I32.Sub);
-            // local.tee 0
+            // local.set 0
             expressions.Add(Local.Set(0));
 
             //

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -139,7 +139,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             argit.Reset();
 
             // The arguments are $sp, ARG0-ARGN, PortableEntrypointThunk.
-            // The general logic is...
             // Compute stack offset needed.
 
             // Align total allocation (args + transition block) to 16 byte boundaries
@@ -226,7 +225,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // call_indirect (i32, i32, i32, i32) -> (i32)
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));
 
-            // local.set (PortableEntrypointThunk)  / At this point we can overwrite with the incoming portable entrypoint local, since the old value it will no longer be used
+            // local.set (PortableEntrypointThunk)  / At this point we can overwrite with the incoming portable entrypoint local, since the old value will no longer be used
             expressions.Add(Local.Set(portableEntrypointLocalIndex));
             //
             // ;Setup sp arg for the final call, with the call address now coming from the portable entrypoint

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -142,8 +142,8 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // The general logic is...
             // Compute stack offset needed.
 
-            // Align stack to 16 byte boundaries
-            int sizeOfStoredLocals = AlignmentHelper.AlignUp(argit.SizeOfFrameArgumentArray(), 16) + transitionBlock.SizeOfTransitionBlock;
+            // Align total allocation (args + transition block) to 16 byte boundaries
+            int sizeOfStoredLocals = AlignmentHelper.AlignUp(argit.SizeOfFrameArgumentArray() + transitionBlock.SizeOfTransitionBlock, 16);
 
             List<WasmExpr> expressions = new List<WasmExpr>();
             // local.get 0
@@ -154,6 +154,18 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             expressions.Add(I32.Sub);
             // local.set 0
             expressions.Add(Local.Set(0));
+
+            // Initialize m_ReturnAddress to 0 at offset 0 of the transition block
+            expressions.Add(Local.Get(0));
+            expressions.Add(I32.Const(0));
+            expressions.Add(I32.Store(0));
+
+            // Store the original caller's frame pointer (SP before allocation) at offset 4
+            expressions.Add(Local.Get(0));
+            expressions.Add(Local.Get(0));
+            expressions.Add(I32.Const(sizeOfStoredLocals));
+            expressions.Add(I32.Add);
+            expressions.Add(I32.Store(4));
 
             //
             // ; Stash all the locals away

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -11,6 +11,7 @@ using Internal.ReadyToRunConstants;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection.Metadata;
 
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
@@ -109,7 +110,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             return comparer.Compare(_helperCell, otherNode._helperCell);
         }
 
-        static CorInfoWasmType[] _helperTypeParams = new CorInfoWasmType[] { CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32 };
+        static CorInfoWasmType[] _helperTypeParams = new CorInfoWasmType[] { CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32, CorInfoWasmType.CORINFO_WASM_TYPE_I32 };
 
         protected override void EmitCode(NodeFactory factory, ref Wasm.WasmEmitter instructionEncoder, bool relocsOnly)
         {
@@ -122,38 +123,28 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             ISymbolNode helperTypeIndex = factory.WasmTypeNode(_helperTypeParams);
 
+            MethodSignature methodSignature = WasmLowering.RaiseSignature(_typeNode.Type, _context);
+            (ArgIterator argit, TransitionBlock transitionBlock) = GCRefMapBuilder.BuildArgIterator(methodSignature, _context);
+
+            int[] offsets = new int[methodSignature.Length];
+            Debug.Assert(offsets.Length == _typeNode.Type.Params.Types.Length - 2);
+
+            int argIndex = 0;
+            int argOffset;
+            while ((argOffset = argit.GetNextOffset()) != TransitionBlock.InvalidOffset)
+            {
+                offsets[argIndex] = argOffset;
+                argIndex++;
+            }
+
+            argit.Reset();
+
             // The arguments are $sp, ARG0-ARGN, PortableEntrypointThunk.
             // The general logic is...
             // Compute stack offset needed.
-            int currentOffset = 0;
-
-            for (int i = 1; i < _typeNode.Type.Params.Types.Length - 1; i++)
-            {
-                WasmValueType type = _typeNode.Type.Params.Types[i];
-                switch (type)
-                {
-                    case WasmValueType.I32:
-                    case WasmValueType.F32:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 4);
-                        currentOffset += 4;
-                        break;
-                    case WasmValueType.I64:
-                    case WasmValueType.F64:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 8);
-                        currentOffset += 8;
-                        break;
-                    case WasmValueType.V128:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 16);
-                        currentOffset += 16;
-                        break;
-
-                    default:
-                        throw new System.Exception("Unexpected wasm type arg");
-                }
-            }
 
             // Align stack to 16 byte boundaries
-            int sizeOfStoredLocals = AlignmentHelper.AlignUp(currentOffset, 16);
+            int sizeOfStoredLocals = AlignmentHelper.AlignUp(argit.SizeOfFrameArgumentArray(), 16) + transitionBlock.SizeOfTransitionBlock;
 
             List<WasmExpr> expressions = new List<WasmExpr>();
             // local.get 0
@@ -178,44 +169,28 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // }
 
             // In the calling convention, the first arg is the sp arg, and the last is the portable entrypoint arg. Each of those are treated specially
-            currentOffset = 0;
             for (int i = 1; i < _typeNode.Type.Params.Types.Length - 1; i++)
             {
                 expressions.Add(Local.Get(0));
                 expressions.Add(Local.Get(i));
                 WasmValueType type = _typeNode.Type.Params.Types[i];
+                int currentOffset = offsets[i - 1];
                 switch (type)
                 {
                     case WasmValueType.I32:
+                        expressions.Add(I32.Store((ulong)currentOffset));
+                        break;
                     case WasmValueType.F32:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 4);
-                        if (type == WasmValueType.I32)
-                        {
-                            expressions.Add(I32.Store((ulong)currentOffset));
-                        }
-                        else
-                        {
-                            expressions.Add(F32.Store((ulong)currentOffset));
-                        }
-                        currentOffset += 4;
+                        expressions.Add(F32.Store((ulong)currentOffset));
                         break;
                     case WasmValueType.I64:
+                        expressions.Add(I64.Store((ulong)currentOffset));
+                        break;
                     case WasmValueType.F64:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 8);
-                        if (type == WasmValueType.I64)
-                        {
-                            expressions.Add(I64.Store((ulong)currentOffset));
-                        }
-                        else
-                        {
-                            expressions.Add(F64.Store((ulong)currentOffset));
-                        }
-                        currentOffset += 8;
+                        expressions.Add(F64.Store((ulong)currentOffset));
                         break;
                     case WasmValueType.V128:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 16);
                         expressions.Add(V128.Store((ulong)currentOffset));
-                        currentOffset += 16;
                         break;
 
                     default:
@@ -231,15 +206,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             expressions.Add(Local.Get(portableEntrypointLocalIndex)); // The address of the portable entrypoint is passed as the second
             expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // The module base address is passed as the third argument
 
+            // Pass the RVA of the Module fixup as the fourth argument
+            // i32.const (RVA of Module fixup)
+            expressions.Add(I32.ConstRVA(factory.ModuleImport));
+
             // Load the helper function address and dispatch
             // global.get {module base}
             expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // Module base used to load the helper function address
-            // i32.const (RVA of R2RHelperID)
-            expressions.Add(I32.ConstRVA(_helperCell));
-            // i32.add
-            expressions.Add(I32.Add);
-            // i32.load 0
-            expressions.Add(I32.Load(0));
+            expressions.Add(I32.LoadWithRVAOffset(_helperCell)); // Load the helper call function pointer from the helper cell, using a load with an RVA offset so that the helper cell can be left as a zero in the R2R image and fixed up at runtime without needing a relocation
             // call_indirect (i32, i32, i32, i32) (returns i32)
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));
 
@@ -262,43 +236,27 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             //   local.set (i+1)
             // }
             // In the calling convention, the first arg is the sp arg, and the last is the portable entrypoint arg. Each of those are treated specially
-            currentOffset = 0;
             for (int i = 1; i < _typeNode.Type.Params.Types.Length - 1; i++)
             {
                 expressions.Add(Local.Get(0));
                 WasmValueType type = _typeNode.Type.Params.Types[i];
+                int currentOffset = offsets[i - 1];
                 switch (type)
                 {
                     case WasmValueType.I32:
+                        expressions.Add(I32.Load((ulong)currentOffset));
+                        break;
                     case WasmValueType.F32:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 4);
-                        if (type == WasmValueType.I32)
-                        {
-                            expressions.Add(I32.Load((ulong)currentOffset));
-                        }
-                        else
-                        {
-                            expressions.Add(F32.Load((ulong)currentOffset));
-                        }
-                        currentOffset += 4;
+                        expressions.Add(F32.Load((ulong)currentOffset));
                         break;
                     case WasmValueType.I64:
+                        expressions.Add(I64.Load((ulong)currentOffset));
+                        break;
                     case WasmValueType.F64:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 8);
-                        if (type == WasmValueType.I64)
-                        {
-                            expressions.Add(I64.Load((ulong)currentOffset));
-                        }
-                        else
-                        {
-                            expressions.Add(F64.Load((ulong)currentOffset));
-                        }
-                        currentOffset += 8;
+                        expressions.Add(F64.Load((ulong)currentOffset));
                         break;
                     case WasmValueType.V128:
-                        currentOffset = AlignmentHelper.AlignUp(currentOffset, 16);
                         expressions.Add(V128.Load((ulong)currentOffset));
-                        currentOffset += 16;
                         break;
 
                     default:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -222,13 +222,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // global.get {module base}
             expressions.Add(Global.Get(WasmObjectWriter.ImageBaseGlobalIndex)); // Module base used to load the helper function address
             expressions.Add(I32.LoadWithRVAOffset(_helperCell)); // Load the helper call function pointer from the helper cell, using a load with an RVA offset so that the helper cell can be left as a zero in the R2R image and fixed up at runtime without needing a relocation
-            // call_indirect (i32, i32, i32, i32) (returns i32)
+            // call_indirect (i32, i32, i32, i32) -> (i32)
             expressions.Add(ControlFlow.CallIndirect(helperTypeIndex, 0));
 
             // local.set (PortableEntrypointThunk)  / At this point we can overwrite with the incoming portable entrypoint local, since the old value it will no longer be used
             expressions.Add(Local.Set(portableEntrypointLocalIndex));
             //
-             // ;Setup sp arg for the final call, with the call address now coming from the portable entrypoint
+            // ;Setup sp arg for the final call, with the call address now coming from the portable entrypoint
             // local.get 0
             expressions.Add(Local.Get(0));
             // i32.const {sizeofstoredlocals}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -118,7 +118,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             Debug.Assert(!instructionEncoder.Is64Bit); // We currently only support 32-bit, and the thunk logic is currently tied to that assumption
 
             // WASM-TODO! This is NOT an efficient way to implement this thunk. Currently it writes all the arguments to the stack, not just the ones which need to be saved for GC purposes.
-            // At some point we'll want to only write the arguments which need GC tracking, and skip the save/restore for other arguments. This will require changes to code
+            // At some point we'll want to only write the arguments which need GC tracking, and skip the save/restore for other arguments. This might require changes to code
             // which is currently architecture neutral on the VM side, so we should wait to do this until we have a better picture of how the VM and compiler sides will interact for this thunk.
 
             ISymbolNode helperTypeIndex = factory.WasmTypeNode(_helperTypeParams);
@@ -154,10 +154,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // i32.sub
             expressions.Add(I32.Sub);
             // local.tee 0
-            expressions.Add(Local.Tee(0));
-
-            // global.set {stack pointer global}  // This is a callout from managed to native, we need to set the global stack pointer so that C++ code will work
-            expressions.Add(Global.Set(0));
+            expressions.Add(Local.Set(0));
 
             //
             // ; Stash all the locals away
@@ -227,6 +224,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             expressions.Add(I32.Const(sizeOfStoredLocals));
             // i32.add
             expressions.Add(I32.Add);
+
             //
             // ; Setup normal args
             // for (int i = 0; i < N; i++)

--- a/src/coreclr/vm/cgensys.h
+++ b/src/coreclr/vm/cgensys.h
@@ -60,7 +60,13 @@ extern "C" void STDCALL VirtualMethodFixupStub(void);
 extern "C" void STDCALL VirtualMethodFixupPatchLabel(void);
 
 #ifdef FEATURE_READYTORUN
+#ifdef TARGET_WASM
+// Wasm requires the signatures to be identical since the implementation is actually in C++
+struct READYTORUN_IMPORT_THUNK_PORTABLE_ENTRYPOINT;
+extern "C" PCODE STDCALL DelayLoad_MethodCall(TransitionBlock* pTransitionBlock, READYTORUN_IMPORT_THUNK_PORTABLE_ENTRYPOINT* pImportThunkEntry, uint8_t *moduleBase, int32_t rvaOfModuleFixup);
+#else
 extern "C" void STDCALL DelayLoad_MethodCall();
+#endif
 
 extern "C" void STDCALL DelayLoad_Helper();
 extern "C" void STDCALL DelayLoad_Helper_Obj();

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -54,13 +54,13 @@ extern "C" __attribute__((naked)) PCODE STDCALL DelayLoad_MethodCall(TransitionB
     asm ("local.get 0\n" /* Capture pTransitionBlock onto the stack for calling DelayLoad_MethodCallImpl function. This also happens to be the callersFramePointer */
          "local.get 0\n" /* Capture callersFramePointer onto the stack for setting the __stack_pointer */
          "global.get __stack_pointer\n" /* Get current value of stack global */
-         "local.set 0\n"  /* Store current stack global into callersFramePointer local */
+         "local.set 0\n"  /* Overwrite local 0 with the previous __stack_pointer value so it can be restored after the call */
          "global.set __stack_pointer\n" /* Set stack global to the initial value of callersFramePointer, which is the current stack pointer for the interpreter call */
          "local.get 1\n" /* Load pImportThunkEntry argument onto the stack for calling DelayLoad_MethodCallImpl function*/
          "local.get 2\n" /* Load moduleBase argument onto the stack for calling DelayLoad_MethodCallImpl function*/
          "local.get 3\n" /* Load rvaOfModuleFixup argument onto the stack for calling DelayLoad_MethodCallImpl function*/
          "call %0\n" /* Call the actual implementation function */
-         "local.get 0\n" /* Restore the original callersFramePointer value into the stack global */
+         "local.get 0\n" /* Reload the saved previous __stack_pointer value for restoration into the stack global */
          "global.set __stack_pointer\n"
          "return" :: "i" (DelayLoad_MethodCallImpl));
 }

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -43,9 +43,26 @@ extern "C" void STDMETHODCALLTYPE JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR Pr
     PORTABILITY_ASSERT("JIT_ProfilerEnterLeaveTailcallStub is not implemented on wasm");
 }
 
-extern "C" void STDCALL DelayLoad_MethodCall()
+extern "C" PCODE STDCALL DelayLoad_MethodCallImpl(TransitionBlock* pTransitionBlock, READYTORUN_IMPORT_THUNK_PORTABLE_ENTRYPOINT* pImportThunkEntry, uint8_t *moduleBase, int32_t rvaOfModuleFixup)
 {
-    PORTABILITY_ASSERT("DelayLoad_MethodCall is not implemented on wasm");
+    Module** ppModule = (Module**)(moduleBase + rvaOfModuleFixup);
+    return ExternalMethodFixupWorker(pTransitionBlock, (TADDR)(moduleBase + pImportThunkEntry->RelocOffset), -1, *ppModule);
+}
+
+extern "C" __attribute__((naked)) PCODE STDCALL DelayLoad_MethodCall(TransitionBlock* pTransitionBlock, READYTORUN_IMPORT_THUNK_PORTABLE_ENTRYPOINT* pImportThunkEntry, uint8_t *moduleBase, int32_t rvaOfModuleFixup)
+{
+    asm ("local.get 0\n" /* Capture pTransitionBlock onto the stack for calling DelayLoad_MethodCallImpl function. This also happens to be the callersFramePointer */
+         "local.get 0\n" /* Capture callersFramePointer onto the stack for setting the __stack_pointer */
+         "global.get __stack_pointer\n" /* Get current value of stack global */
+         "local.set 0\n"  /* Store current stack global into callersFramePointer local */
+         "global.set __stack_pointer\n" /* Set stack global to the initial value of callersFramePointer, which is the current stack pointer for the interpreter call */
+         "local.get 1\n" /* Load pImportThunkEntry argument onto the stack for calling DelayLoad_MethodCallImpl function*/
+         "local.get 2\n" /* Load moduleBase argument onto the stack for calling DelayLoad_MethodCallImpl function*/
+         "local.get 3\n" /* Load rvaOfModuleFixup argument onto the stack for calling DelayLoad_MethodCallImpl function*/
+         "call %0\n" /* Call the actual implementation function */
+         "local.get 0\n" /* Restore the original callersFramePointer value into the stack global */
+         "global.set __stack_pointer\n"
+         "return" :: "i" (DelayLoad_MethodCallImpl));
 }
 
 extern "C" void STDCALL DelayLoad_Helper()


### PR DESCRIPTION
- Rewrite WasmImportThunk generation in terms of the TransitionBlock and the interpreter calling convention
- Update the ArgIterator in crossgen2 to handle the interpreter calling convention, or at least something pretty close to it.
- Move the adjustment of the stack pointer global to the `DelayLoad_MethodCall` function

NOTE: We have not yet handled all of the variation between the interpreter and R2R calling conventions, but this is close enough to make good progress.