### PR TITLE
Port 126929 to 10.0

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -7574,7 +7574,7 @@ void gc_heap::reduce_committed_bytes (void* address, size_t size, int bucket, in
     }
 }
 
-bool gc_heap::virtual_decommit (void* address, size_t size, int bucket, int h_number)
+bool gc_heap::virtual_decommit (void* address, size_t size, int bucket, int h_number, void* end_of_data)
 {
     /**
      * Here are all possible cases for the decommits:
@@ -7588,6 +7588,14 @@ bool gc_heap::virtual_decommit (void* address, size_t size, int bucket, int h_nu
 #endif //!HOST_64BIT
 
     bool decommit_succeeded_p = ((bucket != recorded_committed_bookkeeping_bucket) && use_large_pages_p) ? true : GCToOSInterface::VirtualDecommit (address, size);
+
+    // Large pages: the decommit above is a no-op so memory retains stale data.
+    // Clear up to end_of_data if the caller provided it so that the heap never
+    // observes leftover object references after the region is reused.
+    if (use_large_pages_p && (end_of_data != nullptr) && (end_of_data > address))
+    {
+        memclr ((uint8_t*)address, (uint8_t*)end_of_data - (uint8_t*)address);
+    }
 
     reduce_committed_bytes (address, size, bucket, h_number, decommit_succeeded_p);
 
@@ -13482,7 +13490,7 @@ void gc_heap::distribute_free_regions()
                     size_t end_space = heap_segment_committed (region) - aligned_allocated;
                     if (end_space > 0)
                     {
-                        virtual_decommit (aligned_allocated, end_space, gen_to_oh (i), hn);
+                        virtual_decommit (aligned_allocated, end_space, gen_to_oh (i), hn, heap_segment_used (region));
                         heap_segment_committed (region) = aligned_allocated;
                         heap_segment_used (region) = min (heap_segment_used (region), heap_segment_committed (region));
                         assert (heap_segment_committed (region) > heap_segment_mem (region));

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2478,7 +2478,7 @@ private:
     PER_HEAP_METHOD void decommit_heap_segment (heap_segment* seg);
     PER_HEAP_ISOLATED_METHOD bool virtual_alloc_commit_for_heap (void* addr, size_t size, int h_number);
     PER_HEAP_ISOLATED_METHOD bool virtual_commit (void* address, size_t size, int bucket, int h_number=-1, bool* hard_limit_exceeded_p=NULL);
-    PER_HEAP_ISOLATED_METHOD bool virtual_decommit (void* address, size_t size, int bucket, int h_number=-1);
+    PER_HEAP_ISOLATED_METHOD bool virtual_decommit (void* address, size_t size, int bucket, int h_number=-1, void* end_of_data=nullptr);
     PER_HEAP_ISOLATED_METHOD void reduce_committed_bytes (void* address, size_t size, int bucket, int h_number, bool decommit_succeeded_p);
     friend void destroy_card_table (uint32_t*);
     PER_HEAP_ISOLATED_METHOD void destroy_card_table_helper (uint32_t* c_table);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/126903

 ## Customer Impact
 
 - [x] Customer reported
 - [ ] Found internally
 
 GC heap corruption when `DOTNET_GCLargePages=1` is enabled on Linux (#126903). . Reproducible by calling `GC.Collect(2, 
GCCollectionMode.Aggressive, true, true)` with large pages enabled, but also occurs in normal production workloads without aggressive GC.
 
 ## Regression
 
 - [ ] Yes
 - [x] No
 
 This is a pre-existing bug in the GC's large-page decommit logic. When `GCLargePages` is enabled, the GC skips OS-level
 decommits but still updates bookkeeping as if the decommit succeeded. This causes regions to be reused without being zeroed, leading to heap corruption. The bug has existed since Regions was enabled.
 
 ## Testing
 
The fix was validated by the customer against their production workload. 
 
 ## Risk
 
 Low. The fix clears decommitted memory in the large-pages scenario to ensure regions are properly zeroed before reuse. This is a targeted change to the GC's decommit path that only affects `GCLargePages=1` configurations. The larger fix https://github.com/dotnet/runtime/pull/127290 is made in .NET 11