### PR TITLE
Fix AV in GetObjectFields when enumerating fields on dynamic Continuations

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -7663,6 +7663,8 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectFields(COR_TYPEID id, UL
     if (typeHandle.IsTypeDesc())
         return E_INVALIDARG;
 
+    typeHandle = typeHandle.UpCastTypeIfNeeded();
+
     ApproxFieldDescIterator fieldDescIterator(typeHandle.AsMethodTable(), ApproxFieldDescIterator::INSTANCE_FIELDS);
 
     ULONG32 cFields = fieldDescIterator.Count();


### PR DESCRIPTION
Upcast the type handle before field iteration so that dynamically generated Continuation types resolve to their base class, avoiding an access violation in ApproxFieldDescIterator.