### PR TITLE
Fix trimmed library test assemblies missing from app bundles on tvOS

### DIFF
--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -47,8 +47,8 @@
 
   <!-- When trimming non-exe projects, root the whole intermediate assembly.
        The SDK no longer creates a TrimmerRootAssembly item for Library projects (see
-       Microsoft.NET.ILLink.targets), so update the metadata if the item exists and
-       add it outright when it does not. -->
+       Microsoft.NET.ILLink.targets), so replace any existing item and create it when
+       absent to ensure RootMode="all". -->
   <Target Name="RootEntireIntermediateAssembly" AfterTargets="PrepareForILLink" Condition="'$(OutputType)' != 'Exe'">
     <ItemGroup>
       <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')" />

--- a/eng/testing/tests.mobile.targets
+++ b/eng/testing/tests.mobile.targets
@@ -46,13 +46,13 @@
   </PropertyGroup>
 
   <!-- When trimming non-exe projects, root the whole intermediate assembly.
-       The SDK settings root only the entry point by default. These targets are used not only for standard
-       console apps, but also for test projects without an entry point. -->
+       The SDK no longer creates a TrimmerRootAssembly item for Library projects (see
+       Microsoft.NET.ILLink.targets), so update the metadata if the item exists and
+       add it outright when it does not. -->
   <Target Name="RootEntireIntermediateAssembly" AfterTargets="PrepareForILLink" Condition="'$(OutputType)' != 'Exe'">
     <ItemGroup>
-      <TrimmerRootAssembly Condition="'%(Identity)' == '$(AssemblyName)'">
-        <RootMode>all</RootMode>
-      </TrimmerRootAssembly>
+      <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')" />
+      <TrimmerRootAssembly Include="@(IntermediateAssembly->'%(Filename)')" RootMode="all" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
## Summary

PR #125673 changed `Microsoft.NET.ILLink.targets` to skip creating the `TrimmerRootAssembly` item for Library-output projects. The `RootEntireIntermediateAssembly` target in `eng/testing/tests.mobile.targets` relied on that item existing so it could update its `RootMode` metadata from `EntryPoint` to `all`.

Since the item no longer exists for Library projects, the metadata update is a no-op and the test assembly is left unrooted. ILLink trims it entirely, causing **all Release library tests on tvOS** (both CoreCLR and Mono) to fail with:
```
Test libs were not found (*.Tests.dll was not found in .../AppBundle/...)
```

## Fix

Change `RootEntireIntermediateAssembly` to use `Remove`+`Include` instead of metadata update, so the item is unconditionally created with `RootMode=all` regardless of whether the SDK already created one.

cc @sbomer