### PR TITLE
[release/10.0] [QUIC] Update MsQuic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -161,7 +161,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>10.0.0-preview-20251006.1</MicrosoftPrivateIntellisenseVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.16</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.18</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24167.3</SystemNetMsQuicTransportVersion>
     <!-- emscripten / Node -->
     <MicrosoftNETRuntimeEmscriptenVersion>$(MicrosoftDotNetApiCompatTaskPackageVersion)</MicrosoftNETRuntimeEmscriptenVersion>


### PR DESCRIPTION
Analog of https://github.com/dotnet/runtime/pull/126945 to release/10.0.

## Customer Impact

- [ ] Customer reported
- [X] Found internally

## Regression

- [ ] Yes
- [X] No

## Testing

Standard CI.

## Risk

Low, there's no product code change, only minor version upgrade of MsQuic library.