### PR TITLE
[release/9.0-staging] [QUIC] Update MsQuic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -229,7 +229,7 @@
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rtm.25627.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rtm.24466.4</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.8</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.18</MicrosoftNativeQuicMsQuicSchannelVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>19.1.0-alpha.1.26152.4</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>19.1.0-alpha.1.26152.4</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>


### PR DESCRIPTION
Analog of https://github.com/dotnet/runtime/pull/126945 to release/9.0-staging.

## Customer Impact

- [ ] Customer reported
- [X] Found internally

## Regression

- [ ] Yes
- [X] No

## Testing

Standard CI.

## Risk

Low, there's no product code change, only minor version upgrade of MsQuic library.