### PR TITLE
Fix browser-wasm CI coverage gap for npm config changes

### DIFF
--- a/eng/pipelines/common/evaluate-default-paths.yml
+++ b/eng/pipelines/common/evaluate-default-paths.yml
@@ -66,6 +66,11 @@ parameters:
         src/native/libs/Common/JavaScript/*
         src/native/libs/System.Native.Browser/*
         src/native/libs/System.Runtime.InteropServices.JavaScript.Native/*
+        src/native/package.json
+        src/native/package-lock.json
+        src/native/tsconfig.json
+        src/native/.npmrc
+        src/native/rollup.config*
     ]
     _wasm_chrome: [
         eng/testing/bump-chrome-version.proj

--- a/src/mono/browser/runtime/package.json
+++ b/src/mono/browser/runtime/package.json
@@ -40,7 +40,8 @@
     "typescript": "5.9.2"
   },
   "overrides": {
-    "cross-spawn": "7.0.6"
+    "cross-spawn": "7.0.6",
+    "serialize-javascript": "6.0.2"
   },
   "dependencies": {
     "wasm-feature-detect": "1.8.0"

--- a/src/native/package.json
+++ b/src/native/package.json
@@ -44,7 +44,7 @@
   },
   "overrides": {
     "cross-spawn": "7.0.6",
-    "serialize-javascript": "~6.0.2"
+    "serialize-javascript": "6.0.2"
   },
   "dependencies": {
     "wasm-feature-detect": "1.8.0"

--- a/src/native/package.json
+++ b/src/native/package.json
@@ -43,7 +43,8 @@
     "typescript": "5.9.2"
   },
   "overrides": {
-    "cross-spawn": "7.0.6"
+    "cross-spawn": "7.0.6",
+    "serialize-javascript": "~6.0.2"
   },
   "dependencies": {
     "wasm-feature-detect": "1.8.0"


### PR DESCRIPTION
## Summary

Fix a CI coverage gap where changes to `src/native/package.json` / `package-lock.json` did not trigger the browser-wasm CoreCLR build legs that actually run `npm run rollup`.

This gap allowed Dependabot PRs (#125230, #126217) to pass CI without testing the rollup build, causing post-merge breaks. The same `crypto is not defined` failure has now occurred **three times**.

## Changes

### 1. Pipeline path detection (`evaluate-default-paths.yml`)

Add JS build input files to `_wasm_src_native`:
- `src/native/package.json`
- `src/native/package-lock.json`  
- `src/native/tsconfig.json`
- `src/native/.npmrc`
- `src/native/rollup.config*`

This ensures changes to these files trigger the `wasmbuildtests`, `wasm_mono_runtimetests`, and `wasm_coreclr_runtimetests` subsets.

### 2. npm override for `serialize-javascript` (`package.json`)

Pin `serialize-javascript` to `~6.0.2` via npm overrides. The emsdk bundles Node v18.17.1, which lacks the global `crypto` API that `serialize-javascript` v7+ requires (Node 20+). This is an interim fix until the emsdk Node transport package is updated.

## Root Cause

The `_wasm_src_native` path list already included `src/native/libs/Common/JavaScript/*` and other native JS paths, but not the top-level npm config files (`package.json`, `package-lock.json`) or rollup configuration. When Dependabot bumped `serialize-javascript` from 6.0.2 to 7.0.5 (via `@rollup/plugin-terser` 0.4.4 → 1.0.0), the PR CI only ran LibraryTests legs (which do not invoke rollup). The CoreCLR legs that run `npm ci` + `npm run rollup` were skipped.

Post-merge, any full runtime build hitting the browser-wasm CoreCLR legs would fail with:
```
[!] ReferenceError: crypto is not defined
    at generateUID (serialize-javascript/index.js:54:17)
```

## Related

- Fixes #127008  
- Root cause of reverts: #125340 (Mar 9), #126986 (Apr 16)
- Dependabot PRs that broke: #125230, #126217

/cc @pavelsavara @lewing