### PR TITLE
JIT: Fix loongarch64 Windows build

### DIFF
--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -5223,7 +5223,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             }
             else // ins == load
             {    // pcaddu12i + load or lu12i.w + lu32i.d + load
-                result.insMemoryAccessKind = PERFSCORE_LATENCY_RD_STACK;
+                result.insMemoryAccessKind = PERFSCORE_MEMORY_READ;
                 result.insThroughput       = (CombinedInsCnt == 2) ? PERFSCORE_THROUGHPUT_4C : PERFSCORE_THROUGHPUT_7C;
                 if ((INS_ld_b <= ins) && (ins <= INS_ld_wu))
                 {
@@ -5274,7 +5274,7 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
         { // pcalau12i + (addi.d or ld.d)
             result.insLatency          = id->idIsCnsReloc() ? PERFSCORE_LATENCY_2C : PERFSCORE_LATENCY_5C;
             result.insThroughput       = id->idIsCnsReloc() ? PERFSCORE_THROUGHPUT_6C : PERFSCORE_THROUGHPUT_4C;
-            result.insMemoryAccessKind = id->idIsCnsReloc() ? PERFSCORE_MEMORY_NONE : PERFSCORE_LATENCY_RD_STACK;
+            result.insMemoryAccessKind = id->idIsCnsReloc() ? PERFSCORE_MEMORY_NONE : PERFSCORE_MEMORY_READ;
         }
         else
         {


### PR DESCRIPTION
#126938 introduced a superpmi-diffs Windows build break that I missed when merging it.

cc @LuckyXu-HF @shushanhf @dotnet/jit-contrib 