### PR TITLE
[cDAC] Adding `TryGetContract` on ContractRegistry to allow more custom behavior if contract is not found

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Microsoft.Diagnostics.DataContractReader.Contracts;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
 
 
 namespace Microsoft.Diagnostics.DataContractReader;
@@ -117,8 +117,6 @@ public abstract class ContractRegistry
     /// </summary>
     public virtual IDebugger Debugger => GetContract<IDebugger>();
 
-    public abstract TContract GetContract<TContract>() where TContract : IContract;
-
     /// <summary>
     /// Attempts to get an instance of the requested contract for the target.
     /// </summary>
@@ -126,24 +124,26 @@ public abstract class ContractRegistry
     /// <param name="contract">
     /// When this method returns <see langword="true"/>, contains the requested contract instance; otherwise, <see langword="null"/>.
     /// </param>
+    /// <param name="failureReason">
+    /// When this method returns <see langword="false"/>, contains a human-readable explanation of why the contract could not be retrieved; otherwise, <see langword="null"/>.
+    /// </param>
     /// <returns>
-    /// <see langword="true"/> if the requested contract is present and was retrieved successfully; <see langword="false"/> if the contract is not present or registered and <see cref="GetContract{TContract}"/> throws <see cref="NotImplementedException"/>.
+    /// <see langword="true"/> if the requested contract is present and was retrieved successfully; <see langword="false"/> if the contract is not present or registered"/>.
     /// </returns>
-    /// <exception cref="Exception">
-    /// Any exception thrown by <see cref="GetContract{TContract}"/> other than <see cref="NotImplementedException"/> is not handled by this method and will propagate to the caller.
-    /// </exception>
-    public bool TryGetContract<TContract>([NotNullWhen(true)] out TContract? contract) where TContract : IContract
+    public abstract bool TryGetContract<TContract>([NotNullWhen(true)] out TContract contract, out string? failureReason) where TContract : IContract;
+
+    public TContract GetContract<TContract>() where TContract : IContract
     {
-        try
+        if (!TryGetContract(out TContract contract, out string? failureReason))
         {
-            contract = GetContract<TContract>();
-            return true;
+            throw new NotImplementedException($"Contract '{typeof(TContract).Name}' is not supported by the target. Reason: {failureReason ?? "no reason provided"}");
         }
-        catch (NotImplementedException)
-        {
-            contract = default;
-            return false;
-        }
+        return contract;
+    }
+
+    public bool TryGetContract<TContract>([NotNullWhen(true)] out TContract contract) where TContract : IContract
+    {
+        return TryGetContract(out contract, out _);
     }
 
     /// <summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -119,6 +119,19 @@ public abstract class ContractRegistry
 
     public abstract TContract GetContract<TContract>() where TContract : IContract;
 
+    /// <summary>
+    /// Attempts to get an instance of the requested contract for the target.
+    /// </summary>
+    /// <typeparam name="TContract">The contract type to retrieve.</typeparam>
+    /// <param name="contract">
+    /// When this method returns <see langword="true"/>, contains the requested contract instance; otherwise, <see langword="null"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the requested contract is present and was retrieved successfully; <see langword="false"/> if the contract is not present or registered and <see cref="GetContract{TContract}"/> throws <see cref="NotImplementedException"/>.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Any exception thrown by <see cref="GetContract{TContract}"/> other than <see cref="NotImplementedException"/> is not handled by this method and will propagate to the caller.
+    /// </exception>
     public bool TryGetContract<TContract>([NotNullWhen(true)] out TContract? contract) where TContract : IContract
     {
         try

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using System.Diagnostics.CodeAnalysis;
 
 
 namespace Microsoft.Diagnostics.DataContractReader;
@@ -117,6 +118,20 @@ public abstract class ContractRegistry
     public virtual IDebugger Debugger => GetContract<IDebugger>();
 
     public abstract TContract GetContract<TContract>() where TContract : IContract;
+
+    public bool TryGetContract<TContract>([NotNullWhen(true)] out TContract? contract) where TContract : IContract
+    {
+        try
+        {
+            contract = GetContract<TContract>();
+            return true;
+        }
+        catch (NotImplementedException)
+        {
+            contract = default;
+            return false;
+        }
+    }
 
     /// <summary>
     /// Register a contract implementation for a specific version.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 
 namespace Microsoft.Diagnostics.DataContractReader;
@@ -37,22 +38,36 @@ internal sealed class CachingContractRegistry : ContractRegistry
         _creators[(typeof(TContract), version)] = t => creator(t);
     }
 
-    public override TContract GetContract<TContract>()
+    public override bool TryGetContract<TContract>([NotNullWhen(true)] out TContract contract, out string? failureReason)
     {
+        contract = default!;
+        failureReason = null;
         if (_contracts.TryGetValue(typeof(TContract), out IContract? cached))
-            return (TContract)cached;
+        {
+            contract = (TContract)cached;
+            return true;
+        }
 
         if (!_tryGetContractVersion(TContract.Name, out int version))
-            throw new NotImplementedException($"Contract '{TContract.Name}' is not present in the contract descriptor.");
+        {
+             failureReason = $"Target does not support contract '{typeof(TContract).Name}'.";
+            return false;
+        }
 
         if (!_creators.TryGetValue((typeof(TContract), version), out Func<Target, IContract>? creator))
-            throw new NotImplementedException($"No implementation registered for contract '{TContract.Name}' version {version}.");
+        {
+            failureReason = $"Target supports contract '{typeof(TContract).Name}' version {version}, but no implementation is registered for that version.";
+            return false;
+        }
 
-        TContract contract = (TContract)creator(_target);
+        contract = (TContract)creator(_target);
         if (_contracts.TryAdd(typeof(TContract), contract))
-            return contract;
+        {
+            return true;
+        }
 
-        return (TContract)_contracts[typeof(TContract)];
+        contract = (TContract)_contracts[typeof(TContract)];
+        return true;
     }
 
     public override void Flush()

--- a/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
@@ -521,30 +521,40 @@ internal class TestPlaceholderTarget : Target
         public override void Register<TContract>(int version, Func<Target, TContract> creator)
             => _creators[(typeof(TContract), version)] = t => creator(t);
 
-        public override TContract GetContract<TContract>()
+        public override bool TryGetContract<TContract>([NotNullWhen(true)] out TContract contract, out string? failureReason)
         {
+            contract = default!;
+            failureReason = null;
             if (_resolved.TryGetValue(typeof(TContract), out var cached))
-                return (TContract)cached;
+            {
+                contract = (TContract)cached;
+                return true;
+            }
 
-            IContract contract;
+            IContract resolved;
             if (_mocks.TryGetValue(typeof(TContract), out var mock))
             {
-                contract = mock;
+                resolved = mock;
             }
             else if (_versions.TryGetValue(typeof(TContract), out int version))
             {
                 if (!_creators.TryGetValue((typeof(TContract), version), out var creator))
-                    throw new NotImplementedException($"No implementation registered for contract '{typeof(TContract).Name}' version {version}.");
+                {
+                    failureReason = $"Target supports contract '{typeof(TContract).Name}' version {version}, but no implementation is registered for that version.";
+                    return false;
+                }
 
-                contract = creator(_target);
+                resolved = creator(_target);
             }
             else
             {
-                throw new NotImplementedException($"Contract {typeof(TContract).Name} is not registered. Use SetVersion<T>(version) or SetMock<T>(mock) to configure contracts.");
+                failureReason = $"Contract '{typeof(TContract).Name}' is not supported by the target.";
+                return false;
             }
 
-            _resolved[typeof(TContract)] = contract;
-            return (TContract)contract;
+            _resolved[typeof(TContract)] = resolved;
+            contract = (TContract)resolved;
+            return true;
         }
 
         public override void Flush() { }


### PR DESCRIPTION
Currently, we access the contracts through GetContract, which throws NotImplementedException if the contract is not found. In the vast majority of cases, this fits neatly into the desired behavior - either we use this contract as part of an API that is supposed to return `E_NOTIMPL` when the feature is not enabled, or it is a catastrophic failure if the contract is not found, or both. However, a small subset of APIs have different behavior - we want to, say, return `S_OK` or branch and try another behavior. Currently, doing this requires our control flow to rely on these exceptions. This seeks to eliminate this pattern; in the rare case when a caller wants a different behavior, it can call `TryGetContract` and handle the true and false cases in a custom way. 



More context: https://github.com/dotnet/runtime/pull/126963#discussion_r3090894905