### PR TITLE
Cache Late-bound CLR->COM stubs by MethodDesc

### DIFF
--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -4314,7 +4314,9 @@ namespace
         // This ensures racing threads for the same P/Invoke converge on the same
         // DynamicMethodDesc in the ILStubCache, while different P/Invoke methods or
         // differently flagged stubs get distinct cache entries.
-        if (SF_IsForwardPInvokeStub(dwStubFlags)
+        if (pTargetMD != NULL
+            && pTargetMD->IsPInvoke()
+            && SF_IsForwardPInvokeStub(dwStubFlags)
             && !SF_IsCALLIStub(dwStubFlags)
             && !SF_IsVarArgStub(dwStubFlags))
         {

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -4310,19 +4310,19 @@ namespace
 
         // The target MethodDesc may be NULL for field marshalling.
         // Forward P/Invoke stubs (non-CALLI, non-vararg) each target a specific method,
-        // so the hash blob is just the target MethodDesc pointer. This ensures racing
-        // threads for the same P/Invoke converge on the same DynamicMethodDesc in the
-        // ILStubCache, while different P/Invoke methods get distinct cache entries.
+        // so the hash blob includes the target MethodDesc pointer and the stub flags.
+        // This ensures racing threads for the same P/Invoke converge on the same
+        // DynamicMethodDesc in the ILStubCache, while different P/Invoke methods or
+        // differently flagged stubs get distinct cache entries.
         if (SF_IsForwardPInvokeStub(dwStubFlags)
             && !SF_IsCALLIStub(dwStubFlags)
             && !SF_IsVarArgStub(dwStubFlags))
         {
             isNonSharedStub = true;
         }
-
         // Late-bound COM stubs depend on metadata on the target MethodDesc (DispIdAttribute, associated properties) in addition to just the signature.
         // Cache based on the target MethodDesc and stub flags instead of the signature to avoid false sharing.
-        if (SF_IsCOMLateBoundStub(dwStubFlags))
+        else if (SF_IsCOMLateBoundStub(dwStubFlags))
         {
             isNonSharedStub = true;
         }

--- a/src/coreclr/vm/dllimport.cpp
+++ b/src/coreclr/vm/dllimport.cpp
@@ -4300,29 +4300,43 @@ namespace
     {
         STANDARD_VM_CONTRACT;
 
-        // The hash blob for a forward P/Invoke stub is just the target MethodDesc pointer.
-        // In order to help avoid collisions, ensure various blob sizes are different.
-        // See asserts below.
-        constexpr size_t forwardPInvokeHashBlobSize = sizeof(ILStubHashBlobBase) + sizeof(MethodDesc*);
+        // Some stubs (forward P/Invoke non-varags, late bound COM) each target a specific method.
+        // The hash blob for an unshared stub is just the target MethodDesc pointer and the stub flags.
+        constexpr size_t unsharedStubHashBlobSize = sizeof(ILStubHashBlobBase) + sizeof(DWORD) + sizeof(MethodDesc*);
 
         DWORD dwStubFlags = pParams->m_dwStubFlags;
+
+        bool isNonSharedStub = false;
 
         // The target MethodDesc may be NULL for field marshalling.
         // Forward P/Invoke stubs (non-CALLI, non-vararg) each target a specific method,
         // so the hash blob is just the target MethodDesc pointer. This ensures racing
         // threads for the same P/Invoke converge on the same DynamicMethodDesc in the
         // ILStubCache, while different P/Invoke methods get distinct cache entries.
-        if (pTargetMD != NULL
-            && SF_IsForwardPInvokeStub(dwStubFlags)
+        if (SF_IsForwardPInvokeStub(dwStubFlags)
             && !SF_IsCALLIStub(dwStubFlags)
             && !SF_IsVarArgStub(dwStubFlags))
         {
-            const size_t blobSize = forwardPInvokeHashBlobSize;
+            isNonSharedStub = true;
+        }
+
+        // Late-bound COM stubs depend on metadata on the target MethodDesc (DispIdAttribute, associated properties) in addition to just the signature.
+        // Cache based on the target MethodDesc and stub flags instead of the signature to avoid false sharing.
+        if (SF_IsCOMLateBoundStub(dwStubFlags))
+        {
+            isNonSharedStub = true;
+        }
+
+        if (isNonSharedStub)
+        {
+            _ASSERTE(pTargetMD != NULL);
+            const size_t blobSize = unsharedStubHashBlobSize;
             NewArrayHolder<BYTE> pBytes = new BYTE[blobSize];
             ZeroMemory(pBytes, blobSize);
             ILStubHashBlob* pBlob = (ILStubHashBlob*)(BYTE*)pBytes;
             pBlob->m_cbSizeOfBlob = blobSize;
-            memcpy(pBlob->m_rgbBlobData, &pTargetMD, sizeof(pTargetMD));
+            memcpy(pBlob->m_rgbBlobData, &dwStubFlags, sizeof(dwStubFlags));
+            memcpy(pBlob->m_rgbBlobData + sizeof(dwStubFlags), &pTargetMD, sizeof(pTargetMD));
             pBytes.SuppressRelease();
             return pBlob;
         }
@@ -4381,7 +4395,7 @@ namespace
         if (cbSizeOfBlob.IsOverflow())
             COMPlusThrowHR(COR_E_OVERFLOW);
 
-        _ASSERTE(cbSizeOfBlob.Value() != forwardPInvokeHashBlobSize);
+        _ASSERTE(cbSizeOfBlob.Value() != unsharedStubHashBlobSize);
 
         static_assert(nltMaxValue   <= 0xFF);
         static_assert(nlfMaxValue   <= 0xFF);

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -346,6 +346,19 @@ namespace NetClient
             Assert.Equal("True", dispatchCoerceTesting.BoolToString());
         }
 
+        static void Validate_GetDispId_Methods()
+        {
+            var dispatchTesting = new DispatchTesting();
+
+            Console.WriteLine($"Calling {nameof(DispatchTesting.GetDispIdAsString)} ...");
+            string result1 = dispatchTesting.GetDispIdAsString();
+            Assert.Equal("1000", result1);
+
+            Console.WriteLine($"Calling {nameof(DispatchTesting.GetDispIdAsString2)} ...");
+            string result2 = dispatchTesting.GetDispIdAsString2();
+            Assert.Equal("1001", result2);
+        }
+
         [Fact]
         public static int TestEntryPoint()
         {
@@ -365,6 +378,7 @@ namespace NetClient
                 Validate_LCID_Marshaled();
                 Validate_Enumerator();
                 Validate_ValueCoerce_ReturnToManaged();
+                Validate_GetDispId_Methods();
             }
             catch (Exception e)
             {

--- a/src/tests/Interop/COM/NETServer/DispatchTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchTesting.cs
@@ -102,4 +102,16 @@ public class DispatchTesting : Server.Contract.IDispatchTesting
         objRef = objIn;
         return ret;
     }
+
+    [DispId(1000)]
+    public string GetDispIdAsString()
+    {
+        return "1000";
+    }
+
+    [DispId(1001)]
+    public string GetDispIdAsString2()
+    {
+        return "1001";
+    }
 }

--- a/src/tests/Interop/COM/NativeServer/DispatchTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchTesting.h
@@ -184,6 +184,14 @@ public: // IDispatch
                 V_UNKNOWN(pVarResult) = new Enumerator(10);
                 return S_OK;
             }
+            case 1000:
+            {
+                return GetDispIdAsString_Proxy(pVarResult);
+            }
+            case 1001:
+            {
+                return GetDispIdAsString2_Proxy(pVarResult);
+            }
             }
 
             return E_NOTIMPL;
@@ -272,6 +280,20 @@ public: // IDispatchTesting
         /* [retval][out] */ IUnknown** retval)
     {
         *retval = new Enumerator(10);
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetDispIdAsString(
+        /* [out,retval] */ BSTR *pRetVal)
+    {
+        *pRetVal = SysAllocString(W("1000"));
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GetDispIdAsString2(
+        /* [out,retval] */ BSTR *pRetVal)
+    {
+        *pRetVal = SysAllocString(W("1001"));
         return S_OK;
     }
 
@@ -518,6 +540,30 @@ private:
     {
         V_VT(pVarResult) = VT_I4;
         V_I4(pVarResult) = lcid;
+        return S_OK;
+    }
+
+    HRESULT GetDispIdAsString_Proxy(_Inout_ VARIANT *pVarResult)
+    {
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
+        BSTR result = nullptr;
+        RETURN_IF_FAILED(GetDispIdAsString(&result));
+        V_BSTR(pVarResult) = result;
+        return S_OK;
+    }
+
+    HRESULT GetDispIdAsString2_Proxy(_Inout_ VARIANT *pVarResult)
+    {
+        if (pVarResult == nullptr)
+            return E_POINTER;
+
+        RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
+        BSTR result = nullptr;
+        RETURN_IF_FAILED(GetDispIdAsString2(&result));
+        V_BSTR(pVarResult) = result;
         return S_OK;
     }
 

--- a/src/tests/Interop/COM/NativeServer/DispatchTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchTesting.h
@@ -548,6 +548,7 @@ private:
         if (pVarResult == nullptr)
             return E_POINTER;
 
+        HRESULT hr = S_OK;
         RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
         BSTR result = nullptr;
         RETURN_IF_FAILED(GetDispIdAsString(&result));
@@ -560,6 +561,7 @@ private:
         if (pVarResult == nullptr)
             return E_POINTER;
 
+        HRESULT hr = S_OK;
         RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
         BSTR result = nullptr;
         RETURN_IF_FAILED(GetDispIdAsString2(&result));

--- a/src/tests/Interop/COM/NativeServer/DispatchTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchTesting.h
@@ -549,9 +549,10 @@ private:
             return E_POINTER;
 
         HRESULT hr = S_OK;
-        RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
+        RETURN_IF_FAILED(::VariantClear(pVarResult));
         BSTR result = nullptr;
         RETURN_IF_FAILED(GetDispIdAsString(&result));
+        V_VT(pVarResult) = VT_BSTR;
         V_BSTR(pVarResult) = result;
         return S_OK;
     }
@@ -562,9 +563,10 @@ private:
             return E_POINTER;
 
         HRESULT hr = S_OK;
-        RETURN_IF_FAILED(::VariantChangeType(pVarResult, pVarResult, 0, VT_BSTR));
+        RETURN_IF_FAILED(::VariantClear(pVarResult));
         BSTR result = nullptr;
         RETURN_IF_FAILED(GetDispIdAsString2(&result));
+        V_VT(pVarResult) = VT_BSTR;
         V_BSTR(pVarResult) = result;
         return S_OK;
     }

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -310,6 +310,14 @@ namespace Server.Contract
 
         [DispId(/*DISPID_NEWENUM*/-4)]
         System.Collections.IEnumerator GetEnumerator();
+
+        // Test matching signatures and different metadata (ie DISPID)
+
+        [DispId(1000)]
+        string GetDispIdAsString();
+
+        [DispId(1001)]
+        string GetDispIdAsString2();
     }
 
     [ComVisible(true)]


### PR DESCRIPTION
CLR to COM late-bound stubs encode information about the MethodDesc (such as DispIdAttribute, any associated property info, binding flags) into the IL stub. This causes problems if stubs are shared based exclusively on signature (ie a stub for one IDispatch method could be used for another one when the signatures match). This can cause spurious failures.

To avoid this, encode the hash blob as just the MethodDesc for the CLR to COM late-bound stubs as reuse is highly unlikely between methods anyway (would require two methods with different names but the same signature and same explicit DispID).

Fixes #126869 (validated that the fix works on the repro machine)
