### PR TITLE
Skip covariant-return tests when R2R-compiled

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/CoreClrConfigurationDetection.cs
@@ -4,7 +4,9 @@
 
 using System;
 using System.Globalization;
+using System.IO;
 using System.Reflection;
+using System.Reflection.PortableExecutable;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -43,6 +45,40 @@ public static class CoreClrConfigurationDetection
     public static bool IsAnyJitStress => IsJitStress || IsJitStressRegs || IsJitMinOpts || IsTailCallStress;
 
     public static bool IsAnyJitOptimizationStress => IsAnyJitStress || IsTieredCompilation;
+
+    /// <summary>
+    /// Returns true if the given assembly file on disk contains a ReadyToRun header
+    /// (i.e. was precompiled to native code by crossgen2). Both single-file R2R and
+    /// composite R2R are detected: for composite images, crossgen2 rewrites each
+    /// component MSIL assembly with a real R2R header whose <c>Flags</c> has
+    /// <c>READYTORUN_FLAG_COMPONENT</c> set and whose only section is an
+    /// <c>OwnerCompositeExecutable</c> string referencing the composite file name
+    /// (see <c>docs/design/coreclr/botr/readytorun-format.md</c>). In both cases,
+    /// <c>CorHeader.ManagedNativeHeaderDirectory</c> has a non-zero size.
+    ///
+    /// Note: this reports whether the assembly file is R2R-compiled, not whether the
+    /// runtime is actually executing the R2R code (e.g. <c>DOTNET_ReadyToRun=0</c> leaves
+    /// the header intact but disables R2R use at runtime). That is the desired semantic
+    /// for skip attributes: if the test assembly was R2R'd, skip it even if the current
+    /// run happens to have disabled R2R execution.
+    /// </summary>
+    public static bool IsAssemblyReadyToRunCompiled(Assembly assembly)
+    {
+        string? location = assembly.Location;
+        if (string.IsNullOrEmpty(location))
+            return false;
+
+        try
+        {
+            using FileStream fs = File.OpenRead(location);
+            using PEReader pe = new PEReader(fs);
+            return pe.PEHeaders.CorHeader?.ManagedNativeHeaderDirectory.Size > 0;
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     public static bool IsCheckedRuntime => AssemblyConfigurationEquals("Checked");
     public static bool IsReleaseRuntime => AssemblyConfigurationEquals("Release");

--- a/src/tests/async/covariant-return/covariant-returns.cs
+++ b/src/tests/async/covariant-return/covariant-returns.cs
@@ -8,25 +8,27 @@ using Xunit;
 
 public class CovariantReturns
 {
-    [Fact]
+    public static bool IsNotR2RCompiled => !TestLibrary.CoreClrConfigurationDetection.IsAssemblyReadyToRunCompiled(typeof(CovariantReturns).Assembly);
+
+    [ConditionalFact(typeof(CovariantReturns), nameof(IsNotR2RCompiled))]
     public static void Test0EntryPoint()
     {
         Test0().Wait();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(CovariantReturns), nameof(IsNotR2RCompiled))]
     public static void Test1EntryPoint()
     {
         Test1().Wait();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(CovariantReturns), nameof(IsNotR2RCompiled))]
     public static void Test2EntryPoint()
     {
         Test2().Wait();
     }
 
-    [Fact]
+    [ConditionalFact(typeof(CovariantReturns), nameof(IsNotR2RCompiled))]
     public static void Test2AEntryPoint()
     {
         Test2A().Wait();
@@ -136,7 +138,9 @@ namespace AsyncMicro
     {
         internal static string Trace;
 
-        [Fact]
+        public static bool IsNotR2RCompiled => !TestLibrary.CoreClrConfigurationDetection.IsAssemblyReadyToRunCompiled(typeof(Program).Assembly);
+
+        [ConditionalFact(typeof(Program), nameof(IsNotR2RCompiled))]
         public static void TestPrRepro()
         {
             Derived2 test = new();

--- a/src/tests/async/covariant-return/covariant-returns.csproj
+++ b/src/tests/async/covariant-return/covariant-returns.csproj
@@ -2,10 +2,13 @@
   <PropertyGroup>
     <!-- https://github.com/dotnet/runtime/issues/126685 -->
     <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot'">true</DisableProjectBuild>
-    <!-- https://github.com/dotnet/runtime/issues/126755 -->
-    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Needed for TestLibrary.CoreClrConfigurationDetection.IsNotReadyToRunCompiled,
+         which conditionally skips tests that fail when R2R-compiled (#126755). -->
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
> [!NOTE]
> This PR was prepared with Copilot CLI assistance.

Fixes #126755.

The `<CrossGenTest>false</CrossGenTest>` opt-out in `covariant-returns.csproj` was silently ignored: it is only consumed by `CLRTest.CrossGen.targets` via the per-test wrapper prologue. When a test is referenced from a merged runner it becomes `CLRTestKind=SharedLibrary` with no wrapper, and the merged runner's prologue crossgens every DLL in its output directory regardless of that property.

Replace the broken opt-out with a runtime-detected `ConditionalFact` skip:

- Add `TestLibrary.CoreClrConfigurationDetection.IsAssemblyReadyToRunCompiled(Assembly)` which inspects the PE `CorHeader.ManagedNativeHeaderDirectory`. This covers both single-file R2R and composite R2R: composite components are rewritten with a real R2R header whose `Flags` has `READYTORUN_FLAG_COMPONENT` set and whose only section is `OwnerCompositeExecutable` (see `docs/design/coreclr/botr/readytorun-format.md` and `src/coreclr/inc/pedecoder.inl`).
- Switch the 5 covariant-return `[Fact]` methods to `[ConditionalFact]` gated on a per-class `IsNotR2RCompiled` property that passes `typeof(ThisClass).Assembly` explicitly — a parameterless getter would use `Assembly.GetExecutingAssembly()` and resolve to `TestLibrary.dll`, which is itself R2R'd at Core_Root build time.
- Add `<ProjectReference Include="$(TestLibraryProjectPath)" />` to the csproj: merged-runner children don't get `CoreCLRTestLibrary` auto-referenced (the reference in `src/tests/Directory.Build.targets` is gated on `IsMergedTestRunnerAssembly`).

### Verification

On `linux.x64.Debug` merged `async.dll` runner:

| Mode | Pass | Fail | Skip |
|------|------|------|------|
| IL (default) | 80 | 0 | 0 |
| R2R (`RunCrossGen2=1`) | 75 | 0 | 5 |

The 5 skipped facts in R2R mode are the covariant-return cases that #126755 tracks.
