### PR TITLE
[browser][coreCLR] Fix `loadBootResourceCallback` receiving undefined integrity and refactor config merge

### DIFF
--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -43,7 +43,7 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
         if (typeof loadBootResourceCallback === "function") {
             const blazorType = behaviorToBlazorAssetTypeMap[assetInternal.behavior];
             dotnetAssert.check(blazorType, `Unsupported asset behavior: ${assetInternal.behavior}`);
-            const customLoadResult = loadBootResourceCallback(blazorType, assetInternal.name, asset.resolvedUrl!, assetInternal.integrity!, assetInternal.behavior);
+            const customLoadResult = loadBootResourceCallback(blazorType, assetInternal.name, asset.resolvedUrl!, assetInternal.hash!, assetInternal.behavior);
             dotnetAssert.check(typeof customLoadResult === "string", "loadBootResourceCallback for JS modules must return string URL");
             asset.resolvedUrl = makeURLAbsoluteWithApplicationBase(customLoadResult);
         }
@@ -479,7 +479,7 @@ async function loadResourceFetch(asset: AssetEntryInternal): Promise<Response> {
     if (typeof loadBootResourceCallback === "function") {
         const blazorType = behaviorToBlazorAssetTypeMap[asset.behavior];
         dotnetAssert.check(blazorType, `Unsupported asset behavior: ${asset.behavior}`);
-        const customLoadResult = loadBootResourceCallback(blazorType, asset.name, asset.resolvedUrl!, asset.integrity!, asset.behavior);
+        const customLoadResult = loadBootResourceCallback(blazorType, asset.name, asset.resolvedUrl!, asset.hash!, asset.behavior);
         if (typeof customLoadResult === "string") {
             asset.resolvedUrl = makeURLAbsoluteWithApplicationBase(customLoadResult);
         } else if (typeof customLoadResult === "object") {

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -43,7 +43,7 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
         if (typeof loadBootResourceCallback === "function") {
             const blazorType = behaviorToBlazorAssetTypeMap[assetInternal.behavior];
             dotnetAssert.check(blazorType, `Unsupported asset behavior: ${assetInternal.behavior}`);
-            const customLoadResult = loadBootResourceCallback(blazorType, assetInternal.name, asset.resolvedUrl!, assetInternal.hash!, assetInternal.behavior);
+            const customLoadResult = loadBootResourceCallback(blazorType, assetInternal.name, asset.resolvedUrl!, assetInternal.hash ?? "", assetInternal.behavior);
             dotnetAssert.check(typeof customLoadResult === "string", "loadBootResourceCallback for JS modules must return string URL");
             asset.resolvedUrl = makeURLAbsoluteWithApplicationBase(customLoadResult);
         }
@@ -479,7 +479,7 @@ async function loadResourceFetch(asset: AssetEntryInternal): Promise<Response> {
     if (typeof loadBootResourceCallback === "function") {
         const blazorType = behaviorToBlazorAssetTypeMap[asset.behavior];
         dotnetAssert.check(blazorType, `Unsupported asset behavior: ${asset.behavior}`);
-        const customLoadResult = loadBootResourceCallback(blazorType, asset.name, asset.resolvedUrl!, asset.hash!, asset.behavior);
+        const customLoadResult = loadBootResourceCallback(blazorType, asset.name, asset.resolvedUrl!, asset.hash ?? "", asset.behavior);
         if (typeof customLoadResult === "string") {
             asset.resolvedUrl = makeURLAbsoluteWithApplicationBase(customLoadResult);
         } else if (typeof customLoadResult === "object") {

--- a/src/native/libs/Common/JavaScript/loader/config.ts
+++ b/src/native/libs/Common/JavaScript/loader/config.ts
@@ -29,11 +29,10 @@ function mergeConfigs(target: LoaderConfigInternal, source: Partial<LoaderConfig
     // no need to merge the same object
     if (target === source || source === undefined || source === null) return target;
 
-    mergeResources(target.resources!, source.resources!);
-    const mergedResources = target.resources;
-    const mergedEnvironmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
-    const mergedRuntimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
-    const mergedConfigProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
+    const mergedResources = mergeResources(target.resources!, source.resources || {} as any);
+    const mergedEnvironmentVariables = { ...target.environmentVariables, ...source.environmentVariables || {} };
+    const mergedRuntimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions || []];
+    const mergedConfigProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig?.runtimeOptions?.configProperties || {} };
     // Copy all remaining simple properties from source (e.g. maxParallelDownloads,
     // applicationCulture, disableIntegrityCheck, etc.) that don't need special merge logic.
     Object.assign(target, source);
@@ -58,25 +57,25 @@ function mergeResources(target: Assets, source: Assets): Assets {
     // no need to merge the same object
     if (target === source || source === undefined || source === null) return target;
 
-    target.hash = source.hash ?? target.hash;
-    target.coreAssembly = [...target.coreAssembly!, ...source.coreAssembly!];
-    target.assembly = [...target.assembly!, ...source.assembly!];
-    target.lazyAssembly = [...target.lazyAssembly!, ...source.lazyAssembly!];
-    target.corePdb = [...target.corePdb!, ...source.corePdb!];
-    target.pdb = [...target.pdb!, ...source.pdb!];
-    target.jsModuleWorker = [...target.jsModuleWorker!, ...source.jsModuleWorker!];
-    target.jsModuleNative = [...target.jsModuleNative!, ...source.jsModuleNative!];
-    target.jsModuleDiagnostics = [...target.jsModuleDiagnostics!, ...source.jsModuleDiagnostics!];
-    target.jsModuleRuntime = [...target.jsModuleRuntime!, ...source.jsModuleRuntime!];
-    target.wasmSymbols = [...target.wasmSymbols!, ...source.wasmSymbols!];
-    target.wasmNative = [...target.wasmNative!, ...source.wasmNative!];
-    target.icu = [...target.icu!, ...source.icu!];
-    target.vfs = [...target.vfs!, ...source.vfs!];
-    target.coreVfs = [...target.coreVfs!, ...source.coreVfs!];
-    target.modulesAfterConfigLoaded = [...target.modulesAfterConfigLoaded!, ...source.modulesAfterConfigLoaded!];
-    target.modulesAfterRuntimeReady = [...target.modulesAfterRuntimeReady!, ...source.modulesAfterRuntimeReady!];
-    target.extensions = { ...target.extensions!, ...source.extensions! };
-    for (const key in source.satelliteResources) {
+    target.hash = source.hash ?? target.hash ?? "";
+    target.coreAssembly = [...target.coreAssembly!, ...source.coreAssembly || []];
+    target.assembly = [...target.assembly!, ...source.assembly || []];
+    target.lazyAssembly = [...target.lazyAssembly!, ...source.lazyAssembly || []];
+    target.corePdb = [...target.corePdb!, ...source.corePdb || []];
+    target.pdb = [...target.pdb!, ...source.pdb || []];
+    target.jsModuleWorker = [...target.jsModuleWorker!, ...source.jsModuleWorker || []];
+    target.jsModuleNative = [...target.jsModuleNative!, ...source.jsModuleNative || []];
+    target.jsModuleDiagnostics = [...target.jsModuleDiagnostics!, ...source.jsModuleDiagnostics || []];
+    target.jsModuleRuntime = [...target.jsModuleRuntime!, ...source.jsModuleRuntime || []];
+    target.wasmSymbols = [...target.wasmSymbols!, ...source.wasmSymbols || []];
+    target.wasmNative = [...target.wasmNative!, ...source.wasmNative || []];
+    target.icu = [...target.icu!, ...source.icu || []];
+    target.vfs = [...target.vfs!, ...source.vfs || []];
+    target.coreVfs = [...target.coreVfs!, ...source.coreVfs || []];
+    target.modulesAfterConfigLoaded = [...target.modulesAfterConfigLoaded!, ...source.modulesAfterConfigLoaded || []];
+    target.modulesAfterRuntimeReady = [...target.modulesAfterRuntimeReady!, ...source.modulesAfterRuntimeReady || []];
+    target.extensions = { ...target.extensions!, ...source.extensions || {} };
+    for (const key in source.satelliteResources || {}) {
         target.satelliteResources![key] = [...target.satelliteResources![key] || [], ...source.satelliteResources![key] || []];
     }
     return target;

--- a/src/native/libs/Common/JavaScript/loader/config.ts
+++ b/src/native/libs/Common/JavaScript/loader/config.ts
@@ -29,27 +29,29 @@ function mergeConfigs(target: LoaderConfigInternal, source: Partial<LoaderConfig
     // no need to merge the same object
     if (target === source || source === undefined || source === null) return target;
 
-    const mergedResources = mergeResources(target.resources!, source.resources || {} as any);
-    const mergedEnvironmentVariables = { ...target.environmentVariables, ...source.environmentVariables || {} };
-    const mergedRuntimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions || []];
-    const mergedConfigProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig?.runtimeOptions?.configProperties || {} };
-    // Copy all remaining simple properties from source (e.g. maxParallelDownloads,
-    // applicationCulture, disableIntegrityCheck, etc.) that don't need special merge logic.
+    // Merge collections: target values first, then source values appended/spread on top.
+    mergeResources(target.resources!, source.resources!);
+    // For scalar fields with defaults, prefer source when defined, otherwise keep target default.
+    // We patch source so that Object.assign below copies the correct resolved value.
+    source.appendElementOnExit = source.appendElementOnExit !== undefined ? source.appendElementOnExit : target.appendElementOnExit;
+    source.logExitCode = source.logExitCode !== undefined ? source.logExitCode : target.logExitCode;
+    source.exitOnUnhandledError = source.exitOnUnhandledError !== undefined ? source.exitOnUnhandledError : target.exitOnUnhandledError;
+    source.loadAllSatelliteResources = source.loadAllSatelliteResources !== undefined ? source.loadAllSatelliteResources : target.loadAllSatelliteResources;
+    source.mainAssemblyName = source.mainAssemblyName !== undefined ? source.mainAssemblyName : target.mainAssemblyName;
+    source.virtualWorkingDirectory = source.virtualWorkingDirectory !== undefined ? source.virtualWorkingDirectory : target.virtualWorkingDirectory;
+    source.debugLevel = source.debugLevel !== undefined ? source.debugLevel : target.debugLevel;
+    source.diagnosticTracing = source.diagnosticTracing !== undefined ? source.diagnosticTracing : target.diagnosticTracing;
+    // Merge maps and arrays: target values first, source values merged on top.
+    source.environmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
+    source.runtimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
+    source.runtimeConfig!.runtimeOptions!.configProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
+    // Copy all properties from source into target, including any simple properties
+    // (e.g. maxParallelDownloads, applicationCulture, disableIntegrityCheck, etc.)
+    // that don't need special merge logic.
+    const mergedResources = target.resources;
     Object.assign(target, source);
-    // Restore the merged values that Object.assign would have overwritten.
+    // Restore merged resources that Object.assign would have overwritten.
     target.resources = mergedResources;
-    target.environmentVariables = mergedEnvironmentVariables;
-    target.runtimeOptions = mergedRuntimeOptions;
-    target.runtimeConfig!.runtimeOptions!.configProperties = mergedConfigProperties;
-    // For boolean/scalar fields, prefer source when defined, otherwise keep target default.
-    target.appendElementOnExit = source.appendElementOnExit !== undefined ? source.appendElementOnExit : target.appendElementOnExit;
-    target.logExitCode = source.logExitCode !== undefined ? source.logExitCode : target.logExitCode;
-    target.exitOnUnhandledError = source.exitOnUnhandledError !== undefined ? source.exitOnUnhandledError : target.exitOnUnhandledError;
-    target.loadAllSatelliteResources = source.loadAllSatelliteResources !== undefined ? source.loadAllSatelliteResources : target.loadAllSatelliteResources;
-    target.mainAssemblyName = source.mainAssemblyName !== undefined ? source.mainAssemblyName : target.mainAssemblyName;
-    target.virtualWorkingDirectory = source.virtualWorkingDirectory !== undefined ? source.virtualWorkingDirectory : target.virtualWorkingDirectory;
-    target.debugLevel = source.debugLevel !== undefined ? source.debugLevel : target.debugLevel;
-    target.diagnosticTracing = source.diagnosticTracing !== undefined ? source.diagnosticTracing : target.diagnosticTracing;
     return target;
 }
 

--- a/src/native/libs/Common/JavaScript/loader/config.ts
+++ b/src/native/libs/Common/JavaScript/loader/config.ts
@@ -30,6 +30,19 @@ function mergeConfigs(target: LoaderConfigInternal, source: Partial<LoaderConfig
     if (target === source || source === undefined || source === null) return target;
 
     mergeResources(target.resources!, source.resources!);
+    const mergedResources = target.resources;
+    const mergedEnvironmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
+    const mergedRuntimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
+    const mergedConfigProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
+    // Copy all remaining simple properties from source (e.g. maxParallelDownloads,
+    // applicationCulture, disableIntegrityCheck, etc.) that don't need special merge logic.
+    Object.assign(target, source);
+    // Restore the merged values that Object.assign would have overwritten.
+    target.resources = mergedResources;
+    target.environmentVariables = mergedEnvironmentVariables;
+    target.runtimeOptions = mergedRuntimeOptions;
+    target.runtimeConfig!.runtimeOptions!.configProperties = mergedConfigProperties;
+    // For boolean/scalar fields, prefer source when defined, otherwise keep target default.
     target.appendElementOnExit = source.appendElementOnExit !== undefined ? source.appendElementOnExit : target.appendElementOnExit;
     target.logExitCode = source.logExitCode !== undefined ? source.logExitCode : target.logExitCode;
     target.exitOnUnhandledError = source.exitOnUnhandledError !== undefined ? source.exitOnUnhandledError : target.exitOnUnhandledError;
@@ -38,9 +51,6 @@ function mergeConfigs(target: LoaderConfigInternal, source: Partial<LoaderConfig
     target.virtualWorkingDirectory = source.virtualWorkingDirectory !== undefined ? source.virtualWorkingDirectory : target.virtualWorkingDirectory;
     target.debugLevel = source.debugLevel !== undefined ? source.debugLevel : target.debugLevel;
     target.diagnosticTracing = source.diagnosticTracing !== undefined ? source.diagnosticTracing : target.diagnosticTracing;
-    target.environmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
-    target.runtimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
-    target.runtimeConfig!.runtimeOptions!.configProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
     return target;
 }
 
@@ -68,11 +78,6 @@ function mergeResources(target: Assets, source: Assets): Assets {
     target.extensions = { ...target.extensions!, ...source.extensions! };
     for (const key in source.satelliteResources) {
         target.satelliteResources![key] = [...target.satelliteResources![key] || [], ...source.satelliteResources![key] || []];
-    }
-    for (const key in target.satelliteResources) {
-        if (!Object.prototype.hasOwnProperty.call(source.satelliteResources, key)) {
-            target.satelliteResources![key] = target.satelliteResources![key] || [];
-        }
     }
     return target;
 }

--- a/src/native/libs/Common/JavaScript/loader/config.ts
+++ b/src/native/libs/Common/JavaScript/loader/config.ts
@@ -30,18 +30,17 @@ function mergeConfigs(target: LoaderConfigInternal, source: Partial<LoaderConfig
     if (target === source || source === undefined || source === null) return target;
 
     mergeResources(target.resources!, source.resources!);
-    source.appendElementOnExit = source.appendElementOnExit !== undefined ? source.appendElementOnExit : target.appendElementOnExit;
-    source.logExitCode = source.logExitCode !== undefined ? source.logExitCode : target.logExitCode;
-    source.exitOnUnhandledError = source.exitOnUnhandledError !== undefined ? source.exitOnUnhandledError : target.exitOnUnhandledError;
-    source.loadAllSatelliteResources = source.loadAllSatelliteResources !== undefined ? source.loadAllSatelliteResources : target.loadAllSatelliteResources;
-    source.mainAssemblyName = source.mainAssemblyName !== undefined ? source.mainAssemblyName : target.mainAssemblyName;
-    source.virtualWorkingDirectory = source.virtualWorkingDirectory !== undefined ? source.virtualWorkingDirectory : target.virtualWorkingDirectory;
-    source.debugLevel = source.debugLevel !== undefined ? source.debugLevel : target.debugLevel;
-    source.diagnosticTracing = source.diagnosticTracing !== undefined ? source.diagnosticTracing : target.diagnosticTracing;
-    source.environmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
-    source.runtimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
-    source.runtimeConfig!.runtimeOptions!.configProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
-    Object.assign(target, source);
+    target.appendElementOnExit = source.appendElementOnExit !== undefined ? source.appendElementOnExit : target.appendElementOnExit;
+    target.logExitCode = source.logExitCode !== undefined ? source.logExitCode : target.logExitCode;
+    target.exitOnUnhandledError = source.exitOnUnhandledError !== undefined ? source.exitOnUnhandledError : target.exitOnUnhandledError;
+    target.loadAllSatelliteResources = source.loadAllSatelliteResources !== undefined ? source.loadAllSatelliteResources : target.loadAllSatelliteResources;
+    target.mainAssemblyName = source.mainAssemblyName !== undefined ? source.mainAssemblyName : target.mainAssemblyName;
+    target.virtualWorkingDirectory = source.virtualWorkingDirectory !== undefined ? source.virtualWorkingDirectory : target.virtualWorkingDirectory;
+    target.debugLevel = source.debugLevel !== undefined ? source.debugLevel : target.debugLevel;
+    target.diagnosticTracing = source.diagnosticTracing !== undefined ? source.diagnosticTracing : target.diagnosticTracing;
+    target.environmentVariables = { ...target.environmentVariables, ...source.environmentVariables };
+    target.runtimeOptions = [...target.runtimeOptions!, ...source.runtimeOptions!];
+    target.runtimeConfig!.runtimeOptions!.configProperties = { ...target.runtimeConfig!.runtimeOptions!.configProperties!, ...source.runtimeConfig!.runtimeOptions!.configProperties! };
     return target;
 }
 
@@ -49,31 +48,33 @@ function mergeResources(target: Assets, source: Assets): Assets {
     // no need to merge the same object
     if (target === source || source === undefined || source === null) return target;
 
-    source.coreAssembly = [...target.coreAssembly!, ...source.coreAssembly!];
-    source.assembly = [...target.assembly!, ...source.assembly!];
-    source.lazyAssembly = [...target.lazyAssembly!, ...source.lazyAssembly!];
-    source.corePdb = [...target.corePdb!, ...source.corePdb!];
-    source.pdb = [...target.pdb!, ...source.pdb!];
-    source.jsModuleWorker = [...target.jsModuleWorker!, ...source.jsModuleWorker!];
-    source.jsModuleNative = [...target.jsModuleNative!, ...source.jsModuleNative!];
-    source.jsModuleDiagnostics = [...target.jsModuleDiagnostics!, ...source.jsModuleDiagnostics!];
-    source.jsModuleRuntime = [...target.jsModuleRuntime!, ...source.jsModuleRuntime!];
-    source.wasmSymbols = [...target.wasmSymbols!, ...source.wasmSymbols!];
-    source.wasmNative = [...target.wasmNative!, ...source.wasmNative!];
-    source.icu = [...target.icu!, ...source.icu!];
-    source.vfs = [...target.vfs!, ...source.vfs!];
-    source.modulesAfterConfigLoaded = [...target.modulesAfterConfigLoaded!, ...source.modulesAfterConfigLoaded!];
-    source.modulesAfterRuntimeReady = [...target.modulesAfterRuntimeReady!, ...source.modulesAfterRuntimeReady!];
-    source.extensions = { ...target.extensions!, ...source.extensions! };
+    target.hash = source.hash ?? target.hash;
+    target.coreAssembly = [...target.coreAssembly!, ...source.coreAssembly!];
+    target.assembly = [...target.assembly!, ...source.assembly!];
+    target.lazyAssembly = [...target.lazyAssembly!, ...source.lazyAssembly!];
+    target.corePdb = [...target.corePdb!, ...source.corePdb!];
+    target.pdb = [...target.pdb!, ...source.pdb!];
+    target.jsModuleWorker = [...target.jsModuleWorker!, ...source.jsModuleWorker!];
+    target.jsModuleNative = [...target.jsModuleNative!, ...source.jsModuleNative!];
+    target.jsModuleDiagnostics = [...target.jsModuleDiagnostics!, ...source.jsModuleDiagnostics!];
+    target.jsModuleRuntime = [...target.jsModuleRuntime!, ...source.jsModuleRuntime!];
+    target.wasmSymbols = [...target.wasmSymbols!, ...source.wasmSymbols!];
+    target.wasmNative = [...target.wasmNative!, ...source.wasmNative!];
+    target.icu = [...target.icu!, ...source.icu!];
+    target.vfs = [...target.vfs!, ...source.vfs!];
+    target.coreVfs = [...target.coreVfs!, ...source.coreVfs!];
+    target.modulesAfterConfigLoaded = [...target.modulesAfterConfigLoaded!, ...source.modulesAfterConfigLoaded!];
+    target.modulesAfterRuntimeReady = [...target.modulesAfterRuntimeReady!, ...source.modulesAfterRuntimeReady!];
+    target.extensions = { ...target.extensions!, ...source.extensions! };
     for (const key in source.satelliteResources) {
-        source.satelliteResources![key] = [...target.satelliteResources![key] || [], ...source.satelliteResources![key] || []];
+        target.satelliteResources![key] = [...target.satelliteResources![key] || [], ...source.satelliteResources![key] || []];
     }
     for (const key in target.satelliteResources) {
         if (!Object.prototype.hasOwnProperty.call(source.satelliteResources, key)) {
-            source.satelliteResources![key] = target.satelliteResources![key] || [];
+            target.satelliteResources![key] = target.satelliteResources![key] || [];
         }
     }
-    return Object.assign(target, source);
+    return target;
 }
 
 function defaultConfig(target: LoaderConfigInternal) {
@@ -120,4 +121,5 @@ function normalizeResources(target: Assets) {
     if (!target.satelliteResources) target.satelliteResources = {};
     if (!target.extensions) target.extensions = {};
     if (!target.vfs) target.vfs = [];
+    if (!target.coreVfs) target.coreVfs = [];
 }

--- a/src/native/libs/Common/JavaScript/loader/config.ts
+++ b/src/native/libs/Common/JavaScript/loader/config.ts
@@ -59,7 +59,7 @@ function mergeResources(target: Assets, source: Assets): Assets {
     // no need to merge the same object
     if (target === source || source === undefined || source === null) return target;
 
-    target.hash = source.hash ?? target.hash ?? "";
+    target.hash = source.hash ?? target.hash;
     target.coreAssembly = [...target.coreAssembly!, ...source.coreAssembly || []];
     target.assembly = [...target.assembly!, ...source.assembly || []];
     target.lazyAssembly = [...target.lazyAssembly!, ...source.lazyAssembly || []];

--- a/src/native/libs/Common/JavaScript/types/internal.ts
+++ b/src/native/libs/Common/JavaScript/types/internal.ts
@@ -55,7 +55,6 @@ export type EmscriptenModuleInternal = EmscriptenModule & DotnetModuleConfig & {
 }
 
 export interface AssetEntryInternal extends AssetEntry {
-    integrity?: string
     cache?: RequestCache
     useCredentials?: boolean
     culture?: string


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `loadBootResourceCallback` was always receiving `undefined` for the `integrity` parameter, and refactors the loader config merge logic for correctness and clarity.

## Changes

### Bug fix: `integrity` parameter in `loadBootResourceCallback`

The `AssetEntryInternal.integrity` field was never assigned anywhere in the codebase, so both call sites in `assets.ts` that passed `assetInternal.integrity!` to `loadBootResourceCallback` were always passing `undefined`. The fix replaces this with `assetInternal.hash ?? ""`, using the `hash` field from the base `AssetEntry` type which is actually populated from the asset manifest. The dead `integrity` field is removed from `AssetEntryInternal`.

### Config merge refactor (`mergeResources` / `mergeConfigs`)

The old `mergeResources` wrote merged values into `source`, then used `Object.assign(target, source)` to copy everything back to `target`. This was:
- **Fragile**: `Object.assign` overwrote the already-merged `resources` object on `target` with the unmerged one from `source`.
- **Error-prone for satellite resources**: Required two separate loops — one for source keys and one for target-only keys — because target was being replaced wholesale.

The new code writes directly to `target`, which:
- Eliminates the need for the second satellite resources loop (target-only keys are already there).
- Uses `|| []` fallbacks on source arrays for defensive handling of partial `Assets` objects.
- Adds `hash` merge for the top-level `Assets.hash` manifest hash.

In `mergeConfigs`, the merged `target.resources` is saved before `Object.assign(target, source)` and restored afterward, so the scalar property copy doesn't overwrite the already-merged resources.

### Missing `coreVfs` handling

The `coreVfs` field existed on the `Assets` type but was missing from both `mergeResources` and `normalizeResources`. Both functions now handle it.
