### PR TITLE
[Experiment] JIT: more aggressive branchless folding on ARM64

### DIFF
--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -436,7 +436,15 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
         }
 
         // Cost to allow for "x = cond ? a + b : c + d".
-        if (thenCost > 7 || elseCost > 7)
+        // On ARM64 the result instruction (csel/csinc/csinv/csneg) is ~1c and
+        // not predicted, so tolerate substantially more work on both arms to
+        // turn a predicted branch into a data dependency.
+#ifdef TARGET_ARM64
+        const int maxArmCost = 15;
+#else
+        const int maxArmCost = 7;
+#endif
+        if (thenCost > maxArmCost || elseCost > maxArmCost)
         {
             JITDUMP("Skipping if-conversion that will evaluate RHS unconditionally at costs %d,%d\n", thenCost,
                     elseCost);
@@ -444,11 +452,17 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
         }
     }
 
+#ifndef TARGET_ARM64
     if (!m_compiler->compStressCompile(Compiler::STRESS_IF_CONVERSION_INNER_LOOPS, 25))
     {
         // Don't optimise the block if it is inside a loop. Loop-carried
         // dependencies can cause significant stalls if if-converted.
         // Detect via the block weight as that will be high when inside a loop.
+        //
+        // On ARM64 csel/csinc/ccmp turn a mispredict into a fixed 1c data
+        // dependency, which is typically a win even inside loops; skip this
+        // guard entirely there so we fold branchlessly whenever the cost
+        // budget allows.
 
         if (m_startBlock->getBBWeight(m_compiler) > BB_UNITY_WEIGHT * 1.05)
         {
@@ -470,6 +484,9 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
             return false;
         }
     }
+#else
+    (void)pReachabilityBudget;
+#endif // !TARGET_ARM64
 
     // Get the select node inputs.
     var_types selectType;
@@ -832,7 +849,14 @@ PhaseStatus Compiler::optIfConversion()
     BasicBlock* block = fgLastBB;
 
     // Budget for optReachability - to avoid spending too much time detecting loops in large methods.
+    // Irrelevant on ARM64 where we no longer skip inside-loop candidates (csel
+    // has fixed latency and doesn't suffer from mispredicts), but we still
+    // keep the parameter for other targets.
+#ifdef TARGET_ARM64
+    int reachabilityBudget = INT_MAX;
+#else
     int reachabilityBudget = 20000;
+#endif
     while (block != nullptr)
     {
         OptIfConversionDsc optIfConversionDsc(this, block);

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1010,8 +1010,15 @@ bool OptBoolsDsc::optOptimizeCompareChainCondBlock()
         int op1Cost = cond1->GetCostEx();
         int op2Cost = cond2->GetCostEx();
         // The cost of combing three simple conditions is 32.
+        // On ARM64 ccmp is cheap and un-predicted so allow chains with
+        // substantially more work per leaf and longer overall chains.
+#ifdef TARGET_ARM64
+        int maxOp1Cost = op1IsCondChain ? 63 : 15;
+        int maxOp2Cost = op2IsCondChain ? 63 : 15;
+#else
         int maxOp1Cost = op1IsCondChain ? 31 : 7;
         int maxOp2Cost = op2IsCondChain ? 31 : 7;
+#endif
 
         // Cost to allow for chain size of three.
         if (op1Cost > maxOp1Cost || op2Cost > maxOp2Cost)
@@ -1179,7 +1186,11 @@ bool OptBoolsDsc::optOptimizeBoolsChkTypeCostCond()
 
     // The second condition must not be too expensive
     //
+#ifdef TARGET_ARM64
+    if (m_c2->GetCostEx() > 20)
+#else
     if (m_c2->GetCostEx() > 12)
+#endif
     {
         return false;
     }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -1326,11 +1326,29 @@ namespace System.Buffers
             public static Vector128<byte> NegateIfNeeded(Vector128<byte> result) => result;
             public static Vector256<byte> NegateIfNeeded(Vector256<byte> result) => result;
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static int IndexOfFirstMatch(Vector128<byte> result) => Vector128.IndexOfFirstMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
+            public static int IndexOfFirstMatch(Vector128<byte> result)
+            {
+                // On Arm64 the default lowering of `~Equals(result, Zero)` is `cmeq v, result, #0 ; mvn v, v`
+                // (two dependent vector ops feeding the serial shrn/fmov/rbit/clz chain that extracts the
+                // first-set-byte index). `CompareTest(result, result)` produces the same "is-nonzero" mask
+                // in a single `cmtst` instruction, shortening the critical path by one cycle.
+                if (AdvSimd.Arm64.IsSupported)
+                {
+                    return Vector128.IndexOfFirstMatch(AdvSimd.CompareTest(result, result));
+                }
+                return Vector128.IndexOfFirstMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
+            }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int IndexOfFirstMatch(Vector256<byte> result) => Vector256.IndexOfFirstMatch(~Vector256.Equals(result, Vector256<byte>.Zero));
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static int IndexOfLastMatch(Vector128<byte> result) => Vector128.IndexOfLastMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
+            public static int IndexOfLastMatch(Vector128<byte> result)
+            {
+                if (AdvSimd.Arm64.IsSupported)
+                {
+                    return Vector128.IndexOfLastMatch(AdvSimd.CompareTest(result, result));
+                }
+                return Vector128.IndexOfLastMatch(~Vector128.Equals(result, Vector128<byte>.Zero));
+            }
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static int IndexOfLastMatch(Vector256<byte> result) => Vector256.IndexOfLastMatch(~Vector256.Equals(result, Vector256<byte>.Zero));
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -1789,6 +1789,49 @@ namespace System.Text
             Debug.Assert(elementCount - currentOffsetInElements >= SizeOfVector128, "We should be able to run at least one whole vector.");
 
             nuint finalOffsetWhereCanRunLoop = elementCount - SizeOfVector128;
+
+            // On Arm64, unroll the main loop 2x (process 2 * Vector128 = 32 chars -> 32 bytes
+            // per iteration). Neoverse-class cores have 2x 128-bit NEON load pipes and 2x store
+            // pipes, so the unrolled body lets the OOO engine overlap two independent
+            // load/narrow/store chains per cycle. On x64 the 256-bit and 512-bit specialized
+            // variants are preferred, so this unroll only fires when we ended up on the 128-bit
+            // path (i.e., arm64, or x64 with only SSE2).
+            if (AdvSimd.Arm64.IsSupported && (elementCount - currentOffsetInElements) >= 2 * SizeOfVector128)
+            {
+                nuint finalOffsetWhereCanRunUnrolledLoop = elementCount - 2 * SizeOfVector128;
+                do
+                {
+                    // Four unaligned 128-bit loads (ideally fused into two ldp q,q on arm64),
+                    // OR-reduction to detect any non-ASCII, two narrows, two aligned stores.
+
+                    Vector128<ushort> utf16Vector0 = Vector128.LoadUnsafe(ref utf16Buffer, currentOffsetInElements);
+                    Vector128<ushort> utf16Vector1 = Vector128.LoadUnsafe(ref utf16Buffer, currentOffsetInElements + SizeOfVector128 / sizeof(short));
+                    Vector128<ushort> utf16Vector2 = Vector128.LoadUnsafe(ref utf16Buffer, currentOffsetInElements + 2 * SizeOfVector128 / sizeof(short));
+                    Vector128<ushort> utf16Vector3 = Vector128.LoadUnsafe(ref utf16Buffer, currentOffsetInElements + 3 * SizeOfVector128 / sizeof(short));
+                    Vector128<ushort> combinedVector = (utf16Vector0 | utf16Vector1) | (utf16Vector2 | utf16Vector3);
+
+                    if (VectorContainsNonAsciiChar(combinedVector))
+                    {
+                        // Fall through to the single-step loop; it will re-scan this 32-char
+                        // window and detect the non-ASCII position precisely.
+                        break;
+                    }
+
+                    Debug.Assert(((nuint)pAsciiBuffer + currentOffsetInElements) % SizeOfVector128 == 0, "Write should be aligned.");
+                    Vector128<byte> asciiVector0 = ExtractAsciiVector(utf16Vector0, utf16Vector1);
+                    Vector128<byte> asciiVector1 = ExtractAsciiVector(utf16Vector2, utf16Vector3);
+                    asciiVector0.StoreUnsafe(ref asciiBuffer, currentOffsetInElements);
+                    asciiVector1.StoreUnsafe(ref asciiBuffer, currentOffsetInElements + SizeOfVector128);
+
+                    currentOffsetInElements += 2 * SizeOfVector128;
+                } while (currentOffsetInElements <= finalOffsetWhereCanRunUnrolledLoop);
+
+                if (currentOffsetInElements > finalOffsetWhereCanRunLoop)
+                {
+                    goto Finish;
+                }
+            }
+
             do
             {
                 // In a loop, perform two unaligned reads, narrow to a single vector, then aligned write one vector.


### PR DESCRIPTION
> [!NOTE]
> This PR was drafted with help from GitHub Copilot.

Experiment: tune JIT heuristics to fold to branchless (csel/ccmp) more aggressively on ARM64.

- `ifconversion.cpp`: raise RHS cost cap 7->15 and drop the inside-loop guard on ARM64.
- `optimizebools.cpp`: raise compare-chain caps (7->15 leaf, 31->63 chain) and c2 cost cap 12->20 on ARM64.

Other targets unchanged. Just a test run for diffs/perf.