### PR TITLE
Force MetaDataGetDispenser to be linked into singlefilehost

### DIFF
--- a/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.DotNet.Cli.Build.Framework;
 using Microsoft.DotNet.CoreSetup.Test;
 using Xunit;
@@ -24,6 +25,56 @@ namespace AppHost.Bundle.Tests
                     .Execute()
                     .Should().Pass()
                     .And.HaveStdOutContaining("Hello World");
+            }
+        }
+
+        [Fact]
+        private void ExpectedExports()
+        {
+            string[] expectedExports =
+            [
+                "DotNetRuntimeInfo",
+                "g_dacTable",
+                "MetaDataGetDispenser",
+            ];
+
+            string singleFileHostPath = Binaries.SingleFileHost.FilePath;
+
+            if (OperatingSystem.IsWindows())
+            {
+                IntPtr handle = NativeLibrary.Load(singleFileHostPath);
+                try
+                {
+                    foreach (string exportName in expectedExports)
+                    {
+                        Assert.True(
+                            NativeLibrary.TryGetExport(handle, exportName, out _),
+                            $"Expected singlefilehost to export {exportName}");
+                    }
+                }
+                finally
+                {
+                    NativeLibrary.Free(handle);
+                }
+            }
+            else
+            {
+                // Use nm to check for exported dynamic symbols.
+                // On macOS, nm shows all symbols; on Linux, -D shows dynamic symbols.
+                string args = OperatingSystem.IsMacOS()
+                    ? singleFileHostPath
+                    : $"-D {singleFileHostPath}";
+
+                CommandResult result = Command.Create("nm", args)
+                    .CaptureStdOut()
+                    .CaptureStdErr()
+                    .Execute();
+                result.Should().Pass();
+
+                foreach (string exportName in expectedExports)
+                {
+                    Assert.Contains(exportName, result.StdOut);
+                }
             }
         }
     }

--- a/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -36,6 +36,7 @@ namespace AppHost.Bundle.Tests
                 "DotNetRuntimeInfo",
                 "g_dacTable",
                 "MetaDataGetDispenser",
+                "DotNetRuntimeContractDescriptor",
             ];
 
             string singleFileHostPath = Binaries.SingleFileHost.FilePath;

--- a/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/StaticHost.cs
@@ -59,13 +59,14 @@ namespace AppHost.Bundle.Tests
             }
             else
             {
-                // Use nm to check for exported dynamic symbols.
-                // On macOS, nm shows all symbols; on Linux, -D shows dynamic symbols.
-                string args = OperatingSystem.IsMacOS()
-                    ? singleFileHostPath
-                    : $"-D {singleFileHostPath}";
+                // Use nm to check for exported defined symbols.
+                // On macOS, -gUj shows external defined symbol names only.
+                // On Linux, -D --defined-only shows defined dynamic symbols.
+                Command command = OperatingSystem.IsMacOS()
+                    ? Command.Create("nm", "-gUj", singleFileHostPath)
+                    : Command.Create("nm", "-D", "--defined-only", singleFileHostPath);
 
-                CommandResult result = Command.Create("nm", args)
+                CommandResult result = command
                     .CaptureStdOut()
                     .CaptureStdErr()
                     .Execute();

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -266,13 +266,22 @@ endif()
 
 set_property(TARGET singlefilehost PROPERTY ENABLE_EXPORTS 1)
 
-# Force the linker to pull in MetaDataGetDispenser from coreclr_static even though
-# nothing in singlefilehost references it directly. Without this, the linker's
-# dead code elimination drops mscoree.o and the export is missing from the binary.
+# Force the linker to pull in symbols from coreclr_static even though nothing in
+# singlefilehost references them directly. Without this, the linker's dead code
+# elimination can drop object files and the exports are missing from the binary.
+# This should be kept in sync with singlefilehost_unixexports.src.
 if(CLR_CMAKE_TARGET_APPLE)
-    target_link_options(singlefilehost PRIVATE -Wl,-u,_MetaDataGetDispenser)
+    target_link_options(singlefilehost PRIVATE
+        -Wl,-u,_DotNetRuntimeInfo
+        -Wl,-u,_g_dacTable
+        -Wl,-u,_MetaDataGetDispenser
+        -Wl,-u,_DotNetRuntimeContractDescriptor)
 elseif(NOT CLR_CMAKE_TARGET_WIN32)
-    target_link_options(singlefilehost PRIVATE -Wl,-u,MetaDataGetDispenser)
+    target_link_options(singlefilehost PRIVATE
+        -Wl,-u,DotNetRuntimeInfo
+        -Wl,-u,g_dacTable
+        -Wl,-u,MetaDataGetDispenser
+        -Wl,-u,DotNetRuntimeContractDescriptor)
 endif()
 
 target_link_libraries(

--- a/src/native/corehost/apphost/static/CMakeLists.txt
+++ b/src/native/corehost/apphost/static/CMakeLists.txt
@@ -266,6 +266,15 @@ endif()
 
 set_property(TARGET singlefilehost PROPERTY ENABLE_EXPORTS 1)
 
+# Force the linker to pull in MetaDataGetDispenser from coreclr_static even though
+# nothing in singlefilehost references it directly. Without this, the linker's
+# dead code elimination drops mscoree.o and the export is missing from the binary.
+if(CLR_CMAKE_TARGET_APPLE)
+    target_link_options(singlefilehost PRIVATE -Wl,-u,_MetaDataGetDispenser)
+elseif(NOT CLR_CMAKE_TARGET_WIN32)
+    target_link_options(singlefilehost PRIVATE -Wl,-u,MetaDataGetDispenser)
+endif()
+
 target_link_libraries(
     singlefilehost
     PRIVATE


### PR DESCRIPTION
Add linker flags on Unix/macOS to force MetaDataGetDispenser as an undefined symbol, which makes the linker pull mscoree.o from coreclr_static. On Windows, the .def file already forces this.

Add a test that validates the export is present in the singlefilehost binary using NativeLibrary.

See https://github.com/dotnet/runtime/issues/126634. We'll want to backport to 10.0.

cc @dotnet/appmodel @dotnet/dotnet-diag 