### PR TITLE
Backport System.Text.RegularExpressions XML docs from dotnet-api-docs to source

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/libraries/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);SYSTEM_TEXT_REGULAREXPRESSIONS</DefineConstants>
-    <UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
@@ -3,10 +3,25 @@
 
 namespace System.Text.RegularExpressions
 {
-    /// <summary>
-    /// Represents the results from a single subexpression capture. The object represents
-    /// one substring for a single successful capture.
-    /// </summary>
+    /// <summary>Represents the results from a single successful subexpression capture.</summary>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="Capture"/> object is immutable and has no public constructor. Instances are returned
+    /// through the <see cref="CaptureCollection"/> object, which is returned by the
+    /// <see cref="Group.Captures"/> property. However, the <c>Match.Captures</c> property provides
+    /// information about the same match as the
+    /// <see cref="Match"/> object.
+    /// </para>
+    /// <para>
+    /// If you do not apply a quantifier to a capturing group, the <see cref="Group.Captures"/>
+    /// property returns a <see cref="CaptureCollection"/> with a single <see cref="Capture"/> object
+    /// that provides information about the same capture as the <see cref="Group"/> object. If you do
+    /// apply a quantifier to a capturing group, the <c>Group.Index</c>, <c>Group.Length</c>, and
+    /// <c>Group.Value</c> properties provide information only about the last captured group, whereas
+    /// the <see cref="Capture"/> objects in the <see cref="CaptureCollection"/> provide information
+    /// about all subexpression captures.
+    /// </para>
+    /// </remarks>
     public class Capture
     {
         internal Capture(string? text, int index, int length)
@@ -16,10 +31,14 @@ namespace System.Text.RegularExpressions
             Length = length;
         }
 
-        /// <summary>Returns the position in the original string where the first character of captured substring was found.</summary>
+        /// <summary>
+        /// The position in the original string where the first character of the captured substring is found.
+        /// </summary>
+        /// <value>The zero-based starting position in the original string where the captured substring is found.</value>
         public int Index { get; private protected set; }
 
-        /// <summary>Returns the length of the captured substring.</summary>
+        /// <summary>Gets the length of the captured substring.</summary>
+        /// <value>The length of the captured substring.</value>
         public int Length { get; private protected set; }
 
         /// <summary>The original string</summary>
@@ -27,13 +46,26 @@ namespace System.Text.RegularExpressions
 
         /// <summary>Gets the captured substring from the input string.</summary>
         /// <value>The substring that is captured by the match.</value>
+        /// <remarks>
+        /// If a call to the <see cref="Regex.Match(string)"/> or <see cref="Match.NextMatch"/> method fails to
+        /// find a match, the value of the returned <c>Match.Value</c> property is <see cref="string.Empty"/>.
+        /// If the regular expression engine is unable to match a capturing group, the value of the returned
+        /// <c>Group.Value</c> property is <see cref="string.Empty"/>.
+        /// </remarks>
         public string Value => Text is string text ? text.Substring(Index, Length) : string.Empty;
 
         /// <summary>Gets the captured span from the input string.</summary>
         /// <value>The span that is captured by the match.</value>
         public ReadOnlySpan<char> ValueSpan => Text is string text ? text.AsSpan(Index, Length) : [];
 
-        /// <summary>Returns the substring that was matched.</summary>
+        /// <summary>
+        /// Retrieves the captured substring from the input string by calling the
+        /// <see cref="Value"/> property.
+        /// </summary>
+        /// <returns>The substring that was captured by the match.</returns>
+        /// <remarks>
+        /// <c>ToString</c> is actually an internal call to the <see cref="Value"/> property.
+        /// </remarks>
         public override string ToString() => Value;
 
         /// <summary>The substring to the left of the capture</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Capture.cs
@@ -32,7 +32,7 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// The position in the original string where the first character of the captured substring is found.
+        /// Gets the position in the original string where the first character of the captured substring is found.
         /// </summary>
         /// <value>The zero-based starting position in the original string where the captured substring is found.</value>
         public int Index { get; private protected set; }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
@@ -18,7 +18,6 @@ namespace System.Text.RegularExpressions
     /// </para>
     /// <list type="bullet">
     /// <item>
-    /// <description>
     /// The <see cref="Group.Captures" /> property. Each member of the collection represents a substring
     /// captured by a capturing group. If a quantifier is not applied to a capturing group, the
     /// <see cref="CaptureCollection" /> includes a single <see cref="Capture" /> object that represents
@@ -26,15 +25,12 @@ namespace System.Text.RegularExpressions
     /// capturing group, the <see cref="CaptureCollection" /> includes one <see cref="Capture" /> object
     /// for each captured substring, and the <see cref="Group" /> object provides information only about
     /// the last captured substring.
-    /// </description>
     /// </item>
     /// <item>
-    /// <description>
     /// The <c>Match.Captures</c> property. In this case, the collection consists of a single
     /// <see cref="Capture" /> object that provides information about the match as a whole. That is, the
     /// <see cref="CaptureCollection" /> object provides the same information as the <see cref="Match" />
     /// object.
-    /// </description>
     /// </item>
     /// </list>
     /// <para>
@@ -66,7 +62,7 @@ namespace System.Text.RegularExpressions
         public int Count => _capcount;
 
         /// <summary>Gets an individual member of the collection.</summary>
-        /// <param name="i">Index into the capture collection.</param>
+        /// <param name="i">The index into the capture collection.</param>
         /// <value>The captured substring at position <paramref name="i" /> in the collection.</value>
         /// <exception cref="ArgumentOutOfRangeException">
         /// <paramref name="i" /> is less than 0 or greater than or equal to

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
@@ -142,7 +142,10 @@ namespace System.Text.RegularExpressions
         /// <exception cref="ArgumentNullException">
         /// <paramref name="array" /> is <see langword="null" />.
         /// </exception>
-        /// <exception cref="ArgumentOutOfRangeException">
+        /// <exception cref="ArgumentException">
+        /// <paramref name="array" /> is multidimensional.
+        /// </exception>
+        /// <exception cref="IndexOutOfRangeException">
         /// <paramref name="arrayIndex" /> is outside the bounds of <paramref name="array" />.
         /// </exception>
         public void CopyTo(Array array, int arrayIndex)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/CaptureCollection.cs
@@ -8,9 +8,41 @@ using System.Diagnostics;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// Represents a sequence of capture substrings. The object is used
-    /// to return the set of captures done by a single capturing group.
+    /// Represents the set of captures made by a single capturing group. The collection is immutable
+    /// (read-only) and has no public constructor.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="CaptureCollection" /> object contains one or more <see cref="Capture" /> objects.
+    /// Instances of the <see cref="CaptureCollection" /> class are returned by the following properties:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// The <see cref="Group.Captures" /> property. Each member of the collection represents a substring
+    /// captured by a capturing group. If a quantifier is not applied to a capturing group, the
+    /// <see cref="CaptureCollection" /> includes a single <see cref="Capture" /> object that represents
+    /// the same captured substring as the <see cref="Group" /> object. If a quantifier is applied to a
+    /// capturing group, the <see cref="CaptureCollection" /> includes one <see cref="Capture" /> object
+    /// for each captured substring, and the <see cref="Group" /> object provides information only about
+    /// the last captured substring.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// The <c>Match.Captures</c> property. In this case, the collection consists of a single
+    /// <see cref="Capture" /> object that provides information about the match as a whole. That is, the
+    /// <see cref="CaptureCollection" /> object provides the same information as the <see cref="Match" />
+    /// object.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// To iterate through the members of the collection, you should use the collection iteration construct
+    /// provided by your language (such as <c>foreach</c> in C#) instead of retrieving the enumerator that
+    /// is returned by the <see cref="GetEnumerator" /> method.
+    /// </para>
+    /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(CollectionDebuggerProxy<Capture>))]
     public class CaptureCollection : IList<Capture>, IReadOnlyList<Capture>, IList
@@ -25,15 +57,34 @@ namespace System.Text.RegularExpressions
             _capcount = _group._capcount;
         }
 
+        /// <summary>Gets a value that indicates whether the collection is read only.</summary>
+        /// <value><see langword="true" /> in all cases.</value>
         public bool IsReadOnly => true;
 
-        /// <summary>Returns the number of captures.</summary>
+        /// <summary>Gets the number of substrings captured by the group.</summary>
+        /// <value>The number of items in the <see cref="CaptureCollection" />.</value>
         public int Count => _capcount;
 
-        /// <summary>Returns a specific capture, by index, in this collection.</summary>
+        /// <summary>Gets an individual member of the collection.</summary>
+        /// <param name="i">Index into the capture collection.</param>
+        /// <value>The captured substring at position <paramref name="i" /> in the collection.</value>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="i" /> is less than 0 or greater than or equal to
+        /// <see cref="Count" />.
+        /// </exception>
         public Capture this[int i] => GetCapture(i);
 
-        /// <summary>Provides an enumerator in the same order as Item[].</summary>
+        /// <summary>Provides an enumerator that iterates through the collection.</summary>
+        /// <returns>
+        /// An object that contains all <see cref="Capture" /> objects within the
+        /// <see cref="CaptureCollection" />.
+        /// </returns>
+        /// <remarks>
+        /// Instead of calling the <see cref="GetEnumerator" /> method to retrieve an enumerator that lets
+        /// you iterate through the <see cref="Capture" /> objects in the collection, you should use the
+        /// collection iteration construct provided by your programming language (such as <c>foreach</c>
+        /// in C#).
+        /// </remarks>
         public IEnumerator GetEnumerator() => new Enumerator(this);
 
         IEnumerator<Capture> IEnumerable<Capture>.GetEnumerator() => new Enumerator(this);
@@ -73,10 +124,27 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether access to the collection is synchronized (thread-safe).
+        /// </summary>
+        /// <value><see langword="false" /> in all cases.</value>
         public bool IsSynchronized => false;
 
+        /// <summary>Gets an object that can be used to synchronize access to the collection.</summary>
+        /// <value>An object that can be used to synchronize access to the collection.</value>
         public object SyncRoot => _group;
 
+        /// <summary>
+        /// Copies all the elements of the collection to the given array beginning at the given index.
+        /// </summary>
+        /// <param name="array">The array the collection is to be copied into.</param>
+        /// <param name="arrayIndex">The position in the destination array where copying is to begin.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="array" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is outside the bounds of <paramref name="array" />.
+        /// </exception>
         public void CopyTo(Array array, int arrayIndex)
         {
             if (array is null)
@@ -90,6 +158,27 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>
+        /// Copies the elements of the collection to an <see cref="Array" />, starting at a particular
+        /// <see cref="Array" /> index.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional <see cref="Array" /> that is the destination of the elements copied from
+        /// the collection. The <see cref="Array" /> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">
+        /// The zero-based index in <paramref name="array" /> at which copying begins.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="array" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is less than 0.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The number of elements in the source collection is greater than the available space from
+        /// <paramref name="arrayIndex" /> to the end of the destination <paramref name="array" />.
+        /// </exception>
         public void CopyTo(Capture[] array, int arrayIndex)
         {
             if (array is null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GeneratedRegexAttribute.cs
@@ -6,71 +6,97 @@ using System.Threading;
 
 namespace System.Text.RegularExpressions;
 
-/// <summary>Instructs the System.Text.RegularExpressions source generator to generate an implementation of the specified regular expression.</summary>
+/// <summary>
+/// Instructs the System.Text.RegularExpressions source generator to generate an implementation of the specified regular expression.
+/// </summary>
 /// <remarks>
 /// <para>
-/// The generator associated with this attribute only supports C#.  It only supplies an implementation when applied to partial, parameterless, non-generic methods
-/// or get-only properties that are typed to return <see cref="Regex"/>.
+/// The generator associated with this attribute only supports C#. It only supplies an implementation when applied to
+/// partial, parameterless, non-generic methods or get-only properties that are typed to return <see cref="Regex"/>.
 /// </para>
 /// <para>
-/// When the <see cref="Regex"/> supports case-insensitive matches (either by passing <see cref="RegexOptions.IgnoreCase"/> or using the inline `(?i)` switch in the pattern) the regex
-/// engines will use an internal casing table to transform the passed in pattern into an equivalent case-sensitive one. For example, given the pattern `abc`, the engines
-/// will transform it to the equivalent pattern `[Aa][Bb][Cc]`. The equivalences found in this internal casing table can change over time, for example in the case new characters are added to
-/// a new version of Unicode. When using the source generator, this transformation happens at compile time, which means the casing table used to find the
-/// equivalences will depend on the target framework at compile time. This differs from the rest of the <see cref="Regex"/> engines, which perform this transformation at run-time, meaning
-/// they will always use casing table for the current runtime.
+/// When the <see cref="Regex"/> supports case-insensitive matches (either by passing
+/// <see cref="RegexOptions.IgnoreCase"/> or using the inline <c>(?i)</c> switch in the pattern) the regex engines will
+/// use an internal casing table to transform the passed in pattern into an equivalent case-sensitive one. For example,
+/// given the pattern <c>abc</c>, the engines will transform it to the equivalent pattern <c>[Aa][Bb][Cc]</c>. The
+/// equivalences found in this internal casing table can change over time, for example in the case new characters are
+/// added to a new version of Unicode. When using the source generator, this transformation happens at compile time,
+/// which means the casing table used to find the equivalences will depend on the target framework at compile time.
+/// This differs from the rest of the <see cref="Regex"/> engines, which perform this transformation at run time,
+/// meaning they will always use casing table for the current runtime.
 /// </para>
 /// </remarks>
 [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
 public sealed class GeneratedRegexAttribute : Attribute
 {
-    /// <summary>Initializes a new instance of the <see cref="GeneratedRegexAttribute"/> with the specified pattern.</summary>
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneratedRegexAttribute"/> with the specified pattern.
+    /// </summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     public GeneratedRegexAttribute([StringSyntax(StringSyntaxAttribute.Regex)] string pattern) : this(pattern, RegexOptions.None)
     {
     }
 
-    /// <summary>Initializes a new instance of the <see cref="GeneratedRegexAttribute"/> with the specified pattern and options.</summary>
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneratedRegexAttribute"/> with the specified pattern and options.
+    /// </summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
     public GeneratedRegexAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) : this(pattern, options, Timeout.Infinite)
     {
     }
 
-    /// <summary>Initializes a new instance of the <see cref="GeneratedRegexAttribute"/> with the specified pattern and options.</summary>
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneratedRegexAttribute"/> with the specified pattern and options.
+    /// </summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
-    /// <param name="cultureName">The name of a culture to be used for case-insensitive comparisons. <paramref name="cultureName"/> is not case-sensitive.</param>
+    /// <param name="cultureName">The name of a culture to be used for case-insensitive comparisons.
+    /// <paramref name="cultureName"/> is not case-sensitive.</param>
     /// <remarks>
-    /// For a list of predefined culture names on Windows systems, see the Language tag column in the <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c">list of
-    /// language/region names supported by Windows</see>. Culture names follow the standard defined by <see href="https://tools.ietf.org/html/bcp47">BCP 47</see>. In addition,
-    /// starting with Windows 10, <paramref name="cultureName"/> can be any valid BCP-47 language tag.
-    ///
+    /// For a list of predefined culture names on Windows systems, see the Language tag column in the
+    /// <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c">list of
+    /// language/region names supported by Windows</see>. Culture names follow the standard defined by
+    /// <see href="https://tools.ietf.org/html/bcp47">BCP 47</see>. In addition, starting with Windows 10,
+    /// <paramref name="cultureName"/> can be any valid BCP-47 language tag.
+    /// <para>
     /// If <paramref name="cultureName"/> is <see cref="string.Empty"/>, the invariant culture will be used.
+    /// </para>
     /// </remarks>
     public GeneratedRegexAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, string cultureName) : this(pattern, options, Timeout.Infinite, cultureName)
     {
     }
 
-    /// <summary>Initializes a new instance of the <see cref="GeneratedRegexAttribute"/> with the specified pattern, options, and timeout.</summary>
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneratedRegexAttribute"/> with the specified pattern, options, and time-out value.
+    /// </summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
-    /// <param name="matchTimeoutMilliseconds">A time-out interval (milliseconds), or <see cref="Timeout.Infinite"/> to indicate that the method should not time out.</param>
+    /// <param name="matchTimeoutMilliseconds">A time-out interval (milliseconds), or <see cref="Timeout.Infinite"/>
+    /// to indicate that the method should not time out.</param>
     public GeneratedRegexAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, int matchTimeoutMilliseconds) : this(pattern, options, matchTimeoutMilliseconds, string.Empty /* Empty string means Invariant culture */)
     {
     }
 
-    /// <summary>Initializes a new instance of the <see cref="GeneratedRegexAttribute"/> with the specified pattern, options, and timeout.</summary>
+    /// <summary>
+    /// Initializes a new instance of <see cref="GeneratedRegexAttribute"/> with the specified pattern, options,
+    /// time-out value, and culture.
+    /// </summary>
     /// <param name="pattern">The regular expression pattern to match.</param>
     /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
-    /// <param name="matchTimeoutMilliseconds">A time-out interval (milliseconds), or <see cref="Timeout.Infinite"/> to indicate that the method should not time out.</param>
-    /// <param name="cultureName">The name of a culture to be used for case-insensitive comparisons. <paramref name="cultureName"/> is not case-sensitive.</param>
+    /// <param name="matchTimeoutMilliseconds">A time-out interval (milliseconds), or <see cref="Timeout.Infinite"/>
+    /// to indicate that the method should not time out.</param>
+    /// <param name="cultureName">The name of a culture to be used for case-insensitive comparisons.
+    /// <paramref name="cultureName"/> is not case-sensitive.</param>
     /// <remarks>
-    /// For a list of predefined culture names on Windows systems, see the Language tag column in the <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c">list of
-    /// language/region names supported by Windows</see>. Culture names follow the standard defined by <see href="https://tools.ietf.org/html/bcp47">BCP 47</see>. In addition,
-    /// starting with Windows 10, <paramref name="cultureName"/> can be any valid BCP-47 language tag.
-    ///
+    /// For a list of predefined culture names on Windows systems, see the Language tag column in the
+    /// <see href="https://learn.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c">list of
+    /// language/region names supported by Windows</see>. Culture names follow the standard defined by
+    /// <see href="https://tools.ietf.org/html/bcp47">BCP 47</see>. In addition, starting with Windows 10,
+    /// <paramref name="cultureName"/> can be any valid BCP-47 language tag.
+    /// <para>
     /// If <paramref name="cultureName"/> is <see cref="string.Empty"/>, the invariant culture will be used.
+    /// </para>
     /// </remarks>
     public GeneratedRegexAttribute([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, int matchTimeoutMilliseconds, string cultureName)
     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
@@ -3,11 +3,19 @@
 
 namespace System.Text.RegularExpressions
 {
-    /// <summary>
-    /// Represents the results from a single capturing group. A capturing group can
-    /// capture zero, one, or more strings in a single match because of quantifiers, so
-    /// Group supplies a collection of Capture objects.
-    /// </summary>
+    /// <summary>Represents the results from a single capturing group.</summary>
+    /// <remarks>
+    /// <para>
+    /// A capturing group can capture zero, one, or more strings in a single match because of
+    /// quantifiers. (For more information, see
+    /// <see href="/dotnet/standard/base-types/quantifiers-in-regular-expressions">Quantifiers</see>.)
+    /// All the substrings matched by a single capturing group are available from the
+    /// <see cref="Captures"/> property. Information about the last substring captured can be accessed
+    /// directly from the <c>Value</c> and <c>Index</c> properties. (That is, the <see cref="Group"/>
+    /// instance is equivalent to the last item of the collection returned by the <see cref="Captures"/>
+    /// property, which reflects the last capture made by the capturing group.)
+    /// </para>
+    /// </remarks>
     public class Group : Capture
     {
         internal static readonly Group s_emptyGroup = new Group(string.Empty, [], 0, string.Empty);
@@ -24,21 +32,53 @@ namespace System.Text.RegularExpressions
             Name = name;
         }
 
-        /// <summary>Indicates whether the match is successful.</summary>
+        /// <summary>Gets a value indicating whether the match is successful.</summary>
+        /// <value>
+        /// <see langword="true"/> if the match is successful; otherwise, <see langword="false"/>.
+        /// </value>
+        /// <remarks>
+        /// The <c>Success</c> property is <see langword="true"/> if at least one substring was captured
+        /// by this group. It is equivalent to the Boolean expression
+        /// <c>Group.Captures.Count &gt; 0</c>.
+        /// </remarks>
         public bool Success => _capcount != 0;
 
+        /// <summary>Returns the name of the capturing group represented by the current instance.</summary>
+        /// <value>The name of the capturing group represented by the current instance.</value>
         public string Name { get; }
 
         /// <summary>
-        /// Returns a collection of all the captures matched by the capturing
-        /// group, in innermost-leftmost-first order (or innermost-rightmost-first order if
-        /// compiled with the "r" option). The collection may have zero or more items.
+        /// Gets a collection of all the captures matched by the capturing group, in
+        /// innermost-leftmost-first order (or innermost-rightmost-first order if the regular expression
+        /// is modified with the <see cref="RegexOptions.RightToLeft"/> option). The collection may have
+        /// zero or more items.
         /// </summary>
+        /// <value>The collection of substrings matched by the group.</value>
+        /// <remarks>
+        /// <para>
+        /// If a quantifier is not applied to a capturing group, the collection returned by the
+        /// <see cref="Captures"/> property contains a single <see cref="Capture"/> object that provides
+        /// information about the same substring as the <see cref="Group"/> object.
+        /// </para>
+        /// <para>
+        /// The real utility of the <see cref="Captures"/> property occurs when a quantifier is applied
+        /// to a capturing group so that the group captures multiple substrings in a single regular
+        /// expression. In this case, the <see cref="Group"/> object contains information about the last
+        /// captured substring, whereas the <see cref="Captures"/> property contains information about
+        /// all the substrings captured by the group.
+        /// </para>
+        /// </remarks>
         public CaptureCollection Captures => _capcoll ??= new CaptureCollection(this);
 
         /// <summary>
-        /// Returns a Group object equivalent to the one supplied that is safe to share between multiple threads.
+        /// Returns a <see cref="Group"/> object equivalent to the one supplied that is safe to share
+        /// between multiple threads.
         /// </summary>
+        /// <param name="inner">The input <see cref="Group"/> object.</param>
+        /// <returns>A regular expression <see cref="Group"/> object.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="inner"/> is <see langword="null"/>.
+        /// </exception>
         public static Group Synchronized(Group inner)
         {
             if (inner == null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Group.cs
@@ -8,7 +8,7 @@ namespace System.Text.RegularExpressions
     /// <para>
     /// A capturing group can capture zero, one, or more strings in a single match because of
     /// quantifiers. (For more information, see
-    /// <see href="/dotnet/standard/base-types/quantifiers-in-regular-expressions">Quantifiers</see>.)
+    /// <see href="https://github.com/dotnet/docs/blob/main/docs/standard/base-types/quantifiers-in-regular-expressions.md">Quantifiers</see>.)
     /// All the substrings matched by a single capturing group are available from the
     /// <see cref="Captures"/> property. Information about the last substring captured can be accessed
     /// directly from the <c>Value</c> and <c>Index</c> properties. (That is, the <see cref="Group"/>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
@@ -71,7 +71,7 @@ namespace System.Text.RegularExpressions
         /// <value>The member of the collection specified by <paramref name="groupnum" />.</value>
         /// <remarks>
         /// <para>
-        /// The <see cref="this[int]" /> property is the indexer of the <see cref="GroupCollection" />
+        /// This property is the indexer of the <see cref="GroupCollection" />
         /// class. It allows you to enumerate the members of the collection by using a <c>foreach</c>
         /// statement.
         /// </para>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/GroupCollection.cs
@@ -9,9 +9,32 @@ using System.Diagnostics.CodeAnalysis;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// Represents a sequence of capture substrings. The object is used
-    /// to return the set of captures done by a single capturing group.
+    /// Returns the set of captured groups in a single match. The collection is immutable (read-only) and
+    /// has no public constructor.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="GroupCollection" /> class is a zero-based collection class that consists of one or
+    /// more <see cref="Group" /> objects that provide information about captured groups in a regular
+    /// expression match. The collection is immutable (read-only) and has no public constructor. A
+    /// <see cref="GroupCollection" /> object is returned by the <see cref="Match.Groups" /> property.
+    /// </para>
+    /// <para>
+    /// The collection contains one or more <see cref="Group" /> objects. If the match is successful, the
+    /// first element in the collection contains the <see cref="Group" /> object that corresponds to the
+    /// entire match. Each subsequent element represents a captured group, if the regular expression
+    /// includes capturing groups. Matches from numbered (unnamed) capturing groups appear in numeric
+    /// order before matches from named capturing groups. If the match is unsuccessful, the collection
+    /// contains a single <see cref="Group" /> object whose <see cref="Group.Success" /> property is
+    /// <see langword="false" /> and whose <see cref="Capture.Value" /> property equals
+    /// <see cref="string.Empty" />.
+    /// </para>
+    /// <para>
+    /// To iterate through the members of the collection, you should use the collection iteration
+    /// construct provided by your language (such as <c>foreach</c> in C#) instead of retrieving the
+    /// enumerator that is returned by the <see cref="GetEnumerator" /> method.
+    /// </para>
+    /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(CollectionDebuggerProxy<Group>))]
     public class GroupCollection : IList<Group>, IReadOnlyList<Group>, IList, IReadOnlyDictionary<string, Group>
@@ -30,18 +53,76 @@ namespace System.Text.RegularExpressions
 
         internal void Reset() => _groups = null;
 
+        /// <summary>Gets a value that indicates whether the collection is read only.</summary>
+        /// <value><see langword="true" /> in all cases.</value>
         public bool IsReadOnly => true;
 
-        /// <summary>Returns the number of groups.</summary>
+        /// <summary>Returns the number of groups in the collection.</summary>
+        /// <value>The number of groups in the collection.</value>
+        /// <remarks>
+        /// The <see cref="GroupCollection" /> object always has at least one member. If a match is
+        /// unsuccessful, the <see cref="Match.Groups" /> property returns a
+        /// <see cref="GroupCollection" /> object that contains a single member.
+        /// </remarks>
         public int Count => _match._matchcount.Length;
 
+        /// <summary>Enables access to a member of the collection by integer index.</summary>
+        /// <param name="groupnum">The zero-based index of the collection member to be retrieved.</param>
+        /// <value>The member of the collection specified by <paramref name="groupnum" />.</value>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="this[int]" /> property is the indexer of the <see cref="GroupCollection" />
+        /// class. It allows you to enumerate the members of the collection by using a <c>foreach</c>
+        /// statement.
+        /// </para>
+        /// <para>
+        /// You can also use this property to retrieve individual captured groups by their index number.
+        /// You can determine the number of items in the collection by retrieving the value of the
+        /// <see cref="Count" /> property. Valid values for the <paramref name="groupnum" /> parameter
+        /// range from 0 to one less than the number of items in the collection.
+        /// </para>
+        /// <para>
+        /// If <paramref name="groupnum" /> is not the index of a member of the collection, or if
+        /// <paramref name="groupnum" /> is the index of a capturing group that has not been matched in
+        /// the input string, the method returns a <see cref="Group" /> object whose
+        /// <see cref="Group.Success" /> property is <see langword="false" /> and whose
+        /// <c>Group.Value</c> property is <see cref="string.Empty" />.
+        /// </para>
+        /// </remarks>
         public Group this[int groupnum] => GetGroup(groupnum);
 
+        /// <summary>Enables access to a member of the collection by string index.</summary>
+        /// <param name="groupname">The name of a capturing group.</param>
+        /// <value>The member of the collection specified by <paramref name="groupname" />.</value>
+        /// <remarks>
+        /// <para>
+        /// <paramref name="groupname" /> can be either the name of a capturing group that is defined by
+        /// the <c>(?&lt;name&gt;)</c> element in a regular expression, or the string representation of
+        /// the number of a capturing group.
+        /// </para>
+        /// <para>
+        /// If <paramref name="groupname" /> is not the name of a capturing group in the collection, or
+        /// if <paramref name="groupname" /> is the name of a capturing group that has not been matched in
+        /// the input string, the method returns a <see cref="Group" /> object whose
+        /// <see cref="Group.Success" /> property is <see langword="false" /> and whose
+        /// <c>Group.Value</c> property is <see cref="string.Empty" />.
+        /// </para>
+        /// </remarks>
         public Group this[string groupname] => _match._regex is null ?
             Group.s_emptyGroup :
             GetGroup(_match._regex.GroupNumberFromName(groupname));
 
-        /// <summary>Provides an enumerator in the same order as Item[].</summary>
+        /// <summary>Provides an enumerator that iterates through the collection.</summary>
+        /// <returns>
+        /// An enumerator that contains all <see cref="Group" /> objects in the
+        /// <see cref="GroupCollection" />.
+        /// </returns>
+        /// <remarks>
+        /// Instead of calling the <see cref="GetEnumerator" /> method to retrieve an enumerator that lets
+        /// you iterate through the <see cref="Group" /> objects in the collection, you should use the
+        /// collection iteration construct provided by your programming language (such as <c>foreach</c>
+        /// in C#).
+        /// </remarks>
         public IEnumerator GetEnumerator() => new Enumerator(this);
 
         IEnumerator<Group> IEnumerable<Group>.GetEnumerator() => new Enumerator(this);
@@ -87,10 +168,36 @@ namespace System.Text.RegularExpressions
             return _groups[groupnum - 1];
         }
 
+        /// <summary>
+        /// Gets a value that indicates whether access to the <see cref="GroupCollection" /> is
+        /// synchronized (thread-safe).
+        /// </summary>
+        /// <value><see langword="false" /> in all cases.</value>
         public bool IsSynchronized => false;
 
+        /// <summary>
+        /// Gets an object that can be used to synchronize access to the
+        /// <see cref="GroupCollection" />.
+        /// </summary>
+        /// <value>
+        /// A copy of the <see cref="Match" /> object to synchronize.
+        /// </value>
         public object SyncRoot => _match;
 
+        /// <summary>
+        /// Copies all the elements of the collection to the given array beginning at the given index.
+        /// </summary>
+        /// <param name="array">The array the collection is to be copied into.</param>
+        /// <param name="arrayIndex">The position in the destination array where copying is to begin.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="array" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is outside the bounds of <paramref name="array" />.
+        /// -or-
+        /// <paramref name="arrayIndex" /> plus <see cref="Count" /> is outside the bounds of
+        /// <paramref name="array" />.
+        /// </exception>
         public void CopyTo(Array array, int arrayIndex)
         {
             if (array is null)
@@ -104,6 +211,29 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>
+        /// Copies the elements of the group collection to a <see cref="Group" /> array, starting at a
+        /// particular array index.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional array that is the destination of the elements copied from the group
+        /// collection. The array must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">
+        /// The zero-based index in <paramref name="array" /> at which copying begins.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="array" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is less than zero.
+        /// -or-
+        /// <paramref name="arrayIndex" /> is greater than the length of <paramref name="array" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The length of <paramref name="array" /> minus <paramref name="arrayIndex" /> is less than the
+        /// group collection count.
+        /// </exception>
         public void CopyTo(Group[] array, int arrayIndex)
         {
             if (array is null)
@@ -194,6 +324,19 @@ namespace System.Text.RegularExpressions
         IEnumerator<KeyValuePair<string, Group>> IEnumerable<KeyValuePair<string, Group>>.GetEnumerator() =>
             new Enumerator(this);
 
+        /// <summary>
+        /// Attempts to retrieve a group identified by the provided name key, if it exists in the group
+        /// collection.
+        /// </summary>
+        /// <param name="key">A string with the group name key to look for.</param>
+        /// <param name="value">
+        /// When the method returns, the group whose name is <paramref name="key" />, if it is found;
+        /// otherwise, <see langword="null" /> if not found.
+        /// </param>
+        /// <returns>
+        /// <see langword="true" /> if a group identified by the provided name key exists;
+        /// <see langword="false" /> otherwise.
+        /// </returns>
         public bool TryGetValue(string key, [NotNullWhen(true)] out Group? value)
         {
             Group group = this[key];
@@ -207,8 +350,19 @@ namespace System.Text.RegularExpressions
             return true;
         }
 
+        /// <summary>
+        /// Determines whether the group collection contains a captured group identified by the specified
+        /// name.
+        /// </summary>
+        /// <param name="key">A string with the name of the captured group to locate.</param>
+        /// <returns>
+        /// <see langword="true" /> if the group collection contains a captured group identified by
+        /// <paramref name="key" />; <see langword="false" /> otherwise.
+        /// </returns>
         public bool ContainsKey(string key) => _match._regex!.GroupNumberFromName(key) >= 0;
 
+        /// <summary>Gets a string enumeration that contains the name keys of the group collection.</summary>
+        /// <value>The name keys of the group collection.</value>
         public IEnumerable<string> Keys
         {
             get
@@ -220,6 +374,8 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets a group enumeration with all the groups in the group collection.</summary>
+        /// <value>A group enumeration.</value>
         public IEnumerable<Group> Values
         {
             get

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -190,7 +190,7 @@ namespace System.Text.RegularExpressions
         /// The <paramref name="replacement"/> parameter is a standard regular expression replacement
         /// pattern. It can consist of literal characters and regular expression substitutions. For more
         /// information, see
-        /// <see href="/dotnet/standard/base-types/substitutions-in-regular-expressions">Substitutions</see>.
+        /// <see href="https://github.com/dotnet/docs/blob/main/docs/standard/base-types/substitutions-in-regular-expressions.md">Substitutions</see>.
         /// </para>
         /// </remarks>
         public virtual string Result(string replacement)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -6,31 +6,38 @@ using System.Diagnostics;
 
 namespace System.Text.RegularExpressions
 {
-    /// <summary>
-    /// Represents the results from a single regular expression match.
-    /// </summary>
+    /// <summary>Represents the results from a single regular expression match.</summary>
     /// <remarks>
-    /// Match is the result class for a regex search.
-    /// It returns the location, length, and substring for
-    /// the entire match as well as every captured group.
-    ///
-    /// Match is also used during the search to keep track of each capture for each group.  This is
-    /// done using the "_matches" array.  _matches[x] represents an array of the captures for group x.
-    /// This array consists of start and length pairs, and may have empty entries at the end.  _matchcount[x]
-    /// stores how many captures a group has.  Note that _matchcount[x]*2 is the length of all the valid
-    /// values in _matches.  _matchcount[x]*2-2 is the Start of the last capture, and _matchcount[x]*2-1 is the
-    /// Length of the last capture
-    ///
-    /// For example, if group 2 has one capture starting at position 4 with length 6,
-    /// _matchcount[2] == 1
-    /// _matches[2][0] == 4
-    /// _matches[2][1] == 6
-    ///
-    /// Values in the _matches array can also be negative.  This happens when using the balanced match
-    /// construct, "(?&lt;start-end&gt;...)".  When the "end" group matches, a capture is added for both the "start"
-    /// and "end" groups.  The capture added for "start" receives the negative values, and these values point to
-    /// the next capture to be balanced.  They do NOT point to the capture that "end" just balanced out.  The negative
-    /// values are indices into the _matches array transformed by the formula -3-x.  This formula also untransforms.
+    /// <para>
+    /// The <see cref="Match"/> class is immutable and has no public constructor. An instance of the
+    /// <see cref="Match"/> class is returned by the <see cref="Regex.Match(string)"/> method and
+    /// represents the first pattern match in a string. Subsequent matches are represented by
+    /// <see cref="Match"/> objects returned by the <see cref="Match.NextMatch"/> method. In addition, a
+    /// <see cref="MatchCollection"/> object that consists of zero, one, or more <see cref="Match"/>
+    /// objects is returned by the <see cref="Regex.Matches(string)"/> method.
+    /// </para>
+    /// <para>
+    /// If the <see cref="Regex.Matches(string)"/> method fails to match a regular expression pattern in
+    /// an input string, it returns an empty <see cref="MatchCollection"/> object. You can then use a
+    /// <see langword="foreach"/> construct to iterate over the collection.
+    /// </para>
+    /// <para>
+    /// If the <see cref="Regex.Match(string)"/> method fails to match the regular expression pattern, it
+    /// returns a <see cref="Match"/> object that is equal to <see cref="Match.Empty"/>. You can use the
+    /// <see cref="Group.Success"/> property to determine whether the match was successful.
+    /// </para>
+    /// <para>
+    /// If a pattern match is successful, the <see cref="Capture.Value"/> property contains the matched
+    /// substring, the <see cref="Capture.Index"/> property indicates the zero-based starting position of
+    /// the matched substring in the input string, and the <see cref="Capture.Length"/> property indicates
+    /// the length of the matched substring in the input string.
+    /// </para>
+    /// <para>
+    /// Because a single match can involve multiple capturing groups, <see cref="Match"/> has a
+    /// <see cref="Groups"/> property that returns the <see cref="GroupCollection"/>. The
+    /// <see cref="Match"/> instance itself is equivalent to the first object in the collection, at
+    /// <c>Match.Groups[0]</c>, which represents the entire match.
+    /// </para>
     /// </remarks>
     public class Match : Group
     {
@@ -59,7 +66,12 @@ namespace System.Text.RegularExpressions
             _balancing = false;
         }
 
-        /// <summary>Returns an empty Match object.</summary>
+        /// <summary>Gets the empty group. All failed matches return this empty match.</summary>
+        /// <value>An empty match.</value>
+        /// <remarks>
+        /// This property should not be used to determine if a match is successful. Instead, use the
+        /// <see cref="Group.Success"/> property.
+        /// </remarks>
         public static Match Empty { get; } = new Match(null, 1, string.Empty, 0);
 
         internal void Reset(string? text, int textLength)
@@ -88,13 +100,64 @@ namespace System.Text.RegularExpressions
         /// </remarks>
         internal bool FoundMatch => _matchcount[0] > 0;
 
+        /// <summary>
+        /// Gets a collection of groups matched by the regular expression.
+        /// </summary>
+        /// <value>The character groups matched by the pattern.</value>
+        /// <remarks>
+        /// <para>
+        /// A regular expression pattern can include subexpressions, which are defined by enclosing a
+        /// portion of the regular expression pattern in parentheses. Every such subexpression forms a
+        /// group. The <see cref="Groups"/> property provides access to information about those
+        /// subexpression matches. For example, the regular expression pattern <c>(\d{3})-(\d{3}-\d{4})</c>,
+        /// which matches North American telephone numbers, has two subexpressions. The first consists of
+        /// the area code, which composes the first three digits of the telephone number. This group is
+        /// captured by the first set of parentheses, <c>(\d{3})</c>. The second consists of the
+        /// individual telephone number, which composes the last seven digits of the telephone number.
+        /// This group is captured by the second set of parentheses, <c>(\d{3}-\d{4})</c>.
+        /// </para>
+        /// <para>
+        /// The <see cref="GroupCollection"/> object returned by the <see cref="Groups"/> property always
+        /// has at least one member. If the regular expression engine cannot find any matches in a
+        /// particular input string, the single <see cref="Group"/> object in the collection has its
+        /// <c>Group.Success</c> property set to <see langword="false"/> and its <c>Group.Value</c>
+        /// property set to <see cref="string.Empty"/>.
+        /// </para>
+        /// <para>
+        /// If the collection has more than one member, the first item in the collection is the same as
+        /// the <see cref="Match"/> object (the entire match). Each subsequent member represents a
+        /// captured group, if the regular expression includes capturing groups. Groups can be accessed by
+        /// their integer index or, for named groups, by name.
+        /// </para>
+        /// </remarks>
         public virtual GroupCollection Groups => _groupcoll ??= new GroupCollection(this, null);
 
         /// <summary>
-        /// Returns a new Match with the results for the next match, starting
-        /// at the position at which the last match ended (at the character beyond the last
-        /// matched character).
+        /// Returns a new <see cref="Match"/> object with the results for the next match, starting at the
+        /// position at which the last match ended (at the character after the last matched character).
         /// </summary>
+        /// <returns>The next regular expression match.</returns>
+        /// <remarks>
+        /// <para>
+        /// This method is similar to calling <see cref="Regex.Match(string, int)"/> again and passing
+        /// <c>Index + Length</c> as the new starting position.
+        /// </para>
+        /// <para>
+        /// This method does not modify the current instance. Instead, it returns a new
+        /// <see cref="Match"/> object that contains information about the next match.
+        /// </para>
+        /// <para>
+        /// Attempting to retrieve the next match may throw a <see cref="RegexMatchTimeoutException"/> if
+        /// a time-out value for matching operations is in effect and the attempt to find the next match
+        /// exceeds that time-out interval.
+        /// </para>
+        /// <para>
+        /// When attempting to match a regular expression pattern against an empty match, the regular
+        /// expression engine will advance one character in the input string before retrying the match, to
+        /// avoid an infinite loop. Callers should not assume that each match will advance by at least one
+        /// position, since zero-width matches are possible.
+        /// </para>
+        /// </remarks>
         public Match NextMatch()
         {
             Regex? r = _regex;
@@ -105,10 +168,31 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Returns the expansion of the passed replacement pattern. For
-        /// example, if the replacement pattern is ?$1$2?, Result returns the concatenation
-        /// of Group(1).ToString() and Group(2).ToString().
+        /// Returns the expansion of the passed replacement pattern. For example, if the replacement
+        /// pattern is <c>$1$2</c>, <see cref="Result"/> returns the concatenation of
+        /// <c>Groups[1].Value</c> and <c>Groups[2].Value</c>.
         /// </summary>
+        /// <param name="replacement">The replacement pattern to use.</param>
+        /// <returns>The expanded version of the <paramref name="replacement"/> parameter.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="replacement"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="NotSupportedException">Expansion is not allowed for this pattern.</exception>
+        /// <remarks>
+        /// <para>
+        /// Whereas the <see cref="Regex.Replace(string, string)"/> method replaces all matches in an
+        /// input string with a specified replacement pattern, the <see cref="Result"/> method replaces a
+        /// single match with a specified replacement pattern. Because it operates on an individual match,
+        /// it is also possible to perform processing on the matched string before you call the
+        /// <see cref="Result"/> method.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter is a standard regular expression replacement
+        /// pattern. It can consist of literal characters and regular expression substitutions. For more
+        /// information, see
+        /// <see href="/dotnet/standard/base-types/substitutions-in-regular-expressions">Substitutions</see>.
+        /// </para>
+        /// </remarks>
         public virtual string Result(string replacement)
         {
             if (replacement is null)
@@ -141,9 +225,14 @@ namespace System.Text.RegularExpressions
             GroupToStringImpl(_matchcount.Length - 1);
 
         /// <summary>
-        /// Returns a Match instance equivalent to the one supplied that is safe to share
+        /// Returns a <see cref="Match"/> instance equivalent to the one supplied that is safe to share
         /// between multiple threads.
         /// </summary>
+        /// <param name="inner">The input <see cref="Match"/> object.</param>
+        /// <returns>A regular expression <see cref="Match"/> object.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="inner"/> is <see langword="null"/>.
+        /// </exception>
         public static Match Synchronized(Match inner)
         {
             if (inner is null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Match.cs
@@ -66,7 +66,7 @@ namespace System.Text.RegularExpressions
             _balancing = false;
         }
 
-        /// <summary>Gets the empty group. All failed matches return this empty match.</summary>
+        /// <summary>Gets the empty match. All failed matches return this empty match.</summary>
         /// <value>An empty match.</value>
         /// <remarks>
         /// This property should not be used to determine if a match is successful. Instead, use the

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
@@ -8,9 +8,48 @@ using System.Diagnostics;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// Represents the set of names appearing as capturing group
-    /// names in a regular expression.
+    /// Represents the set of successful matches found by iteratively applying a regular expression
+    /// pattern to the input string. The collection is immutable (read-only) and has no public
+    /// constructor. The <see cref="Regex.Matches(string)" /> method returns a
+    /// <see cref="MatchCollection" /> object.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The collection contains zero or more <see cref="Match" /> objects. If the match is successful,
+    /// the collection is populated with one <see cref="Match" /> object for each match found in the
+    /// input string. If the match is unsuccessful, the collection contains no <see cref="Match" />
+    /// objects, and its <see cref="Count" /> property equals zero.
+    /// </para>
+    /// <para>
+    /// When applying a regular expression pattern to a particular input string, the regular expression
+    /// engine uses either of two techniques to build the <see cref="MatchCollection" /> object:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <b>Direct evaluation.</b> The <see cref="MatchCollection" /> object is populated all at once,
+    /// with all matches resulting from a particular call to the <see cref="Regex.Matches(string)" />
+    /// method. This technique is used when the collection's <see cref="Count" /> property is accessed.
+    /// It typically is the more expensive method of populating the collection and entails a greater
+    /// performance hit.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <b>Lazy evaluation.</b> The <see cref="MatchCollection" /> object is populated as needed on a
+    /// match-by-match basis. It is equivalent to the regular expression engine calling the
+    /// <see cref="Regex.Match(string)" /> method repeatedly and adding each match to the collection.
+    /// This technique is used when the collection is accessed through its <see cref="GetEnumerator" />
+    /// method, or when it is accessed using the <c>foreach</c> statement.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// To iterate through the members of the collection, you should use the collection iteration
+    /// construct provided by your language (such as <c>foreach</c> in C#) instead of retrieving the
+    /// enumerator that is returned by the <see cref="GetEnumerator" /> method.
+    /// </para>
+    /// </remarks>
     [DebuggerDisplay("Count = {Count}")]
     [DebuggerTypeProxy(typeof(CollectionDebuggerProxy<Match>))]
     public class MatchCollection : IList<Match>, IReadOnlyList<Match>, IList
@@ -37,11 +76,29 @@ namespace System.Text.RegularExpressions
             _done = false;
         }
 
+        /// <summary>Gets a value that indicates whether the collection is read only.</summary>
+        /// <value><see langword="true" /> in all cases.</value>
         public bool IsReadOnly => true;
 
-        /// <summary>
-        /// Returns the number of captures.
-        /// </summary>
+        /// <summary>Gets the number of matches.</summary>
+        /// <value>The number of matches.</value>
+        /// <remarks>
+        /// <para>
+        /// Accessing the <see cref="Count" /> property causes the regular expression engine to populate
+        /// the collection using direct evaluation. In contrast, calling the <see cref="GetEnumerator" />
+        /// method (or using the <c>foreach</c> statement) causes the regular expression engine to
+        /// populate the collection on an as-needed basis using lazy evaluation. Direct evaluation can be
+        /// a much more expensive method of building the collection than lazy evaluation.
+        /// </para>
+        /// <para>
+        /// Because the <see cref="MatchCollection" /> object is generally populated by using lazy
+        /// evaluation, trying to determine the number of elements in the collection before it has been
+        /// fully populated may throw a <see cref="RegexMatchTimeoutException" /> exception. This
+        /// exception can be thrown if a time-out value for matching operations is in effect, and the
+        /// attempt to find a single match exceeds that time-out interval.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public int Count
         {
             get
@@ -51,9 +108,35 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /// <summary>
-        /// Returns the ith Match in the collection.
-        /// </summary>
+        /// <summary>Gets an individual member of the collection.</summary>
+        /// <param name="i">Index into the <see cref="Match" /> collection.</param>
+        /// <value>The captured substring at position <paramref name="i" /> in the collection.</value>
+        /// <remarks>
+        /// <para>
+        /// In C#, the <see cref="this[int]" /> property is an indexer; it is not explicitly referenced
+        /// in code, but instead allows the <see cref="MatchCollection" /> to be accessed as if it were
+        /// an array.
+        /// </para>
+        /// <para>
+        /// Typically, individual items in the <see cref="MatchCollection" /> are accessed by their index
+        /// only after the total number of items in the collection has been determined from the
+        /// <see cref="Count" /> property. However, accessing the <see cref="Count" /> property causes
+        /// the regular expression engine to use direct evaluation to build the collection all at once.
+        /// This is typically more expensive than iterating the collection using the
+        /// <see cref="GetEnumerator" /> method or the <c>foreach</c> statement.
+        /// </para>
+        /// <para>
+        /// Because the <see cref="MatchCollection" /> object is generally populated by using lazy
+        /// evaluation, trying to navigate to a specific match may throw a
+        /// <see cref="RegexMatchTimeoutException" /> exception. This exception can be thrown if a
+        /// time-out value for matching operations is in effect, and the attempt to find a specific
+        /// match exceeds that time-out interval.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="i" /> is less than 0 or greater than or equal to <see cref="Count" />.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public virtual Match this[int i]
         {
             get
@@ -67,7 +150,35 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /// <summary>Provides an enumerator in the same order as Item[i].</summary>
+        /// <summary>Provides an enumerator that iterates through the collection.</summary>
+        /// <returns>
+        /// An object that contains all <see cref="Match" /> objects within the
+        /// <see cref="MatchCollection" />.
+        /// </returns>
+        /// <remarks>
+        /// <para>
+        /// Instead of calling the <see cref="GetEnumerator" /> method to retrieve an enumerator that
+        /// lets you iterate through the <see cref="Match" /> objects in the collection, you should use
+        /// the collection iteration construct provided by your programming language (such as
+        /// <c>foreach</c> in C#).
+        /// </para>
+        /// <para>
+        /// Iterating the members of the <see cref="MatchCollection" /> using the
+        /// <see cref="GetEnumerator" /> method (or the <c>foreach</c> statement) causes the regular
+        /// expression engine to populate the collection on an as-needed basis using lazy evaluation.
+        /// In contrast, the regular expression engine uses direct evaluation to populate the collection
+        /// all at once when the <see cref="Count" /> property is accessed. This can be a much more
+        /// expensive method of building the collection than lazy evaluation.
+        /// </para>
+        /// <para>
+        /// Because the <see cref="MatchCollection" /> object is generally populated by using lazy
+        /// evaluation, trying to navigate to the next member of the collection may throw a
+        /// <see cref="RegexMatchTimeoutException" /> exception. This exception can be thrown if a
+        /// time-out value for matching operations is in effect, and the attempt to find the next match
+        /// exceeds that time-out interval.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public IEnumerator GetEnumerator() => new Enumerator(this);
 
         IEnumerator<Match> IEnumerable<Match>.GetEnumerator() => new Enumerator(this);
@@ -112,16 +223,58 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>
+        /// Gets a value indicating whether access to the collection is synchronized (thread-safe).
+        /// </summary>
+        /// <value><see langword="false" /> in all cases.</value>
         public bool IsSynchronized => false;
 
+        /// <summary>Gets an object that can be used to synchronize access to the collection.</summary>
+        /// <value>
+        /// An object that can be used to synchronize access to the collection. This property always
+        /// returns the object itself.
+        /// </value>
         public object SyncRoot => this;
 
+        /// <summary>
+        /// Copies all the elements of the collection to the given array starting at the given index.
+        /// </summary>
+        /// <param name="array">The array the collection is to be copied into.</param>
+        /// <param name="arrayIndex">The position in the array where copying is to begin.</param>
+        /// <remarks>
+        /// Because the <see cref="MatchCollection" /> object is generally populated by using lazy
+        /// evaluation, trying to copy the collection before it has been fully populated may throw a
+        /// <see cref="RegexMatchTimeoutException" /> exception. This exception can be thrown if a
+        /// time-out value for matching operations is in effect, and the attempt to find a single match
+        /// exceeds that time-out interval.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="array" /> is a multi-dimensional array.
+        /// </exception>
+        /// <exception cref="IndexOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is outside the bounds of <paramref name="array" />.
+        /// -or-
+        /// <paramref name="arrayIndex" /> plus <see cref="Count" /> is outside the bounds of
+        /// <paramref name="array" />.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public void CopyTo(Array array, int arrayIndex)
         {
             EnsureInitialized();
             ((ICollection)_matches).CopyTo(array, arrayIndex);
         }
 
+        /// <summary>
+        /// Copies the elements of the collection to an <see cref="Array" />, starting at a particular
+        /// <see cref="Array" /> index.
+        /// </summary>
+        /// <param name="array">
+        /// The one-dimensional <see cref="Array" /> that is the destination of the elements copied from
+        /// the collection. The <see cref="Array" /> must have zero-based indexing.
+        /// </param>
+        /// <param name="arrayIndex">
+        /// The zero-based index in <paramref name="array" /> at which copying begins.
+        /// </param>
         public void CopyTo(Match[] array, int arrayIndex)
         {
             EnsureInitialized();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
@@ -249,13 +249,16 @@ namespace System.Text.RegularExpressions
         /// exceeds that time-out interval.
         /// </remarks>
         /// <exception cref="ArgumentException">
-        /// <paramref name="array" /> is a multi-dimensional array.
-        /// </exception>
-        /// <exception cref="IndexOutOfRangeException">
-        /// <paramref name="arrayIndex" /> is outside the bounds of <paramref name="array" />.
+        /// <paramref name="array" /> is multi-dimensional.
         /// -or-
-        /// <paramref name="arrayIndex" /> plus <see cref="Count" /> is outside the bounds of
-        /// <paramref name="array" />.
+        /// The number of elements in the source <see cref="MatchCollection" /> is greater than the
+        /// available space from <paramref name="arrayIndex" /> to the end of <paramref name="array" />.
+        /// -or-
+        /// The type of the source <see cref="MatchCollection" /> cannot be cast automatically to the
+        /// type of the destination <paramref name="array" />.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="arrayIndex" /> is less than the lower bound of <paramref name="array" />.
         /// </exception>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public void CopyTo(Array array, int arrayIndex)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/MatchCollection.cs
@@ -26,8 +26,9 @@ namespace System.Text.RegularExpressions
     /// </para>
     /// <list type="bullet">
     /// <item>
+    /// <term>Direct evaluation</term>
     /// <description>
-    /// <b>Direct evaluation.</b> The <see cref="MatchCollection" /> object is populated all at once,
+    /// The <see cref="MatchCollection" /> object is populated all at once,
     /// with all matches resulting from a particular call to the <see cref="Regex.Matches(string)" />
     /// method. This technique is used when the collection's <see cref="Count" /> property is accessed.
     /// It typically is the more expensive method of populating the collection and entails a greater
@@ -35,8 +36,9 @@ namespace System.Text.RegularExpressions
     /// </description>
     /// </item>
     /// <item>
+    /// <term>Lazy evaluation</term>
     /// <description>
-    /// <b>Lazy evaluation.</b> The <see cref="MatchCollection" /> object is populated as needed on a
+    /// The <see cref="MatchCollection" /> object is populated as needed on a
     /// match-by-match basis. It is equivalent to the regular expression engine calling the
     /// <see cref="Regex.Match(string)" /> method repeatedly and adding each match to the collection.
     /// This technique is used when the collection is accessed through its <see cref="GetEnumerator" />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -13,20 +13,20 @@ namespace System.Text.RegularExpressions
     public partial class Regex
     {
         /// <summary>
-        /// Gets or sets the maximum number of entries in the current static cache of compiled regular
-        /// expressions.
+        /// Gets or sets the maximum number of entries in the current static cache of regular expression
+        /// instances.
         /// </summary>
         /// <value>The maximum number of entries in the static cache.</value>
         /// <remarks>
         /// <para>
-        /// The <see cref="Regex"/> class maintains an internal cache of compiled regular expressions used in
+        /// The <see cref="Regex"/> class maintains an internal cache of regular expression instances used in
         /// static <see cref="Regex"/> method calls, such as <see cref="Regex.Match(string, string)"/> or
         /// <see cref="Regex.Replace(string, string, string)"/>. If the value specified in a set operation is
         /// less than the current cache size, cache entries are discarded until the cache size is equal to the
         /// specified value.
         /// </para>
         /// <para>
-        /// By default, the cache holds 15 compiled static regular expressions. Your application typically
+        /// By default, the cache holds 15 static regular expression instances. Your application typically
         /// will not have to modify the size of the cache. Use the <see cref="CacheSize"/> property only when
         /// you want to turn off caching or when you have an unusually large cache.
         /// </para>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -12,6 +12,26 @@ namespace System.Text.RegularExpressions
 {
     public partial class Regex
     {
+        /// <summary>
+        /// Gets or sets the maximum number of entries in the current static cache of compiled regular
+        /// expressions.
+        /// </summary>
+        /// <value>The maximum number of entries in the static cache.</value>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Regex"/> class maintains an internal cache of compiled regular expressions used in
+        /// static <see cref="Regex"/> method calls, such as <see cref="Regex.Match(string, string)"/> or
+        /// <see cref="Regex.Replace(string, string, string)"/>. If the value specified in a set operation is
+        /// less than the current cache size, cache entries are discarded until the cache size is equal to the
+        /// specified value.
+        /// </para>
+        /// <para>
+        /// By default, the cache holds 15 compiled static regular expressions. Your application typically
+        /// will not have to modify the size of the cache. Use the <see cref="CacheSize"/> property only when
+        /// you want to turn off caching or when you have an unusually large cache.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">The value in a set operation is less than zero.</exception>
         public static int CacheSize
         {
             get => RegexCache.MaxCacheSize;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateMatches.cs
@@ -95,15 +95,22 @@ namespace System.Text.RegularExpressions
             new ValueMatchEnumerator(this, input, startat);
 
         /// <summary>
-        /// Represents an enumerator containing the set of successful matches found by iteratively applying a regular expression pattern to the input span.
+        /// Represents an enumerator containing the set of successful matches found by iteratively applying
+        /// a regular expression pattern to the input span.
         /// </summary>
         /// <remarks>
-        /// The enumerator has no public constructor. The <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/> method returns a <see cref="Regex.ValueMatchEnumerator"/>
-        /// object.The enumerator will lazily iterate over zero or more <see cref="ValueMatch"/> objects. If there is at least one successful match in the span, then
-        /// <see cref="MoveNext"/> returns <see langword="true"/> and <see cref="Current"/> will contain the first <see cref="ValueMatch"/>. If there are no successful matches,
-        /// then <see cref="MoveNext"/> returns <see langword="false"/> and <see cref="Current"/> throws an <see cref="InvalidOperationException"/>.
-        ///
-        /// This type is a ref struct since it stores the input span as a field in order to be able to lazily iterate over it.
+        /// <para>
+        /// The enumerator has no public constructor. The <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/>
+        /// method returns a <see cref="Regex.ValueMatchEnumerator"/> object. The enumerator will lazily iterate
+        /// over zero or more <see cref="ValueMatch"/> objects. If there is at least one successful match in the
+        /// span, then <see cref="MoveNext"/> returns <see langword="true"/> and <see cref="Current"/> will contain
+        /// the first <see cref="ValueMatch"/>. If there are no successful matches, then <see cref="MoveNext"/>
+        /// returns <see langword="false"/> and <see cref="Current"/> throws an <see cref="InvalidOperationException"/>.
+        /// </para>
+        /// <para>
+        /// This type is a ref struct since it stores the input span as a field in order to be able to lazily
+        /// iterate over it.
+        /// </para>
         /// </remarks>
         public ref struct ValueMatchEnumerator : IEnumerator<ValueMatch>
         {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateSplits.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.EnumerateSplits.cs
@@ -172,7 +172,8 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Represents an enumerator containing the set of splits around successful matches found by iteratively applying a regular expression pattern to the input span.
+        /// Represents an enumerator containing the set of splits around successful matches found by iteratively
+        /// applying a regular expression pattern to the input span.
         /// </summary>
         [StructLayout(LayoutKind.Auto)]
         public ref struct ValueSplitEnumerator : IEnumerator<Range>
@@ -268,9 +269,7 @@ namespace System.Text.RegularExpressions
                 return true;
             }
 
-            /// <summary>
-            /// Gets a <see cref="Range"/> for the split at the current position of the enumerator.
-            /// </summary>
+            /// <summary>Gets the <see cref="Range"/> element at the current position of the enumerator.</summary>
             public readonly Range Current => _currentSplit;
 
             /// <inheritdoc />

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
@@ -8,8 +8,31 @@ namespace System.Text.RegularExpressions
     public partial class Regex
     {
         /// <summary>
-        /// Searches the input string for one or more occurrences of the text supplied in the given pattern.
+        /// Indicates whether the specified regular expression finds a match in the specified input string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IsMatch(string, string)"/> method is typically used to validate a string or to ensure
+        /// that a string conforms to a particular pattern without retrieving that string for subsequent manipulation.
+        /// To retrieve matched strings, call the <see cref="Match(string, string)"/> or
+        /// <see cref="Matches(string, string)"/> method instead.
+        /// </para>
+        /// <para>
+        /// The static <see cref="IsMatch(string, string)"/> method is equivalent to constructing a
+        /// <see cref="Regex"/> object with the specified pattern and calling the <see cref="IsMatch(string)"/>
+        /// instance method. The pattern is cached for rapid retrieval by the regular expression engine.
+        /// </para>
+        /// </remarks>
         public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
             RegexCache.GetOrAdd(pattern).IsMatch(input);
 
@@ -18,58 +41,169 @@ namespace System.Text.RegularExpressions
         /// </summary>
         /// <param name="input">The span to search for a match.</param>
         /// <param name="pattern">The regular expression pattern to match.</param>
-        /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
         /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
             RegexCache.GetOrAdd(pattern).IsMatch(input);
 
         /// <summary>
-        /// Searches the input string for one or more occurrences of the text
-        /// supplied in the pattern parameter with matching options supplied in the options
-        /// parameter.
+        /// Indicates whether the specified regular expression finds a match in the specified input string,
+        /// using the specified matching options.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid <see cref="RegexOptions"/> value.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IsMatch(string, string, RegexOptions)"/> method is typically used to validate a string
+        /// or to ensure that a string conforms to a particular pattern without retrieving that string for
+        /// subsequent manipulation. To retrieve matched strings, call the
+        /// <see cref="Match(string, string, RegexOptions)"/> or
+        /// <see cref="Matches(string, string, RegexOptions)"/> method instead.
+        /// </para>
+        /// <para>
+        /// The static <see cref="IsMatch(string, string, RegexOptions)"/> method is equivalent to constructing a
+        /// <see cref="Regex"/> object with the specified pattern and options and calling the
+        /// <see cref="IsMatch(string)"/> instance method. The pattern is cached for rapid retrieval by the
+        /// regular expression engine.
+        /// </para>
+        /// </remarks>
         public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).IsMatch(input);
 
         /// <summary>
-        /// Indicates whether the specified regular expression finds a match in the specified input span, using the specified matching options.
+        /// Indicates whether the specified regular expression finds a match in the specified input span,
+        /// using the specified matching options.
         /// </summary>
         /// <param name="input">The span to search for a match.</param>
         /// <param name="pattern">The regular expression pattern to match.</param>
         /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
-        /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
         /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not in a valid <see cref="RegexOptions"/> value.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid <see cref="RegexOptions"/> value.
+        /// </exception>
         public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).IsMatch(input);
 
+        /// <summary>
+        /// Indicates whether the specified regular expression finds a match in the specified input string,
+        /// using the specified matching options and time-out interval.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate
+        /// that the method should not time out.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid <see cref="RegexOptions"/> value.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IsMatch(string, string, RegexOptions, TimeSpan)"/> method is typically used to validate
+        /// a string or to ensure that a string conforms to a particular pattern without retrieving that string
+        /// for subsequent manipulation. To retrieve matched strings, call the
+        /// <see cref="Match(string, string, RegexOptions, TimeSpan)"/> or
+        /// <see cref="Matches(string, string, RegexOptions, TimeSpan)"/> method instead.
+        /// </para>
+        /// <para>
+        /// The static <see cref="IsMatch(string, string, RegexOptions, TimeSpan)"/> method is equivalent to
+        /// constructing a <see cref="Regex"/> object with the specified pattern and options and calling the
+        /// <see cref="IsMatch(string)"/> instance method. The pattern is cached for rapid retrieval by the
+        /// regular expression engine.
+        /// </para>
+        /// <para>
+        /// The <paramref name="matchTimeout"/> parameter specifies how long a pattern matching method should try
+        /// to find a match before it times out. Setting a time-out interval prevents regular expressions that
+        /// rely on excessive backtracking from appearing to stop responding when they process input that contains
+        /// near matches. If no match is found in that time interval, the method throws a
+        /// <see cref="RegexMatchTimeoutException"/> exception. <paramref name="matchTimeout"/> overrides any
+        /// default time-out value defined for the application domain in which the method executes.
+        /// </para>
+        /// </remarks>
         public static bool IsMatch(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).IsMatch(input);
 
         /// <summary>
-        /// Indicates whether the specified regular expression finds a match in the specified input span, using the specified matching options and time-out interval.
+        /// Indicates whether the specified regular expression finds a match in the specified input span,
+        /// using the specified matching options and time-out interval.
         /// </summary>
         /// <param name="input">The span to search for a match.</param>
         /// <param name="pattern">The regular expression pattern to match.</param>
         /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
-        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate that the method should not time out.</param>
-        /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate
+        /// that the method should not time out.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
         /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
-        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/></exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern"/> is <see langword="null"/>.</exception>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="options"/> is not in a valid <see cref="RegexOptions"/> value or <paramref name="matchTimeout"/> is negative,
-        /// zero, or greater than approximately 24 days.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid <see cref="RegexOptions"/> value
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
         public static bool IsMatch(ReadOnlySpan<char> input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).IsMatch(input);
 
         /// <summary>
-        /// Searches the input string for one or more matches using the previous pattern,
-        /// options, and starting position.
+        /// Indicates whether the regular expression specified in the <see cref="Regex"/> constructor finds a
+        /// match in a specified input string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IsMatch(string)"/> method is typically used to validate a string or to ensure that a
+        /// string conforms to a particular pattern without retrieving that string for subsequent manipulation.
+        /// To determine whether one or more strings match a regular expression pattern and retrieve them for
+        /// subsequent manipulation, call the <see cref="Match(string)"/> or <see cref="Matches(string)"/> method.
+        /// </para>
+        /// <para>
+        /// The <see cref="RegexMatchTimeoutException"/> exception is thrown if the execution time of the matching
+        /// operation exceeds the time-out interval specified by the
+        /// <see cref="Regex(string, RegexOptions, TimeSpan)"/> constructor. If you do not set a time-out interval
+        /// when you call the constructor, the exception is thrown if the operation exceeds any time-out value
+        /// established for the application domain in which the <see cref="Regex"/> object is created. If no
+        /// time-out is defined in the <see cref="Regex"/> constructor call or in the application domain's
+        /// properties, or if the time-out value is <see cref="Regex.InfiniteMatchTimeout"/>, no exception
+        /// is thrown.
+        /// </para>
+        /// </remarks>
         public bool IsMatch(string input)
         {
             if (input is null)
@@ -81,9 +215,31 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Searches the input string for one or more matches using the previous pattern and options,
-        /// with a new starting position.
+        /// Indicates whether the regular expression specified in the <see cref="Regex"/> constructor finds a
+        /// match in the specified input string, beginning at the specified starting position in the string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="startat">The character position at which to start the search.</param>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="IsMatch(string, int)"/> method is typically used to validate a string or to ensure
+        /// that a string conforms to a particular pattern without retrieving that string for subsequent
+        /// manipulation. To retrieve matched strings, call the <see cref="Match(string, int)"/> or
+        /// <see cref="Matches(string, int)"/> method instead.
+        /// </para>
+        /// <para>
+        /// For more details about <paramref name="startat"/>, see the remarks for
+        /// <see cref="Match(string, int)"/>.
+        /// </para>
+        /// </remarks>
         public bool IsMatch(string input, int startat)
         {
             if (input is null)
@@ -95,46 +251,175 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Indicates whether the regular expression specified in the Regex constructor finds a match in a specified input span.
+        /// Indicates whether the regular expression specified in the <see cref="Regex"/> constructor finds a
+        /// match in a specified input span.
         /// </summary>
         /// <param name="input">The span to search for a match.</param>
-        /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public bool IsMatch(ReadOnlySpan<char> input) =>
             IsMatch(input, RightToLeft ? input.Length : 0);
 
         /// <summary>
-        /// Indicates whether the regular expression specified in the Regex constructor finds a match in a specified input span.
+        /// Indicates whether the regular expression specified in the <see cref="Regex"/> constructor finds a
+        /// match in a specified input span, starting at the specified position.
         /// </summary>
         /// <param name="input">The span to search for a match.</param>
         /// <param name="startat">The zero-based character position at which to start the search.</param>
-        /// <returns><see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.</returns>
+        /// <returns>
+        /// <see langword="true"/> if the regular expression finds a match; otherwise, <see langword="false"/>.
+        /// </returns>
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         public bool IsMatch(ReadOnlySpan<char> input, int startat) =>
             RunSingleMatch(RegexRunnerMode.ExistenceRequired, -1, input, startat).Success;
 
         /// <summary>
-        /// Searches the input string for one or more occurrences of the text
-        /// supplied in the pattern parameter.
+        /// Searches the specified input string for the first occurrence of the specified regular expression.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Match(string, string)"/> method is equivalent to constructing a
+        /// <see cref="Regex"/> object with the specified pattern and calling the instance
+        /// <see cref="Match(string)"/> method. The regular expression engine caches the pattern.
+        /// </para>
+        /// <para>
+        /// You can determine whether the regular expression pattern has been found in the input string by
+        /// checking the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Group.Success"/> property. If a match
+        /// is found, the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Capture.Value"/> property contains the
+        /// matched substring. If no match is found, its value is <see cref="string.Empty"/>.
+        /// </para>
+        /// <para>
+        /// You can retrieve subsequent matches by repeatedly calling the returned <see cref="System.Text.RegularExpressions.Match"/> object's
+        /// <see cref="Match.NextMatch"/> method. You can also retrieve all matches in a single method call by
+        /// calling the <see cref="Matches(string, string)"/> method.
+        /// </para>
+        /// </remarks>
         public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
             RegexCache.GetOrAdd(pattern).Match(input);
 
         /// <summary>
-        /// Searches the input string for one or more occurrences of the text
-        /// supplied in the pattern parameter. Matching is modified with an option
-        /// string.
+        /// Searches the input string for the first occurrence of the specified regular expression, using the
+        /// specified matching options.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Match(string, string, RegexOptions)"/> method is equivalent to constructing a
+        /// <see cref="Regex"/> object with the <see cref="Regex(string, RegexOptions)"/> constructor and calling
+        /// the instance <see cref="Match(string)"/> method.
+        /// </para>
+        /// <para>
+        /// You can determine whether the regular expression pattern has been found in the input string by
+        /// checking the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Group.Success"/> property. You can
+        /// retrieve subsequent matches by repeatedly calling the returned <see cref="System.Text.RegularExpressions.Match"/> object's
+        /// <see cref="Match.NextMatch"/> method. You can also retrieve all matches in a single method call by
+        /// calling the <see cref="Matches(string, string, RegexOptions)"/> method.
+        /// </para>
+        /// </remarks>
         public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Match(input);
 
+        /// <summary>
+        /// Searches the input string for the first occurrence of the specified regular expression, using the
+        /// specified matching options and time-out interval.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate
+        /// that the method should not time out.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Match(string, string, RegexOptions, TimeSpan)"/> method is equivalent to
+        /// constructing a <see cref="Regex"/> object with the
+        /// <see cref="Regex(string, RegexOptions, TimeSpan)"/> constructor and calling the instance
+        /// <see cref="Match(string)"/> method.
+        /// </para>
+        /// <para>
+        /// You can determine whether the regular expression pattern has been found in the input string by
+        /// checking the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Group.Success"/> property. You can
+        /// retrieve subsequent matches by repeatedly calling the returned <see cref="System.Text.RegularExpressions.Match"/> object's
+        /// <see cref="Match.NextMatch"/> method.
+        /// </para>
+        /// <para>
+        /// The <paramref name="matchTimeout"/> parameter specifies how long a pattern matching method should try
+        /// to find a match before it times out. Setting a time-out interval prevents regular expressions that
+        /// rely on excessive backtracking from appearing to stop responding when they process input that contains
+        /// near matches. If no match is found in that time interval, the method throws a
+        /// <see cref="RegexMatchTimeoutException"/> exception. <paramref name="matchTimeout"/> overrides any
+        /// default time-out value defined for the application domain in which the method executes.
+        /// </para>
+        /// </remarks>
         public static Match Match(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Match(input);
 
         /// <summary>
-        /// Matches a regular expression with a string and returns
-        /// the precise result as a Match object.
+        /// Searches the specified input string for the first occurrence of the regular expression specified in
+        /// the <see cref="Regex"/> constructor.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Match(string)"/> method returns the first substring that matches a regular expression
+        /// pattern in an input string.
+        /// </para>
+        /// <para>
+        /// You can determine whether the regular expression pattern has been found in the input string by
+        /// checking the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Group.Success"/> property. If a match
+        /// is found, the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Capture.Value"/> property contains the
+        /// matched substring. If no match is found, its value is <see cref="string.Empty"/>.
+        /// </para>
+        /// <para>
+        /// This method returns the first match. You can retrieve subsequent matches by repeatedly calling the
+        /// returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Match.NextMatch"/> method. You can also retrieve all
+        /// matches in a single method call by calling <see cref="Matches(string)"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="RegexMatchTimeoutException"/> exception is thrown if the execution time of the matching
+        /// operation exceeds the time-out interval specified by the
+        /// <see cref="Regex(string, RegexOptions, TimeSpan)"/> constructor. If you do not set a time-out interval
+        /// when you call the constructor, the exception is thrown if the operation exceeds any time-out value
+        /// established for the application domain in which the <see cref="Regex"/> object is created. If no
+        /// time-out is defined in the <see cref="Regex"/> constructor call or in the application domain's
+        /// properties, or if the time-out value is <see cref="Regex.InfiniteMatchTimeout"/>, no exception
+        /// is thrown.
+        /// </para>
+        /// </remarks>
         public Match Match(string input)
         {
             if (input is null)
@@ -146,9 +431,22 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Matches a regular expression with a string and returns
-        /// the precise result as a Match object.
+        /// Searches the input string for the first occurrence of a regular expression, beginning at the
+        /// specified starting position in the string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="startat">The zero-based character position at which to start the search.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// For more information about <paramref name="startat"/>, see
+        /// <see href="/dotnet/fundamentals/runtime-libraries/system-text-regularexpressions-regex-match">
+        /// Supplemental API remarks for Regex.Match</see>.
+        /// </remarks>
         public Match Match(string input, int startat)
         {
             if (input is null)
@@ -160,8 +458,49 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Matches a regular expression with a string and returns the precise result as a Match object.
+        /// Searches the input string for the first occurrence of a regular expression, beginning at the
+        /// specified starting position and searching only the specified number of characters.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="beginning">The zero-based character position in the input string that defines the
+        /// leftmost position to be searched.</param>
+        /// <param name="length">The number of characters in the substring to include in the search.</param>
+        /// <returns>An object that contains information about the match.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="beginning"/> is less than zero or greater than the length of
+        /// <paramref name="input"/>.
+        /// -or-
+        /// <paramref name="length"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// -or-
+        /// <paramref name="beginning"/> + <paramref name="length"/> - 1 identifies a position that is outside
+        /// the range of <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Match(string, int, int)"/> method searches the portion of <paramref name="input"/>
+        /// defined by the <paramref name="beginning"/> and <paramref name="length"/> parameters for the regular
+        /// expression pattern. <paramref name="beginning"/> always defines the index of the leftmost character
+        /// to include in the search, and <paramref name="length"/> defines the maximum number of characters to
+        /// search. Together, they define the range of the search. The behavior is exactly as if the input was
+        /// effectively <c>input.Substring(beginning, length)</c>, except that the index of any match is counted
+        /// relative to the start of <paramref name="input"/>. This means that any anchors or zero-width
+        /// assertions at the start or end of the pattern behave as if there is no input outside of this range.
+        /// </para>
+        /// <para>
+        /// If the search proceeds from left to right (the default), the regular expression engine searches from
+        /// the character at index <paramref name="beginning"/> to the character at index
+        /// <paramref name="beginning"/> + <paramref name="length"/> - 1. If the regular expression engine was
+        /// instantiated by using the <see cref="RegexOptions.RightToLeft"/> option, the engine searches from the
+        /// character at index <paramref name="beginning"/> + <paramref name="length"/> - 1 to the character at
+        /// index <paramref name="beginning"/>.
+        /// </para>
+        /// <para>
+        /// This method returns the first match found within this range. You can retrieve subsequent matches by
+        /// repeatedly calling the returned <see cref="System.Text.RegularExpressions.Match"/> object's <see cref="Match.NextMatch"/> method.
+        /// </para>
+        /// </remarks>
         public Match Match(string input, int beginning, int length)
         {
             if (input is null)
@@ -173,23 +512,170 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Returns all the successful matches as if Match were called iteratively numerous times.
+        /// Searches the specified input string for all occurrences of a specified regular expression.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>
+        /// A collection of the <see cref="System.Text.RegularExpressions.Match"/> objects found by the search. If no matches are found, the
+        /// method returns an empty collection object.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Matches(string, string)"/> method is similar to the
+        /// <see cref="Match(string, string)"/> method, except that it returns information about all the matches
+        /// found in the input string, instead of a single match.
+        /// </para>
+        /// <para>
+        /// The static <c>Matches</c> methods are equivalent to constructing a <see cref="Regex"/> object with
+        /// the specified regular expression pattern and calling the instance method <c>Matches</c>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Matches(string, string)"/> method uses lazy evaluation to populate the returned
+        /// <see cref="MatchCollection"/> object. Accessing members of this collection such as
+        /// <see cref="MatchCollection.Count"/> and <see cref="MatchCollection.CopyTo(System.Array, int)"/> causes the collection to
+        /// be populated immediately. To take advantage of lazy evaluation, iterate the collection by using
+        /// <see langword="foreach"/>.
+        /// </para>
+        /// <para>
+        /// Because of its lazy evaluation, calling the <see cref="Matches(string, string)"/> method does not
+        /// throw a <see cref="RegexMatchTimeoutException"/> exception. However, the exception is thrown when an
+        /// operation is performed on the <see cref="MatchCollection"/> object returned by this method, if a
+        /// matching operation exceeds the time-out interval.
+        /// </para>
+        /// </remarks>
         public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
             RegexCache.GetOrAdd(pattern).Matches(input);
 
         /// <summary>
-        /// Returns all the successful matches as if Match were called iteratively numerous times.
+        /// Searches the specified input string for all occurrences of a specified regular expression, using the
+        /// specified matching options.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <returns>
+        /// A collection of the <see cref="System.Text.RegularExpressions.Match"/> objects found by the search. If no matches are found, the
+        /// method returns an empty collection object.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Matches(string, string, RegexOptions)"/> method is similar to the
+        /// <see cref="Match(string, string, RegexOptions)"/> method, except that it returns information about all
+        /// the matches found in the input string, instead of a single match.
+        /// </para>
+        /// <para>
+        /// The static <c>Matches</c> methods are equivalent to constructing a <see cref="Regex"/> object with
+        /// the specified regular expression pattern and calling the instance method <c>Matches</c>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Matches(string, string, RegexOptions)"/> method uses lazy evaluation to populate the
+        /// returned <see cref="MatchCollection"/> object. Accessing members of this collection such as
+        /// <see cref="MatchCollection.Count"/> and <see cref="MatchCollection.CopyTo(System.Array, int)"/> causes the collection to
+        /// be populated immediately. To take advantage of lazy evaluation, iterate the collection by using
+        /// <see langword="foreach"/>.
+        /// </para>
+        /// <para>
+        /// Because of its lazy evaluation, calling the <see cref="Matches(string, string, RegexOptions)"/>
+        /// method does not throw a <see cref="RegexMatchTimeoutException"/> exception. However, the exception is
+        /// thrown when an operation is performed on the <see cref="MatchCollection"/> object returned by this
+        /// method, if a matching operation exceeds the time-out interval.
+        /// </para>
+        /// </remarks>
         public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Matches(input);
 
+        /// <summary>
+        /// Searches the specified input string for all occurrences of a specified regular expression, using the
+        /// specified matching options and time-out interval.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that specify options for matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate
+        /// that the method should not time out.</param>
+        /// <returns>
+        /// A collection of the <see cref="System.Text.RegularExpressions.Match"/> objects found by the search. If no matches are found, the
+        /// method returns an empty collection object.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Matches(string, string, RegexOptions, TimeSpan)"/> method is similar to the
+        /// <see cref="Match(string, string, RegexOptions, TimeSpan)"/> method, except that it returns information
+        /// about all the matches found in the input string, instead of a single match.
+        /// </para>
+        /// <para>
+        /// The static <c>Matches</c> methods are equivalent to constructing a <see cref="Regex"/> object with
+        /// the specified regular expression pattern and calling the instance method <c>Matches</c>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Matches(string, string, RegexOptions, TimeSpan)"/> method uses lazy evaluation to
+        /// populate the returned <see cref="MatchCollection"/> object. Accessing members of this collection
+        /// such as <see cref="MatchCollection.Count"/> and <see cref="MatchCollection.CopyTo(System.Array, int)"/> causes the
+        /// collection to be populated immediately. To take advantage of lazy evaluation, iterate the collection
+        /// by using <see langword="foreach"/>.
+        /// </para>
+        /// <para>
+        /// Because of its lazy evaluation, calling the
+        /// <see cref="Matches(string, string, RegexOptions, TimeSpan)"/> method does not throw a
+        /// <see cref="RegexMatchTimeoutException"/> exception. However, an exception is thrown when an operation
+        /// is performed on the <see cref="MatchCollection"/> object returned by this method, if a matching
+        /// operation exceeds the time-out interval specified by the <paramref name="matchTimeout"/> parameter.
+        /// </para>
+        /// </remarks>
         public static MatchCollection Matches(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Matches(input);
 
         /// <summary>
-        /// Returns all the successful matches as if Match was called iteratively numerous times.
+        /// Searches the specified input string for all occurrences of a regular expression.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <returns>
+        /// A collection of the <see cref="System.Text.RegularExpressions.Match"/> objects found by the search. If no matches are found, the
+        /// method returns an empty collection object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Matches(string)"/> method is similar to the <see cref="Match(string)"/> method,
+        /// except that it returns information about all the matches found in the input string, instead of a
+        /// single match. The collection includes only matches and terminates at the first non-match.
+        /// </para>
+        /// <para>
+        /// The <see cref="Matches(string)"/> method uses lazy evaluation to populate the returned
+        /// <see cref="MatchCollection"/> object. Accessing members of this collection such as
+        /// <see cref="MatchCollection.Count"/> and <see cref="MatchCollection.CopyTo(System.Array, int)"/> causes the collection to
+        /// be populated immediately. To take advantage of lazy evaluation, iterate the collection by using
+        /// <see langword="foreach"/>.
+        /// </para>
+        /// <para>
+        /// Because of its lazy evaluation, calling the <see cref="Matches(string)"/> method does not throw a
+        /// <see cref="RegexMatchTimeoutException"/> exception. However, the exception is thrown when an operation
+        /// is performed on the <see cref="MatchCollection"/> object returned by this method, if the
+        /// <see cref="Regex.MatchTimeout"/> property is not <see cref="Regex.InfiniteMatchTimeout"/> and a
+        /// matching operation exceeds the time-out interval.
+        /// </para>
+        /// </remarks>
         public MatchCollection Matches(string input)
         {
             if (input is null)
@@ -201,8 +687,44 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Returns all the successful matches as if Match was called iteratively numerous times.
+        /// Searches the specified input string for all occurrences of a regular expression, beginning at the
+        /// specified starting position in the string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="startat">The character position in the input string at which to start the search.</param>
+        /// <returns>
+        /// A collection of the <see cref="System.Text.RegularExpressions.Match"/> objects found by the search. If no matches are found, the
+        /// method returns an empty collection object.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="input"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Matches(string, int)"/> method is similar to the <see cref="Match(string, int)"/>
+        /// method, except that it returns information about all the matches found in the input string, instead
+        /// of a single match.
+        /// </para>
+        /// <para>
+        /// For more details about <paramref name="startat"/>, see the remarks for
+        /// <see cref="Match(string, int)"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Matches(string, int)"/> method uses lazy evaluation to populate the returned
+        /// <see cref="MatchCollection"/> object. Accessing members of this collection such as
+        /// <see cref="MatchCollection.Count"/> and <see cref="MatchCollection.CopyTo(System.Array, int)"/> causes the collection to
+        /// be populated immediately. To take advantage of lazy evaluation, iterate the collection by using
+        /// <see langword="foreach"/>.
+        /// </para>
+        /// <para>
+        /// Because of its lazy evaluation, calling the <see cref="Matches(string, int)"/> method does not throw
+        /// a <see cref="RegexMatchTimeoutException"/> exception. However, the exception is thrown when an
+        /// operation is performed on the <see cref="MatchCollection"/> object returned by this method, if the
+        /// <see cref="Regex.MatchTimeout"/> property is not <see cref="Regex.InfiniteMatchTimeout"/> and a
+        /// matching operation exceeds the time-out interval.
+        /// </para>
+        /// </remarks>
         public MatchCollection Matches(string input, int startat)
         {
             if (input is null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Match.cs
@@ -444,7 +444,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         /// <remarks>
         /// For more information about <paramref name="startat"/>, see
-        /// <see href="/dotnet/fundamentals/runtime-libraries/system-text-regularexpressions-regex-match">
+        /// <see href="https://github.com/dotnet/docs/blob/main/docs/fundamentals/runtime-libraries/system-text-regularexpressions-regex-match.md">
         /// Supplemental API remarks for Regex.Match</see>.
         /// </remarks>
         public Match Match(string input, int startat)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Replace.cs
@@ -5,7 +5,23 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.RegularExpressions
 {
-    // Callback class
+    /// <summary>
+    /// Represents the method that is called each time a regular expression match is found during a
+    /// <see cref="Regex.Replace(string, MatchEvaluator)"/> method operation.
+    /// </summary>
+    /// <param name="match">The <see cref="Match"/> object that represents a single regular expression
+    /// match during a <see cref="Regex.Replace(string, MatchEvaluator)"/> method operation.</param>
+    /// <returns>A string returned by the method that is represented by the
+    /// <see cref="MatchEvaluator"/> delegate.</returns>
+    /// <remarks>
+    /// You can use a <see cref="MatchEvaluator"/> delegate method to perform a custom verification or
+    /// manipulation operation for each match found by a replacement method such as
+    /// <see cref="Regex.Replace(string, MatchEvaluator)"/>. For each matched string, the
+    /// <see cref="Regex.Replace(string, MatchEvaluator)"/> method calls the
+    /// <see cref="MatchEvaluator"/> delegate method with a <see cref="Match"/> object that represents
+    /// the match. The delegate method performs whatever processing you prefer and returns a string that
+    /// the <see cref="Regex.Replace(string, MatchEvaluator)"/> method substitutes for the matched string.
+    /// </remarks>
     public delegate string MatchEvaluator(Match match);
 
     internal delegate bool MatchCallback<TState>(ref TState state, Match match);
@@ -13,28 +29,189 @@ namespace System.Text.RegularExpressions
     public partial class Regex
     {
         /// <summary>
-        /// Replaces all occurrences of the pattern with the <paramref name="replacement"/> pattern, starting at
-        /// the first character in the input string.
+        /// In a specified input string, replaces all strings that match a specified regular expression pattern
+        /// with a specified replacement string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the method
+        /// returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="replacement"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Replace(string, string, string)"/> methods are equivalent to constructing a
+        /// <see cref="Regex"/> object with the specified regular expression pattern and calling the instance method
+        /// <see cref="Replace(string, string)"/>.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter specifies the string that replaces each match in
+        /// <paramref name="input"/>. <paramref name="replacement"/> can consist of any combination of literal text
+        /// and <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// Substitutions are the only regular expression language elements that are recognized in a replacement
+        /// pattern.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern, string replacement) =>
             RegexCache.GetOrAdd(pattern).Replace(input, replacement);
 
         /// <summary>
-        /// Replaces all occurrences of
-        /// the <paramref name="pattern "/>with the <paramref name="replacement "/>
-        /// pattern, starting at the first character in the input string.
+        /// In a specified input string, replaces all strings that match a specified regular expression with a
+        /// specified replacement string. Specified options modify the matching operation.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for
+        /// matching.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the method
+        /// returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="replacement"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Replace(string, string, string, RegexOptions)"/> methods are equivalent to
+        /// constructing a <see cref="Regex"/> object with the specified regular expression pattern and calling the
+        /// instance method <see cref="Replace(string, string)"/>.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter specifies the string that replaces each match in
+        /// <paramref name="input"/>. <paramref name="replacement"/> can consist of any combination of literal text
+        /// and <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// Substitutions are the only regular expression language elements that are recognized in a replacement
+        /// pattern.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the <paramref name="options"/> parameter,
+        /// the search for matches begins at the end of the input string and moves left; otherwise, the search
+        /// begins at the start of the input string and moves right.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, string replacement, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, replacement);
 
+        /// <summary>
+        /// In a specified input string, replaces all strings that match a specified regular expression with a
+        /// specified replacement string. Additional parameters specify options that modify the matching operation
+        /// and a time-out interval if no match is found.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for
+        /// matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to
+        /// indicate that the method should not time out.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the method
+        /// returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="replacement"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Replace(string, string, string, RegexOptions, TimeSpan)"/> methods are equivalent
+        /// to constructing a <see cref="Regex"/> object with the specified regular expression pattern and calling
+        /// the instance method <see cref="Replace(string, string)"/>.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter specifies the string that replaces each match in
+        /// <paramref name="input"/>. <paramref name="replacement"/> can consist of any combination of literal text
+        /// and <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// Substitutions are the only regular expression language elements that are recognized in a replacement
+        /// pattern.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the <paramref name="options"/> parameter,
+        /// the search for matches begins at the end of the input string and moves left; otherwise, the search
+        /// begins at the start of the input string and moves right.
+        /// </para>
+        /// <para>
+        /// The <paramref name="matchTimeout"/> parameter specifies how long a pattern matching method should try
+        /// to find a match before it times out. Setting a time-out interval prevents regular expressions that rely
+        /// on excessive backtracking from appearing to stop responding when they process input that contains near
+        /// matches. <paramref name="matchTimeout"/> overrides any default time-out value defined for the
+        /// application domain in which the method executes.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, string replacement, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, replacement);
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the
-        /// <paramref name="replacement"/> pattern, starting at the first character in the
-        /// input string.
+        /// In a specified input string, replaces all strings that match a regular expression pattern with a
+        /// specified replacement string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="replacement"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The search for the pattern begins at the beginning of the <paramref name="input"/> string.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter specifies the string that replaces each match.
+        /// <paramref name="replacement"/> can consist of any combination of literal text and
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// Substitutions are the only regular expression language elements that are recognized in a replacement
+        /// pattern.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, string replacement)
         {
             if (input is null)
@@ -46,10 +223,36 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the
-        /// <paramref name="replacement"/> pattern, starting at the first character in the
-        /// input string.
+        /// In a specified input string, replaces a specified maximum number of strings that match a regular
+        /// expression pattern with a specified replacement string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <param name="count">The maximum number of times the replacement can occur.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="replacement"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The search begins at the start of the <paramref name="input"/> string. The <paramref name="replacement"/>
+        /// parameter specifies the string that replaces each match and supports
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// </para>
+        /// <para>
+        /// If <paramref name="count"/> is negative, replacements continue to the end of the string.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, string replacement, int count)
         {
             if (input is null)
@@ -61,10 +264,38 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the
-        /// <paramref name="replacement"/> pattern, starting at the character position
-        /// <paramref name="startat"/>.
+        /// In a specified input substring, replaces a specified maximum number of strings that match a regular
+        /// expression pattern with a specified replacement string.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="replacement">The replacement string.</param>
+        /// <param name="count">The maximum number of times the replacement can occur.</param>
+        /// <param name="startat">The character position in the input string where the search begins.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that the replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="replacement"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// For more details about <paramref name="startat"/>, see the Remarks section of
+        /// <see cref="Match(string, int)"/>.
+        /// </para>
+        /// <para>
+        /// The <paramref name="replacement"/> parameter specifies the string that replaces each match and supports
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/substitutions-in-regular-expressions">substitutions</see>.
+        /// </para>
+        /// <para>
+        /// If <paramref name="count"/> is negative, replacements continue to the end of the string.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, string replacement, int count, int startat)
         {
             if (input is null)
@@ -84,26 +315,190 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Replaces all occurrences of the <paramref name="pattern"/> with the recent
-        /// replacement pattern.
+        /// In a specified input string, replaces all strings that match a specified regular expression with a
+        /// string returned by a <see cref="MatchEvaluator"/> delegate.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="evaluator"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method is useful for replacing a regular expression match if any of the following conditions is
+        /// true: the replacement string cannot readily be specified by a regular expression replacement pattern,
+        /// the replacement string results from processing the matched string, or the replacement string results
+        /// from conditional processing.
+        /// </para>
+        /// <para>
+        /// The method is equivalent to calling the <see cref="Regex.Matches(string, string)"/> method and passing
+        /// each <see cref="System.Text.RegularExpressions.Match"/> object in the returned <see cref="MatchCollection"/> to the
+        /// <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern, MatchEvaluator evaluator) =>
             RegexCache.GetOrAdd(pattern).Replace(input, evaluator);
 
         /// <summary>
-        /// Replaces all occurrences of the <paramref name="pattern"/> with the recent
-        /// replacement pattern, starting at the first character.
+        /// In a specified input string, replaces all strings that match a specified regular expression with a
+        /// string returned by a <see cref="MatchEvaluator"/> delegate. Specified options modify the matching
+        /// operation.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for
+        /// matching.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="evaluator"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method is useful for replacing a regular expression match if any of the following conditions is
+        /// true: the replacement string cannot readily be specified by a regular expression replacement pattern,
+        /// the replacement string results from processing the matched string, or the replacement string results
+        /// from conditional processing.
+        /// </para>
+        /// <para>
+        /// The method is equivalent to calling the <see cref="Regex.Matches(string, string)"/> method and passing
+        /// each <see cref="System.Text.RegularExpressions.Match"/> object in the returned <see cref="MatchCollection"/> to the
+        /// <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the <paramref name="options"/> parameter,
+        /// the search for matches begins at the end of the input string and moves left; otherwise, the search
+        /// begins at the start of the input string and moves right.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, MatchEvaluator evaluator, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Replace(input, evaluator);
 
+        /// <summary>
+        /// In a specified input string, replaces all substrings that match a specified regular expression with a
+        /// string returned by a <see cref="MatchEvaluator"/> delegate. Additional parameters specify options that
+        /// modify the matching operation and a time-out interval if no match is found.
+        /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that provide options for
+        /// matching.</param>
+        /// <param name="matchTimeout">A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to
+        /// indicate that the method should not time out.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If <paramref name="pattern"/> is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/>, <paramref name="pattern"/>, or <paramref name="evaluator"/> is
+        /// <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of <see cref="RegexOptions"/> values.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method is useful for replacing a regular expression match if any of the following conditions is
+        /// true: the replacement string cannot readily be specified by a regular expression replacement pattern,
+        /// the replacement string results from processing the matched string, or the replacement string results
+        /// from conditional processing.
+        /// </para>
+        /// <para>
+        /// The method is equivalent to calling the <see cref="Regex.Matches(string, string)"/> method and passing
+        /// each <see cref="System.Text.RegularExpressions.Match"/> object in the returned <see cref="MatchCollection"/> to the
+        /// <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the <paramref name="options"/> parameter,
+        /// the search for matches begins at the end of the input string and moves left; otherwise, the search
+        /// begins at the start of the input string and moves right.
+        /// </para>
+        /// <para>
+        /// The <paramref name="matchTimeout"/> parameter specifies how long a pattern matching method should try
+        /// to find a match before it times out. <paramref name="matchTimeout"/> overrides any default time-out
+        /// value defined for the application domain in which the method executes.
+        /// </para>
+        /// </remarks>
         public static string Replace(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, MatchEvaluator evaluator, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Replace(input, evaluator);
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the recent
-        /// replacement pattern, starting at the first character position.
+        /// In a specified input string, replaces all strings that match a specified regular expression with a
+        /// string returned by a <see cref="MatchEvaluator"/> delegate.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="evaluator"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method is useful for replacing a regular expression match if any of the following conditions is
+        /// true: the replacement string cannot readily be specified by a regular expression replacement pattern,
+        /// the replacement string results from processing the matched string, or the replacement string results
+        /// from conditional processing.
+        /// </para>
+        /// <para>
+        /// The method is equivalent to calling the <see cref="Regex.Matches(string)"/> method and passing each
+        /// <see cref="System.Text.RegularExpressions.Match"/> object in the returned <see cref="MatchCollection"/> to the
+        /// <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, MatchEvaluator evaluator)
         {
             if (input is null)
@@ -115,9 +510,43 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the recent
-        /// replacement pattern, starting at the first character position.
+        /// In a specified input string, replaces a specified maximum number of strings that match a regular
+        /// expression pattern with a string returned by a <see cref="MatchEvaluator"/> delegate.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <param name="count">The maximum number of times the replacement will occur.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="evaluator"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// This method is useful for replacing a regular expression match if any of the following conditions is
+        /// true: the replacement string cannot readily be specified by a regular expression replacement pattern,
+        /// the replacement string results from processing the matched string, or the replacement string results
+        /// from conditional processing.
+        /// </para>
+        /// <para>
+        /// The method is equivalent to calling the <see cref="Regex.Matches(string)"/> method and passing the
+        /// first <paramref name="count"/> <see cref="System.Text.RegularExpressions.Match"/> objects in the returned
+        /// <see cref="MatchCollection"/> to the <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// <para>
+        /// If <paramref name="count"/> is negative, replacements continue to the end of the string.
+        /// </para>
+        /// <para>
+        /// Because the method returns <paramref name="input"/> unchanged if there is no match, you can use the
+        /// <see cref="object.ReferenceEquals(object?, object?)"/> method to determine whether the method has made
+        /// any replacements.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, MatchEvaluator evaluator, int count)
         {
             if (input is null)
@@ -129,10 +558,36 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Replaces all occurrences of the previously defined pattern with the recent
-        /// replacement pattern, starting at the character position
-        /// <paramref name="startat"/>.
+        /// In a specified input substring, replaces a specified maximum number of strings that match a regular
+        /// expression pattern with a string returned by a <see cref="MatchEvaluator"/> delegate.
         /// </summary>
+        /// <param name="input">The string to search for a match.</param>
+        /// <param name="evaluator">A custom method that examines each match and returns either the original
+        /// matched string or a replacement string.</param>
+        /// <param name="count">The maximum number of times the replacement will occur.</param>
+        /// <param name="startat">The character position in the input string where the search begins.</param>
+        /// <returns>
+        /// A new string that is identical to the input string, except that a replacement string takes the place
+        /// of each matched string. If the regular expression pattern is not matched in the current instance, the
+        /// method returns the current instance unchanged.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="evaluator"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// For more details about <paramref name="startat"/>, see the Remarks section of
+        /// <see cref="Match(string, int)"/>.
+        /// </para>
+        /// <para>
+        /// The method passes the first <paramref name="count"/> <see cref="System.Text.RegularExpressions.Match"/> objects to the
+        /// <paramref name="evaluator"/> delegate.
+        /// </para>
+        /// </remarks>
         public string Replace(string input, MatchEvaluator evaluator, int count, int startat)
         {
             if (input is null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -27,8 +27,8 @@ namespace System.Text.RegularExpressions
         /// instance method <see cref="Split(string)"/>.
         /// </para>
         /// <para>
-        /// The <see cref="Regex"/>.Split methods are similar to the
-        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// The <see cref="Regex.Split(string)">Regex.Split</see> methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex.Split(string)">Regex.Split</see> splits
         /// the string at a delimiter determined by a regular expression instead of a set of
         /// characters. If the regular expression pattern includes capturing parentheses, the
         /// captured text is included in the resulting string array. If the pattern includes
@@ -68,8 +68,8 @@ namespace System.Text.RegularExpressions
         /// and calling the instance method <see cref="Split(string)"/>.
         /// </para>
         /// <para>
-        /// The <see cref="Regex"/>.Split methods are similar to the
-        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// The <see cref="Regex.Split(string)">Regex.Split</see> methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex.Split(string)">Regex.Split</see> splits
         /// the string at a delimiter determined by a regular expression instead of a set of
         /// characters. If the regular expression pattern includes capturing parentheses, the
         /// captured text is included in the resulting string array. If the pattern includes
@@ -121,8 +121,8 @@ namespace System.Text.RegularExpressions
         /// expression pattern and calling the instance method <see cref="Split(string)"/>.
         /// </para>
         /// <para>
-        /// The <see cref="Regex"/>.Split methods are similar to the
-        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// The <see cref="Regex.Split(string)">Regex.Split</see> methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex.Split(string)">Regex.Split</see> splits
         /// the string at a delimiter determined by a regular expression instead of a set of
         /// characters. If the regular expression pattern includes capturing parentheses, the
         /// captured text is included in the resulting string array. If the pattern includes
@@ -159,8 +159,8 @@ namespace System.Text.RegularExpressions
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         /// <remarks>
         /// <para>
-        /// The <see cref="Regex"/>.Split methods are similar to the
-        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// The <see cref="Regex.Split(string)">Regex.Split</see> methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex.Split(string)">Regex.Split</see> splits
         /// the string at a delimiter determined by a regular expression instead of a set of
         /// characters. The string is split as many times as possible. If no match is found, the
         /// return value contains one element whose value is the original input string.
@@ -202,7 +202,7 @@ namespace System.Text.RegularExpressions
         /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
         /// <remarks>
         /// <para>
-        /// The <see cref="Regex"/>.Split methods are similar to
+        /// The <see cref="Regex.Split(string)">Regex.Split</see> methods are similar to
         /// <see cref="string.Split(char[])"/>. The <paramref name="count"/> parameter specifies
         /// the maximum number of substrings into which the input string can be split; the last
         /// string contains the unsplit remainder of the string. A <paramref name="count"/> value of

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Split.cs
@@ -9,25 +9,175 @@ namespace System.Text.RegularExpressions
     public partial class Regex
     {
         /// <summary>
-        /// Splits the <paramref name="input "/>string at the position defined
-        /// by <paramref name="pattern"/>.
+        /// Splits an input string into an array of substrings at the positions defined by a regular
+        /// expression pattern.
         /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Split(string, string)"/> methods are equivalent to constructing a
+        /// <see cref="Regex"/> object with the specified regular expression pattern and calling the
+        /// instance method <see cref="Split(string)"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Regex"/>.Split methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// the string at a delimiter determined by a regular expression instead of a set of
+        /// characters. If the regular expression pattern includes capturing parentheses, the
+        /// captured text is included in the resulting string array. If the pattern includes
+        /// capturing parentheses, any captured text is included in the resulting string array, but
+        /// is not counted when determining whether the count limit has been reached.
+        /// </para>
+        /// <para>
+        /// If two adjacent matches are found, an empty string is placed in the array.
+        /// </para>
+        /// </remarks>
         public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern) =>
             RegexCache.GetOrAdd(pattern).Split(input);
 
         /// <summary>
-        /// Splits the <paramref name="input "/>string at the position defined by <paramref name="pattern"/>.
+        /// Splits an input string into an array of substrings at the positions defined by a
+        /// specified regular expression pattern. Specified options modify the matching operation.
         /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">
+        /// A bitwise combination of the enumeration values that provide options for matching.
+        /// </param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of
+        /// <see cref="RegexOptions"/> values.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Split(string, string, RegexOptions)"/> methods are equivalent to
+        /// constructing a <see cref="Regex"/> object with the specified regular expression pattern
+        /// and calling the instance method <see cref="Split(string)"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Regex"/>.Split methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// the string at a delimiter determined by a regular expression instead of a set of
+        /// characters. If the regular expression pattern includes capturing parentheses, the
+        /// captured text is included in the resulting string array. If the pattern includes
+        /// capturing parentheses, any captured text is included in the resulting string array, but
+        /// is not counted when determining whether the count limit has been reached.
+        /// </para>
+        /// <para>
+        /// If two adjacent matches are found, an empty string is placed in the array.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the
+        /// <paramref name="options"/> parameter, the search for matches begins at the end of the
+        /// input string and moves left.
+        /// </para>
+        /// </remarks>
         public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) =>
             RegexCache.GetOrAdd(pattern, options, s_defaultMatchTimeout).Split(input);
 
+        /// <summary>
+        /// Splits an input string into an array of substrings at the positions defined by a
+        /// specified regular expression pattern. Additional parameters specify options that modify
+        /// the matching operation and a time-out interval if no match is found.
+        /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">
+        /// A bitwise combination of the enumeration values that provide options for matching.
+        /// </param>
+        /// <param name="matchTimeout">
+        /// A time-out interval, or <see cref="Regex.InfiniteMatchTimeout"/> to indicate that the
+        /// method should not time out.
+        /// </param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> or <paramref name="pattern"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options"/> is not a valid bitwise combination of
+        /// <see cref="RegexOptions"/> values.
+        /// -or-
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The static <see cref="Split(string, string, RegexOptions, TimeSpan)"/> methods are
+        /// equivalent to constructing a <see cref="Regex"/> object with the specified regular
+        /// expression pattern and calling the instance method <see cref="Split(string)"/>.
+        /// </para>
+        /// <para>
+        /// The <see cref="Regex"/>.Split methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// the string at a delimiter determined by a regular expression instead of a set of
+        /// characters. If the regular expression pattern includes capturing parentheses, the
+        /// captured text is included in the resulting string array. If the pattern includes
+        /// capturing parentheses, any captured text is included in the resulting string array, but
+        /// is not counted when determining whether the count limit has been reached.
+        /// </para>
+        /// <para>
+        /// If two adjacent matches are found, an empty string is placed in the array.
+        /// </para>
+        /// <para>
+        /// If you specify <see cref="RegexOptions.RightToLeft"/> for the
+        /// <paramref name="options"/> parameter, the search for matches begins at the end of the
+        /// input string and moves left.
+        /// </para>
+        /// <para>
+        /// The <paramref name="matchTimeout"/> parameter specifies how long a pattern matching
+        /// method should try to find a match before it times out.
+        /// <paramref name="matchTimeout"/> overrides any default time-out value defined for the
+        /// application domain in which the method executes.
+        /// </para>
+        /// </remarks>
         public static string[] Split(string input, [StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) =>
             RegexCache.GetOrAdd(pattern, options, matchTimeout).Split(input);
 
         /// <summary>
-        /// Splits the <paramref name="input"/> string at the position defined by a
-        /// previous pattern.
+        /// Splits an input string into an array of substrings at the positions defined by a
+        /// regular expression pattern specified in the <see cref="Regex"/> constructor.
         /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Regex"/>.Split methods are similar to the
+        /// <see cref="string.Split(char[])"/> method, except that <see cref="Regex"/>.Split splits
+        /// the string at a delimiter determined by a regular expression instead of a set of
+        /// characters. The string is split as many times as possible. If no match is found, the
+        /// return value contains one element whose value is the original input string.
+        /// </para>
+        /// <para>
+        /// If the regular expression can match the empty string, <see cref="Split(string)"/> will
+        /// split the string into an array of single-character strings because the empty string
+        /// delimiter can be found at every location.
+        /// </para>
+        /// <para>
+        /// If capturing parentheses are used in the expression, any captured text is included in
+        /// the resulting string array.
+        /// </para>
+        /// <para>
+        /// If two adjacent matches are found, an empty string is placed in the array.
+        /// </para>
+        /// </remarks>
         public string[] Split(string input)
         {
             if (input is null)
@@ -39,9 +189,34 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Splits the <paramref name="input"/> string at the position defined by a
-        /// previous pattern.
+        /// Splits an input string a specified maximum number of times into an array of substrings,
+        /// at the positions defined by a regular expression specified in the <see cref="Regex"/>
+        /// constructor.
         /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <param name="count">The maximum number of times the split can occur.</param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Regex"/>.Split methods are similar to
+        /// <see cref="string.Split(char[])"/>. The <paramref name="count"/> parameter specifies
+        /// the maximum number of substrings into which the input string can be split; the last
+        /// string contains the unsplit remainder of the string. A <paramref name="count"/> value of
+        /// zero provides the default behavior of splitting as many times as possible.
+        /// </para>
+        /// <para>
+        /// If capturing parentheses are used in the expression, any captured text is included in
+        /// the resulting string array but is not counted toward the <paramref name="count"/> limit.
+        /// </para>
+        /// <para>
+        /// Empty strings that result from adjacent matches are counted when determining whether
+        /// the number of matches has reached <paramref name="count"/>.
+        /// </para>
+        /// </remarks>
         public string[] Split(string input, int count)
         {
             if (input is null)
@@ -53,8 +228,39 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Splits the <paramref name="input"/> string at the position defined by a previous pattern.
+        /// Splits an input string a specified maximum number of times into an array of substrings,
+        /// at the positions defined by a regular expression specified in the <see cref="Regex"/>
+        /// constructor. The search for the regular expression pattern starts at a specified
+        /// character position in the input string.
         /// </summary>
+        /// <param name="input">The string to split.</param>
+        /// <param name="count">The maximum number of times the split can occur.</param>
+        /// <param name="startat">
+        /// The character position in the input string where the search begins.
+        /// </param>
+        /// <returns>An array of strings.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="startat"/> is less than zero or greater than the length of
+        /// <paramref name="input"/>.
+        /// </exception>
+        /// <exception cref="RegexMatchTimeoutException">A time-out occurred.</exception>
+        /// <remarks>
+        /// <para>
+        /// For more details about <paramref name="startat"/>, see the Remarks section of
+        /// <see cref="Match(string, int)"/>.
+        /// </para>
+        /// <para>
+        /// If capturing parentheses are used in the expression, any captured text is included in
+        /// the resulting string array but is not counted toward the <paramref name="count"/> limit.
+        /// </para>
+        /// <para>
+        /// Empty strings that result from adjacent matches are counted when determining whether
+        /// the number of matches has reached <paramref name="count"/>.
+        /// </para>
+        /// </remarks>
         public string[] Split(string input, int count, int startat)
         {
             if (input is null)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Timeout.cs
@@ -31,6 +31,22 @@ namespace System.Text.RegularExpressions
         // Neither of these would motivate such an addition now, but the API exists.
 
         /// <summary>Specifies that a pattern-matching operation should not time out.</summary>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Regex(string, RegexOptions, TimeSpan)"/> constructor and a number of static matching
+        /// methods use the <see cref="InfiniteMatchTimeout"/> constant to indicate that the attempt to find a
+        /// pattern match should not time out.
+        /// </para>
+        /// <para>
+        /// Setting the regular expression engine's time-out value to <see cref="InfiniteMatchTimeout"/> can
+        /// cause regular expressions that rely on excessive backtracking to appear to stop responding when
+        /// processing text that nearly matches the regular expression pattern. If you disable time-outs, you
+        /// should ensure that your regular expression does not rely on excessive backtracking and that it
+        /// handles text that nearly matches the regular expression pattern. For more information about handling
+        /// backtracking, see
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/backtracking-in-regular-expressions">Backtracking</see>.
+        /// </para>
+        /// </remarks>
         public static readonly TimeSpan InfiniteMatchTimeout = Timeout.InfiniteTimeSpan;
 
         /// <summary>
@@ -43,19 +59,40 @@ namespace System.Text.RegularExpressions
         /// </remarks>
         internal static readonly TimeSpan s_defaultMatchTimeout = InitDefaultMatchTimeout();
 
-        /// <summary>Timeout for the execution of this <see cref="Regex"/>.</summary>
+        /// <summary>
+        /// The maximum amount of time that can elapse in a pattern-matching operation before the operation
+        /// times out.
+        /// </summary>
         protected internal TimeSpan internalMatchTimeout;
 
-        /// <summary>Gets the timeout interval of the current instance.</summary>
+        /// <summary>Gets the time-out interval of the current instance.</summary>
+        /// <value>
+        /// The maximum time interval that can elapse in a pattern-matching operation before a
+        /// <see cref="RegexMatchTimeoutException"/> is thrown, or <see cref="InfiniteMatchTimeout"/> if
+        /// time-outs are disabled.
+        /// </value>
         /// <remarks>
-        /// The <see cref="MatchTimeout"/> property defines the approximate maximum time interval for a <see cref="Regex"/> instance to execute a single matching
-        /// operation before the operation times out. The regular expression engine throws a <see cref="RegexMatchTimeoutException"/> exception during
-        /// its next timing check after the timeout interval has elapsed. This prevents the regular expression engine from processing input strings
-        /// that require excessive backtracking. The backtracking implementations guarantee that no more than O(N) work (N == length of the input)
-        /// will be performed between timeout checks, though may check more frequently. This enables the implementations to use mechanisms like
-        /// <see cref="string.IndexOf(char)"/> to search the input. Timeouts are considered optional for non-backtracking implementations
-        /// (<see cref="RegexOptions.NonBacktracking"/>), as the purpose of the timeout is to thwart excessive backtracking. Such implementations
-        /// may incur up to O(N * M) operations (N == length of the input, M == length of the pattern) as part of processing input.
+        /// <para>
+        /// The <see cref="MatchTimeout"/> property defines the approximate maximum time interval for a
+        /// <see cref="Regex"/> instance to execute a single matching operation before the operation times out.
+        /// The regular expression engine throws a <see cref="RegexMatchTimeoutException"/> exception during
+        /// its next timing check after the time-out interval has elapsed. This prevents the regular expression
+        /// engine from processing input strings that require excessive backtracking. For more information, see
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/backtracking-in-regular-expressions">Backtracking</see>
+        /// and
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/best-practices">Best Practices for Regular Expressions</see>.
+        /// </para>
+        /// <para>
+        /// This property is read-only. You can set its value explicitly for an individual <see cref="Regex"/>
+        /// object by calling the <see cref="Regex(string, RegexOptions, TimeSpan)"/> constructor; and you can
+        /// set its value for all <see cref="Regex"/> matching operations in an application domain by calling
+        /// the <see cref="AppDomain.SetData(string, object?)"/> method and providing a <see cref="TimeSpan"/>
+        /// value for the "REGEX_DEFAULT_MATCH_TIMEOUT" property.
+        /// </para>
+        /// <para>
+        /// If you do not explicitly set a time-out interval, the default value
+        /// <see cref="InfiniteMatchTimeout"/> is used, and matching operations do not time out.
+        /// </para>
         /// </remarks>
         public TimeSpan MatchTimeout => internalMatchTimeout;
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -26,16 +26,11 @@ namespace System.Text.RegularExpressions
     /// to extract, edit, replace, or delete text substrings; and to add the extracted strings to a
     /// collection to generate a report.
     /// </para>
-    /// <para>
-    /// For more information, see the following articles:
-    /// </para>
-    /// <list type="bullet">
-    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-language-quick-reference">.NET Regular Expression Language</see></item>
-    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</see></item>
-    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/best-practices">Best Practices for Regular Expressions</see></item>
-    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/backtracking-in-regular-expressions">Backtracking</see></item>
-    /// </list>
     /// </remarks>
+    /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-language-quick-reference">.NET Regular Expression Language</related>
+    /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</related>
+    /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/best-practices">Best Practices for Regular Expressions</related>
+    /// <related type="Article" href="https://learn.microsoft.com/dotnet/standard/base-types/backtracking-in-regular-expressions">Backtracking</related>
     public partial class Regex : ISerializable
     {
         /// <summary>The regular expression pattern that was passed to the constructor.</summary>
@@ -71,6 +66,7 @@ namespace System.Text.RegularExpressions
 
         private volatile RegexRunner? _runner;                // cached runner
 
+        /// <summary>Initializes a new instance of the <see cref="Regex" /> class.</summary>
 #if DEBUG
         // These members aren't used from Regex(), but we want to keep them in debug builds for now,
         // so this is a convenient place to include them rather than needing a debug-only illink file.
@@ -79,7 +75,6 @@ namespace System.Text.RegularExpressions
         [DynamicDependency(nameof(SampleMatches))]
         [DynamicDependency(nameof(Explore))]
 #endif
-        /// <summary>Initializes a new instance of the <see cref="Regex" /> class.</summary>
         protected Regex()
         {
             internalMatchTimeout = s_defaultMatchTimeout;
@@ -294,7 +289,7 @@ namespace System.Text.RegularExpressions
         /// Compiles one or more specified <see cref="Regex" /> objects to a named assembly.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">
-        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// Creating an assembly of compiled regular expressions is not supported.
         /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname) =>
@@ -304,7 +299,7 @@ namespace System.Text.RegularExpressions
         /// Compiles one or more specified <see cref="Regex" /> objects to a named assembly with the specified attributes.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">
-        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// Creating an assembly of compiled regular expressions is not supported.
         /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes) =>
@@ -315,7 +310,7 @@ namespace System.Text.RegularExpressions
         /// to a named assembly with the specified attributes.
         /// </summary>
         /// <exception cref="PlatformNotSupportedException">
-        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// Creating an assembly of compiled regular expressions is not supported.
         /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes, string? resourceFile)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.cs
@@ -19,16 +19,55 @@ namespace System.Text.RegularExpressions
     /// Represents an immutable regular expression. Also contains static methods that
     /// allow use of regular expressions without instantiating a Regex explicitly.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The <see cref="Regex"/> class represents the .NET regular expression engine.
+    /// It can be used to quickly parse large amounts of text to find specific character patterns;
+    /// to extract, edit, replace, or delete text substrings; and to add the extracted strings to a
+    /// collection to generate a report.
+    /// </para>
+    /// <para>
+    /// For more information, see the following articles:
+    /// </para>
+    /// <list type="bullet">
+    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-language-quick-reference">.NET Regular Expression Language</see></item>
+    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">Regular Expression Options</see></item>
+    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/best-practices">Best Practices for Regular Expressions</see></item>
+    /// <item><see href="https://learn.microsoft.com/dotnet/standard/base-types/backtracking-in-regular-expressions">Backtracking</see></item>
+    /// </list>
+    /// </remarks>
     public partial class Regex : ISerializable
     {
+        /// <summary>The regular expression pattern that was passed to the constructor.</summary>
         [StringSyntax(StringSyntaxAttribute.Regex)]
-        protected internal string? pattern;                   // The string pattern provided
-        protected internal RegexOptions roptions;             // the top-level options from the options string
-        protected internal RegexRunnerFactory? factory;       // Factory used to create runner instances for executing the regex
-        protected internal Hashtable? caps;                   // if captures are sparse, this is the hashtable capnum->index
-        protected internal Hashtable? capnames;               // if named captures are used, this maps names->index
-        protected internal string[]? capslist;                // if captures are sparse or named captures are used, this is the sorted list of names
-        protected internal int capsize;                       // the size of the capture array
+        protected internal string? pattern;
+
+        /// <summary>The regular expression options that were passed to the constructor.</summary>
+        protected internal RegexOptions roptions;
+
+        /// <summary>A factory used to create <see cref="RegexRunner"/> instances for executing the regular expression.</summary>
+        protected internal RegexRunnerFactory? factory;
+
+        /// <summary>
+        /// When captures are sparse, maps capture numbers to their corresponding index
+        /// in the capture array. Otherwise, <see langword="null"/>.
+        /// </summary>
+        protected internal Hashtable? caps;
+
+        /// <summary>
+        /// When named captures are used, maps capture names to their corresponding index.
+        /// Otherwise, <see langword="null"/>.
+        /// </summary>
+        protected internal Hashtable? capnames;
+
+        /// <summary>
+        /// When captures are sparse or named captures are used, contains the sorted list of capture names.
+        /// Otherwise, <see langword="null"/>.
+        /// </summary>
+        protected internal string[]? capslist;
+
+        /// <summary>The number of capturing groups defined in the regular expression pattern.</summary>
+        protected internal int capsize;
 
         private volatile RegexRunner? _runner;                // cached runner
 
@@ -40,27 +79,55 @@ namespace System.Text.RegularExpressions
         [DynamicDependency(nameof(SampleMatches))]
         [DynamicDependency(nameof(Explore))]
 #endif
+        /// <summary>Initializes a new instance of the <see cref="Regex" /> class.</summary>
         protected Regex()
         {
             internalMatchTimeout = s_defaultMatchTimeout;
         }
 
         /// <summary>
-        /// Creates a regular expression object for the specified regular expression.
+        /// Initializes a new instance of the <see cref="Regex" /> class for the specified regular expression.
         /// </summary>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern" /> is <see langword="null" />.</exception>
         public Regex([StringSyntax(StringSyntaxAttribute.Regex)] string pattern) :
             this(pattern, culture: null)
         {
         }
 
         /// <summary>
-        /// Creates a regular expression object for the specified regular expression, with options that modify the pattern.
+        /// Initializes a new instance of the <see cref="Regex" /> class for the specified regular expression,
+        /// with options that modify the pattern.
         /// </summary>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options" /> is not a valid <see cref="RegexOptions" /> value.
+        /// </exception>
         public Regex([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options) :
             this(pattern, options, s_defaultMatchTimeout, culture: null)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Regex" /> class for the specified regular expression,
+        /// with options that modify the pattern and a value that specifies how long a pattern matching method
+        /// should attempt a match before it times out.
+        /// </summary>
+        /// <param name="pattern">The regular expression pattern to match.</param>
+        /// <param name="options">A bitwise combination of the enumeration values that modify the regular expression.</param>
+        /// <param name="matchTimeout">
+        /// A time-out interval, or <see cref="InfiniteMatchTimeout" /> to indicate that the method should not time out.
+        /// </param>
+        /// <exception cref="ArgumentException">A regular expression parsing error occurred.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="pattern" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="options" /> is not a valid <see cref="RegexOptions" /> value, or
+        /// <paramref name="matchTimeout" /> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
         public Regex([StringSyntax(StringSyntaxAttribute.Regex, nameof(options))] string pattern, RegexOptions options, TimeSpan matchTimeout) :
             this(pattern, options, matchTimeout, culture: null)
         {
@@ -169,6 +236,10 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Initializes a new instance of the <see cref="Regex" /> class by using serialized data.</summary>
+        /// <param name="info">The object that contains a serialized pattern and <see cref="RegexOptions" /> information.</param>
+        /// <param name="context">The destination for this serialization. (This parameter is not used; specify <see langword="null" />.)</param>
+        /// <exception cref="PlatformNotSupportedException">Serialization of <see cref="Regex" /> objects is not supported.</exception>
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected Regex(SerializationInfo info, StreamingContext context) =>
@@ -177,6 +248,7 @@ namespace System.Text.RegularExpressions
         void ISerializable.GetObjectData(SerializationInfo si, StreamingContext context) =>
             throw new PlatformNotSupportedException();
 
+        /// <summary>Gets or sets a dictionary that maps numbered capturing groups to their index values.</summary>
         [CLSCompliant(false), DisallowNull]
         protected IDictionary? Caps
         {
@@ -192,6 +264,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets or sets a dictionary that maps named capturing groups to their index values.</summary>
         [CLSCompliant(false), DisallowNull]
         protected IDictionary? CapNames
         {
@@ -217,14 +290,33 @@ namespace System.Text.RegularExpressions
         private static RegexRunnerFactory? Compile(string pattern, RegexTree regexTree, RegexOptions options, bool hasTimeout) =>
             RegexCompiler.Compile(pattern, regexTree, options, hasTimeout);
 
+        /// <summary>
+        /// Compiles one or more specified <see cref="Regex" /> objects to a named assembly.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">
+        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname) =>
             CompileToAssembly(regexinfos, assemblyname, null, null);
 
+        /// <summary>
+        /// Compiles one or more specified <see cref="Regex" /> objects to a named assembly with the specified attributes.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">
+        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes) =>
             CompileToAssembly(regexinfos, assemblyname, attributes, null);
 
+        /// <summary>
+        /// Compiles one or more specified <see cref="Regex" /> objects and a specified resource file
+        /// to a named assembly with the specified attributes.
+        /// </summary>
+        /// <exception cref="PlatformNotSupportedException">
+        /// .NET Core and .NET 5+: Creating an assembly of compiled regular expressions is not supported.
+        /// </exception>
         [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static void CompileToAssembly(RegexCompilationInfo[] regexinfos, AssemblyName assemblyname, CustomAttributeBuilder[]? attributes, string? resourceFile)
         {
@@ -263,14 +355,25 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Escapes a minimal set of metacharacters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and
-        /// whitespace) by replacing them with their \ codes. This converts a string so that
-        /// it can be used as a constant within a regular expression safely. (Note that the
-        /// reason # and whitespace must be escaped is so the string can be used safely
-        /// within an expression parsed with x mode. If future Regex features add
-        /// additional metacharacters, developers should depend on Escape to escape those
-        /// characters as well.)
+        /// Escapes a minimal set of characters (\, *, +, ?, |, {, [, (, ), ^, $, ., #, and white space)
+        /// by replacing them with their escape codes. This instructs the regular expression engine to interpret
+        /// these characters literally rather than as metacharacters.
         /// </summary>
+        /// <param name="str">The input string that contains the text to convert.</param>
+        /// <returns>A string of characters with metacharacters converted to their escaped form.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="str" /> is <see langword="null" />.</exception>
+        /// <remarks>
+        /// <para>
+        /// <see cref="Escape" /> converts a string so that the regular expression engine will interpret any
+        /// metacharacters that it may contain as character literals. It is particularly important for strings
+        /// that are defined dynamically using characters not known at design time.
+        /// </para>
+        /// <para>
+        /// While this method escapes the straight opening bracket ([) and opening brace ({) characters,
+        /// it does not escape their corresponding closing characters (] and }). In most cases, escaping
+        /// these is not necessary.
+        /// </para>
+        /// </remarks>
         public static string Escape(string str)
         {
             if (str is null)
@@ -281,9 +384,21 @@ namespace System.Text.RegularExpressions
             return RegexParser.Escape(str);
         }
 
-        /// <summary>
-        /// Unescapes any escaped characters in the input string.
-        /// </summary>
+        /// <summary>Converts any escaped characters in the input string.</summary>
+        /// <param name="str">The input string containing the text to convert.</param>
+        /// <returns>A string of characters with any escaped characters converted to their unescaped form.</returns>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="str" /> includes an unrecognized escape sequence.
+        /// </exception>
+        /// <exception cref="ArgumentNullException"><paramref name="str" /> is <see langword="null" />.</exception>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Unescape" /> method reverses the transformation performed by the
+        /// <see cref="Escape" /> method by removing the escape character ("\") from each escaped character.
+        /// It also unescapes hexadecimal values in verbatim string literals, converting them to the actual
+        /// printable characters (for example, <c>\x07</c> becomes <c>\a</c>).
+        /// </para>
+        /// </remarks>
         public static string Unescape(string str)
         {
             if (str is null)
@@ -294,25 +409,39 @@ namespace System.Text.RegularExpressions
             return RegexParser.Unescape(str);
         }
 
-        /// <summary>
-        /// Returns the options passed into the constructor
-        /// </summary>
+        /// <summary>Gets the options that were passed into the <see cref="Regex" /> constructor.</summary>
+        /// <value>
+        /// One or more members of the <see cref="RegexOptions" /> enumeration that represent options that were passed
+        /// to the <see cref="Regex" /> constructor.
+        /// </value>
+        /// <remarks>
+        /// The value of the <see cref="Options" /> property consists of one or more members of the
+        /// <see cref="RegexOptions" /> enumeration. If no options were defined in the constructor,
+        /// its value is <see cref="RegexOptions.None" />. The <see cref="Options" /> property does
+        /// not reflect inline options defined in the regular expression pattern itself.
+        /// </remarks>
         public RegexOptions Options => roptions;
 
-        /// <summary>
-        /// Indicates whether the regular expression matches from right to left.
-        /// </summary>
+        /// <summary>Gets a value that indicates whether the regular expression searches from right to left.</summary>
+        /// <value>
+        /// <see langword="true" /> if the regular expression searches from right to left; otherwise,
+        /// <see langword="false" />.
+        /// </value>
         public bool RightToLeft => (roptions & RegexOptions.RightToLeft) != 0;
 
-        /// <summary>
-        /// Returns the regular expression pattern passed into the constructor
-        /// </summary>
+        /// <summary>Returns the regular expression pattern that was passed into the <see cref="Regex" /> constructor.</summary>
+        /// <returns>
+        /// The pattern that was passed into the <see cref="Regex" /> constructor.
+        /// </returns>
         public override string ToString() => pattern!;
 
-        /// <summary>
-        /// Returns the GroupNameCollection for the regular expression. This collection contains the
-        /// set of strings used to name capturing groups in the expression.
-        /// </summary>
+        /// <summary>Returns an array of capturing group names for the regular expression.</summary>
+        /// <returns>A string array of group names.</returns>
+        /// <remarks>
+        /// The collection of group names contains the set of strings used to name capturing groups in the
+        /// expression. Even if capturing groups are not explicitly named, they are automatically assigned
+        /// numerical names ("0", "1", "2", and so on). Group "0" always designates the entire match.
+        /// </remarks>
         public string[] GetGroupNames()
         {
             string[] result;
@@ -333,9 +462,13 @@ namespace System.Text.RegularExpressions
             return result;
         }
 
-        /// <summary>
-        /// Returns the integer group number corresponding to a group name.
-        /// </summary>
+        /// <summary>Returns an array of capturing group numbers that correspond to group names in an array.</summary>
+        /// <returns>An integer array of group numbers.</returns>
+        /// <remarks>
+        /// Groups can be referred to using both their assigned number and their name (if one was provided).
+        /// The returned array is ordered so that each number maps to the same group name returned by
+        /// <see cref="GetGroupNames" /> at the corresponding index.
+        /// </remarks>
         public int[] GetGroupNumbers()
         {
             int[] result;
@@ -363,17 +496,37 @@ namespace System.Text.RegularExpressions
             return result;
         }
 
-        /// <summary>
-        /// Retrieves a group name that corresponds to a group number.
-        /// </summary>
+        /// <summary>Gets the group name that corresponds to the specified group number.</summary>
+        /// <param name="i">The group number to convert to the corresponding group name.</param>
+        /// <returns>
+        /// A string that contains the group name associated with the specified group number. If there is no
+        /// group name that corresponds to the specified group number, the method returns <see cref="string.Empty" />.
+        /// </returns>
+        /// <remarks>
+        /// A regular expression pattern may contain either named or numbered capturing groups. Numbered groups
+        /// are delimited by the syntax <c>(subexpression)</c> and are assigned numbers based on their order in
+        /// the regular expression. Named groups are delimited by the syntax <c>(?&lt;name&gt;subexpression)</c>.
+        /// The <see cref="GroupNameFromNumber" /> method identifies both named groups and numbered groups by
+        /// their ordinal positions in the regular expression.
+        /// </remarks>
         public string GroupNameFromNumber(int i)
         {
             return RegexParser.GroupNameFromNumber(caps, capslist, capsize, i);
         }
 
-        /// <summary>
-        /// Returns a group number that corresponds to a group name, or -1 if the name is not a recognized group name.
-        /// </summary>
+        /// <summary>Returns the group number that corresponds to the specified group name.</summary>
+        /// <param name="name">The group name to convert to the corresponding group number.</param>
+        /// <returns>
+        /// The group number that corresponds to the specified group name, or -1 if
+        /// <paramref name="name" /> is not a valid group name.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="name" /> is <see langword="null" />.</exception>
+        /// <remarks>
+        /// The <see cref="GroupNumberFromName" /> method identifies both named groups and numbered groups by
+        /// their ordinal positions in the regular expression. Ordinal position zero always represents the
+        /// entire regular expression. All numbered groups are then counted before named groups, regardless
+        /// of their actual position in the regular expression pattern.
+        /// </remarks>
         public int GroupNumberFromName(string name)
         {
             if (name is null)
@@ -399,6 +552,11 @@ namespace System.Text.RegularExpressions
             Interlocked.CompareExchange(ref field, new WeakReference<RegexReplacement?>(null), null) ??
             field;
 
+        /// <summary>
+        /// Used by a <see cref="Regex" /> object generated by the
+        /// <see cref="CompileToAssembly(RegexCompilationInfo[], AssemblyName)" /> method. This method is obsolete.
+        /// </summary>
+        /// <exception cref="NotSupportedException">References have already been initialized.</exception>
         [Obsolete(Obsoletions.RegexExtensibilityImplMessage, DiagnosticId = Obsoletions.RegexExtensibilityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected void InitializeReferences()

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
@@ -8,11 +8,6 @@ namespace System.Text.RegularExpressions
     /// <summary>
     /// Provides information about a regular expression that is used to compile a regular expression to a stand-alone assembly.
     /// </summary>
-    /// <remarks>
-    /// This class was used with <see cref="Regex.CompileToAssembly(RegexCompilationInfo[], System.Reflection.AssemblyName)"/>
-    /// to define regular expressions to be compiled into an assembly. That API is not supported in .NET Core.
-    /// Use <see cref="GeneratedRegexAttribute"/> with the regular expression source generator instead.
-    /// </remarks>
     [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class RegexCompilationInfo
     {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompilationInfo.cs
@@ -5,6 +5,14 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>
+    /// Provides information about a regular expression that is used to compile a regular expression to a stand-alone assembly.
+    /// </summary>
+    /// <remarks>
+    /// This class was used with <see cref="Regex.CompileToAssembly(RegexCompilationInfo[], System.Reflection.AssemblyName)"/>
+    /// to define regular expressions to be compiled into an assembly. That API is not supported in .NET Core.
+    /// Use <see cref="GeneratedRegexAttribute"/> with the regular expression source generator instead.
+    /// </remarks>
     [Obsolete(Obsoletions.RegexCompileToAssemblyMessage, DiagnosticId = Obsoletions.RegexCompileToAssemblyDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class RegexCompilationInfo
     {
@@ -14,11 +22,47 @@ namespace System.Text.RegularExpressions
 
         private TimeSpan _matchTimeout;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexCompilationInfo"/> class that contains information
+        /// about a regular expression to be included in an assembly.
+        /// </summary>
+        /// <param name="pattern">The regular expression to compile.</param>
+        /// <param name="options">The regular expression options to use when compiling the regular expression.</param>
+        /// <param name="name">The name of the type that represents the compiled regular expression.</param>
+        /// <param name="fullnamespace">The namespace to which the new type belongs.</param>
+        /// <param name="ispublic">
+        /// <see langword="true"/> to make the compiled regular expression publicly visible; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="pattern"/> is <see langword="null"/>, or <paramref name="name"/> is <see langword="null"/>,
+        /// or <paramref name="fullnamespace"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is <see cref="string.Empty"/>.</exception>
         public RegexCompilationInfo(string pattern, RegexOptions options, string name, string fullnamespace, bool ispublic)
             : this(pattern, options, name, fullnamespace, ispublic, Regex.s_defaultMatchTimeout)
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexCompilationInfo"/> class that contains information
+        /// about a regular expression with a specified time-out value to be included in an assembly.
+        /// </summary>
+        /// <param name="pattern">The regular expression to compile.</param>
+        /// <param name="options">The regular expression options to use when compiling the regular expression.</param>
+        /// <param name="name">The name of the type that represents the compiled regular expression.</param>
+        /// <param name="fullnamespace">The namespace to which the new type belongs.</param>
+        /// <param name="ispublic">
+        /// <see langword="true"/> to make the compiled regular expression publicly visible; otherwise, <see langword="false"/>.
+        /// </param>
+        /// <param name="matchTimeout">The default time-out interval for the regular expression.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="pattern"/> is <see langword="null"/>, or <paramref name="name"/> is <see langword="null"/>,
+        /// or <paramref name="fullnamespace"/> is <see langword="null"/>.
+        /// </exception>
+        /// <exception cref="ArgumentException"><paramref name="name"/> is <see cref="string.Empty"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// <paramref name="matchTimeout"/> is negative, zero, or greater than approximately 24 days.
+        /// </exception>
         public RegexCompilationInfo(string pattern, RegexOptions options, string name, string fullnamespace, bool ispublic, TimeSpan matchTimeout)
         {
             Pattern = pattern;
@@ -29,8 +73,17 @@ namespace System.Text.RegularExpressions
             MatchTimeout = matchTimeout;
         }
 
+        /// <summary>Gets or sets a value that indicates whether the compiled regular expression has public visibility.</summary>
+        /// <value>
+        /// <see langword="true"/> if the regular expression has public visibility; otherwise, <see langword="false"/>.
+        /// </value>
         public bool IsPublic { get; set; }
 
+        /// <summary>Gets or sets the regular expression's default time-out interval.</summary>
+        /// <value>
+        /// The default maximum time interval that can elapse in a pattern-matching operation before a
+        /// <see cref="RegexMatchTimeoutException"/> is thrown, or <see cref="Regex.InfiniteMatchTimeout"/> if time-outs are disabled.
+        /// </value>
         public TimeSpan MatchTimeout
         {
             get => _matchTimeout;
@@ -41,6 +94,10 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets or sets the name of the type that represents the compiled regular expression.</summary>
+        /// <value>The name of the new type.</value>
+        /// <exception cref="ArgumentNullException">The value for this property is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException">The value for this property is an empty string.</exception>
         public string Name
         {
             get => _name;
@@ -52,6 +109,9 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets or sets the namespace to which the new type belongs.</summary>
+        /// <value>The namespace of the new type.</value>
+        /// <exception cref="ArgumentNullException">The value for this property is <see langword="null"/>.</exception>
         public string Namespace
         {
             get => _nspace;
@@ -63,8 +123,13 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Gets or sets the options to use when compiling the regular expression.</summary>
+        /// <value>A bitwise combination of the enumeration values.</value>
         public RegexOptions Options { get; set; }
 
+        /// <summary>Gets or sets the regular expression to compile.</summary>
+        /// <value>The regular expression to compile.</value>
+        /// <exception cref="ArgumentNullException">The value for this property is <see langword="null"/>.</exception>
         public string Pattern
         {
             get => _pattern;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
@@ -7,18 +7,69 @@ using System.Runtime.Serialization;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// This is the exception that is thrown when a RegEx matching timeout occurs.
+    /// The exception that is thrown when the execution time of a regular expression pattern-matching
+    /// method exceeds its time-out interval.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The presence of a <see cref="RegexMatchTimeoutException"/> exception generally indicates one
+    /// of the following conditions:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>
+    ///       The regular expression engine is backtracking excessively as it attempts to match the input
+    ///       text to the regular expression pattern.
+    ///     </description>
+    ///   </item>
+    ///   <item>
+    ///     <description>
+    ///       The time-out interval has been set too low, especially given high machine load.
+    ///     </description>
+    ///   </item>
+    /// </list>
+    /// <para>
+    /// The way in which an exception handler handles an exception depends on the cause of the exception:
+    /// </para>
+    /// <para>
+    /// If the time-out results from excessive backtracking, your exception handler should abandon the
+    /// attempt to match the input and inform the user that a time-out has occurred in the regular
+    /// expression pattern-matching method. If possible, information about the regular expression pattern,
+    /// which is available from the <see cref="Pattern"/> property, and the input that caused excessive
+    /// backtracking, which is available from the <see cref="Input"/> property, should be logged so that
+    /// the issue can be investigated and the regular expression pattern modified. Time-outs due to
+    /// excessive backtracking are always reproducible.
+    /// </para>
+    /// <para>
+    /// If the time-out results from setting the time-out threshold too low, you can increase the time-out
+    /// interval and retry the matching operation. The current time-out interval is available from the
+    /// <see cref="MatchTimeout"/> property. When a <see cref="RegexMatchTimeoutException"/> exception is
+    /// thrown, the regular expression engine maintains its state so that any future invocations return the
+    /// same result, as if the exception did not occur. The recommended pattern is to wait for a brief,
+    /// random time interval after the exception is thrown before calling the matching method again. This
+    /// can be repeated several times. However, the number of repetitions should be small in case the
+    /// time-out is caused by excessive backtracking.
+    /// </para>
+    /// </remarks>
     [Serializable]
     [System.Runtime.CompilerServices.TypeForwardedFrom("System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")]
     public class RegexMatchTimeoutException : TimeoutException, ISerializable
     {
         /// <summary>
-        /// Constructs a new RegexMatchTimeoutException.
+        /// Initializes a new instance of the <see cref="RegexMatchTimeoutException"/> class with
+        /// information about the regular expression pattern, the input text, and the time-out interval.
         /// </summary>
-        /// <param name="regexInput">Matching timeout occurred during matching within the specified input.</param>
-        /// <param name="regexPattern">Matching timeout occurred during matching to the specified pattern.</param>
-        /// <param name="matchTimeout">Matching timeout occurred because matching took longer than the specified timeout.</param>
+        /// <param name="regexInput">The input text processed by the regular expression engine when the
+        /// time-out occurred.</param>
+        /// <param name="regexPattern">The pattern used by the regular expression engine when the time-out
+        /// occurred.</param>
+        /// <param name="matchTimeout">The time-out interval.</param>
+        /// <remarks>
+        /// The <paramref name="regexInput"/>, <paramref name="regexPattern"/>, and
+        /// <paramref name="matchTimeout"/> values are assigned to the <see cref="Input"/>,
+        /// <see cref="Pattern"/>, and <see cref="MatchTimeout"/> properties of the new
+        /// <see cref="RegexMatchTimeoutException"/> object.
+        /// </remarks>
         public RegexMatchTimeoutException(string regexInput, string regexPattern, TimeSpan matchTimeout)
             : base(SR.RegexMatchTimeoutException_Occurred)
         {
@@ -28,29 +79,56 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// This constructor is provided in compliance with common .NET Framework design patterns;
-        /// developers should prefer using the constructor
-        /// <code>public RegexMatchTimeoutException(string input, string pattern, TimeSpan matchTimeout)</code>.
+        /// Initializes a new instance of the <see cref="RegexMatchTimeoutException"/> class with a
+        /// system-supplied message.
         /// </summary>
+        /// <remarks>
+        /// This constructor initializes the <see cref="Exception.Message"/> property of the new instance
+        /// to a system-supplied message that describes the error. This message is localized for the
+        /// current system culture.
+        /// </remarks>
         public RegexMatchTimeoutException() : base(SR.RegexMatchTimeoutException_Occurred) { }
 
         /// <summary>
-        /// This constructor is provided in compliance with common .NET Framework design patterns;
-        /// developers should prefer using the constructor
-        /// <code>public RegexMatchTimeoutException(string input, string pattern, TimeSpan matchTimeout)</code>.
+        /// Initializes a new instance of the <see cref="RegexMatchTimeoutException"/> class with the
+        /// specified message string.
         /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="message">A string that describes the exception.</param>
+        /// <remarks>
+        /// The <paramref name="message"/> string is assigned to the
+        /// <see cref="Exception.Message"/> property. The string should be localized for the current
+        /// culture.
+        /// </remarks>
         public RegexMatchTimeoutException(string message) : base(message ?? SR.RegexMatchTimeoutException_Occurred) { }
 
         /// <summary>
-        /// This constructor is provided in compliance with common .NET Framework design patterns;
-        /// developers should prefer using the constructor
-        /// <code>public RegexMatchTimeoutException(string input, string pattern, TimeSpan matchTimeout)</code>.
+        /// Initializes a new instance of the <see cref="RegexMatchTimeoutException"/> class with a
+        /// specified error message and a reference to the inner exception that is the cause of this
+        /// exception.
         /// </summary>
-        /// <param name="message">The error message that explains the reason for the exception.</param>
-        /// <param name="inner">The exception that is the cause of the current exception, or a <code>null</code>.</param>
+        /// <param name="message">A string that describes the exception.</param>
+        /// <param name="inner">The exception that is the cause of the current exception.</param>
+        /// <remarks>
+        /// <para>
+        /// Typically, you use this overload to handle an exception in a <c>try</c>/<c>catch</c> block.
+        /// The <paramref name="inner"/> parameter should be a reference to the exception object handled
+        /// in the <c>catch</c> block, or it can be <see langword="null"/>. This value is then assigned
+        /// to the <see cref="Exception.InnerException"/> property.
+        /// </para>
+        /// <para>
+        /// The <paramref name="message"/> string is assigned to the
+        /// <see cref="Exception.Message"/> property. The string should be localized for the current
+        /// culture.
+        /// </para>
+        /// </remarks>
         public RegexMatchTimeoutException(string message, Exception inner) : base(message ?? SR.RegexMatchTimeoutException_Occurred, inner) { }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RegexMatchTimeoutException"/> class with
+        /// serialized data.
+        /// </summary>
+        /// <param name="info">The object that contains the serialized data.</param>
+        /// <param name="context">The stream that contains the serialized data.</param>
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
         protected RegexMatchTimeoutException(SerializationInfo info, StreamingContext context)
@@ -61,6 +139,12 @@ namespace System.Text.RegularExpressions
             MatchTimeout = new TimeSpan(info.GetInt64("timeoutTicks"));
         }
 
+        /// <summary>
+        /// Populates a <see cref="SerializationInfo"/> object with the data needed to serialize a
+        /// <see cref="RegexMatchTimeoutException"/> object.
+        /// </summary>
+        /// <param name="info">The serialization information object to populate with data.</param>
+        /// <param name="context">The destination for this serialization.</param>
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
         {
@@ -70,10 +154,56 @@ namespace System.Text.RegularExpressions
             info.AddValue("timeoutTicks", MatchTimeout.Ticks);
         }
 
+        /// <summary>
+        /// Gets the input text that the regular expression engine was processing when the time-out
+        /// occurred.
+        /// </summary>
+        /// <value>The regular expression input text.</value>
+        /// <remarks>
+        /// <para>
+        /// This property reflects the value of the <c>regexInput</c> parameter of the
+        /// <see cref="RegexMatchTimeoutException(string, string, TimeSpan)"/> constructor. If this
+        /// parameter is not explicitly initialized in a constructor call, its value is
+        /// <see cref="string.Empty"/>.
+        /// </para>
+        /// <para>
+        /// When the exception is thrown by the regular expression engine, the value of the
+        /// <see cref="Input"/> property reflects the entire input string passed to the regular
+        /// expression engine. It does not reflect a partial string, such as the substring that the
+        /// engine searches in the call to a method such as
+        /// <see cref="Regex.Match(string, int)"/>.
+        /// </para>
+        /// </remarks>
         public string Input { get; } = string.Empty;
 
+        /// <summary>
+        /// Gets the regular expression pattern that was used in the matching operation when the time-out
+        /// occurred.
+        /// </summary>
+        /// <value>The regular expression pattern.</value>
+        /// <remarks>
+        /// This property reflects the value of the <c>regexPattern</c> parameter of the
+        /// <see cref="RegexMatchTimeoutException(string, string, TimeSpan)"/> constructor. If the
+        /// parameter is not properly initialized in a constructor call, its value is
+        /// <see cref="string.Empty"/>.
+        /// </remarks>
         public string Pattern { get; } = string.Empty;
 
+        /// <summary>Gets the time-out interval for a regular expression match.</summary>
+        /// <value>The time-out interval.</value>
+        /// <remarks>
+        /// <para>
+        /// This property reflects the value of the <c>matchTimeout</c> parameter of the
+        /// <see cref="RegexMatchTimeoutException(string, string, TimeSpan)"/> constructor. If the
+        /// parameter is not properly initialized in a constructor call, its value is
+        /// <c>TimeSpan.FromTicks(-1)</c>.
+        /// </para>
+        /// <para>
+        /// The value of this property reflects the time-out interval set in the call to the
+        /// <see cref="Regex"/> constructor or static method. It does not reflect the exact interval
+        /// that has elapsed from the beginning of the method call to the time the exception is thrown.
+        /// </para>
+        /// </remarks>
         public TimeSpan MatchTimeout { get; } = TimeSpan.FromTicks(-1);
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexMatchTimeoutException.cs
@@ -17,15 +17,11 @@ namespace System.Text.RegularExpressions
     /// </para>
     /// <list type="bullet">
     ///   <item>
-    ///     <description>
     ///       The regular expression engine is backtracking excessively as it attempts to match the input
     ///       text to the regular expression pattern.
-    ///     </description>
     ///   </item>
     ///   <item>
-    ///     <description>
     ///       The time-out interval has been set too low, especially given high machine load.
-    ///     </description>
     ///   </item>
     /// </list>
     /// <para>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexOptions.cs
@@ -3,6 +3,17 @@
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>Provides enumerated values to use to set regular expression options.</summary>
+    /// <remarks>
+    /// <para>
+    /// Several options provided by members of the <see cref="RegexOptions"/> enumeration (in particular,
+    /// <see cref="RegexOptions.ExplicitCapture"/>, <see cref="RegexOptions.IgnoreCase"/>,
+    /// <see cref="RegexOptions.Multiline"/>, and <see cref="RegexOptions.Singleline"/>) can instead be
+    /// provided by using an inline option character in the regular expression pattern. For details, see
+    /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+    /// Regular Expression Options</see>.
+    /// </para>
+    /// </remarks>
     [Flags]
 #if SYSTEM_TEXT_REGULAREXPRESSIONS
     public
@@ -11,47 +22,109 @@ namespace System.Text.RegularExpressions
 #endif
     enum RegexOptions
     {
-        /// <summary>Use default behavior.</summary>
+        /// <summary>
+        /// Specifies that no options are set. For more information about the default behavior of the regular
+        /// expression engine, see the "Default Options" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         None = 0x0000,
 
-        /// <summary>Use case-insensitive matching.</summary>
+        /// <summary>
+        /// Specifies case-insensitive matching. For more information, see the "Case-Insensitive Matching"
+        /// section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         IgnoreCase = 0x0001, // "i"
 
         /// <summary>
-        /// Use multiline mode, where ^ and $ match the beginning and end of each line
-        /// (instead of the beginning and end of the input string).
+        /// Multiline mode. Changes the meaning of <c>^</c> and <c>$</c> so they match at the beginning
+        /// and end, respectively, of any line, and not just the beginning and end of the entire string.
+        /// For more information, see the "Multiline Mode" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
         /// </summary>
         Multiline = 0x0002, // "m"
 
         /// <summary>
-        /// Do not capture unnamed groups. The only valid captures are explicitly named
-        /// or numbered groups of the form (?&lt;name&gt; subexpression).
+        /// Specifies that the only valid captures are explicitly named or numbered groups of the form
+        /// <c>(?&lt;name&gt;...)</c>. This allows unnamed parentheses to act as noncapturing groups without
+        /// the syntactic clumsiness of the expression <c>(?:...)</c>. For more information, see the
+        /// "Explicit Captures Only" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
         /// </summary>
         ExplicitCapture = 0x0004, // "n"
 
-        /// <summary>Compile the regular expression to Microsoft intermediate language (MSIL).</summary>
+        /// <summary>
+        /// Specifies that the regular expression is compiled to MSIL code, instead of being interpreted.
+        /// Compiled regular expressions maximize run-time performance at the expense of initialization time.
+        /// For more information, see the "Compiled Regular Expressions" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         Compiled = 0x0008,
 
         /// <summary>
-        /// Use single-line mode, where the period (.) matches every character (instead of every character except \n).
+        /// Specifies single-line mode. Changes the meaning of the dot (<c>.</c>) so it matches every character
+        /// (instead of every character except <c>\n</c>). For more information, see the "Single-line Mode"
+        /// section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
         /// </summary>
         Singleline = 0x0010, // "s"
 
-        /// <summary>Exclude unescaped white space from the pattern, and enable comments after a number sign (#).</summary>
+        /// <summary>
+        /// Eliminates unescaped white space from the pattern and enables comments marked with <c>#</c>.
+        /// However, this value does not affect or eliminate white space in
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/character-classes-in-regular-expressions">
+        /// character classes</see>, numeric
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/quantifiers-in-regular-expressions">
+        /// quantifiers</see>, or tokens that mark the beginning of individual
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-language-quick-reference">
+        /// regular expression language elements</see>. For more information, see the "Ignore White Space"
+        /// section of the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         IgnorePatternWhitespace = 0x0020, // "x"
 
-        /// <summary>Change the search direction. Search moves from right to left instead of from left to right.</summary>
+        /// <summary>
+        /// Specifies that the search will be from right to left instead of from left to right. For more
+        /// information, see the "Right-to-Left Mode" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         RightToLeft = 0x0040,
 
-        /// <summary>Enable ECMAScript-compliant behavior for the expression.</summary>
+        /// <summary>
+        /// Enables ECMAScript-compliant behavior for the expression. This value can be used only in
+        /// conjunction with the <see cref="IgnoreCase"/>, <see cref="Multiline"/>, and
+        /// <see cref="Compiled"/> values. The use of this value with any other values results in an
+        /// exception.
+        /// </summary>
+        /// <remarks>
+        /// For more information on the <see cref="ECMAScript"/> option, see the "ECMAScript Matching
+        /// Behavior" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </remarks>
         ECMAScript = 0x0100,
 
-        /// <summary>Ignore cultural differences in language.</summary>
+        /// <summary>
+        /// Specifies that cultural differences in language are ignored. For more information, see the
+        /// "Comparison Using the Invariant Culture" section in the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
+        /// </summary>
         CultureInvariant = 0x0200,
 
         /// <summary>
         /// Enable matching using an approach that avoids backtracking and guarantees linear-time processing
-        /// in the length of the input.
+        /// in the length of the input. For more information, see the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
         /// </summary>
         /// <remarks>
         /// Certain features aren't available when this option is set, including balancing groups,
@@ -64,7 +137,9 @@ namespace System.Text.RegularExpressions
         /// <summary>
         /// Make <c>^</c>, <c>$</c>, <c>\Z</c>, and <c>.</c> recognize all common newline sequences
         /// (<c>\r\n</c>, <c>\r</c>, <c>\n</c>, <c>\v</c> (VT), <c>\f</c> (FF), and the Unicode newlines <c>\u0085</c>, <c>\u2028</c>, <c>\u2029</c>)
-        /// instead of only <c>\n</c>.
+        /// instead of only <c>\n</c>. For more information, see the
+        /// <see href="https://learn.microsoft.com/dotnet/standard/base-types/regular-expression-options">
+        /// Regular Expression Options</see> article.
         /// </summary>
         AnyNewLine = 0x0800,
     }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseError.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseError.cs
@@ -126,7 +126,7 @@ namespace System.Text.RegularExpressions
         /// </summary>
         InsufficientClosingParentheses,
         /// <summary>
-        /// A quantifier range in a regular expression is inverse, like <code>{10,1}</code> instead of <code>(1,10}</code>.
+        /// A quantifier range in a regular expression is inverse, like <c>{10,1}</c> instead of <c>{1,10}</c>.
         /// </summary>
         ReversedQuantifierRange,
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseException.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParseException.cs
@@ -7,8 +7,8 @@ using System.Runtime.Serialization;
 namespace System.Text.RegularExpressions
 {
     /// <summary>
-    /// An exception as a result of a parse error in a regular expression <see cref="RegularExpressions"/>, with
-    /// detailed information in the <see cref="Error"/> and <see cref="Offset"/> properties.
+    /// An exception as a result of a parse error in a regular expression, with detailed information in the
+    /// <see cref="Error"/> and <see cref="Offset"/> properties.
     /// </summary>
     [Serializable]
 #if SYSTEM_TEXT_REGULAREXPRESSIONS
@@ -19,9 +19,14 @@ namespace System.Text.RegularExpressions
     sealed class RegexParseException : ArgumentException
     {
         /// <summary>Gets the error that happened during parsing.</summary>
+        /// <value>The error that occurred during parsing.</value>
         public RegexParseError Error { get; }
 
-        /// <summary>Gets the zero-based character offset in the regular expression pattern where the parse error occurs.</summary>
+        /// <summary>
+        /// Gets the zero-based character offset in the regular expression pattern where the parse error
+        /// occurs.
+        /// </summary>
+        /// <value>The offset at which the parse error occurs.</value>
         public int Offset { get; }
 
         // No need for a serialization ctor: we swap the active type during serialization.
@@ -32,6 +37,15 @@ namespace System.Text.RegularExpressions
             Offset = offset;
         }
 
+        /// <summary>
+        /// Sets the <paramref name="info"/> object with the parameter name and additional exception
+        /// information.
+        /// </summary>
+        /// <param name="info">The object that holds the serialized object data.</param>
+        /// <param name="context">The contextual information about the source or destination.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="info"/> is <see langword="null"/>.
+        /// </exception>
 #if NET
         [Obsolete(Obsoletions.LegacyFormatterImplMessage, DiagnosticId = Obsoletions.LegacyFormatterImplDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunner.cs
@@ -109,6 +109,7 @@ namespace System.Text.RegularExpressions
         private bool _checkTimeout;
         private long _timeoutOccursAt;
 
+        /// <summary>Initializes a new instance of the <see cref="RegexRunner"/> class.</summary>
         protected RegexRunner() { }
 
         /// <summary>Used by a <see cref="Regex"/> object to scan the input <paramref name="text"/> looking for the next match.</summary>
@@ -159,6 +160,7 @@ namespace System.Text.RegularExpressions
             InternalScan(runregex!, beginning, beginning + text.Length);
         }
 
+        /// <summary>Used by a <see cref="Regex"/> object to scan the input <paramref name="text"/>.</summary>
         [Obsolete(Obsoletions.RegexExtensibilityImplMessage, DiagnosticId = Obsoletions.RegexExtensibilityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         protected Match? Scan(Regex regex, string text, int textbeg, int textend, int textstart, int prevlen, bool quick) =>
             Scan(regex, text, textbeg, textend, textstart, prevlen, quick, regex.MatchTimeout);
@@ -353,6 +355,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
+        /// <summary>Checks whether the operation has timed out, and throws <see cref="RegexMatchTimeoutException"/> if it has.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected internal void CheckTimeout()
         {
@@ -436,6 +439,7 @@ namespace System.Text.RegularExpressions
         /// <summary>Called to determine a char's inclusion in the \w set.</summary>
         internal static bool IsWordChar(char ch) => RegexCharClass.IsWordChar(ch);
 
+        /// <summary>Determines whether the position at the specified index is an ECMA-compatible word boundary.</summary>
         protected bool IsECMABoundary(int index, int startpos, int endpos)
         {
             return (index > startpos && RegexCharClass.IsECMAWordChar(runtext![index - 1])) !=
@@ -449,6 +453,7 @@ namespace System.Text.RegularExpressions
                    ((uint)index < (uint)inputSpan.Length && RegexCharClass.IsECMAWordChar(inputSpan[index]));
         }
 
+        /// <summary>Determines whether the specified character is in the given character set and category.</summary>
         [Obsolete(Obsoletions.RegexExtensibilityImplMessage, DiagnosticId = Obsoletions.RegexExtensibilityDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         protected static bool CharInSet(char ch, string set, string category)
         {
@@ -456,6 +461,7 @@ namespace System.Text.RegularExpressions
             return RegexCharClass.CharInClass(ch, charClass);
         }
 
+        /// <summary>Determines whether the specified character matches the given character class string.</summary>
         public static bool CharInClass(char ch, string charClass)
         {
             return RegexCharClass.CharInClass(ch, charClass);
@@ -599,9 +605,7 @@ namespace System.Text.RegularExpressions
             }
         }
 
-        /*
-         * Called by Go() to revert the last capture
-         */
+        /// <summary>Called by <see cref="Go"/> to revert the last capture.</summary>
         protected void Uncapture()
         {
             int capnum = Popcrawl();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerFactory.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexRunnerFactory.cs
@@ -5,10 +5,15 @@ using System.ComponentModel;
 
 namespace System.Text.RegularExpressions
 {
+    /// <summary>Creates a <see cref="RegexRunner"/> for a <see cref="Regex"/>.</summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public abstract class RegexRunnerFactory
     {
+        /// <summary>Initializes a new instance of the <see cref="RegexRunnerFactory"/> class.</summary>
         protected RegexRunnerFactory() { }
+
+        /// <summary>Creates a <see cref="RegexRunner"/> instance for the <see cref="Regex"/>.</summary>
+        /// <returns>A <see cref="RegexRunner"/> instance.</returns>
         protected internal abstract RegexRunner CreateInstance();
     }
 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/ValueMatch.cs
@@ -3,12 +3,12 @@
 
 namespace System.Text.RegularExpressions
 {
-    /// <summary>
-    /// Represents the results from a single regular expression match.
-    /// </summary>
+    /// <summary>Represents the results from a single regular expression match.</summary>
     /// <remarks>
-    /// The <see cref="ValueMatch"/> type is immutable and has no public constructor. An instance of the <see cref="ValueMatch"/> struct is returned by the
-    /// <see cref="Regex.ValueMatchEnumerator.Current"/> method when iterating over the results from calling <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/>.
+    /// The <see cref="ValueMatch"/> type is immutable and has no public constructor. An instance of the
+    /// <see cref="ValueMatch"/> struct is returned by the
+    /// <see cref="Regex.ValueMatchEnumerator.Current"/> method when iterating over the results from
+    /// calling <see cref="Regex.EnumerateMatches(ReadOnlySpan{char})"/>.
     /// </remarks>
     public readonly ref struct ValueMatch
     {
@@ -16,9 +16,11 @@ namespace System.Text.RegularExpressions
         private readonly int _length;
 
         /// <summary>
-        /// Crates an instance of the <see cref="ValueMatch"/> type based on the passed in <paramref name="index"/> and <paramref name="length"/>.
+        /// Creates an instance of the <see cref="ValueMatch"/> type based on the passed in
+        /// <paramref name="index"/> and <paramref name="length"/>.
         /// </summary>
-        /// <param name="index">The position in the original span where the first character of the captured sliced span is found.</param>
+        /// <param name="index">The position in the original span where the first character of the
+        /// captured sliced span is found.</param>
         /// <param name="length">The length of the captured sliced span.</param>
         internal ValueMatch(int index, int length)
         {
@@ -27,13 +29,12 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
-        /// Gets the position in the original span where the first character of the captured sliced span is found.
+        /// Gets the position in the original span where the first character of the captured sliced
+        /// span is found.
         /// </summary>
         public int Index => _index;
 
-        /// <summary>
-        /// Gets the length of the captured sliced span.
-        /// </summary>
+        /// <summary>Gets the length of the captured sliced span.</summary>
         public int Length => _length;
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Motivation

New APIs like `RegexOptions.AnyNewLine` and `RegexOptions.NonBacktracking` have documentation in source code but only "To be added." stubs in the dotnet-api-docs repo, so they show up undocumented on learn.microsoft.com. Similarly, `GeneratedRegexAttribute` members were documented in source but stubbed in the docs repo.

Rather than patch these individually in the docs repo, this PR makes the source code the single source of truth by backporting the richer dotnet-api-docs content into `///` comments and flipping the `UseCompilerGeneratedDocXmlFile` switch. This is part of the broader initiative tracked in https://github.com/dotnet/dotnet-api-docs/issues/10722.

## What changed

- **24 files** in `src/libraries/System.Text.RegularExpressions/src/` &#8212; all changes are XML doc comments (`///`), with these exceptions:
  - Removed `<UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>` from the csproj (flips the switch so compiler-generated XML becomes authoritative)
  - Converted inline `//` comments on protected fields in `Regex.cs` to `///` XML doc comments (required to avoid CS1591 errors)
  - Removed a `// Callback class` comment in `RegexRunnerFactory.cs` (replaced by `/// <summary>`)
- **No behavioral code changes.**

## Merge strategy

- **Default: dotnet-api-docs text wins** &#8212; richer, editor-reviewed content preferred over minimal source stubs
- **Source text kept where docs-repo was missing** &#8212; `AnyNewLine`, `NonBacktracking`, `GeneratedRegexAttribute` members had docs in source but only "To be added." in the docs repo
- **.NET Framework-specific content stripped** &#8212; `CompileToAssembly` remarks, Framework version notes, etc.

## Format conversion

Docs-repo uses a custom XML/Markdown hybrid format. This was converted to standard `///` XML:

| docs-repo | source `///` |
|-----------|-------------|
| `<format type="text/markdown">` | `<remarks>`, `<para>`, `<list>` |
| Backtick code | `<c>...</c>` |
| `[text](url)` | `<see href="url">text</see>` |
| Markdown tables | `<list type="table">` |

## Follow-up needed (by docs team)

Per the process in dotnet/dotnet-api-docs#10722:
- Add `System.Text.RegularExpressions` namespace to `disallow-edits.yml`
- Set `open_to_public_contributors` to `false` in the API docs repo
- Add to the docs CI pipeline for ongoing validation

## Testing

- Build: 0 errors, 0 warnings (Release)
- Tests: net481 (15,932 passed), net11.0 (32,068 passed)
