### PR TITLE
Fix cDAC stack walker infinite loop on InlinedCallFrame with unreadable managed code

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -97,6 +97,15 @@ internal readonly struct StackWalk_1 : IStackWalk
                 {
                     handle.FrameIter.Next();
                 }
+                else if (!IsManaged(handle.Context.InstructionPointer, out _))
+                {
+                    // The InlinedCallFrame has an active call but the caller's IP is not
+                    // in a known managed code range (e.g. partial dump without JIT code
+                    // heaps). Advance past the frame to prevent an infinite loop — without
+                    // managed code range data the walker would repeatedly re-process the
+                    // same InlinedCallFrame.
+                    handle.FrameIter.Next();
+                }
                 break;
             case StackWalkState.SW_ERROR:
             case StackWalkState.SW_COMPLETE:


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-assisted.

## Summary

Fix an infinite loop in the cDAC stack walker when processing an `InlinedCallFrame` with an active P/Invoke call whose `CallerReturnAddress` is not in a known managed code range.

## Problem

When the cDAC stack walker encounters an `InlinedCallFrame` with an active call (i.e., `CallerReturnAddress != null`), it:

1. Sets the context IP to `CallerReturnAddress` via `UpdateContextFromFrame`
2. Checks `IsInlineCallFrameWithActiveCall()` → true → does **not** advance the frame iterator
3. Calls `UpdateState()` which checks `IsManaged(CallerReturnAddress)`

If `IsManaged()` returns false (e.g., when analyzing a partial/mini dump that does not include JIT code heaps), the walker stays in `SW_FRAME` state and re-processes the same `InlinedCallFrame` indefinitely.

This was discovered while investigating in-process mini core dumps on mobile platforms, where the dump captures the runtime DATA segment (cDAC descriptor, thread store, frame chains, stacks) but not the JIT code heap regions.

## Fix

After `UpdateContextFromFrame` updates the context for an active `InlinedCallFrame`, check whether the caller IP is recognized as managed code. If it is not, advance past the frame — the same behavior as for inactive `InlinedCallFrame`s. This only affects scenarios where managed code ranges are unreadable; in normal operation `IsManaged()` returns true and the existing behavior is preserved.

## Testing

- Verified the fix resolves the infinite loop on a Mach-O ARM64 mini dump with 5 managed threads
- Existing cDAC contract tests pass (43/43)
- Stack walk dump tests are conditional on debuggee availability and are not affected by this change