### PR TITLE
[ios-clr] Disable Debug CoreCLR smoke jobs on Apple mobile and enable aggressive trimming in Release

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -207,34 +207,35 @@ jobs:
 #
 # tvOS
 # Build the whole product using CoreCLR and run libraries smoke tests (Debug)
+# Tracked in https://github.com/dotnet/runtime/issues/124344
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Debug
-    runtimeFlavor: coreclr
-    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-    isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
-    platforms:
-      - tvos_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: coreclrContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
-      - name: illinkContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR_Smoke
-      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false $(_runSmokeTestsOnlyArg) /p:BuildTestsOnHelix=true /p:UsePortableRuntimePack=false
-      timeoutInMinutes: 240
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Debug
+#     runtimeFlavor: coreclr
+#     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+#     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
+#     platforms:
+#       - tvos_arm64
+#     variables:
+#       # map dependencies variables to local variables
+#       - name: librariesContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+#       - name: coreclrContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+#       - name: illinkContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_CoreCLR_Smoke
+#       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false $(_runSmokeTestsOnlyArg) /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
+#       timeoutInMinutes: 240
+#       # extra steps, run tests
+#       postBuildSteps:
+#         - template: /eng/pipelines/libraries/helix.yml
+#           parameters:
+#             creator: dotnet-bot
+#             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+#             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -147,7 +147,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR
-      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
+      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:EnableAggressiveTrimming=true
       timeoutInMinutes: 240
       # extra steps, run tests
       postBuildSteps:
@@ -203,34 +203,35 @@ jobs:
 #
 # iOSSimulator
 # Build the whole product using CoreCLR and run libraries smoke tests (Debug)
+# Tracked in https://github.com/dotnet/runtime/issues/124344
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Debug
-    runtimeFlavor: coreclr
-    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-    isiOSLikeSimulatorOnlyBuild: ${{ parameters.isiOSLikeSimulatorOnlyBuild }}
-    platforms:
-      - iossimulator_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: coreclrContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
-      - name: illinkContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR_Smoke
-      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
-      timeoutInMinutes: 240
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Debug
+#     runtimeFlavor: coreclr
+#     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+#     isiOSLikeSimulatorOnlyBuild: ${{ parameters.isiOSLikeSimulatorOnlyBuild }}
+#     platforms:
+#       - iossimulator_arm64
+#     variables:
+#       # map dependencies variables to local variables
+#       - name: librariesContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+#       - name: coreclrContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+#       - name: illinkContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_CoreCLR_Smoke
+#       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:EnableAggressiveTrimming=true
+#       timeoutInMinutes: 240
+#       # extra steps, run tests
+#       postBuildSteps:
+#         - template: /eng/pipelines/libraries/helix.yml
+#           parameters:
+#             creator: dotnet-bot
+#             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+#             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -296,7 +296,7 @@ jobs:
     jobParameters:
       testGroup: innerloop
       nameSuffix: AllSubsets_CoreCLR_AppSandbox
-      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:DevTeamProvisioning=adhoc /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAppSandbox=true
+      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:DevTeamProvisioning=adhoc /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAppSandbox=true /p:EnableAdditionalTimezoneChecks=true /p:EnableAggressiveTrimming=true
       timeoutInMinutes: 240
       # extra steps, run tests
       postBuildSteps:
@@ -309,34 +309,35 @@ jobs:
 #
 # MacCatalyst
 # Build the whole product using CoreCLR and run libraries smoke tests (Debug)
+# Tracked in https://github.com/dotnet/runtime/issues/124344
 #
-- template: /eng/pipelines/common/platform-matrix.yml
-  parameters:
-    jobTemplate: /eng/pipelines/common/global-build-job.yml
-    helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-    buildConfig: Debug
-    runtimeFlavor: coreclr
-    isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
-    isMacCatalystOnlyBuild: ${{ parameters.isMacCatalystOnlyBuild }}
-    platforms:
-      - maccatalyst_arm64
-    variables:
-      # map dependencies variables to local variables
-      - name: librariesContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-      - name: coreclrContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
-      - name: illinkContainsChange
-        value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
-    jobParameters:
-      testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR_Smoke_Debug
-      buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:DevTeamProvisioning=adhoc /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true
-      timeoutInMinutes: 240
-      # extra steps, run tests
-      postBuildSteps:
-        - template: /eng/pipelines/libraries/helix.yml
-          parameters:
-            creator: dotnet-bot
-            testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
-            extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+# - template: /eng/pipelines/common/platform-matrix.yml
+#   parameters:
+#     jobTemplate: /eng/pipelines/common/global-build-job.yml
+#     helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
+#     buildConfig: Debug
+#     runtimeFlavor: coreclr
+#     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
+#     isMacCatalystOnlyBuild: ${{ parameters.isMacCatalystOnlyBuild }}
+#     platforms:
+#       - maccatalyst_arm64
+#     variables:
+#       # map dependencies variables to local variables
+#       - name: librariesContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
+#       - name: coreclrContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
+#       - name: illinkContainsChange
+#         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
+#     jobParameters:
+#       testGroup: innerloop
+#       nameSuffix: AllSubsets_CoreCLR_Smoke_Debug
+#       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true $(_runSmokeTestsOnlyArg) /p:DevTeamProvisioning=adhoc /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:EnableAggressiveTrimming=true
+#       timeoutInMinutes: 240
+#       # extra steps, run tests
+#       postBuildSteps:
+#         - template: /eng/pipelines/libraries/helix.yml
+#           parameters:
+#             creator: dotnet-bot
+#             testRunNamePrefixSuffix: CoreCLR_$(_BuildConfig)
+#             extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true


### PR DESCRIPTION
## Description

Part of splitting #125439 into smaller, self-contained PRs.

The Debug `AllSubsets_CoreCLR_Smoke` jobs for tvOS, iOSSimulator, and MacCatalyst are unstable and tracked in #124344. In the corresponding Release jobs, enable `EnableAggressiveTrimming` and `EnableAdditionalTimezoneChecks` so CI tests the trimmed library build path that ships to customers.