### PR TITLE
[ios-clr] Update IsMetadataUpdateSupported to aggressive trimming instead of NativeAOT

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -253,7 +253,7 @@ namespace System
         public static bool IsInvokingFinalizersSupported => !IsNativeAot;
         public static bool IsTypeEquivalenceSupported => !IsNativeAot && !IsMonoRuntime && IsWindows;
 
-        public static bool IsMetadataUpdateSupported => !IsNativeAot;
+        public static bool IsMetadataUpdateSupported => !IsBuiltWithAggressiveTrimming;
 
         // System.Security.Cryptography.Xml.XmlDsigXsltTransform.GetOutput() relies on XslCompiledTransform which relies
         // heavily on Reflection.Emit

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/ReflectionCacheTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/ReflectionCacheTests.cs
@@ -77,7 +77,6 @@ namespace System.Reflection.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/50978", TestRuntimes.Mono)]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMetadataUpdateSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
         public void InvokeClearCache_NoExceptions()
         {
             Action<Type[]> clearCache = GetClearCacheMethod();


### PR DESCRIPTION
## Description

This PR updates IsMetadataUpdateSupported to aggressive trimming instead of Native AOT to avoid using ActiveIssue for Apple mobile tests that are not supported.
