### PR TITLE
[ios-clr] Generalize Moq test guards and exclude DI tests on Apple mobile

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/CompilationLibraryTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/CompilationLibraryTests.cs
@@ -14,8 +14,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
     public class CompilationLibraryTests
     {
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void ResolveReferencePathsAcceptsCustomResolvers()
         {
             var fail = new Mock<ICompilationAssemblyResolver>();

--- a/src/libraries/Microsoft.Extensions.DependencyModel/tests/CompositeResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/tests/CompositeResolverTests.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
     public class CompositeResolverTests
     {
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void ReturnsFirstSuccessfulResolve()
         {
             var fail = new Mock<ICompilationAssemblyResolver>();
@@ -47,8 +46,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void PassesLibraryToAllResolvers()
         {
             var fail = new Mock<ICompilationAssemblyResolver>();
@@ -69,8 +67,7 @@ namespace Microsoft.Extensions.DependencyModel.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void PopulatedAssemblies()
         {
             var fail = new Mock<ICompilationAssemblyResolver>();

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs
@@ -593,7 +593,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task HostStopAsyncCanBeCancelledEarly()
         {
             var service = new Mock<IHostedService>();
@@ -625,7 +625,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task HostStopAsyncUsesDefaultTimeoutIfGivenTokenDoesNotFire()
         {
             var service = new Mock<IHostedService>();
@@ -658,7 +658,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task WebHostStopAsyncUsesDefaultTimeoutIfNoTokenProvided()
         {
             var service = new Mock<IHostedService>();
@@ -1215,7 +1215,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void Dispose_DisposesAppConfigurationProviders()
         {
             var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
@@ -1240,7 +1240,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void Dispose_DisposesHostConfigurationProviders()
         {
             var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
@@ -1316,7 +1316,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task DisposeAsync_DisposesAppConfigurationProviders()
         {
             var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
@@ -1341,7 +1341,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task DisposeAsync_DisposesHostConfigurationProviders()
         {
             var providerMock = new Mock<ConfigurationProvider>().As<IDisposable>();
@@ -1366,7 +1366,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void ThrowExceptionForCustomImplementationOfIHostApplicationLifetime()
         {
             var hostApplicationLifetimeMock = new Mock<IHostApplicationLifetime>();

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/InvokeWithRefLikeArgs.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Reflection/InvokeWithRefLikeArgs.cs
@@ -35,9 +35,8 @@ namespace System.Reflection.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/40738")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
         public static void MethodTakesRefToRefStructAsArg_ThrowsNSE()
         {
             // Use a Binder to trick the reflection stack into treating the returned null

--- a/src/libraries/System.Runtime/tests/System.Text.Encoding.Tests/Encoding/TranscodingStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Text.Encoding.Tests/Encoding/TranscodingStreamTests.cs
@@ -40,8 +40,7 @@ namespace System.Text.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void AsyncMethods_ReturnCanceledTaskIfCancellationTokenTripped()
         {
             // Arrange
@@ -79,8 +78,7 @@ namespace System.Text.Tests
             Assert.Throws<ArgumentNullException>("outerStreamEncoding", () => Encoding.CreateTranscodingStream(Stream.Null, Encoding.UTF8, null));
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         [InlineData(true)]
         [InlineData(false)]
         public void CanRead_DelegatesToInnerStream(bool expectedCanRead)
@@ -103,8 +101,7 @@ namespace System.Text.Tests
             Assert.False(actualCanReadAfterDispose);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         [InlineData(true)]
         [InlineData(false)]
         public void CanWrite_DelegatesToInnerStream(bool expectedCanWrite)
@@ -203,8 +200,7 @@ namespace System.Text.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void Flush_FlushesInnerStreamButNotDecodedState()
         {
             // Arrange
@@ -397,8 +393,7 @@ namespace System.Text.Tests
             }
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public Task ReadApm()
         {
             // Tests TranscodingStream.BeginRead / EndRead
@@ -439,8 +434,7 @@ namespace System.Text.Tests
             suppressExpectedCancellationTokenAsserts: true); // APM pattern doesn't allow flowing CancellationToken
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         [MemberData(nameof(ReadWriteTestBufferLengths))]
         public Task ReadAsync_ByteArray(int bufferLength)
         {
@@ -459,8 +453,7 @@ namespace System.Text.Tests
             });
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         [MemberData(nameof(ReadWriteTestBufferLengths))]
         public async Task ReadAsync_Memory(int bufferLength)
         {
@@ -726,7 +719,7 @@ namespace System.Text.Tests
             Assert.Equal(0, innerStream.Position);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void Write_WithPartialData()
         {
             MemoryStream innerStream = new MemoryStream();
@@ -775,8 +768,7 @@ namespace System.Text.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task WriteAsync_WithFullData()
         {
             MemoryStream sink = new MemoryStream();
@@ -836,8 +828,7 @@ namespace System.Text.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public async Task WriteAsync_WithPartialData()
         {
             MemoryStream sink = new MemoryStream();
@@ -893,8 +884,7 @@ namespace System.Text.Tests
         }
 
         // Moq heavily utilizes RefEmit, which does not work on most aot workloads
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsReflectionEmitSupported), nameof(PlatformDetection.IsNotBuiltWithAggressiveTrimming))]
         public void WriteApm()
         {
             // Arrange

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -699,6 +699,8 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Text.Json\tests\System.Text.Json.Tests\System.Text.Json.Tests.csproj" />
 
     <!-- Not supported on Apple mobile -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.External.Tests\Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.TraceSource\tests\System.Diagnostics.TraceSource.Config.Tests\System.Diagnostics.TraceSource.Config.Tests.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description

Part of splitting #125439 into smaller, self-contained PRs. Two related changes:

- **Moq test guards.** Replace `[ActiveIssue(#124344, IsAppleMobile && IsCoreCLR)]` band-aids with `IsNotBuiltWithAggressiveTrimming` on the existing `ConditionalFact`. Castle DynamicProxy (used by Moq) needs runtime metadata that aggressive trimming strips, so the correct guard is aggressive-trimming, not runtime flavor. Matches the established repo-wide pattern for Moq-based tests.
- **DI test project exclusions.** `Microsoft.Extensions.DependencyInjection.Tests` and its `ExternalContainers` (Stashbox-based) sibling are already excluded on Mono AOT iOS/tvOS/MacCatalyst (#50724), NativeAOT (>2/3 failing due to Ref.Emit), tvOS (#60713), and Android (crashes). Classify both as "Not supported on Apple mobile" in the Apple-mobile CoreCLR `ItemGroup`, consistent with those precedents.

## Changes

Source (remove stale ActiveIssue, add `IsNotBuiltWithAggressiveTrimming` to existing `ConditionalFact`):

- `Microsoft.Extensions.DependencyModel/tests/CompilationLibraryTests.cs`
- `Microsoft.Extensions.DependencyModel/tests/CompositeResolverTests.cs`
- `Microsoft.Extensions.Hosting/tests/UnitTests/Internal/HostTests.cs`
- `System.Runtime/tests/System.Runtime.Tests/System/Reflection/InvokeWithRefLikeArgs.cs`
- `System.Text.Encoding/tests/System.Text.Encoding.Tests/Encoding/TranscodingStreamTests.cs`

Project:

- `src/libraries/tests.proj` — add `Microsoft.Extensions.DependencyInjection.Tests.csproj` and `Microsoft.Extensions.DependencyInjection.ExternalContainers.Tests.csproj` under the `Not supported on Apple mobile` group.

> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.
