### PR TITLE
[ios-clr] Skip EventPipe listener tests on iOS/tvOS

### DIFF
--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs
@@ -30,7 +30,8 @@ namespace BasicEventSourceTests
         {
             TheoryData<Listener> data = new TheoryData<Listener>();
 
-            if (PlatformDetection.IsNetCore && PlatformDetection.IsNotAndroid && PlatformDetection.IsNotBrowser && 
+            if (PlatformDetection.IsNetCore && PlatformDetection.IsNotAndroid && PlatformDetection.IsNotBrowser &&
+                !PlatformDetection.IsiOS && !PlatformDetection.IstvOS &&
                 (PlatformDetection.IsNotMonoRuntime || PlatformDetection.IsMacCatalyst))
             {
                 data.Add(new EventPipeListener());

--- a/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
+++ b/src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs
@@ -31,6 +31,7 @@ namespace BasicEventSourceTests
         {
             TheoryData<Listener> data = new TheoryData<Listener>();
             if (PlatformDetection.IsNetCore && PlatformDetection.IsNotAndroid && PlatformDetection.IsNotBrowser &&
+                !PlatformDetection.IsiOS && !PlatformDetection.IstvOS &&
                 (PlatformDetection.IsNotMonoRuntime || PlatformDetection.IsMacCatalyst))
             {
                 data.Add(new EventPipeListener());

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -704,13 +704,13 @@
 
   <!-- https://github.com/dotnet/runtime/issues/124044 -->
   <ItemGroup Condition="('$(TargetOS)' == 'iossimulator' or '$(TargetOS)' == 'tvossimulator' or '$(TargetOS)' == 'maccatalyst') and '$(RuntimeFlavor)' == 'CoreCLR' and '$(UseNativeAOTRuntime)' != 'true'">
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Reflection.Tests\InvokeEmit\System.Reflection.InvokeEmit.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Reflection.Tests\InvokeInterpreted\System.Reflection.InvokeInterpreted.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Reflection.Tests\System.Reflection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Numerics.Tensors\tests\System.Numerics.Tensors.Tests.csproj" />
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\tests\Microsoft.Extensions.Logging.EventSource.Tests.csproj" />
   </ItemGroup>
 
   <!--


### PR DESCRIPTION
## Description

Part of splitting #125439 into smaller, self-contained PRs.

The EventPipe IPC socket path is unreachable from inside the iOS/tvOS app sandbox, so the `EventPipeListener` cannot be constructed. Exclude it from the `GetListeners` theory data on those platforms. Also exclude `Microsoft.Extensions.Logging.EventSource.Tests` on Apple mobile CoreCLR for the same root cause; re-enable the `System.Diagnostics.Tracing.Tests` project now that `EventPipeListener` is guarded.

## Changes

- `src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWrite.cs` — add `!IsiOS && !IstvOS` to the `EventPipeListener` guard.
- `src/libraries/System.Diagnostics.Tracing/tests/BasicEventSourceTest/TestsWriteEvent.cs` — same guard.
- `src/libraries/tests.proj` — remove `System.Diagnostics.Tracing.Tests.csproj` exclusion; add `Microsoft.Extensions.Logging.EventSource.Tests.csproj` exclusion.

> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.
