### PR TITLE
[ios-clr] Disable tests failing on Apple mobile CoreCLR

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -132,6 +132,7 @@ namespace System.Net.NameResolution.Tests
         };
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124079", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public void DnsGetHostAddresses_LocalHost_ReturnsSameAsGetHostEntry()
         {
             IPAddress[] addresses = Dns.GetHostAddresses(TestSettings.LocalHost);

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/DllImportTests.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/CustomAttributes/DllImportTests.cs
@@ -14,6 +14,7 @@ namespace System.Reflection.Tests
     public static partial class CustomAttributeTests
     {
         [ActiveIssue("https://github.com/mono/mono/issues/15340", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile), nameof(PlatformDetection.IsCoreCLR))]
         [Fact]
         public static void TestDllImportPseudoCustomAttribute()
         {

--- a/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/IncrementalHashTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.DotNet.RemoteExecutor;
+using Microsoft.DotNet.XUnitExtensions;
 using Test.Cryptography;
 using Xunit;
 
@@ -134,6 +135,7 @@ namespace System.Security.Cryptography.Tests
 
         [Theory]
         [MemberData(nameof(GetHashAlgorithms))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124344", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst)]
         public static void Verify_Clone_Hash(HashAlgorithm referenceAlgorithm, HashAlgorithmName hashAlgorithmName)
         {
             VerifyCloneResult(referenceAlgorithm, () => IncrementalHash.CreateHash(hashAlgorithmName));


### PR DESCRIPTION
## Description

Part of splitting #125439 into smaller, self-contained PRs.

Disable three tests that are failing on Apple mobile CoreCLR by adding `[ActiveIssue]` attributes referencing the tracking issues. These are genuine failures that need separate investigation.

## Changes

- `System.Net.NameResolution` — disable `DnsGetHostAddresses_LocalHost_ReturnsSameAsGetHostEntry` on iOS/tvOS/MacCatalyst (tracked in dotnet/runtime#124079).
- `System.Security.Cryptography` — disable `Verify_Clone_Hash` on iOS/tvOS/MacCatalyst (tracked in dotnet/runtime#124344).
- `System.Reflection.MetadataLoadContext` — disable `TestDllImportPseudoCustomAttribute` on Apple mobile CoreCLR (tracked in dotnet/runtime#124344).

> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.
