### PR TITLE
[release/10.0] Enhance createdump to detect alt stack execution

### DIFF
--- a/src/coreclr/debug/createdump/createdumppal.cpp
+++ b/src/coreclr/debug/createdump/createdumppal.cpp
@@ -23,7 +23,8 @@ typedef BOOL (*PFN_PAL_VirtualUnwindOutOfProc)(
     CONTEXT *context,
     PULONG64 functionStart,
     SIZE_T baseAddress,
-    UnwindReadMemoryCallback readMemoryCallback);
+    UnwindReadMemoryCallback readMemoryCallback,
+    bool *isSignalFrame);
 
 typedef BOOL (*PFN_PAL_GetUnwindInfoSize)(
     SIZE_T baseAddress,
@@ -129,13 +130,14 @@ PAL_VirtualUnwindOutOfProc(
     CONTEXT *context,
     PULONG64 functionStart,
     SIZE_T baseAddress,
-    UnwindReadMemoryCallback readMemoryCallback)
+    UnwindReadMemoryCallback readMemoryCallback,
+    bool *isSignalFrame)
 {
     if (!InitializePAL() || g_PAL_VirtualUnwindOutOfProc == nullptr)
     {
         return FALSE;
     }
-    return g_PAL_VirtualUnwindOutOfProc(context, functionStart, baseAddress, readMemoryCallback);
+    return g_PAL_VirtualUnwindOutOfProc(context, functionStart, baseAddress, readMemoryCallback, isSignalFrame);
 }
 
 BOOL

--- a/src/coreclr/debug/createdump/threadinfo.cpp
+++ b/src/coreclr/debug/createdump/threadinfo.cpp
@@ -51,6 +51,8 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
     uint64_t previousSp = 0;
     uint64_t previousIp = 0;
     int ipMatchCount = 0;
+    bool isSignalFrame = false;
+    bool crossedSignalTrampoline = false;
 
     // For each native frame, add a page around the IP and any unwind info not already
     // added in VisitProgramHeader (Linux) and VisitSection (MacOS) to the dump.
@@ -69,9 +71,18 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
             sp++;
         }
 #endif
-        if (ip == 0 || sp <= previousSp) {
+        // When a signal handler uses SA_ONSTACK (alternate signal stack), the SP can legitimately
+        // decrease when unwinding crosses the signal trampoline back to the original thread stack.
+        // Allow the SP decrease if the current frame is a signal trampoline (detected by the
+        // previous unwind call) and we haven't already crossed one (limit to one crossing to
+        // bound corruption damage).
+        if (ip == 0 || sp == 0 || (sp <= previousSp && (!isSignalFrame || crossedSignalTrampoline))) {
             TRACE_VERBOSE("Unwind: sp not increasing or ip == 0 sp %p ip %p\n", (void*)sp, (void*)ip);
             break;
+        }
+        if (sp < previousSp)
+        {
+            crossedSignalTrampoline = true;
         }
         // Break out of the endless loop if the IP matches over a 1000 times. This is a fallback
         // behavior of libunwind when the module the IP is in doesn't have unwind info and for
@@ -104,7 +115,8 @@ ThreadInfo::UnwindNativeFrames(CONTEXT* pContext)
 
         // Unwind the native frame adding all the memory accessed to the core dump via the read memory adapter.
         ULONG64 functionStart;
-        if (!PAL_VirtualUnwindOutOfProc(pContext, &functionStart, baseAddress, ReadMemoryAdapter)) {
+        isSignalFrame = false;
+        if (!PAL_VirtualUnwindOutOfProc(pContext, &functionStart, baseAddress, ReadMemoryAdapter, &isSignalFrame)) {
             TRACE("Unwind: PAL_VirtualUnwindOutOfProc returned false\n");
             break;
         }

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -2494,7 +2494,7 @@ typedef BOOL(*UnwindReadMemoryCallback)(PVOID address, PVOID buffer, SIZE_T size
 
 PALIMPORT BOOL PALAPI PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
 
-PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback);
+PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback, bool *isSignalFrame);
 
 PALIMPORT BOOL PALAPI PAL_GetUnwindInfoSize(SIZE_T baseAddress, ULONG64 ehFrameHdrAddr, UnwindReadMemoryCallback readMemoryCallback, PULONG64 ehFrameStart, PULONG64 ehFrameSize);
 

--- a/src/coreclr/pal/src/exception/remote-unwind.cpp
+++ b/src/coreclr/pal/src/exception/remote-unwind.cpp
@@ -2334,16 +2334,22 @@ Parameters:
     functionStart - the pointer to return the starting address of the function or nullptr
     baseAddress - base address of the module to find the unwind info
     readMemoryCallback - reads memory from the target
+    isSignalFrame - output parameter: set to true if the unwound-to frame is a signal trampoline
 --*/
 BOOL
 PALAPI
-PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback)
+PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback, bool *isSignalFrame)
 {
     unw_addr_space_t addrSpace = 0;
     unw_cursor_t cursor;
     libunwindInfo info;
     BOOL result = FALSE;
     int st;
+
+    if (isSignalFrame)
+    {
+        *isSignalFrame = false;
+    }
 
     info.BaseAddress = baseAddress;
     info.Context = context;
@@ -2414,6 +2420,14 @@ PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T base
     {
         result = FALSE;
         goto exit;
+    }
+
+    // Check if the frame we landed on is a signal trampoline. When a signal handler uses
+    // SA_ONSTACK, stepping from a signal frame crosses from the alternate signal stack to the
+    // original thread stack, which can cause the SP to decrease.
+    if (isSignalFrame && unw_is_signal_frame(&cursor) > 0)
+    {
+        *isSignalFrame = true;
     }
 
     UnwindContextToContext(&cursor, context);
@@ -2578,7 +2592,7 @@ PAL_GetUnwindInfoSize(SIZE_T baseAddress, ULONG64 ehFrameHdrAddr, UnwindReadMemo
 
 BOOL
 PALAPI
-PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback)
+PAL_VirtualUnwindOutOfProc(CONTEXT *context, PULONG64 functionStart, SIZE_T baseAddress, UnwindReadMemoryCallback readMemoryCallback, bool *isSignalFrame)
 {
     return FALSE;
 }


### PR DESCRIPTION
Fixes .NET 10 version of #126981

# Description
createdump's UnwindNativeFrames fails to capture the original thread stack when a crash occurs on a thread using an alternate signal stack. The native unwinder's monotonic-SP guard breaks we cross crosses the signal trampoline back to the original stack, because the SP legitimately decreases. This causes the unwinder to stop early, omitting the original stack memory from the dump.

The fix uses libunwind's `unw_is_signal_frame` in `PAL_VirtualUnwindOutOfProc` to detect signal trampoline frames. When a signal frame is detected, `UnwindNativeFrames` allows a SP decrease, enabling the unwinder to cross back to the original stack and capture its memory.

# Customer Impact

Minidumps collected via createdump for crashes on alternate signal stacks are missing the original thread's stack memory. This makes the dumps incomplete and difficult to debug - native frames below the signal handler are absent from the stack walk, and you can only get the managed stack separately via clrstack. Watson and WinDBG both fail to do this automatically.

#  Regression

We added the SP monotonic check ~7 years ago to prevent corruption unwinding issues.

#  Testing

The following scenario was tested as proxy of customer's issue: Pinvoke into native library with some frames before hitting a nullref on a secondary thread. Pre-fix the repro shows the early bail unwind. The fix captured the full unwind across the signal trampoline, identifies the libc trampoline, and includes original stack memory in the dump. I also validated the fix works both with and without dwarf unwind info in the crashing native library.

#  Risk

Low. The change is narrowly scoped to createdump's native unwind path and some of the DAC's lazy state machine unwinding. unw_get_proc_info reuses the same cache unw_step populates - no additional remote memory reads. If unw_is_signal_frame returns false due to some libc not marking the trampoline correctly, behavior is identical to before - no regression.

