### PR TITLE
Fix gc hole when resuming async continuation via interpreter

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1057,6 +1057,10 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
 
     frames.interpMethodContextFrame.pRetVal = (int8_t*)returnValueLocation;
 
+    // resultStorage is an interior pointer into a managed continuation object, passed from DispatchContinuations
+    // in AsyncHelpers. We must report it to the GC so it gets updated if the object moves.
+    GCPROTECT_BEGININTERIOR(resultStorage);
+
     InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext);
 
     if (frames.interpreterFrame.GetContinuation() == NULL)
@@ -1081,6 +1085,8 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
             }
         }
     }
+
+    GCPROTECT_END();
 
     contRef = (CONTINUATIONREF)frames.interpreterFrame.GetContinuation();
     frames.interpreterFrame.Pop();


### PR DESCRIPTION
AsyncHelpers_ResumeInterpreterContinuationWorker receives an interior pointer that was not reported to the GC. It seems like this issue was happening only in InterpMode=1. It is likely that in full interpreter mode, the continuation object was conservatively pinned by chance from the interpreter stack.

Fixes random crashes in objects-captured runtime test.