### PR TITLE
Run libtests in interpmode1 so it is faster

### DIFF
--- a/eng/pipelines/coreclr/libraries-interpreter.yml
+++ b/eng/pipelines/coreclr/libraries-interpreter.yml
@@ -24,7 +24,6 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: Release
           platforms:
-          - windows_x64
           - osx_arm64
           - linux_x64
           helixQueueGroup: libraries
@@ -39,4 +38,4 @@ extends:
                   creator: dotnet-bot
                   extraHelixArguments: /maxcpucount:10
                   scenarios:
-                  - interpmode3
+                  - interpmode1

--- a/src/libraries/sendtohelixhelp.proj
+++ b/src/libraries/sendtohelixhelp.proj
@@ -37,7 +37,7 @@
         '$(Scenario)' == 'gcstress0xc_jitstress1' or
         '$(Scenario)' == 'gcstress0xc_jitstress2' or
         '$(Scenario)' == 'gcstress0xc_jitminopts_heapverify1'">06:00:00</_workItemTimeout>
-    <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and '$(Scenario)' == 'interpmode3'">01:30:00</_workItemTimeout>
+    <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and '$(Scenario)' == 'interpmode1'">01:00:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and '$(TargetsAppleMobile)' == 'true'">01:15:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and '$(TargetOS)' == 'android'">00:30:00</_workItemTimeout>
     <_workItemTimeout Condition="'$(_workItemTimeout)' == '' and '$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR'">01:30:00</_workItemTimeout>


### PR DESCRIPTION
Remove windows runs from the pipeline. Many suites fail with com related tests and windows is not really relevant as a target for now. We still run full runtime tests on windows.

STJ.Tests
- jit 2min
- interpmode1 15min
- interpmode3 >1.5h

This also uncovers a new set of failures that we will need to address