### PR TITLE
[browser] Export useful browser tuntime TypeScript types

### DIFF
--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -790,4 +790,4 @@ declare global {
 declare const createDotnetRuntime: CreateDotnetRuntimeType;
 
 export { GlobalizationMode, createDotnetRuntime as default, dotnet, exit };
-export type { AssetBehaviors, AssetEntry, CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, EmscriptenModule, IMemoryView, ModuleAPI, MonoConfig, RuntimeAPI };
+export type { AssemblyAsset, Asset, AssetBehaviors, AssetEntry, Assets, BootModule, CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, EmscriptenModule, IMemoryView, IcuAsset, JsAsset, LoadBootResourceCallback, LoadingResource, ModuleAPI, MonoConfig, PdbAsset, ResourceExtensions, ResourceList, RuntimeAPI, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType };

--- a/src/mono/browser/runtime/types/export-types.ts
+++ b/src/mono/browser/runtime/types/export-types.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import type { IMemoryView } from "../marshal";
-import type { CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, RuntimeAPI, MonoConfig, ModuleAPI, AssetEntry, GlobalizationMode, AssetBehaviors } from ".";
+import type { CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, RuntimeAPI, MonoConfig, ModuleAPI, Assets, Asset, AssetEntry, AssemblyAsset, AssetBehaviors, BootModule, GlobalizationMode, IcuAsset, JsAsset, LoadBootResourceCallback, LoadingResource, PdbAsset, ResourceExtensions, ResourceList, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType } from ".";
 import type { EmscriptenModule } from "./emscripten";
 import type { dotnet, exit } from "../loader/index";
 
@@ -21,6 +21,6 @@ export default createDotnetRuntime;
 
 export {
     EmscriptenModule,
-    RuntimeAPI, ModuleAPI, DotnetHostBuilder, DotnetModuleConfig, CreateDotnetRuntimeType, MonoConfig, IMemoryView, AssetEntry, GlobalizationMode, AssetBehaviors,
+    RuntimeAPI, ModuleAPI, DotnetHostBuilder, DotnetModuleConfig, CreateDotnetRuntimeType, MonoConfig, IMemoryView, Assets, Asset, AssetEntry, AssemblyAsset, AssetBehaviors, BootModule, GlobalizationMode, IcuAsset, JsAsset, LoadBootResourceCallback, LoadingResource, PdbAsset, ResourceExtensions, ResourceList, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType,
     dotnet, exit
 };

--- a/src/native/libs/Common/JavaScript/loader/dotnet.d.ts
+++ b/src/native/libs/Common/JavaScript/loader/dotnet.d.ts
@@ -756,4 +756,4 @@ declare global {
 }
 
 export { GlobalizationMode, createDotnetRuntime as default, dotnet, exit };
-export type { AssetBehaviors, AssetEntry, CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, EmscriptenModule, IMemoryView, LoaderConfig, ModuleAPI, RuntimeAPI };
+export type { AssemblyAsset, Asset, AssetBehaviors, AssetEntry, Assets, BootModule, CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, EmscriptenModule, IMemoryView, IcuAsset, JsAsset, LoadBootResourceCallback, LoaderConfig, LoadingResource, ModuleAPI, PdbAsset, ResourceExtensions, ResourceList, RuntimeAPI, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType };

--- a/src/native/libs/Common/JavaScript/types/export-api.ts
+++ b/src/native/libs/Common/JavaScript/types/export-api.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import type { CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, ModuleAPI, LoaderConfig, IMemoryView, AssetEntry, GlobalizationMode, AssetBehaviors, RuntimeAPI, dotnet, exit } from "./public-api";
+import type { CreateDotnetRuntimeType, DotnetHostBuilder, DotnetModuleConfig, ModuleAPI, LoaderConfig, IMemoryView, Assets, Asset, AssetEntry, AssemblyAsset, AssetBehaviors, BootModule, GlobalizationMode, IcuAsset, JsAsset, LoadBootResourceCallback, LoadingResource, PdbAsset, ResourceExtensions, ResourceList, RuntimeAPI, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType, dotnet, exit } from "./public-api";
 import type { EmscriptenModule } from "./emscripten";
 
 declare const createDotnetRuntime: CreateDotnetRuntimeType;
@@ -14,6 +14,6 @@ export default createDotnetRuntime;
 
 export {
     EmscriptenModule,
-    RuntimeAPI, ModuleAPI, DotnetHostBuilder, DotnetModuleConfig, CreateDotnetRuntimeType, LoaderConfig, IMemoryView, AssetEntry, GlobalizationMode, AssetBehaviors,
+    RuntimeAPI, ModuleAPI, DotnetHostBuilder, DotnetModuleConfig, CreateDotnetRuntimeType, LoaderConfig, IMemoryView, Assets, Asset, AssetEntry, AssemblyAsset, AssetBehaviors, BootModule, GlobalizationMode, IcuAsset, JsAsset, LoadBootResourceCallback, LoadingResource, PdbAsset, ResourceExtensions, ResourceList, SymbolsAsset, VfsAsset, WasmAsset, WebAssemblyBootResourceType,
     dotnet, exit
 };


### PR DESCRIPTION
This exports the browser asset-related types from the public TypeScript entrypoints for both Mono and CoreCLR.

These types were already defined in the underlying runtime type declarations, but they were not consistently re-exported from the public API surfaces. This change makes them available to consumers in both runtimes through the intended top-level type export files.

This improves the usability of the browser runtime TypeScript APIs by making the existing asset model types discoverable and importable without reaching into internal type declaration files.

The issue was discussed with @pavelsavara on .NET's Discord server.
