### PR TITLE
Update Microsoft.Diagnostics.Runtime to 4.0.722401

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -155,7 +155,7 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.26210.1</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>4.0.722401</MicrosoftDiagnosticsRuntimeVersion>
     <AwesomeAssertionsVersion>8.0.2</AwesomeAssertionsVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -155,7 +155,7 @@
     <NewtonsoftJsonVersion>13.0.3</NewtonsoftJsonVersion>
     <NewtonsoftJsonBsonVersion>1.0.2</NewtonsoftJsonBsonVersion>
     <MoqVersion>4.18.4</MoqVersion>
-    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.26210.1</MicrosoftDiagnosticsRuntimeVersion>
+    <MicrosoftDiagnosticsRuntimeVersion>4.0.0-beta.26217.1</MicrosoftDiagnosticsRuntimeVersion>
     <AwesomeAssertionsVersion>8.0.2</AwesomeAssertionsVersion>
     <FsCheckVersion>2.14.3</FsCheckVersion>
     <CommandLineParserVersion>2.9.1</CommandLineParserVersion>

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -148,18 +148,6 @@ public abstract class DumpTestBase : IDisposable
 
         if (_dumpInfo is not null)
         {
-            // Cross-bitness dump reading is not yet supported when a 32-bit host
-            // tries to read a 64-bit dump (see microsoft/clrmd#1423).
-            // The reverse (64-bit host reading 32-bit dump) works fine.
-            bool isDump64Bit = _dumpInfo.Arch is "x64" or "arm64" or "riscv64" or "loongarch64";
-            bool isHost64Bit = IntPtr.Size == 8;
-            if (isDump64Bit && !isHost64Bit)
-            {
-                throw new SkipTestException(
-                    $"32-bit host cannot read 64-bit dumps: dump is {_dumpInfo.Arch}. " +
-                    $"See microsoft/clrmd#1423.");
-            }
-
             foreach (SkipOnOSAttribute attr in method.GetCustomAttributes<SkipOnOSAttribute>())
             {
                 if (attr.IncludeOnly is not null)


### PR DESCRIPTION
Update ClrMD to the first stable release with cross-bitness address truncation fixes ([microsoft/clrmd#1423](https://github.com/microsoft/clrmd/pull/1423)).

## Changes

- **`eng/Versions.props`**: Update `MicrosoftDiagnosticsRuntimeVersion` from `4.0.0-beta.26210.1` to `4.0.722401` (stable release)
- **`DumpTestBase.cs`**: Remove the cross-bitness dump test skip added in #127118 — ClrMD 4.0.722401 now correctly handles sign-extended `CLRDATA_ADDRESS` values, enabling 32-bit hosts to read 64-bit dumps

## What was fixed in ClrMD

ClrMD 4.0.722401 includes:
- `ClrDataAddress` type with explicit sign-extension handling (`FromTargetAddress` / `ToAddress`)
- ABI-safe COM vtable marshalling (addresses as `ulong` primitives, not structs)
- `unchecked` casts to prevent `OverflowException` on sign-extended 32-bit addresses
- Full verification against `sospriv.idl` in dotnet/runtime

## Cross-platform verification

xplat cDAC dump tests pass with the skip removed:
https://dev.azure.com/dnceng-public/public/_build/results?buildId=1398682&view=ms.vss-test-web.build-test-results-tab