### PR TITLE
[cDAC] Implement GetMethodDefinitionByToken in ClrDataModule

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
@@ -355,7 +355,38 @@ public sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCLRD
         => LegacyFallbackHelper.CanFallback() && _legacyModule is not null ? _legacyModule.EndEnumMethodInstancesByName(handle) : HResults.E_NOTIMPL;
 
     int IXCLRDataModule.GetMethodDefinitionByToken(/*mdMethodDef*/ uint token, DacComNullableByRef<IXCLRDataMethodDefinition> methodDefinition)
-        => LegacyFallbackHelper.CanFallback() && _legacyModule is not null ? _legacyModule.GetMethodDefinitionByToken(token, methodDefinition) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        int hrLocal = HResults.S_OK;
+        IXCLRDataMethodDefinition? legacyMethod = null;
+        try
+        {
+            if (_legacyModule is not null)
+            {
+                DacComNullableByRef<IXCLRDataMethodDefinition> legacyMethodOut = new(isNullRef: false);
+                hrLocal = _legacyModule.GetMethodDefinitionByToken(token, legacyMethodOut);
+                legacyMethod = legacyMethodOut.Interface;
+            }
+
+            if ((EcmaMetadataUtils.TokenType)(token & EcmaMetadataUtils.TokenTypeMask) != EcmaMetadataUtils.TokenType.mdtMethodDef)
+                throw new ArgumentException();
+
+            methodDefinition.Interface = new ClrDataMethodDefinition(_target, _address, token, legacyMethod);
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyModule is not null)
+        {
+            Debug.ValidateHResult(hr, hrLocal);
+        }
+#endif
+
+        return hr;
+    }
 
     int IXCLRDataModule.StartEnumDataByName(char* name, uint flags, IXCLRDataAppDomain? appDomain, IXCLRDataTask? tlsTask, ulong* handle)
         => LegacyFallbackHelper.CanFallback() && _legacyModule is not null ? _legacyModule.StartEnumDataByName(name, flags, appDomain, tlsTask, handle) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
@@ -34,6 +34,12 @@ internal static class LegacyFallbackHelper
 
         // Loader heap traversal — not yet implemented in the cDAC (PR #125129).
         nameof(ISOSDacInterface.TraverseLoaderHeap),
+
+        // IXCLRDataMethodDefinition — not yet implemented in the cDAC.
+        nameof(IXCLRDataMethodDefinition.StartEnumInstances),
+        nameof(IXCLRDataMethodDefinition.GetName),
+        nameof(IXCLRDataMethodDefinition.SetCodeNotification),
+        nameof(IXCLRDataMethodDefinition.HasClassOrMethodInstantiation),
     };
 
     // Files whose methods are all allowed to fall back.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
@@ -29,9 +29,6 @@ internal static class LegacyFallbackHelper
         // IMetaDataImport QI — needed until managed MetadataReader wrapper lands (PR #127028).
         nameof(ICustomQueryInterface.GetInterface),
 
-        // IXCLRDataModule — not yet implemented in the cDAC.
-        nameof(IXCLRDataModule.GetMethodDefinitionByToken),
-
         // GC heap analysis — not yet implemented in the cDAC (PR #125895).
         nameof(ISOSDacInterface11.IsTrackedType),
 


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Implement `IXCLRDataModule.GetMethodDefinitionByToken` in the cDAC `ClrDataModule` wrapper instead of delegating entirely to the legacy DAC. Remove it from the no-fallback allowlist and add newly-exposed downstream methods.

## Changes

**`ClrDataModule.cs`** — Replaced the one-line legacy delegation stub with a full cDAC implementation that:
1. Calls the legacy implementation first (if available) for DEBUG parity validation
2. Validates the token is an `mdtMethodDef` (throws `ArgumentException` → `E_INVALIDARG`)
3. Creates a `ClrDataMethodDefinition` with the token, module address, and legacy method definition
4. Includes `#if DEBUG` `ValidateHResult` check against the legacy result

**`LegacyFallbackHelper.cs`** — Removed `GetMethodDefinitionByToken` from the no-fallback allowlist. Added four `IXCLRDataMethodDefinition` methods that are now exposed as blocked fallbacks because `GetMethodDefinitionByToken` returns a cDAC-managed wrapper instead of a legacy object:
- `StartEnumInstances`
- `GetName`
- `SetCodeNotification`
- `HasClassOrMethodInstantiation`

These methods are not yet implemented in the cDAC and must remain on the allowlist until they are.

## Pattern

Follows the same pattern used by `EnumMethodDefinitionByName` (line 302) which already creates `ClrDataMethodDefinition` objects in the same way.

The C++ legacy implementation (`task.cpp:2215-2251`) validates the token type, then calls `ClrDataMethodDefinition::NewFromModule` which simply creates a `ClrDataMethodDefinition` — the cDAC version mirrors this behavior.

## Motivation

This enables removing `GetMethodDefinitionByToken` from the cDAC no-fallback allowlist (#126752).