### PR TITLE
Add managed ilasm round-trip testing support

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -547,6 +547,7 @@ jobs:
         ${{ if in(parameters.testGroup, 'ilasm') }}:
           scenarios:
           - ilasmroundtrip
+          - managedilasmroundtrip
 
     ########################################################################################################
     #

--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -547,7 +547,6 @@ jobs:
         ${{ if in(parameters.testGroup, 'ilasm') }}:
           scenarios:
           - ilasmroundtrip
-          - managedilasmroundtrip
 
     ########################################################################################################
     #

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -337,6 +337,11 @@ def is_managed_exe_assembly(file):
 print("")
 print("ILASM RoundTrips")
 
+if os.environ.get("IlasmRoundTripUseManagedIlasm") == "1":
+  ilasm_path = os.path.join(os.environ["CORE_ROOT"], "managed-ilasm", "ilasm")
+else:
+  ilasm_path = os.path.join(os.environ["CORE_ROOT"], "ilasm")
+
 if not os.path.exists("IL-RT"):
   os.mkdir("IL-RT")
 
@@ -367,7 +372,7 @@ for inputAssemblyName in glob.glob("*.dll"):
           proc.kill()
           sys.exit(1)
 
-      ilasm_args = f'{os.environ["CORE_ROOT"]}/ilasm -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
+      ilasm_args = f'{ilasm_path} -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
       print(ilasm_args)
       proc = subprocess.Popen(ilasm_args, shell=True)
 
@@ -384,7 +389,7 @@ for inputAssemblyName in glob.glob("*.dll"):
 
         hash = hash_file(inputAssemblyName)
 
-        ilasm_args = f'{os.environ["CORE_ROOT"]}/ilasm -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
+        ilasm_args = f'{ilasm_path} -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
         print(ilasm_args)
         proc = subprocess.Popen(ilasm_args, shell=True)
 
@@ -407,7 +412,7 @@ for inputAssemblyName in glob.glob("*.dll"):
 
         pdbName = inputAssemblyName.replace('.dll', '.pdb')
 
-        ilasm_args = f'{os.environ["CORE_ROOT"]}/ilasm -output={pdbName} {ilasmSwitches} {disassemblyName}'
+        ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
         print(ilasm_args)
         proc = subprocess.Popen(ilasm_args, shell=True)
 
@@ -419,7 +424,7 @@ for inputAssemblyName in glob.glob("*.dll"):
 
         hash = hash_file(pdbName)
 
-        ilasm_args = f'{os.environ["CORE_ROOT"]}/ilasm -output={pdbName} {ilasmSwitches} {disassemblyName}'
+        ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
         print(ilasm_args)
         proc = subprocess.Popen(ilasm_args, shell=True)
 

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -372,6 +372,10 @@ for inputAssemblyName in glob.glob("*.dll"):
           proc.kill()
           sys.exit(1)
 
+      if proc.returncode != 0:
+          print(f"ILDASM failed with exit code {proc.returncode}")
+          sys.exit(1)
+
       ilasm_args = f'{ilasm_path} -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
       print(ilasm_args)
       proc = subprocess.Popen(ilasm_args, shell=True)
@@ -382,63 +386,76 @@ for inputAssemblyName in glob.glob("*.dll"):
           proc.kill()
           sys.exit(1)
 
-      test_det = proc.returncode == 0
+      if proc.returncode != 0:
+          print(f"ILASM failed with exit code {proc.returncode}")
+          sys.exit(1)
 
       # Test determinism
-      if test_det:
 
-        hash = hash_file(inputAssemblyName)
+      hash = hash_file(inputAssemblyName)
 
-        ilasm_args = f'{ilasm_path} -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
-        print(ilasm_args)
-        proc = subprocess.Popen(ilasm_args, shell=True)
+      ilasm_args = f'{ilasm_path} -output={inputAssemblyName} {ilasmSwitches} {disassemblyName}'
+      print(ilasm_args)
+      proc = subprocess.Popen(ilasm_args, shell=True)
 
-        try:
-            proc.communicate()
-        except:
-            proc.kill()
-            sys.exit(1)
-
-        if hash != hash_file(inputAssemblyName):
-          print("ILASM determinism failed")
+      try:
+          proc.communicate()
+      except:
+          proc.kill()
           sys.exit(1)
-        else:
-          print("ILASM determinism succeeded")
 
-        # Test PDB determinism
-
-        if not is_managed_debug_assembly(inputAssemblyName):
-          ilasmSwitches = ilasmSwitches + " -DEBUG"
-
-        pdbName = inputAssemblyName.replace('.dll', '.pdb')
-
-        ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
-        print(ilasm_args)
-        proc = subprocess.Popen(ilasm_args, shell=True)
-
-        try:
-            proc.communicate()
-        except:
-            proc.kill()
-            sys.exit(1)
-
-        hash = hash_file(pdbName)
-
-        ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
-        print(ilasm_args)
-        proc = subprocess.Popen(ilasm_args, shell=True)
-
-        try:
-            proc.communicate()
-        except:
-            proc.kill()
-            sys.exit(1)
-
-        if hash != hash_file(pdbName):
-          print("ILASM PDB determinism failed")
+      if proc.returncode != 0:
+          print(f"ILASM failed with exit code {proc.returncode}")
           sys.exit(1)
-        else:
-          print("ILASM PDB determinism succeeded")
+
+      if hash != hash_file(inputAssemblyName):
+        print("ILASM determinism failed")
+        sys.exit(1)
+      else:
+        print("ILASM determinism succeeded")
+
+      # Test PDB determinism
+
+      if not is_managed_debug_assembly(inputAssemblyName):
+        ilasmSwitches = ilasmSwitches + " -DEBUG"
+
+      pdbName = inputAssemblyName.replace('.dll', '.pdb')
+
+      ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
+      print(ilasm_args)
+      proc = subprocess.Popen(ilasm_args, shell=True)
+
+      try:
+          proc.communicate()
+      except:
+          proc.kill()
+          sys.exit(1)
+
+      if proc.returncode != 0:
+          print(f"ILASM failed with exit code {proc.returncode}")
+          sys.exit(1)
+
+      hash = hash_file(pdbName)
+
+      ilasm_args = f'{ilasm_path} -output={pdbName} {ilasmSwitches} {disassemblyName}'
+      print(ilasm_args)
+      proc = subprocess.Popen(ilasm_args, shell=True)
+
+      try:
+          proc.communicate()
+      except:
+          proc.kill()
+          sys.exit(1)
+
+      if proc.returncode != 0:
+          print(f"ILASM failed with exit code {proc.returncode}")
+          sys.exit(1)
+
+      if hash != hash_file(pdbName):
+        print("ILASM PDB determinism failed")
+        sys.exit(1)
+      else:
+        print("ILASM PDB determinism succeeded")
 
       print("")
 

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -7,8 +7,10 @@
 
 
   <!-- DOTNET_* variables that can be specified for a test scenario -->
-  <!-- There is a non-DOTNET variable here: RunningIlasmRoundTrip. When set to 1, this triggers CoreCLR round-trip testing.
-       The value is read in the test wrapper scripts. When set in a __TestEnv script, it is set before it is read.
+  <!-- There are non-DOTNET variables here: RunningIlasmRoundTrip and IlasmRoundTripUseManagedIlasm.
+       RunningIlasmRoundTrip, when set to 1, triggers CoreCLR round-trip testing.
+       IlasmRoundTripUseManagedIlasm, when set to 1, uses the managed ilasm for round-trip testing.
+       Both values are read in the test wrapper scripts. When set in a __TestEnv script, they are set before they are read.
        The DOTNET_ processing handling below allows for variables not prefixed by 'DOTNET_'.
   -->
   <PropertyGroup>

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -66,6 +66,7 @@
       DOTNET_JitForceControlFlowGuard;
       DOTNET_JitCFGUseDispatcher;
       RunningIlasmRoundTrip;
+      IlasmRoundTripUseManagedIlasm;
       DOTNET_JitSynthesizeCounts;
       DOTNET_JitCheckSynthesizedCounts;
       DOTNET_JitRLCSEGreedy;

--- a/src/tests/Common/testenvironment.proj
+++ b/src/tests/Common/testenvironment.proj
@@ -192,6 +192,7 @@
     <TestEnvironment Include="jitcfg_dispatcher_never" JitForceControlFlowGuard="1" JitCFGUseDispatcher="0" />
     <TestEnvironment Include="jitcfg_gcstress0xc" JitForceControlFlowGuard="1" GCStress="0xC" />
     <TestEnvironment Include="ilasmroundtrip" RunningIlasmRoundTrip="1" />
+    <TestEnvironment Include="managedilasmroundtrip" RunningIlasmRoundTrip="1" IlasmRoundTripUseManagedIlasm="1" />
     <TestEnvironment Include="clrinterpreter" TieredCompilation="1" />
     <TestEnvironment Include="defaultpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" />
     <TestEnvironment Include="fullpgo" TieredPGO="1" TieredCompilation="1" TC_QuickJitForLoops="1" ReadyToRun="0" JitProfileCasts="1"/>

--- a/src/tests/Interop/IJW/Directory.Build.props
+++ b/src/tests/Interop/IJW/Directory.Build.props
@@ -11,6 +11,8 @@
     <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
     <!-- C++/CLI not supported with NativeAOT -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- IJW assemblies contain native code that cannot be round-tripped through ilasm -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -5,6 +5,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Takes long time to compile and not interesting from AOT perspective -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- This test generates IL that is too large for ilasm to round-trip -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>Full</DebugType>

--- a/src/tests/Loader/classloader/MethodImpl/InternalMethodImplTest.csproj
+++ b/src/tests/Loader/classloader/MethodImpl/InternalMethodImplTest.csproj
@@ -1,4 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- RequiresProcessIsolation due to IlasmRoundTripIncompatible -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="InternalMethodImplTest.cs" />
   </ItemGroup>

--- a/src/tests/Loader/classloader/regressions/dev10_403582/dev10_403582.ilproj
+++ b/src/tests/Loader/classloader/regressions/dev10_403582/dev10_403582.ilproj
@@ -1,10 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for NativeAotIncompatible -->
+    <!-- Needed for NativeAotIncompatible, IlasmRoundTripIncompatible -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Testing various TypeLoadExceptions -->
     <NativeAotIncompatible>true</NativeAotIncompatible>
+    <!-- ildasm crashes on genmeth.dll. See https://github.com/dotnet/runtime/issues/127576 -->
+    <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -73,6 +73,7 @@ if /i "%1" == "gcstresslevel"                           (set DOTNET_GCStress=%2&
 if /i "%1" == "gcsimulator"                             (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 if /i "%1" == "longgc"                                  (set __LongGCTests=1&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
+if /i "%1" == "usemanagedilasm"                          (set __UseManagedIlasm=1&shift&goto Arg_Loop)
 if /i "%1" == "timeout"                                 (set __TestTimeout=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "runincontext"                            (set RunInUnloadableContext=1&shift&goto Arg_Loop)
 if /i "%1" == "tieringtest"                             (set TieringTest=1&shift&goto Arg_Loop)
@@ -150,6 +151,10 @@ if defined __GCSimulatorTests (
 
 if defined __IlasmRoundTrip (
     set __RuntestPyArgs=%__RuntestPyArgs% --ilasmroundtrip
+)
+
+if defined __UseManagedIlasm (
+    set __RuntestPyArgs=%__RuntestPyArgs% --use_managed_ilasm
 )
 
 if defined __TestEnv (

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -28,6 +28,7 @@ set __msbuildExtraArgs=
 set __LongGCTests=
 set __GCSimulatorTests=
 set __IlasmRoundTrip=
+set __UseManagedIlasm=
 set __PrintLastResultsOnly=
 set LogsDirArg=
 set RunInUnloadableContext=
@@ -73,7 +74,7 @@ if /i "%1" == "gcstresslevel"                           (set DOTNET_GCStress=%2&
 if /i "%1" == "gcsimulator"                             (set __GCSimulatorTests=1&shift&goto Arg_Loop)
 if /i "%1" == "longgc"                                  (set __LongGCTests=1&shift&goto Arg_Loop)
 if /i "%1" == "ilasmroundtrip"                          (set __IlasmRoundTrip=1&shift&goto Arg_Loop)
-if /i "%1" == "usemanagedilasm"                          (set __UseManagedIlasm=1&shift&goto Arg_Loop)
+if /i "%1" == "usemanagedilasm"                          (set __IlasmRoundTrip=1&set __UseManagedIlasm=1&shift&goto Arg_Loop)
 if /i "%1" == "timeout"                                 (set __TestTimeout=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "runincontext"                            (set RunInUnloadableContext=1&shift&goto Arg_Loop)
 if /i "%1" == "tieringtest"                             (set TieringTest=1&shift&goto Arg_Loop)

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -831,6 +831,10 @@ def run_tests(args,
         os.environ["RunningIlasmRoundTrip"] = "1"
 
     if args.use_managed_ilasm:
+        if not args.ilasmroundtrip:
+            print("--use_managed_ilasm implies --ilasmroundtrip; enabling ilasm round trip.")
+            print("Setting RunningIlasmRoundTrip=1")
+            os.environ["RunningIlasmRoundTrip"] = "1"
         print("Using managed ILasm for round trip.")
         print("Setting IlasmRoundTripUseManagedIlasm=1")
         os.environ["IlasmRoundTripUseManagedIlasm"] = "1"

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -101,6 +101,7 @@ parser.add_argument("--il_link", dest="il_link", action="store_true", default=Fa
 parser.add_argument("--long_gc", dest="long_gc", action="store_true", default=False)
 parser.add_argument("--gcsimulator", dest="gcsimulator", action="store_true", default=False)
 parser.add_argument("--ilasmroundtrip", dest="ilasmroundtrip", action="store_true", default=False)
+parser.add_argument("--use_managed_ilasm", dest="use_managed_ilasm", action="store_true", default=False)
 parser.add_argument("--run_crossgen2_tests", dest="run_crossgen2_tests", action="store_true", default=False)
 parser.add_argument("--large_version_bubble", dest="large_version_bubble", action="store_true", default=False)
 parser.add_argument("--synthesize_pgo", dest="synthesize_pgo", action="store_true", default=False)
@@ -829,6 +830,11 @@ def run_tests(args,
         print("Setting RunningIlasmRoundTrip=1")
         os.environ["RunningIlasmRoundTrip"] = "1"
 
+    if args.use_managed_ilasm:
+        print("Using managed ILasm for round trip.")
+        print("Setting IlasmRoundTripUseManagedIlasm=1")
+        os.environ["IlasmRoundTripUseManagedIlasm"] = "1"
+
     if args.run_crossgen2_tests:
         print("Running tests R2R (Crossgen2)")
         print("Setting RunCrossGen2=1")
@@ -977,6 +983,11 @@ def setup_args(args):
                               "ilasmroundtrip",
                               lambda arg: True,
                               "Error setting ilasmroundtrip")
+
+    coreclr_setup_args.verify(args,
+                              "use_managed_ilasm",
+                              lambda arg: True,
+                              "Error setting use_managed_ilasm")
 
     coreclr_setup_args.verify(args,
                               "large_version_bubble",


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

## Summary

This PR adds infrastructure to run ilasm round-trip tests using the new managed ilasm (located in the `managed-ilasm/` subfolder of Core_Root) alongside the existing native ilasm.

This does not enable the leg in CI as we need #127297 to have any semblance of a passing run.

## Changes

### Runtime environment variable support
- **`CLRTest.Jit.targets`**: The generated ilasm round-trip Python script checks `IlasmRoundTripUseManagedIlasm` env var at runtime. When set to `1`, ilasm invocations use `managed-ilasm/ilasm` instead of the native `ilasm` in Core_Root.
- **`testenvironment.proj`**: Registered `IlasmRoundTripUseManagedIlasm` in the `DOTNETVariables` list, and added a new `managedilasmroundtrip` test scenario that sets both `RunningIlasmRoundTrip=1` and `IlasmRoundTripUseManagedIlasm=1`.

### CLI support for local testing
- **`run.py`**: Added `--use_managed_ilasm` argument that sets the env var and can be combined with `--ilasmroundtrip`.
- **`run.cmd`**: Added `usemanagedilasm` option that passes through to `run.py`.