### PR TITLE
Suppress debugger filter notification for UCO entrypoint during EH dispatch

### DIFF
--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -180,9 +180,9 @@ void ExInfo::MakeCallbacksRelatedToHandler(
         {
             m_EHClauseInfo.SetEHClauseType(COR_PRF_CLAUSE_FILTER);
 
-            // Suppress the debugger filter notification for runtime helper that invokes
+            // Suppress the debugger filter notification for the runtime helper that invokes
             // the main program entrypoint (Environment.CallEntryPoint). This method has
-            // filter clause that may return false, but the debugger intercepts at the notification
+            // a filter clause that may return false, but the debugger intercepts at the notification
             // before the filter evaluates, preventing the exception from propagating as unhandled.
             if (pMD != g_pEnvironmentCallEntryPointMethodDesc)
             {

--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -181,9 +181,9 @@ void ExInfo::MakeCallbacksRelatedToHandler(
             m_EHClauseInfo.SetEHClauseType(COR_PRF_CLAUSE_FILTER);
 
             // Suppress the debugger filter notification for runtime helper that invokes
-            // the main program entrypoint. This method has filter clauses that may
-            // return false, but the debugger intercepts at the notification before the filter
-            // evaluates, preventing the exception from propagating as unhandled.
+            // the main program entrypoint (Environment.CallEntryPoint). This method has
+            // filter clause that may return false, but the debugger intercepts at the notification
+            // before the filter evaluates, preventing the exception from propagating as unhandled.
             if (pMD != g_pEnvironmentCallEntryPointMethodDesc)
             {
                 EEToDebuggerExceptionInterfaceWrapper::ExceptionFilter(pMD, (TADDR) dwHandlerStartPC, pEHClause->FilterOffset, (BYTE*)sf.SP);

--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -180,8 +180,8 @@ void ExInfo::MakeCallbacksRelatedToHandler(
         {
             m_EHClauseInfo.SetEHClauseType(COR_PRF_CLAUSE_FILTER);
 
-            // Suppress the debugger filter notification for runtime-invoked UCO entrypoint methods.
-            // These methods have filter clauses (e.g., `catch when (captureException)`) that may
+            // Suppress the debugger filter notification for runtime helper that invokes
+            // the main program entrypoint. This method has filter clauses that may
             // return false, but the debugger intercepts at the notification before the filter
             // evaluates, preventing the exception from propagating as unhandled.
             if (pMD != g_pEnvironmentCallEntryPointMethodDesc)

--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -179,7 +179,15 @@ void ExInfo::MakeCallbacksRelatedToHandler(
         if (fIsFilterHandler)
         {
             m_EHClauseInfo.SetEHClauseType(COR_PRF_CLAUSE_FILTER);
-            EEToDebuggerExceptionInterfaceWrapper::ExceptionFilter(pMD, (TADDR) dwHandlerStartPC, pEHClause->FilterOffset, (BYTE*)sf.SP);
+
+            // Suppress the debugger filter notification for runtime-invoked UCO entrypoint methods.
+            // These methods have filter clauses (e.g., `catch when (captureException)`) that may
+            // return false, but the debugger intercepts at the notification before the filter
+            // evaluates, preventing the exception from propagating as unhandled.
+            if (pMD != g_pEnvironmentCallEntryPointMethodDesc)
+            {
+                EEToDebuggerExceptionInterfaceWrapper::ExceptionFilter(pMD, (TADDR) dwHandlerStartPC, pEHClause->FilterOffset, (BYTE*)sf.SP);
+            }
 
             EEToProfilerExceptionInterfaceWrapper::ExceptionSearchFilterEnter(pMD);
             ETW::ExceptionLog::ExceptionFilterBegin(pMD, (PVOID)dwHandlerStartPC);


### PR DESCRIPTION
PR #126222 moved the app entrypoint from native CallDescrWorkerInternal to managed Environment.CallEntryPoint (UnmanagedCallersOnly). This method has a filter clause (catch when (captureException)) that exists in the EH table even when captureException is false. During first-pass exception dispatch, MakeCallbacksRelatedToHandler notifies the debugger about the filter via ExceptionFilter() before the filter funclet evaluates. The debugger intercepts at this notification, preventing the exception from propagating as unhandled — breaking debugger exception interception scenarios.

Skip the debugger ExceptionFilter notification for the known UCO entrypoint method while preserving profiler and ETW notifications.