### PR TITLE
[cDAC] Implement ClrDataMethodDefinition APIs

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -2,8 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Runtime.InteropServices.Marshalling;
 using System.Diagnostics;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using System.Text;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 
 namespace Microsoft.Diagnostics.DataContractReader.Legacy;
@@ -26,20 +30,290 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         _token = token;
         _legacyImpl = legacyImpl;
     }
+
+    private TargetPointer TryResolveMethodDesc()
+    {
+        ILoader loader = _target.Contracts.Loader;
+        Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(_module);
+        ModuleLookupTables tables = loader.GetLookupTables(moduleHandle);
+        TargetPointer methodDescAddr = loader.GetModuleLookupMapElement(tables.MethodDefToDesc, _token, out _);
+
+        return methodDescAddr;
+    }
+
+    private static bool HasClassInstantiation(Target target, MethodDescHandle md)
+    {
+        IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+        TargetPointer mtAddr = rts.GetMethodTable(md);
+        TypeHandle mt = rts.GetTypeHandle(mtAddr);
+
+        return !rts.GetInstantiation(mt).IsEmpty;
+    }
+
+    private static bool HasMethodInstantiation(Target target, MethodDescHandle md)
+    {
+        IRuntimeTypeSystem rts = target.Contracts.RuntimeTypeSystem;
+        if (rts.IsGenericMethodDefinition(md))
+            return true;
+
+        return !rts.GetGenericMethodInstantiation(md).IsEmpty;
+    }
+
+    private static bool HasClassOrMethodInstantiation(Target target, MethodDescHandle md)
+    {
+        return HasClassInstantiation(target, md) || HasMethodInstantiation(target, md);
+    }
+
+    private string GetFullMethodNameFromMetadata()
+    {
+        ILoader loader = _target.Contracts.Loader;
+        Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(_module);
+        IEcmaMetadata ecmaMetadata = _target.Contracts.EcmaMetadata;
+        MetadataReader reader = ecmaMetadata.GetMetadata(moduleHandle)
+            ?? throw new InvalidOperationException("Failed to get metadata reader");
+
+        int rowId = (int)(_token & 0x00FFFFFF);
+        MethodDefinitionHandle methodDefHandle = MetadataTokens.MethodDefinitionHandle(rowId);
+        MethodDefinition methodDef = reader.GetMethodDefinition(methodDefHandle);
+        string methodName = reader.GetString(methodDef.Name);
+
+        TypeDefinitionHandle typeDefHandle = methodDef.GetDeclaringType();
+        if (typeDefHandle.IsNil)
+            return methodName;
+
+        TypeDefinition typeDef = reader.GetTypeDefinition(typeDefHandle);
+        string typeName = reader.GetString(typeDef.Name);
+        string namespaceName = reader.GetString(typeDef.Namespace);
+
+        StringBuilder sb = new();
+        if (!string.IsNullOrEmpty(namespaceName))
+        {
+            sb.Append(namespaceName);
+            sb.Append('.');
+        }
+        sb.Append(typeName);
+        sb.Append('.');
+        sb.Append(methodName);
+
+        return sb.ToString();
+    }
+
     int IXCLRDataMethodDefinition.GetTypeDefinition(DacComNullableByRef<IXCLRDataTypeDefinition> typeDefinition)
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetTypeDefinition(typeDefinition) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodDefinition.StartEnumInstances(IXCLRDataAppDomain? appDomain, ulong* handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.StartEnumInstances(appDomain, handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_FALSE;
+        *handle = 0;
+
+        // Start the legacy enumeration to keep it in sync with the cDAC enumeration.
+        // EnumInstance passes the legacy method instance to ClrDataMethodInstance,
+        // which delegates some operations to it.
+        ulong legacyHandle = default;
+        int hrLocal = default;
+        if (_legacyImpl is not null)
+        {
+            hrLocal = _legacyImpl.StartEnumInstances(appDomain, &legacyHandle);
+        }
+
+        try
+        {
+            TargetPointer methodDescAddr = TryResolveMethodDesc();
+            if (methodDescAddr == TargetPointer.Null)
+            {
+                hr = HResults.S_FALSE;
+            }
+            else
+            {
+                SOSDacImpl.EnumMethodInstances emi = new(_target, methodDescAddr, TargetPointer.Null);
+                emi.LegacyHandle = legacyHandle;
+
+                *handle = (ulong)((IEnum<MethodDescHandle>)emi).GetHandle();
+                hr = emi.Start();
+                if (hr == HResults.S_FALSE)
+                {
+                    GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)(*handle));
+                    gcHandle.Free();
+                    *handle = 0;
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            Debug.ValidateHResult(hr, hrLocal);
+        }
+#endif
+
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.EnumInstance(ulong* handle, DacComNullableByRef<IXCLRDataMethodInstance> instance)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.EnumInstance(handle, instance) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        if (*handle == 0)
+            return HResults.S_FALSE;
+
+        GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)(*handle));
+        if (gcHandle.Target is not SOSDacImpl.EnumMethodInstances emi)
+            return HResults.E_INVALIDARG;
+
+        // Advance the legacy enumeration to keep it in sync with the cDAC enumeration.
+        // The legacy method instance is passed to ClrDataMethodInstance for delegation.
+        IXCLRDataMethodInstance? legacyMethod = null;
+        int hrLocal = default;
+        if (_legacyImpl is not null)
+        {
+            ulong legacyHandle = emi.LegacyHandle;
+            DacComNullableByRef<IXCLRDataMethodInstance> legacyMethodOut = new(isNullRef: false);
+            hrLocal = _legacyImpl.EnumInstance(&legacyHandle, legacyMethodOut);
+            legacyMethod = legacyMethodOut.Interface;
+            emi.LegacyHandle = legacyHandle;
+        }
+
+        try
+        {
+            if (emi.Enumerator.MoveNext())
+            {
+                MethodDescHandle methodDesc = emi.Enumerator.Current;
+                instance.Interface = new ClrDataMethodInstance(_target, methodDesc, emi._appDomain, legacyMethod);
+            }
+            else
+            {
+                hr = HResults.S_FALSE;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            // Fall back to the legacy DAC result when available, otherwise propagate the error.
+            if (_legacyImpl is not null)
+            {
+                hr = hrLocal;
+                instance.Interface = legacyMethod;
+            }
+            else
+            {
+                hr = ex.HResult;
+            }
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            Debug.ValidateHResult(hr, hrLocal);
+        }
+#endif
+
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.EndEnumInstances(ulong handle)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.EndEnumInstances(handle) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        try
+        {
+            if (handle == 0)
+                throw new ArgumentException();
+
+            GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)handle);
+            if (gcHandle.Target is not SOSDacImpl.EnumMethodInstances emi)
+                throw new ArgumentException();
+
+            gcHandle.Free();
+
+            if (_legacyImpl is not null && emi.LegacyHandle != TargetPointer.Null)
+            {
+                int hrLocal = _legacyImpl.EndEnumInstances(emi.LegacyHandle);
+                if (hrLocal < 0)
+                    hr = hrLocal;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.GetName(uint flags, uint bufLen, uint* nameLen, char* name)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetName(flags, bufLen, nameLen, name) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        try
+        {
+            if (flags != 0)
+                throw new ArgumentException();
+
+            StringBuilder sb = new();
+
+            TargetPointer methodDescAddr = TryResolveMethodDesc();
+
+            if (methodDescAddr != TargetPointer.Null)
+            {
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                MethodDescHandle methodDescHandle = rts.GetMethodDescHandle(methodDescAddr);
+                TypeNameBuilder.AppendMethodInternal(
+                    _target,
+                    sb,
+                    methodDescHandle,
+                    TypeNameFormat.FormatSignature |
+                    TypeNameFormat.FormatNamespace |
+                    TypeNameFormat.FormatFullInst);
+            }
+            else
+            {
+                sb.Append(GetFullMethodNameFromMetadata());
+            }
+
+            OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, sb.ToString());
+
+            if (name is not null && bufLen < (uint)(sb.Length + 1))
+            {
+                hr = HResults.S_FALSE;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint nameLenLocal = 0;
+            char[] nameBufLocal = new char[bufLen > 0 ? bufLen : 1];
+            int hrLocal;
+            fixed (char* pNameBufLocal = nameBufLocal)
+            {
+                hrLocal = _legacyImpl.GetName(flags, bufLen, &nameLenLocal, name is null ? null : pNameBufLocal);
+            }
+
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0 && hrLocal >= 0)
+            {
+                if (nameLen is not null)
+                    Debug.Assert(nameLenLocal == *nameLen, $"cDAC: {*nameLen:x}, DAC: {nameLenLocal:x}");
+
+                if (name is not null && nameLenLocal > 0)
+                {
+                    string dacName = new string(nameBufLocal, 0, (int)nameLenLocal - 1);
+                    string cdacName = new string(name);
+                    Debug.Assert(dacName == cdacName, $"cDAC: {cdacName}, DAC: {dacName}");
+                }
+            }
+        }
+#endif
+
+        return hr;
+    }
 
     int IXCLRDataMethodDefinition.GetTokenAndScope(uint* token, DacComNullableByRef<IXCLRDataModule> mod)
     {
@@ -123,5 +397,42 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.GetRepresentativeEntryAddress(addr) : HResults.E_NOTIMPL;
 
     int IXCLRDataMethodDefinition.HasClassOrMethodInstantiation(int* bGeneric)
-        => LegacyFallbackHelper.CanFallback() && _legacyImpl is not null ? _legacyImpl.HasClassOrMethodInstantiation(bGeneric) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        try
+        {
+            TargetPointer methodDescAddr = TryResolveMethodDesc();
+            if (methodDescAddr == TargetPointer.Null)
+            {
+                hr = unchecked((int)0x8000FFFF); // E_UNEXPECTED
+            }
+            else
+            {
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                MethodDescHandle methodDescHandle = rts.GetMethodDescHandle(methodDescAddr);
+                *bGeneric = HasClassOrMethodInstantiation(_target, methodDescHandle) ? 1 : 0;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            int bGenericLocal = 0;
+            int hrLocal = _legacyImpl.HasClassOrMethodInstantiation(&bGenericLocal);
+
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0 && hrLocal >= 0 && bGeneric is not null)
+            {
+                Debug.Assert(bGenericLocal == *bGeneric, $"cDAC: {*bGeneric}, DAC: {bGenericLocal}");
+            }
+        }
+#endif
+
+        return hr;
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -171,6 +171,9 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         if (gcHandle.Target is not SOSDacImpl.EnumMethodInstances emi)
             return HResults.E_INVALIDARG;
 
+        if (instance.IsNullRef)
+            return HResults.E_INVALIDARG;
+
         // Advance the legacy enumeration to keep it in sync with the cDAC enumeration.
         // The legacy method instance is passed to ClrDataMethodInstance for delegation.
         IXCLRDataMethodInstance? legacyMethod = null;
@@ -410,17 +413,16 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
 
         try
         {
+            if (bGeneric is null)
+                throw new NullReferenceException();
+
             TargetPointer methodDescAddr = TryResolveMethodDesc();
             if (methodDescAddr == TargetPointer.Null)
-            {
-                hr = unchecked((int)0x8000FFFF); // E_UNEXPECTED
-            }
-            else
-            {
-                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
-                MethodDescHandle methodDescHandle = rts.GetMethodDescHandle(methodDescAddr);
-                *bGeneric = HasClassOrMethodInstantiation(_target, methodDescHandle) ? 1 : 0;
-            }
+                throw new System.Runtime.InteropServices.COMException(null, unchecked((int)0x8000FFFF)); // E_UNEXPECTED
+
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            MethodDescHandle methodDescHandle = rts.GetMethodDescHandle(methodDescAddr);
+            *bGeneric = HasClassOrMethodInstantiation(_target, methodDescHandle) ? (int)Interop.BOOL.TRUE : (int)Interop.BOOL.FALSE;
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -171,9 +171,6 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         if (gcHandle.Target is not SOSDacImpl.EnumMethodInstances emi)
             return HResults.E_INVALIDARG;
 
-        if (instance.IsNullRef)
-            return HResults.E_INVALIDARG;
-
         // Advance the legacy enumeration to keep it in sync with the cDAC enumeration.
         // The legacy method instance is passed to ClrDataMethodInstance for delegation.
         IXCLRDataMethodInstance? legacyMethod = null;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -139,7 +139,11 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         }
         finally
         {
-            // If we didn't transfer the legacy handle into the enum state, end it now.
+            // The legacy enumeration is started eagerly (before the cDAC try block) so
+            // that EnumInstance can advance both enumerations in lockstep. If the cDAC
+            // side fails to produce an enum (no MethodDesc, exception, or emi.Start()
+            // returns S_FALSE), the legacy handle would be orphaned because the caller
+            // receives *handle == 0 and has no way to call End. Clean it up here.
             if (_legacyImpl is not null && legacyHandle != default)
             {
                 _legacyImpl.EndEnumInstances(legacyHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodDefinition.cs
@@ -119,28 +119,31 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
         try
         {
             TargetPointer methodDescAddr = TryResolveMethodDesc();
-            if (methodDescAddr == TargetPointer.Null)
-            {
-                hr = HResults.S_FALSE;
-            }
-            else
+            if (methodDescAddr != TargetPointer.Null)
             {
                 SOSDacImpl.EnumMethodInstances emi = new(_target, methodDescAddr, TargetPointer.Null);
                 emi.LegacyHandle = legacyHandle;
 
-                *handle = (ulong)((IEnum<MethodDescHandle>)emi).GetHandle();
                 hr = emi.Start();
-                if (hr == HResults.S_FALSE)
+                if (hr == HResults.S_OK)
                 {
-                    GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)(*handle));
-                    gcHandle.Free();
-                    *handle = 0;
+                    *handle = (ulong)((IEnum<MethodDescHandle>)emi).GetHandle();
+                    // Legacy handle ownership transferred to emi — don't clean up below.
+                    legacyHandle = default;
                 }
             }
         }
         catch (System.Exception ex)
         {
             hr = ex.HResult;
+        }
+        finally
+        {
+            // If we didn't transfer the legacy handle into the enum state, end it now.
+            if (_legacyImpl is not null && legacyHandle != default)
+            {
+                _legacyImpl.EndEnumInstances(legacyHandle);
+            }
         }
 
 #if DEBUG
@@ -226,6 +229,7 @@ public sealed unsafe partial class ClrDataMethodDefinition : IXCLRDataMethodDefi
             if (gcHandle.Target is not SOSDacImpl.EnumMethodInstances emi)
                 throw new ArgumentException();
 
+            ((IEnum<MethodDescHandle>)emi).Dispose();
             gcHandle.Free();
 
             if (_legacyImpl is not null && emi.LegacyHandle != TargetPointer.Null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/LegacyFallbackHelper.cs
@@ -35,11 +35,8 @@ internal static class LegacyFallbackHelper
         // Loader heap traversal — not yet implemented in the cDAC (PR #125129).
         nameof(ISOSDacInterface.TraverseLoaderHeap),
 
-        // IXCLRDataMethodDefinition — not yet implemented in the cDAC.
-        nameof(IXCLRDataMethodDefinition.StartEnumInstances),
-        nameof(IXCLRDataMethodDefinition.GetName),
+        // IXCLRDataMethodDefinition — SetCodeNotification not yet implemented (needs INotifications contract).
         nameof(IXCLRDataMethodDefinition.SetCodeNotification),
-        nameof(IXCLRDataMethodDefinition.HasClassOrMethodInstantiation),
     };
 
     // Files whose methods are all allowed to fall back.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -361,13 +361,30 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
                 EnumMethodInstances emi = new(_target, methodDesc, TargetPointer.Null);
                 emi.LegacyHandle = handleLocal;
 
-                *handle = (ulong)((IEnum<MethodDescHandle>)emi).GetHandle();
                 hr = emi.Start();
+                if (hr == HResults.S_OK)
+                {
+                    *handle = (ulong)((IEnum<MethodDescHandle>)emi).GetHandle();
+                    // Legacy handle ownership transferred to emi — don't clean up below.
+                    handleLocal = default;
+                }
             }
         }
         catch (System.Exception ex)
         {
             hr = ex.HResult;
+        }
+        finally
+        {
+            // The legacy enumeration is started eagerly (before the cDAC try block) so
+            // that EnumMethodInstanceByAddress can advance both enumerations in lockstep.
+            // If the cDAC side fails to produce an enum (exception, no code block found,
+            // or emi.Start() returns S_FALSE), the legacy handle would be orphaned because
+            // the caller receives *handle == 0 and has no way to call End. Clean it up here.
+            if (_legacyProcess is not null && handleLocal != default)
+            {
+                _legacyProcess.EndEnumMethodInstancesByAddress(handleLocal);
+            }
         }
 
 #if DEBUG

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
@@ -1,0 +1,266 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Xunit;
+using static Microsoft.Diagnostics.DataContractReader.Tests.TestHelpers;
+
+namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
+
+/// <summary>
+/// Dump-based integration tests for IXCLRDataMethodDefinition methods.
+/// Tests GetName, HasClassOrMethodInstantiation, and Start/Enum/EndEnumInstances
+/// using the StackWalk and TypeHierarchy debuggee dumps.
+/// </summary>
+public unsafe class IXCLRDataMethodDefinitionDumpTests : DumpTestBase
+{
+    protected override string DebuggeeName => "StackWalk";
+    protected override string DumpType => "full";
+
+    // ========== GetName ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetName_QueryLengthOnly_ReturnsSizeWithoutBuffer(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        uint nameLen;
+        int hr = methodDef.GetName(0, 0, &nameLen, null);
+
+        AssertHResult(HResults.S_OK, hr);
+        Assert.True(nameLen > 1, "Expected nameLen > 1 (name + null terminator)");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetName_FullRetrieval_ReturnsExpectedName(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        uint nameLen;
+        int hr = methodDef.GetName(0, 0, &nameLen, null);
+        AssertHResult(HResults.S_OK, hr);
+
+        char[] nameBuf = new char[nameLen];
+        uint nameLen2;
+        fixed (char* pName = nameBuf)
+        {
+            hr = methodDef.GetName(0, nameLen, &nameLen2, pName);
+        }
+
+        AssertHResult(HResults.S_OK, hr);
+        string name = new string(nameBuf, 0, (int)nameLen2 - 1);
+        Assert.False(string.IsNullOrEmpty(name), "Expected non-empty method name");
+        Assert.Contains("MethodC", name);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetName_TruncatedBuffer_ReturnsSFalse(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        uint fullLen;
+        int hr = methodDef.GetName(0, 0, &fullLen, null);
+        AssertHResult(HResults.S_OK, hr);
+        Assert.True(fullLen > 2, "Need a name long enough to truncate");
+
+        uint truncLen = fullLen - 1;
+        char[] nameBuf = new char[truncLen];
+        uint reportedLen;
+        fixed (char* pName = nameBuf)
+        {
+            hr = methodDef.GetName(0, truncLen, &reportedLen, pName);
+            AssertHResult(HResults.S_FALSE, hr);
+        }
+
+        Assert.Equal(fullLen, reportedLen);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetName_NameIsNullTerminated(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        uint nameLen;
+        int hr = methodDef.GetName(0, 0, &nameLen, null);
+        AssertHResult(HResults.S_OK, hr);
+
+        char[] nameBuf = new char[nameLen];
+        fixed (char* pName = nameBuf)
+        {
+            hr = methodDef.GetName(0, nameLen, null, pName);
+            AssertHResult(HResults.S_OK, hr);
+            Assert.Equal('\0', pName[nameLen - 1]);
+        }
+    }
+
+    // ========== HasClassOrMethodInstantiation ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void HasClassOrMethodInstantiation_NonGenericMethod_ReturnsFalse(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        int bGeneric;
+        int hr = methodDef.HasClassOrMethodInstantiation(&bGeneric);
+
+        AssertHResult(HResults.S_OK, hr);
+        Assert.Equal((int)Interop.BOOL.FALSE, bGeneric);
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void HasClassOrMethodInstantiation_GenericTypeMethod_ReturnsTrue(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetGenericMethodDefinition();
+
+        int bGeneric;
+        int hr = methodDef.HasClassOrMethodInstantiation(&bGeneric);
+
+        AssertHResult(HResults.S_OK, hr);
+        Assert.Equal((int)Interop.BOOL.TRUE, bGeneric);
+    }
+
+    // ========== StartEnumInstances / EnumInstance / EndEnumInstances ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void EnumInstances_NonGenericMethod_ReturnsExactlyOneInstance(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        ulong handle;
+        int hr = methodDef.StartEnumInstances(null, &handle);
+        AssertHResult(HResults.S_OK, hr);
+        Assert.NotEqual(0ul, handle);
+
+        try
+        {
+            DacComNullableByRef<IXCLRDataMethodInstance> instanceOut = new(isNullRef: false);
+            hr = methodDef.EnumInstance(&handle, instanceOut);
+            AssertHResult(HResults.S_OK, hr);
+            Assert.NotNull(instanceOut.Interface);
+
+            DacComNullableByRef<IXCLRDataMethodInstance> instanceOut2 = new(isNullRef: false);
+            hr = methodDef.EnumInstance(&handle, instanceOut2);
+            AssertHResult(HResults.S_FALSE, hr);
+        }
+        finally
+        {
+            hr = methodDef.EndEnumInstances(handle);
+            AssertHResult(HResults.S_OK, hr);
+        }
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void EndEnumInstances_ZeroHandle_ReturnsError(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IXCLRDataMethodDefinition methodDef = GetMethodDefinitionFromStack("MethodC");
+
+        int hr = methodDef.EndEnumInstances(0);
+        Assert.True(hr < 0, $"Expected failure HRESULT for handle=0, got {FormatHResult(hr)}");
+    }
+
+    // ========== Helpers ==========
+
+    /// <summary>
+    /// Finds a managed method by name on the crashing thread's stack, then creates
+    /// a <see cref="ClrDataMethodDefinition"/> from its module and token.
+    /// </summary>
+    private IXCLRDataMethodDefinition GetMethodDefinitionFromStack(string methodName)
+    {
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(frame);
+            if (methodDescPtr == TargetPointer.Null)
+                continue;
+
+            MethodDescHandle mdHandle = rts.GetMethodDescHandle(methodDescPtr);
+            string? name = DumpTestHelpers.GetMethodName(Target, mdHandle);
+            if (name is null || !name.Contains(methodName))
+                continue;
+
+            uint token = rts.GetMethodToken(mdHandle);
+            TargetPointer mt = rts.GetMethodTable(mdHandle);
+            TargetPointer modulePtr = rts.GetModule(rts.GetTypeHandle(mt));
+
+            return new ClrDataMethodDefinition(Target, modulePtr, token, legacyImpl: null);
+        }
+
+        Assert.Fail($"Could not find method '{methodName}' on the crashing thread's stack");
+        return null!;
+    }
+
+    /// <summary>
+    /// Finds a method on a loaded generic type definition in System.Private.CoreLib
+    /// (e.g. <c>List&lt;&gt;</c>) and creates a <see cref="ClrDataMethodDefinition"/>
+    /// for it.
+    /// </summary>
+    private IXCLRDataMethodDefinition GetGenericMethodDefinition()
+    {
+        ILoader loader = Target.Contracts.Loader;
+        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
+
+        TargetPointer systemAssembly = loader.GetSystemAssembly();
+        Contracts.ModuleHandle coreLibModule = loader.GetModuleHandleFromAssemblyPtr(systemAssembly);
+        TypeHandle listTypeDef = rts.GetTypeByNameAndModule(
+            "List`1",
+            "System.Collections.Generic",
+            coreLibModule);
+        Assert.True(listTypeDef.Address != 0, "Could not find List<> type definition in CoreLib");
+
+        TargetPointer modulePtr = rts.GetModule(listTypeDef);
+        IEcmaMetadata ecmaMetadata = Target.Contracts.EcmaMetadata;
+        MetadataReader reader = ecmaMetadata.GetMetadata(coreLibModule)
+            ?? throw new InvalidOperationException("Failed to get metadata reader for CoreLib");
+
+        uint typeToken = rts.GetTypeDefToken(listTypeDef);
+        int rowId = (int)(typeToken & 0x00FFFFFF);
+        TypeDefinitionHandle tdh = MetadataTokens.TypeDefinitionHandle(rowId);
+        TypeDefinition td = reader.GetTypeDefinition(tdh);
+
+        ModuleLookupTables tables = loader.GetLookupTables(coreLibModule);
+        foreach (MethodDefinitionHandle mdh in td.GetMethods())
+        {
+            uint token = (uint)MetadataTokens.GetToken(mdh);
+            TargetPointer mdAddr = loader.GetModuleLookupMapElement(
+                tables.MethodDefToDesc, token, out _);
+            if (mdAddr == TargetPointer.Null)
+                continue;
+
+            return new ClrDataMethodDefinition(Target, modulePtr, token, legacyImpl: null);
+        }
+
+        Assert.Fail("Could not find a loaded method on List<> in CoreLib");
+        return null!;
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Implements 5 of 6 IXCLRDataMethodDefinition APIs in the cDAC's managed ClrDataMethodDefinition wrapper:

| Method | Status |
|--------|--------|
| `GetName` | ✅ Implemented — TypeNameBuilder + metadata fallback |
| `HasClassOrMethodInstantiation` | ✅ Implemented — mirrors native exactly |
| `StartEnumInstances` | ✅ Implemented — reuses `SOSDacImpl.EnumMethodInstances` |
| `EnumInstance` | ✅ Implemented — with legacy sync + exception fallback |
| `EndEnumInstances` | ✅ Implemented — proper cleanup inside try/catch |
| `SetCodeNotification` | ⏳ Deferred — `INotifications` contract lacks JIT notification table write APIs |

## Details

- **GetName**: Uses `TypeNameBuilder` with `FormatSignature|FormatNamespace|FormatFullInst` flags (matching native `daccess.cpp:5268`). Falls back to `GetFullMethodNameFromMetadata` when no MethodDesc is available.
- **HasClassOrMethodInstantiation**: Resolves MethodDesc and delegates to `IRuntimeTypeSystem` contract methods, matching native `task.cpp:3486-3516`.
- **Start/Enum/EndEnumInstances**: Reuses the existing `SOSDacImpl.EnumMethodInstances` infrastructure (same `IEnum<MethodDescHandle>` + GCHandle pattern).
- All implemented methods include `#if DEBUG` cross-validation blocks against the legacy DAC.
- Removes implemented APIs from the `LegacyFallbackHelper` allowlist.

## Testing

- All 1638 existing cDAC tests pass.
- Two rounds of cDAC-specific review completed (initial + deep line-by-line parity audit).