### PR TITLE
cDAC: Remove ad-hoc StrategyBasedComWrappers instantiation

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataAppDomain.cs
@@ -157,9 +157,8 @@ public sealed unsafe partial class ClrDataAppDomain : IXCLRDataAppDomain
         int hr = HResults.S_FALSE;
         try
         {
-            StrategyBasedComWrappers cw = new();
-            object obj = cw.GetOrCreateObjectForComInstance((nint)appDomain, CreateObjectFlags.None);
-            if (obj is ClrDataAppDomain other)
+            if (System.Runtime.InteropServices.ComWrappers.TryGetObject((nint)appDomain, out object? obj)
+                && obj is ClrDataAppDomain other)
             {
                 hr = _appDomain == other._appDomain ? HResults.S_OK : HResults.S_FALSE;
             }

--- a/src/native/managed/cdac/mscordaccore_universal/Entrypoints.cs
+++ b/src/native/managed/cdac/mscordaccore_universal/Entrypoints.cs
@@ -72,16 +72,15 @@ internal static class Entrypoints
     [UnmanagedCallersOnly(EntryPoint = $"{CDAC}create_sos_interface")]
     private static unsafe int CreateSosInterface(IntPtr handle, IntPtr legacyImplPtr, nint* obj)
     {
-        ComWrappers cw = new StrategyBasedComWrappers();
         Target? target = GCHandle.FromIntPtr(handle).Target as Target;
         if (target == null)
             return -1;
 
         object? legacyImpl = legacyImplPtr != IntPtr.Zero
-            ? cw.GetOrCreateObjectForComInstance(legacyImplPtr, CreateObjectFlags.None)
+            ? ComInterfaceMarshaller<ISOSDacInterface>.ConvertToManaged((void*)legacyImplPtr)
             : null;
         Legacy.SOSDacImpl impl = new(target, legacyImpl);
-        nint ptr = cw.GetOrCreateComInterfaceForObject(impl, CreateComInterfaceFlags.None);
+        nint ptr = (nint)ComInterfaceMarshaller<ISOSDacInterface>.ConvertToUnmanaged(impl);
         *obj = ptr;
         return 0;
     }
@@ -110,11 +109,10 @@ internal static class Entrypoints
             return HResults.E_INVALIDARG;
         }
 
-        ComWrappers cw = new StrategyBasedComWrappers();
         object? legacyObj = null;
         if (legacyImplPtr != IntPtr.Zero)
         {
-            legacyObj = cw.GetOrCreateObjectForComInstance(legacyImplPtr, CreateObjectFlags.None);
+            legacyObj = ComInterfaceMarshaller<IDacDbiInterface>.ConvertToManaged((void*)legacyImplPtr);
             if (legacyObj is not Legacy.IDacDbiInterface)
             {
                 *obj = IntPtr.Zero;
@@ -123,7 +121,7 @@ internal static class Entrypoints
         }
 
         Legacy.DacDbiImpl impl = new(target, legacyObj);
-        *obj = cw.GetOrCreateComInterfaceForObject(impl, CreateComInterfaceFlags.None);
+        *obj = (nint)ComInterfaceMarshaller<IDacDbiInterface>.ConvertToUnmanaged(impl);
         return HResults.S_OK;
     }
 
@@ -146,10 +144,9 @@ internal static class Entrypoints
             return HResults.E_INVALIDARG;
         *iface = null;
 
-        ComWrappers cw = new StrategyBasedComWrappers();
-        object legacyTarget = cw.GetOrCreateObjectForComInstance(pLegacyTarget, CreateObjectFlags.None);
+        object legacyTarget = ComInterfaceMarshaller<ICLRDataTarget>.ConvertToManaged((void*)pLegacyTarget)!;
         object? legacyImpl = pLegacyImpl != IntPtr.Zero ?
-            cw.GetOrCreateObjectForComInstance(pLegacyImpl, CreateObjectFlags.None) : null;
+            ComInterfaceMarshaller<ISOSDacInterface>.ConvertToManaged((void*)pLegacyImpl) : null;
 
         ICLRDataTarget dataTarget = legacyTarget as ICLRDataTarget ?? throw new ArgumentException(
             $"{nameof(pLegacyTarget)} does not implement {nameof(ICLRDataTarget)}", nameof(pLegacyTarget));
@@ -196,12 +193,12 @@ internal static class Entrypoints
         }
 
         Legacy.SOSDacImpl impl = new(target, legacyImpl);
-        nint ccw = cw.GetOrCreateComInterfaceForObject(impl, CreateComInterfaceFlags.None);
-        Marshal.QueryInterface(ccw, *pIID, out nint ptrToIface);
+        void* ccw = ComInterfaceMarshaller<IXCLRDataProcess>.ConvertToUnmanaged(impl);
+        Marshal.QueryInterface((nint)ccw, *pIID, out nint ptrToIface);
         *iface = (void*)ptrToIface;
 
         // Decrement reference count on ccw because QI incremented it
-        Marshal.Release(ccw);
+        ComInterfaceMarshaller<IXCLRDataProcess>.Free(ccw);
 
         return 0;
     }


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary

Removes all direct `StrategyBasedComWrappers` instantiation from the cDAC, fixing a bug in `ClrDataAppDomain.IsSameObject` and improving the entrypoint code to use the standard `ComInterfaceMarshaller<T>` API.

## Changes

### Bug fix: `ClrDataAppDomain.IsSameObject` (always returned `S_FALSE`)

The previous code created a `new StrategyBasedComWrappers()` and called `GetOrCreateObjectForComInstance` with `CreateObjectFlags.None`. This **always creates a new RCW** (a `ComObject` wrapper) — it never unwraps CCWs back to their original managed object. So the `obj is ClrDataAppDomain` check always failed, and `IsSameObject` always returned `S_FALSE`.

**Fix:** Use `ComWrappers.TryGetObject(nint, out object?)` instead. This is a static method that correctly unwraps any CCW (from any `ComWrappers` instance) back to its original managed object, making the identity comparison work as intended.

### Cleanup: `Entrypoints.cs` — use `ComInterfaceMarshaller<T>`

The three entrypoint functions (`CreateSosInterface`, `CreateDacDbiInterface`, `CLRDataCreateInstanceImpl`) each created a `new StrategyBasedComWrappers()` per call. These are replaced with `ComInterfaceMarshaller<T>` calls, which internally use `StrategyBasedComWrappers.DefaultMarshallingInstance` — the same process-wide singleton used by all source-generated COM interop code. This ensures cache coherence and eliminates the need to instantiate `StrategyBasedComWrappers` directly.

## Testing

- All 1691 cDAC unit tests pass
- Dump tests require a full runtime build (`clr+libs`) which was not available in this worktree; the changes are limited to COM interop plumbing and do not affect contract logic
