### PR TITLE
[cDAC] refactor ObjectHandle IData

### DIFF
--- a/docs/design/datacontracts/data_descriptor.md
+++ b/docs/design/datacontracts/data_descriptor.md
@@ -311,7 +311,7 @@ The baseline is given in the "regular" format.
   "version": 0,
   "types": [
     {
-      "name": "GCHandle",
+      "name": "ObjectHandle",
       "size": 8,
       "fields": [
         { "name": "Value", "type": "pointer", "offset": 0 }
@@ -369,7 +369,7 @@ If the indirect values table has the values `0x0100ffe0` in offset 0, then a pos
 
 | Type        | Size          | Field Name  | Field Type | Field Offset |
 | ----------- | ------------- | ----------- | ---------- | ------------ |
-| GCHandle    | 8             | Value       | pointer    | 0            |
+| ObjectHandle    | 8             | Value       | pointer    | 0            |
 | Thread      | indeterminate | ThreadState | uint32     | 0            |
 |             |               | ThreadId    | uint32     | 32           |
 |             |               | Next        | pointer    | 128          |

--- a/docs/design/datacontracts/data_descriptor.md
+++ b/docs/design/datacontracts/data_descriptor.md
@@ -369,7 +369,7 @@ If the indirect values table has the values `0x0100ffe0` in offset 0, then a pos
 
 | Type        | Size          | Field Name  | Field Type | Field Offset |
 | ----------- | ------------- | ----------- | ---------- | ------------ |
-| ObjectHandle    | 8             | Value       | pointer    | 0            |
+| ObjectHandle| 8             | Value       | pointer    | 0            |
 | Thread      | indeterminate | ThreadState | uint32     | 0            |
 |             |               | ThreadId    | uint32     | 32           |
 |             |               | Next        | pointer    | 128          |

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -48,12 +48,12 @@ CDAC_TYPE_FIELD(Thread, T_POINTER, DebuggerFilterContext, cdac_data<Thread>::Deb
 #ifdef PROFILING_SUPPORTED
 CDAC_TYPE_FIELD(Thread, T_POINTER, ProfilerFilterContext, cdac_data<Thread>::ProfilerFilterContext)
 #endif // PROFILING_SUPPORTED
-CDAC_TYPE_FIELD(Thread, T_POINTER, ExposedObject, cdac_data<Thread>::ExposedObject)
-CDAC_TYPE_FIELD(Thread, T_POINTER, LastThrownObject, cdac_data<Thread>::LastThrownObject)
+CDAC_TYPE_FIELD(Thread, TYPE(ObjectHandle), ExposedObject, cdac_data<Thread>::ExposedObject)
+CDAC_TYPE_FIELD(Thread, TYPE(ObjectHandle), LastThrownObject, cdac_data<Thread>::LastThrownObject)
 CDAC_TYPE_FIELD(Thread, T_UINT32, LastThrownObjectIsUnhandled, cdac_data<Thread>::LastThrownObjectIsUnhandled)
 CDAC_TYPE_FIELD(Thread, T_POINTER, LinkNext, cdac_data<Thread>::Link)
 CDAC_TYPE_FIELD(Thread, T_POINTER, ThreadLocalDataPtr, cdac_data<Thread>::ThreadLocalDataPtr)
-CDAC_TYPE_FIELD(Thread, T_POINTER, CurrentCustomDebuggerNotification, cdac_data<Thread>::CurrentCustomDebuggerNotification)
+CDAC_TYPE_FIELD(Thread, TYPE(ObjectHandle), CurrentCustomDebuggerNotification, cdac_data<Thread>::CurrentCustomDebuggerNotification)
 #ifndef TARGET_UNIX
 CDAC_TYPE_FIELD(Thread, T_POINTER, UEWatsonBucketTrackerBuckets, cdac_data<Thread>::UEWatsonBucketTrackerBuckets)
 #endif
@@ -99,7 +99,7 @@ CDAC_TYPE_BEGIN(InFlightTLSData)
 CDAC_TYPE_INDETERMINATE(InFlightTLSData)
 CDAC_TYPE_FIELD(InFlightTLSData, T_POINTER, Next, offsetof(InFlightTLSData, pNext))
 CDAC_TYPE_FIELD(InFlightTLSData, TYPE(TLSIndex), TlsIndex, offsetof(InFlightTLSData, tlsIndex))
-CDAC_TYPE_FIELD(InFlightTLSData, T_POINTER, TLSData, offsetof(InFlightTLSData, hTLSData))
+CDAC_TYPE_FIELD(InFlightTLSData, TYPE(ObjectHandle), TLSData, offsetof(InFlightTLSData, hTLSData))
 CDAC_TYPE_END(InFlightTLSData)
 
 CDAC_TYPE_BEGIN(TLSIndex)
@@ -138,7 +138,7 @@ CDAC_TYPE_END(Exception)
 CDAC_TYPE_BEGIN(ExceptionInfo)
 CDAC_TYPE_INDETERMINATE(ExceptionInfo)
 CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, PreviousNestedInfo, offsetof(ExInfo, m_pPrevNestedInfo))
-CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, ThrownObjectHandle, offsetof(ExInfo, m_hThrowable))
+CDAC_TYPE_FIELD(ExceptionInfo, TYPE(ObjectHandle), ThrownObjectHandle, offsetof(ExInfo, m_hThrowable))
 CDAC_TYPE_FIELD(ExceptionInfo, T_UINT32, ExceptionFlags, cdac_data<ExInfo>::ExceptionFlagsValue)
 CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, StackLowBound, cdac_data<ExInfo>::StackLowBound)
 CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, StackHighBound, cdac_data<ExInfo>::StackHighBound)
@@ -151,9 +151,9 @@ CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, CSFEnclosingClause, offsetof(ExInfo, m
 CDAC_TYPE_FIELD(ExceptionInfo, T_POINTER, CallerOfActualHandlerFrame, offsetof(ExInfo, m_sfCallerOfActualHandlerFrame))
 CDAC_TYPE_END(ExceptionInfo)
 
-CDAC_TYPE_BEGIN(GCHandle)
+CDAC_TYPE_BEGIN(ObjectHandle)
 CDAC_TYPE_SIZE(sizeof(OBJECTHANDLE))
-CDAC_TYPE_END(GCHandle)
+CDAC_TYPE_END(ObjectHandle)
 
 // Object
 
@@ -190,7 +190,7 @@ CDAC_TYPE_END(InteropSyncBlockInfo)
 CDAC_TYPE_BEGIN(SyncBlock)
 CDAC_TYPE_INDETERMINATE(SyncBlock)
 CDAC_TYPE_FIELD(SyncBlock, T_POINTER, InteropInfo, cdac_data<SyncBlock>::InteropInfo)
-CDAC_TYPE_FIELD(SyncBlock, T_POINTER, Lock, cdac_data<SyncBlock>::Lock)
+CDAC_TYPE_FIELD(SyncBlock, TYPE(ObjectHandle), Lock, cdac_data<SyncBlock>::Lock)
 CDAC_TYPE_FIELD(SyncBlock, T_UINT32, ThinLock, cdac_data<SyncBlock>::ThinLock)
 CDAC_TYPE_FIELD(SyncBlock, T_POINTER, LinkNext, cdac_data<SyncBlock>::LinkNext)
 CDAC_TYPE_FIELD(SyncBlock, T_UINT32, HashCode, cdac_data<SyncBlock>::HashCode)
@@ -306,7 +306,7 @@ CDAC_TYPE_FIELD(LoaderAllocator, T_POINTER, NewStubPrecodeHeap, cdac_data<Loader
 CDAC_TYPE_FIELD(LoaderAllocator, T_POINTER, DynamicHelpersStubHeap, cdac_data<LoaderAllocator>::DynamicHelpersStubHeap)
 #endif // defined(FEATURE_READYTORUN) && defined(FEATURE_STUBPRECODE_DYNAMIC_HELPERS)
 CDAC_TYPE_FIELD(LoaderAllocator, T_POINTER, VirtualCallStubManager, cdac_data<LoaderAllocator>::VirtualCallStubManager)
-CDAC_TYPE_FIELD(LoaderAllocator, T_POINTER, ObjectHandle, cdac_data<LoaderAllocator>::ObjectHandle)
+CDAC_TYPE_FIELD(LoaderAllocator, TYPE(ObjectHandle), ObjectHandle, cdac_data<LoaderAllocator>::ObjectHandle)
 CDAC_TYPE_END(LoaderAllocator)
 
 CDAC_TYPE_BEGIN(VirtualCallStubManager)
@@ -325,7 +325,7 @@ CDAC_TYPE_END(PEAssembly)
 
 CDAC_TYPE_BEGIN(AssemblyBinder)
 CDAC_TYPE_INDETERMINATE(AssemblyBinder)
-CDAC_TYPE_FIELD(AssemblyBinder, T_POINTER, AssemblyLoadContext, cdac_data<AssemblyBinder>::AssemblyLoadContext)
+CDAC_TYPE_FIELD(AssemblyBinder, TYPE(ObjectHandle), AssemblyLoadContext, cdac_data<AssemblyBinder>::AssemblyLoadContext)
 CDAC_TYPE_END(AssemblyBinder)
 
 CDAC_TYPE_BEGIN(PEImage)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/DataType.cs
@@ -21,7 +21,7 @@ public enum DataType
 
     /* VM Data Types */
 
-    GCHandle,
+    ObjectHandle,
     CodePointer,
     Thread,
     ThreadStore,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ComWrappers_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ComWrappers_1.cs
@@ -72,8 +72,7 @@ internal struct ComWrappers_1 : IComWrappers
 
     public TargetPointer GetComWrappersObjectFromMOW(TargetPointer mow)
     {
-        TargetPointer objHandle = _target.ReadPointer(mow);
-        Data.ObjectHandle handle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(objHandle);
+        Data.ObjectHandle handle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(mow);
         Data.ManagedObjectWrapperHolderObject mowHolderObject = _target.ProcessedData.GetOrAdd<Data.ManagedObjectWrapperHolderObject>(handle.Object);
         return mowHolderObject.WrappedObject;
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ConditionalWeakTable_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ConditionalWeakTable_1.cs
@@ -105,11 +105,10 @@ internal struct ConditionalWeakTable_1 : IConditionalWeakTable
             int entryHashCode = _target.Read<int>(entryAddress + _hashCodeFieldOffset.Value);
             if (entryHashCode == hashCode)
             {
-                TargetPointer depHnd = _target.ReadPointer(entryAddress + _depHndFieldOffset.Value);
-                Data.ObjectHandle handle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(depHnd);
+                Data.ObjectHandle handle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(entryAddress + _depHndFieldOffset.Value);
                 if (handle.Object == key)
                 {
-                    TargetNUInt extraInfo = _target.Contracts.GC.GetHandleExtraInfo(depHnd);
+                    TargetNUInt extraInfo = _target.Contracts.GC.GetHandleExtraInfo(handle.Handle);
                     value = new TargetPointer(extraInfo.Value);
 
                     return true;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Exception_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Exception_1.cs
@@ -18,9 +18,8 @@ internal readonly struct Exception_1 : IException
     {
         Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(exceptionInfoAddr);
         nextNestedExceptionInfo = exceptionInfo.PreviousNestedInfo;
-        thrownObjectHandle = exceptionInfo.ThrownObjectHandle;
-        Data.ObjectHandle throwableObject = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(exceptionInfo.ThrownObjectHandle);
-        return throwableObject.Object;
+        thrownObjectHandle = exceptionInfo.ThrownObjectHandle.Handle;
+        return exceptionInfo.ThrownObjectHandle.Object;
     }
 
     ExceptionData IException.GetExceptionData(TargetPointer exceptionAddr)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -471,8 +471,7 @@ internal readonly struct Loader_1 : ILoader
         Data.Module module = _target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
         Data.PEAssembly peAssembly = _target.ProcessedData.GetOrAdd<Data.PEAssembly>(module.PEAssembly);
         Data.AssemblyBinder binder = _target.ProcessedData.GetOrAdd<Data.AssemblyBinder>(peAssembly.AssemblyBinder);
-        Data.ObjectHandle objectHandle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(binder.AssemblyLoadContext);
-        return objectHandle.Object;
+        return binder.AssemblyLoadContext.Object;
     }
 
     ModuleLookupTables ILoader.GetLookupTables(ModuleHandle handle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -1924,8 +1924,8 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         TargetPointer handleAddr = GetStaticAddressHandle(@base, offset, isRVA, fieldDescPointer, moduleHandle);
         if (type == CorElementType.ValueType && !isRVA)
         {
-            Data.ObjectHandle objectHandle = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(handleAddr);
-            Data.Object obj = _target.ProcessedData.GetOrAdd<Data.Object>(objectHandle.Object);
+            TargetPointer objRef = _target.ReadPointer(handleAddr);
+            Data.Object obj = _target.ProcessedData.GetOrAdd<Data.Object>(objRef);
             return obj.Data;
         }
         return handleAddr;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -98,7 +98,7 @@ internal readonly struct Thread_1 : IThread
             Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(address);
             firstNestedException = exceptionInfo.PreviousNestedInfo;
 
-            if (exceptionInfo.ThrownObjectHandle != TargetPointer.Null)
+            if (exceptionInfo.ThrownObjectHandle.Handle != TargetPointer.Null)
             {
                 uint exceptionFlags = exceptionInfo.ExceptionFlags;
                 hasUnhandledException = (exceptionFlags & (uint)ExceptionFlags.IsUnhandled) != 0
@@ -119,9 +119,9 @@ internal readonly struct Thread_1 : IThread
             thread.RuntimeThreadLocals?.AllocContext.GCAllocationContext.Limit ?? TargetPointer.Null,
             thread.Frame,
             firstNestedException,
-            thread.ExposedObject,
+            thread.ExposedObject.Handle,
             thread.LastThrownObject.Handle,
-            thread.CurrentCustomDebuggerNotification,
+            thread.CurrentCustomDebuggerNotification.Handle,
             thread.LastThrownObjectIsUnhandled != 0,
             hasUnhandledException,
             GetThreadFromLink(thread.LinkNext));
@@ -239,10 +239,10 @@ internal readonly struct Thread_1 : IThread
         if (exceptionInfo == null)
             return TargetPointer.Null;
 
-        if (exceptionInfo.ThrownObjectHandle == TargetPointer.Null || _target.ReadPointer(exceptionInfo.ThrownObjectHandle) == TargetPointer.Null)
+        if (exceptionInfo.ThrownObjectHandle.Handle == TargetPointer.Null || exceptionInfo.ThrownObjectHandle.Object == TargetPointer.Null)
             return TargetPointer.Null;
 
-        return exceptionInfo.ThrownObjectHandle;
+        return exceptionInfo.ThrownObjectHandle.Handle;
     }
 
     byte[] IThread.GetWatsonBuckets(TargetPointer threadPointer)
@@ -251,7 +251,7 @@ internal readonly struct Thread_1 : IThread
         var (thread, exceptionInfo) = GetThreadExceptionInfo(threadPointer);
         if (exceptionInfo == null)
             return Array.Empty<byte>();
-        Data.ObjectHandle throwableObject = _target.ProcessedData.GetOrAdd<Data.ObjectHandle>(exceptionInfo.ThrownObjectHandle);
+        Data.ObjectHandle throwableObject = exceptionInfo.ThrownObjectHandle;
         if (throwableObject.Object != TargetPointer.Null)
         {
             Data.Exception exception = _target.ProcessedData.GetOrAdd<Data.Exception>(throwableObject.Object);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/AssemblyBinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/AssemblyBinder.cs
@@ -11,7 +11,7 @@ internal sealed class AssemblyBinder : IData<AssemblyBinder>
     public AssemblyBinder(Target target, TargetPointer address)
     {
         Target.TypeInfo type = target.GetTypeInfo(DataType.AssemblyBinder);
-        AssemblyLoadContext = target.ReadPointerField(address, type, nameof(AssemblyLoadContext));
+        AssemblyLoadContext = target.ReadDataField<ObjectHandle>(address, type, nameof(AssemblyLoadContext));
     }
-    public TargetPointer AssemblyLoadContext { get; init; }
+    public ObjectHandle AssemblyLoadContext { get; init; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ExceptionInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ExceptionInfo.cs
@@ -13,7 +13,7 @@ internal sealed class ExceptionInfo : IData<ExceptionInfo>
         Target.TypeInfo type = target.GetTypeInfo(DataType.ExceptionInfo);
 
         PreviousNestedInfo = target.ReadPointerField(address, type, nameof(PreviousNestedInfo));
-        ThrownObjectHandle = target.ReadPointerField(address, type, nameof(ThrownObjectHandle));
+        ThrownObjectHandle = target.ReadDataField<ObjectHandle>(address, type, nameof(ThrownObjectHandle));
         if (type.Fields.ContainsKey(nameof(ExceptionWatsonBucketTrackerBuckets)))
             ExceptionWatsonBucketTrackerBuckets = target.ReadPointerField(address, type, nameof(ExceptionWatsonBucketTrackerBuckets));
         ExceptionFlags = target.ReadField<uint>(address, type, nameof(ExceptionFlags));
@@ -26,7 +26,7 @@ internal sealed class ExceptionInfo : IData<ExceptionInfo>
     }
 
     public TargetPointer PreviousNestedInfo { get; }
-    public TargetPointer ThrownObjectHandle { get; }
+    public ObjectHandle ThrownObjectHandle { get; }
     public uint ExceptionFlags { get; }
     public TargetPointer StackLowBound { get; }
     public TargetPointer StackHighBound { get; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InflightTLSData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/InflightTLSData.cs
@@ -13,7 +13,7 @@ internal sealed class InflightTLSData : IData<InflightTLSData>
         Target.TypeInfo type = target.GetTypeInfo(DataType.InFlightTLSData);
         Next = target.ReadPointerField(address, type, nameof(Next));
         TlsIndex = target.ProcessedData.GetOrAdd<TLSIndex>(address + (ulong)type.Fields[nameof(TlsIndex)].Offset);
-        TLSData = target.ProcessedData.GetOrAdd<ObjectHandle>(target.ReadPointerField(address, type, nameof(TLSData)));
+        TLSData = target.ReadDataField<ObjectHandle>(address, type, nameof(TLSData));
     }
     public TargetPointer Next { get; init; }
     public TLSIndex TlsIndex { get; init; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/LoaderAllocator.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/LoaderAllocator.cs
@@ -28,8 +28,7 @@ internal sealed class LoaderAllocator : IData<LoaderAllocator>
 
         VirtualCallStubManager = target.ReadPointerField(address, type, nameof(VirtualCallStubManager));
 
-        ObjectHandle = target.ProcessedData.GetOrAdd<ObjectHandle>(
-            target.ReadPointerField(address, type, nameof(ObjectHandle)));
+        ObjectHandle = target.ReadDataField<ObjectHandle>(address, type, nameof(ObjectHandle));
     }
 
     public uint ReferenceCount { get; init; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ObjectHandle.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/ObjectHandle.cs
@@ -10,11 +10,14 @@ internal sealed class ObjectHandle : IData<ObjectHandle>
 
     public ObjectHandle(Target target, TargetPointer address)
     {
-        Handle = address;
         if (address != TargetPointer.Null)
-            Object = target.ReadPointer(address);
+        {
+            Handle = target.ReadPointer(address);
+            if (Handle != TargetPointer.Null && target.TryReadPointer(Handle, out TargetPointer obj))
+                Object = obj;
+        }
     }
 
-    public TargetPointer Handle { get; init; }
+    public TargetPointer Handle { get; init; } = TargetPointer.Null;
     public TargetPointer Object { get; init; } = TargetPointer.Null;
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncBlock.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/SyncBlock.cs
@@ -16,9 +16,9 @@ internal sealed class SyncBlock : IData<SyncBlock>
         TargetPointer interopInfoPointer = target.ReadPointerField(address, type, nameof(InteropInfo));
         if (interopInfoPointer != TargetPointer.Null)
             InteropInfo = target.ProcessedData.GetOrAdd<InteropSyncBlockInfo>(interopInfoPointer);
-        TargetPointer lockPointer = target.ReadPointerField(address, type, nameof(Lock));
-        if (lockPointer != TargetPointer.Null)
-            Lock = target.ProcessedData.GetOrAdd<ObjectHandle>(lockPointer);
+        ObjectHandle lockHandle = target.ReadDataField<ObjectHandle>(address, type, nameof(Lock));
+        if (lockHandle.Handle != TargetPointer.Null)
+            Lock = lockHandle;
 
         ThinLock = target.ReadField<uint>(address, type, nameof(ThinLock));
         LinkNext = target.ReadPointerField(address, type, nameof(LinkNext));

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
@@ -23,9 +23,8 @@ internal sealed class Thread : IData<Thread>
         CachedStackBase = target.ReadPointerField(address, type, nameof(CachedStackBase));
         CachedStackLimit = target.ReadPointerField(address, type, nameof(CachedStackLimit));
 
-        ExposedObject = target.ReadPointerField(address, type, nameof(ExposedObject));
-        LastThrownObject = target.ProcessedData.GetOrAdd<ObjectHandle>(
-            target.ReadPointerField(address, type, nameof(LastThrownObject)));
+        ExposedObject = target.ReadDataField<ObjectHandle>(address, type, nameof(ExposedObject));
+        LastThrownObject = target.ReadDataField<ObjectHandle>(address, type, nameof(LastThrownObject));
         LastThrownObjectIsUnhandled = target.ReadField<uint>(address, type, nameof(LastThrownObjectIsUnhandled));
         LinkNext = target.ReadPointerField(address, type, nameof(LinkNext));
 
@@ -36,7 +35,7 @@ internal sealed class Thread : IData<Thread>
         ThreadLocalDataPtr = target.ReadPointerField(address, type, nameof(ThreadLocalDataPtr));
         DebuggerFilterContext = target.ReadPointerField(address, type, nameof(DebuggerFilterContext));
         ProfilerFilterContext = target.ReadPointerFieldOrNull(address, type, nameof(ProfilerFilterContext));
-        CurrentCustomDebuggerNotification = target.ReadPointerField(address, type, nameof(CurrentCustomDebuggerNotification));
+        CurrentCustomDebuggerNotification = target.ReadDataField<ObjectHandle>(address, type, nameof(CurrentCustomDebuggerNotification));
     }
 
     public uint Id { get; init; }
@@ -47,7 +46,7 @@ internal sealed class Thread : IData<Thread>
     public TargetPointer Frame { get; init; }
     public TargetPointer CachedStackBase { get; init; }
     public TargetPointer CachedStackLimit { get; init; }
-    public TargetPointer ExposedObject { get; init; }
+    public ObjectHandle ExposedObject { get; init; }
     public ObjectHandle LastThrownObject { get; init; }
     public uint LastThrownObjectIsUnhandled { get; init; }
     public TargetPointer LinkNext { get; init; }
@@ -56,5 +55,5 @@ internal sealed class Thread : IData<Thread>
     public TargetPointer ThreadLocalDataPtr { get; init; }
     public TargetPointer DebuggerFilterContext { get; init; }
     public TargetPointer ProfilerFilterContext { get; init; }
-    public TargetPointer CurrentCustomDebuggerNotification { get; init; }
+    public ObjectHandle CurrentCustomDebuggerNotification { get; init; }
 }

--- a/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.SubDescriptors.cs
+++ b/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.SubDescriptors.cs
@@ -24,7 +24,7 @@ public unsafe partial class TargetTests
             Size = 56,
             Fields = new Dictionary<string, Target.FieldInfo> {
                 { "Field1", new(){ Offset = 8, Type = DataType.uint16, TypeName = DataType.uint16.ToString() }},
-                { "Field2", new(){ Offset = 16, Type = DataType.GCHandle, TypeName = DataType.GCHandle.ToString() }},
+                { "Field2", new(){ Offset = 16, Type = DataType.ObjectHandle, TypeName = DataType.ObjectHandle.ToString() }},
                 { "Field3", new(){ Offset = 32 }}
             }
         },

--- a/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.cs
+++ b/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.cs
@@ -20,7 +20,7 @@ public unsafe partial class TargetTests
             Size = 56,
             Fields = new Dictionary<string, Target.FieldInfo> {
                 { "Field1", new(){ Offset = 8, Type = DataType.uint16, TypeName = DataType.uint16.ToString() }},
-                { "Field2", new(){ Offset = 16, Type = DataType.GCHandle, TypeName = DataType.GCHandle.ToString() }},
+                { "Field2", new(){ Offset = 16, Type = DataType.ObjectHandle, TypeName = DataType.ObjectHandle.ToString() }},
                 { "Field3", new(){ Offset = 32 }}
             }
         },
@@ -33,7 +33,7 @@ public unsafe partial class TargetTests
             }
         },
         // Size only
-        [DataType.GCHandle] = new()
+        [DataType.ObjectHandle] = new()
         {
             Size = 8
         }


### PR DESCRIPTION
ObjectHandle is a strange IData in that it expects the address parameter to be the address field of the OBJECTHANDLE as opposed to the address of the structure like in every other IData. This is annoying because it means we have to first ReadPointer from the address of the ObjectHandle before we construct one, which means these fields have to be typed as pointers instead of TYPE(ObjectHandle). With this refactoring, the parameter to ObjectHandle is now the address of the ObjectHandle, and we can type ObjectHandle fields properly and do ReadDataField<ObjectHandle> where appropriate.