### PR TITLE
JIT: eliminate redundant span checks across loop back-edge phis

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2747,6 +2747,7 @@ class Compiler
     friend class Promotion;
     friend class ReplaceVisitor;
     friend class FlowGraphNaturalLoop;
+    friend class RangeCheck;
 
 #ifdef FEATURE_HW_INTRINSICS
     friend struct GenTreeHWIntrinsic;
@@ -8799,6 +8800,14 @@ public:
 
     template <typename TAssertVisitor>
     AssertVisit optVisitReachingAssertions(ValueNum vn, TAssertVisitor argVisitor);
+
+private:
+    template <typename TAssertVisitor>
+    AssertVisit optVisitReachingAssertionsWorker(ValueNum                         vn,
+                                                 TAssertVisitor                   argVisitor,
+                                                 ValueNumStore::SmallValueNumSet& visitedPhis);
+
+public:
 
     void optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
                                           GenTree*         tree,

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5626,8 +5626,17 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
             return AssertVisit::Abort;
         }
 
-        const ValueNum phiArgVN   = vnStore->VNConservativeNormalValue(phiArg->gtVNPair);
-        ASSERT_TP      assertions = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
+        // Read the VN from the phi arg's SSA def rather than from phiArg->gtVNPair: by SSA
+        // construction the value flowing along this predecessor edge is exactly that SSA
+        // def's value, and m_vnPair is always at least as precise as the cached gtVNPair.
+        // In particular, fgValueNumberPhiDef may leave gtVNPair as NoVN (or as a stale prior
+        // VN) when it refuses to back-patch a loop-varying SSA-def VN into the phi-arg slot
+        // -- a hygiene constraint for general gtVNPair consumers that does not apply here,
+        // since we hand the VN to the visitor together with this edge's assertion set and
+        // never write it back into any tree.
+        LclSsaVarDsc*  phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
+        const ValueNum phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
+        ASSERT_TP      assertions   = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
         if (argVisitor(phiArgVN, assertions) == AssertVisit::Abort)
         {
             // The visitor wants to abort the walk.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5626,17 +5626,18 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
             return AssertVisit::Abort;
         }
 
-        // Read the VN from the phi arg's SSA def rather than from phiArg->gtVNPair: by SSA
-        // construction the value flowing along this predecessor edge is exactly that SSA
-        // def's value, and m_vnPair is always at least as precise as the cached gtVNPair.
-        // In particular, fgValueNumberPhiDef may leave gtVNPair as NoVN (or as a stale prior
-        // VN) when it refuses to back-patch a loop-varying SSA-def VN into the phi-arg slot
-        // -- a hygiene constraint for general gtVNPair consumers that does not apply here,
-        // since we hand the VN to the visitor together with this edge's assertion set and
-        // never write it back into any tree.
-        LclSsaVarDsc*  phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
-        const ValueNum phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
-        ASSERT_TP      assertions   = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
+        ValueNum phiArgVN = vnStore->VNConservativeNormalValue(phiArg->gtVNPair);
+        if (phiArgVN == ValueNumStore::NoVN)
+        {
+            // fgValueNumberPhiDef may leave gtVNPair as NoVN when it refuses to back-patch
+            // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
+            // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
+            // together with this edge's assertion set and never write it back into any tree).
+            // Fall back to the SSA def's VN, which by SSA construction names the same value.
+            LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
+            phiArgVN                   = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
+        }
+        ASSERT_TP assertions = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
         if (argVisitor(phiArgVN, assertions) == AssertVisit::Abort)
         {
             // The visitor wants to abort the walk.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5626,18 +5626,13 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
             return AssertVisit::Abort;
         }
 
-        ValueNum phiArgVN = vnStore->VNConservativeNormalValue(phiArg->gtVNPair);
-        if (phiArgVN == ValueNumStore::NoVN)
-        {
-            // fgValueNumberPhiDef may leave gtVNPair as NoVN when it refuses to back-patch
-            // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
-            // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
-            // together with this edge's assertion set and never write it back into any tree).
-            // Fall back to the SSA def's VN, which by SSA construction names the same value.
-            LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
-            phiArgVN                   = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
-        }
-        ASSERT_TP assertions = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
+        // fgValueNumberPhiDef may leave gtVNPair as NoVN when it refuses to back-patch
+        // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
+        // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
+        // together with this edge's assertion set and never write it back into any tree).
+        LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
+        ValueNum      phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
+        ASSERT_TP     assertions   = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
         if (argVisitor(phiArgVN, assertions) == AssertVisit::Abort)
         {
             // The visitor wants to abort the walk.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5626,17 +5626,14 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
             return AssertVisit::Abort;
         }
 
-        ValueNum phiArgVN = vnStore->VNConservativeNormalValue(phiArg->gtVNPair);
-        if (phiArgVN == ValueNumStore::NoVN)
-        {
-            // fgValueNumberPhiDef may leave gtVNPair as NoVN when it refuses to back-patch
-            // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
-            // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
-            // together with this edge's assertion set and never write it back into any tree).
-            // Fall back to the SSA def's VN, which by SSA construction names the same value.
-            LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
-            phiArgVN                   = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
-        }
+        // fgValueNumberPhiDef may leave gtVNPair as NoVN when it refuses to back-patch
+        // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
+        // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
+        // together with this edge's assertion set and never write it back into any tree).
+        // Fall back to the SSA def's VN, which by SSA construction names the same value.
+        LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
+        ValueNum      phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
+
         ASSERT_TP assertions = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
         if (argVisitor(phiArgVN, assertions) == AssertVisit::Abort)
         {

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5631,10 +5631,9 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
         // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
         // together with this edge's assertion set and never write it back into any tree).
         // Fall back to the SSA def's VN, which by SSA construction names the same value.
-        LclSsaVarDsc* phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
-        ValueNum      phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
-
-        ASSERT_TP assertions = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
+        LclSsaVarDsc*  phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
+        const ValueNum phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
+        ASSERT_TP      assertions   = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);
         if (argVisitor(phiArgVN, assertions) == AssertVisit::Abort)
         {
             // The visitor wants to abort the walk.

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5630,7 +5630,7 @@ Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertV
         // a loop-varying SSA-def VN into the phi-arg slot (a hygiene constraint for general
         // gtVNPair consumers that does not apply here, since we hand the VN to the visitor
         // together with this edge's assertion set and never write it back into any tree).
-        // Fall back to the SSA def's VN, which by SSA construction names the same value.
+        // Use the SSA def's VN directly; by SSA construction it names the same value.
         LclSsaVarDsc*  phiArgSsaDef = lvaGetDesc(phiArg)->GetPerSsaData(phiArg->GetSsaNum());
         const ValueNum phiArgVN     = vnStore->VNConservativeNormalValue(phiArgSsaDef->m_vnPair);
         ASSERT_TP      assertions   = optGetEdgeAssertions(ssaDef->GetBlock(), phiArg->gtPredBB);

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -5582,11 +5582,33 @@ bool Compiler::optLoopComplexityExceeds(FlowGraphNaturalLoop* loop, unsigned lim
 template <typename TAssertVisitor>
 Compiler::AssertVisit Compiler::optVisitReachingAssertions(ValueNum vn, TAssertVisitor argVisitor)
 {
+    ValueNumStore::SmallValueNumSet visitedPhis;
+    return optVisitReachingAssertionsWorker(vn, argVisitor, visitedPhis);
+}
+
+//--------------------------------------------------------------------------------
+// optVisitReachingAssertionsWorker: Worker for optVisitReachingAssertions that takes
+//    an explicit visited-phi set, used to detect cycles when the visitor recursively
+//    re-enters this walk (e.g. via RangeCheck::GetRangeFromAssertions). The set is
+//    threaded across the recursion chain so we can abort on revisits of phi-def VNs
+//    that arise from loop-carried PHIs.
+//
+template <typename TAssertVisitor>
+Compiler::AssertVisit Compiler::optVisitReachingAssertionsWorker(ValueNum                         vn,
+                                                                 TAssertVisitor                   argVisitor,
+                                                                 ValueNumStore::SmallValueNumSet& visitedPhis)
+{
     VNPhiDef phiDef;
     if (!vnStore->GetPhiDef(vn, &phiDef))
     {
         // We assume that the caller already checked assertions for the current block, so we're
         // interested only in assertions for PHI definitions.
+        return AssertVisit::Abort;
+    }
+
+    if (!visitedPhis.Add(this, vn))
+    {
+        JITDUMP("... optVisitReachingAssertions: cycle detected on " FMT_VN "; aborting\n", vn);
         return AssertVisit::Abort;
     }
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1082,17 +1082,33 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         else if (curAssertion.KindIs(Compiler::OAK_GE, Compiler::OAK_GT, Compiler::OAK_LE, Compiler::OAK_LT) &&
                  curAssertion.GetOp2().KindIs(Compiler::O2K_CHECKED_BOUND_ADD_CNS))
         {
+            const ValueNum boundVN  = curAssertion.GetOp2().GetCheckedBound();
+            const int      boundCns = curAssertion.GetOp2().GetCheckedBoundConstant();
+
+            // Check whether normalLclVN VN-equals the op2 expression "(boundVN + boundCns)":
+            //  - trivially, when boundCns is 0 and normalLclVN == boundVN, or
+            //  - when normalLclVN itself is the value-number "ADD(boundVN, boundCns)".
+            //
+            // The general case commonly arises on a loop back-edge where the induction variable
+            // is e.g. V = phi(V0, V - 8), and the back-edge JTRUE generates an assertion of the
+            // form "8 <= (V + -8)" against the phi's VN. We want to apply that assertion to the
+            // value of the back-edge phi-arg "(V - 8)" itself.
+            ValueNum   addOp;
+            int        addCns;
+            const bool normalLclVNMatchesOp2 =
+                ((normalLclVN == boundVN) && (boundCns == 0)) ||
+                (comp->vnStore->IsVNBinFuncWithConst(normalLclVN, VNF_ADD, &addOp, &addCns) && (addOp == boundVN) &&
+                 (addCns == boundCns));
+
             if (canUseCheckedBounds && (normalLclVN == curAssertion.GetOp1().GetVN()))
             {
                 cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
-                limit   = Limit(Limit::keBinOpArray, curAssertion.GetOp2().GetCheckedBound(),
-                                curAssertion.GetOp2().GetCheckedBoundConstant());
+                limit   = Limit(Limit::keBinOpArray, boundVN, boundCns);
             }
-            else if ((normalLclVN == curAssertion.GetOp2().GetCheckedBound()) &&
-                     (curAssertion.GetOp2().GetCheckedBoundConstant() == 0))
+            else if (normalLclVNMatchesOp2)
             {
-                // Check if it's "Const <relop> (checkedBndVN + 0)" or in other words "Const <relop> checkedBndVN"
-                // If normalLclVN == checkedBndVN, then we can deduce "normalLclVN <relop> Const"
+                // Check if it's "Const <relop> (checkedBndVN + cns)" or in other words "Const <relop> normalLclVN"
+                // If normalLclVN VN-equals (checkedBndVN + cns), we can deduce "normalLclVN <relop> Const"
                 //
                 // Example: We created "O1K_VN(vn1) - OAK_GT - O2K_CHECKED_BOUND_ADD_CNS(vn2, 0)"
                 // if vn1 is a constant (say, 100) and vn2 is our normalLclVN, we can deduce "normalLclVN < 100"

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -687,12 +687,6 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
         return result;
     }
 
-    if (!visited->Add(comp, num))
-    {
-        // We've come back to a node we've already visited
-        return result;
-    }
-
     // Currently, we only handle int32 and smaller integer types.
     assert(genTypeSize(comp->vnStore->TypeOfVN(num)) <= 4);
 
@@ -894,10 +888,20 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
         return Compiler::AssertVisit::Abort;
     };
 
-    if (comp->optVisitReachingAssertions(num, visitor) == Compiler::AssertVisit::Continue && !phiRange.IsUndef())
+    // If it's a phi, we need to look at the reaching assertions for each of the phi args and merge them together.
+    if (comp->vnStore->IsPhiDef(num))
     {
-        assert(phiRange.IsConstantRange());
-        result = phiRange;
+        if (!visited->Add(comp, num))
+        {
+            // We already visited this phi in the current search path, which means we have a cycle.
+            return result;
+        }
+
+        if ((comp->optVisitReachingAssertions(num, visitor) == Compiler::AssertVisit::Continue) && !phiRange.IsUndef())
+        {
+            assert(phiRange.IsConstantRange());
+            result = phiRange;
+        }
     }
 
     MergeEdgeAssertions(comp, num, ValueNumStore::NoVN, assertions, &result, false);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1093,11 +1093,17 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             // is e.g. V = phi(V0, V - 8), and the back-edge JTRUE generates an assertion of the
             // form "8 <= (V + -8)" against the phi's VN. We want to apply that assertion to the
             // value of the back-edge phi-arg "(V - 8)" itself.
+            //
+            // Note: when boundCns == 0, the trivial check above is exhaustive -- VN normalizes
+            // ADD(x, 0) to x, so any IsVNBinFuncWithConst match would also have to satisfy
+            // normalLclVN == boundVN, which the trivial check already covers. Skip the lookup
+            // in that case to keep this fast-path cheap.
             ValueNum   addOp;
             int        addCns;
             const bool normalLclVNMatchesOp2 =
                 ((normalLclVN == boundVN) && (boundCns == 0)) ||
-                (comp->vnStore->IsVNBinFuncWithConst(normalLclVN, VNF_ADD, &addOp, &addCns) && (addOp == boundVN) &&
+                ((boundCns != 0) &&
+                 comp->vnStore->IsVNBinFuncWithConst(normalLclVN, VNF_ADD, &addOp, &addCns) && (addOp == boundVN) &&
                  (addCns == boundCns));
 
             if (canUseCheckedBounds && (normalLclVN == curAssertion.GetOp1().GetVN()))

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -848,7 +848,7 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
     Range phiRange = Range(Limit(Limit::keUndef));
     auto  visitor  = [comp, &phiRange, &budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
         // call GetRangeFromAssertions for each reaching VN using reachingAssertions
-        Range edgeRange = GetRangeFromAssertions(comp, reachingVN, reachingAssertions, --budget);
+        Range edgeRange = GetRangeFromAssertions(comp, reachingVN, reachingAssertions, min(3, --budget));
 
         // If phiRange is not yet set, set it to the first edgeRange
         // else merge it with the new edgeRange. Example: [10..100] U [50..150] = [10..150]
@@ -1102,9 +1102,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             int        addCns;
             const bool normalLclVNMatchesOp2 =
                 ((normalLclVN == boundVN) && (boundCns == 0)) ||
-                ((boundCns != 0) &&
-                 comp->vnStore->IsVNBinFuncWithConst(normalLclVN, VNF_ADD, &addOp, &addCns) && (addOp == boundVN) &&
-                 (addCns == boundCns));
+                ((boundCns != 0) && comp->vnStore->IsVNBinFuncWithConst(normalLclVN, VNF_ADD, &addOp, &addCns) &&
+                 (addOp == boundVN) && (addCns == boundCns));
 
             if (canUseCheckedBounds && (normalLclVN == curAssertion.GetOp1().GetVN()))
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -687,7 +687,7 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
         return result;
     }
 
-    if (visited->Add(comp, num))
+    if (!visited->Add(comp, num))
     {
         // We've come back to a node we've already visited
         return result;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -650,17 +650,46 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
 //    comp             - the compiler instance
 //    num              - the value number to analyze range for
 //    assertions       - the assertions to use
+//    budget           - the remaining budget for recursive analysis
 //
 // Return Value:
 //    The computed range
 //
 Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VALARG_TP assertions, int budget)
 {
+    ValueNumStore::SmallValueNumSet set;
+    return GetRangeFromAssertionsWorker(comp, num, assertions, budget, &set);
+}
+
+//------------------------------------------------------------------------
+// GetRangeFromAssertions: Cheaper version of TryGetRange that is based purely on assertions
+//    and does not require a full range analysis based on SSA.
+//
+// Arguments:
+//    comp             - the compiler instance
+//    num              - the value number to analyze range for
+//    assertions       - the assertions to use
+//    budget           - the remaining budget for recursive analysis
+//    visited          - the set of value numbers already visited in the current search
+//                       path to prevent infinite recursion
+//
+// Return Value:
+//    The computed range
+//
+Range RangeCheck::GetRangeFromAssertionsWorker(
+    Compiler* comp, ValueNum num, ASSERT_VALARG_TP assertions, int budget, ValueNumStore::SmallValueNumSet* visited)
+{
     // Start with the widest possible constant range.
     Range result = Range(Limit(Limit::keConstant, INT32_MIN), Limit(Limit::keConstant, INT32_MAX));
 
     if ((num == ValueNumStore::NoVN) || (budget <= 0))
     {
+        return result;
+    }
+
+    if (visited->Add(comp, num))
+    {
+        // We've come back to a node we've already visited
         return result;
     }
 
@@ -699,7 +728,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
                     // if its range is within the castTo range, we can use that (and the cast is basically a no-op).
                     if (comp->vnStore->TypeOfVN(funcApp.m_args[0]) == TYP_INT)
                     {
-                        Range castOpRange = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
+                        Range castOpRange =
+                            GetRangeFromAssertionsWorker(comp, funcApp.m_args[0], assertions, --budget, visited);
                         if (castOpRange.IsConstantRange() &&
                             (castOpRange.LowerLimit().GetConstant() >= castToTypeRange.LowerLimit().GetConstant()) &&
                             (castOpRange.UpperLimit().GetConstant() <= castToTypeRange.UpperLimit().GetConstant()))
@@ -713,7 +743,7 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
 
             case VNF_NEG:
             {
-                Range r1            = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
+                Range r1 = GetRangeFromAssertionsWorker(comp, funcApp.m_args[0], assertions, --budget, visited);
                 Range unaryOpResult = RangeOps::Negate(r1);
 
                 // We can use the result only if it never overflows.
@@ -732,8 +762,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
             case VNF_UMOD:
             {
                 // Get ranges of both operands and perform the same operation on the ranges.
-                Range r1          = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
-                Range r2          = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget);
+                Range r1 = GetRangeFromAssertionsWorker(comp, funcApp.m_args[0], assertions, --budget, visited);
+                Range r2 = GetRangeFromAssertionsWorker(comp, funcApp.m_args[1], assertions, --budget, visited);
                 Range binOpResult = Range(Limit(Limit::keUnknown));
                 switch (funcApp.m_func)
                 {
@@ -799,8 +829,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
                 if ((genActualType(comp->vnStore->TypeOfVN(funcApp.m_args[0])) == TYP_INT) &&
                     (genActualType(comp->vnStore->TypeOfVN(funcApp.m_args[1])) == TYP_INT))
                 {
-                    Range r1 = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
-                    Range r2 = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget);
+                    Range r1 = GetRangeFromAssertionsWorker(comp, funcApp.m_args[0], assertions, --budget, visited);
+                    Range r2 = GetRangeFromAssertionsWorker(comp, funcApp.m_args[1], assertions, --budget, visited);
 
                     bool       isUnsigned = true;
                     genTreeOps cmpOper;
@@ -846,9 +876,9 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
     }
 
     Range phiRange = Range(Limit(Limit::keUndef));
-    auto  visitor  = [comp, &phiRange, &budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
-        // call GetRangeFromAssertions for each reaching VN using reachingAssertions
-        Range edgeRange = GetRangeFromAssertions(comp, reachingVN, reachingAssertions, min(3, --budget));
+    auto  visitor  = [comp, &phiRange, &budget, visited](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+        // call GetRangeFromAssertionsWorker for each reaching VN using reachingAssertions
+        Range edgeRange = GetRangeFromAssertionsWorker(comp, reachingVN, reachingAssertions, --budget, visited);
 
         // If phiRange is not yet set, set it to the first edgeRange
         // else merge it with the new edgeRange. Example: [10..100] U [50..150] = [10..150]

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -662,7 +662,7 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
 }
 
 //------------------------------------------------------------------------
-// GetRangeFromAssertions: Cheaper version of TryGetRange that is based purely on assertions
+// GetRangeFromAssertionsWorker: Cheaper version of TryGetRange that is based purely on assertions
 //    and does not require a full range analysis based on SSA.
 //
 // Arguments:

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -889,19 +889,11 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
     };
 
     // If it's a phi, we need to look at the reaching assertions for each of the phi args and merge them together.
-    if (comp->vnStore->IsPhiDef(num))
+    if (comp->vnStore->IsPhiDef(num) && visited->Add(comp, num) &&
+        (comp->optVisitReachingAssertions(num, visitor) == Compiler::AssertVisit::Continue) && !phiRange.IsUndef())
     {
-        if (!visited->Add(comp, num))
-        {
-            // We already visited this phi in the current search path, which means we have a cycle.
-            return result;
-        }
-
-        if ((comp->optVisitReachingAssertions(num, visitor) == Compiler::AssertVisit::Continue) && !phiRange.IsUndef())
-        {
-            assert(phiRange.IsConstantRange());
-            result = phiRange;
-        }
+        assert(phiRange.IsConstantRange());
+        result = phiRange;
     }
 
     MergeEdgeAssertions(comp, num, ValueNumStore::NoVN, assertions, &result, false);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -654,7 +654,8 @@ void RangeCheck::MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP 
 // Return Value:
 //    The computed range
 //
-Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VALARG_TP assertions, int budget)
+Range RangeCheck::GetRangeFromAssertions(
+    Compiler* comp, ValueNum num, ASSERT_VALARG_TP assertions, int budget, ValueNumStore::SmallValueNumSet* visitedPhis)
 {
     // Start with the widest possible constant range.
     Range result = Range(Limit(Limit::keConstant, INT32_MIN), Limit(Limit::keConstant, INT32_MAX));
@@ -699,7 +700,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
                     // if its range is within the castTo range, we can use that (and the cast is basically a no-op).
                     if (comp->vnStore->TypeOfVN(funcApp.m_args[0]) == TYP_INT)
                     {
-                        Range castOpRange = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
+                        Range castOpRange =
+                            GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget, visitedPhis);
                         if (castOpRange.IsConstantRange() &&
                             (castOpRange.LowerLimit().GetConstant() >= castToTypeRange.LowerLimit().GetConstant()) &&
                             (castOpRange.UpperLimit().GetConstant() <= castToTypeRange.UpperLimit().GetConstant()))
@@ -713,7 +715,7 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
 
             case VNF_NEG:
             {
-                Range r1            = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
+                Range r1 = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget, visitedPhis);
                 Range unaryOpResult = RangeOps::Negate(r1);
 
                 // We can use the result only if it never overflows.
@@ -732,8 +734,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
             case VNF_UMOD:
             {
                 // Get ranges of both operands and perform the same operation on the ranges.
-                Range r1          = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
-                Range r2          = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget);
+                Range r1          = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget, visitedPhis);
+                Range r2          = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget, visitedPhis);
                 Range binOpResult = Range(Limit(Limit::keUnknown));
                 switch (funcApp.m_func)
                 {
@@ -799,8 +801,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
                 if ((genActualType(comp->vnStore->TypeOfVN(funcApp.m_args[0])) == TYP_INT) &&
                     (genActualType(comp->vnStore->TypeOfVN(funcApp.m_args[1])) == TYP_INT))
                 {
-                    Range r1 = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget);
-                    Range r2 = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget);
+                    Range r1 = GetRangeFromAssertions(comp, funcApp.m_args[0], assertions, --budget, visitedPhis);
+                    Range r2 = GetRangeFromAssertions(comp, funcApp.m_args[1], assertions, --budget, visitedPhis);
 
                     bool       isUnsigned = true;
                     genTreeOps cmpOper;
@@ -845,10 +847,19 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
         return result;
     }
 
+    // Top-level entry: allocate the visited-phi set on the stack. Recursive entries (made
+    // by the visitor below through GetRangeFromAssertions) thread the existing set forward
+    // so cycles through loop-carried PHIs are detected.
+    ValueNumStore::SmallValueNumSet localVisited;
+    if (visitedPhis == nullptr)
+    {
+        visitedPhis = &localVisited;
+    }
+
     Range phiRange = Range(Limit(Limit::keUndef));
-    auto  visitor  = [comp, &phiRange, &budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+    auto  visitor  = [comp, &phiRange, &budget, visitedPhis](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
         // call GetRangeFromAssertions for each reaching VN using reachingAssertions
-        Range edgeRange = GetRangeFromAssertions(comp, reachingVN, reachingAssertions, min(3, --budget));
+        Range edgeRange = GetRangeFromAssertions(comp, reachingVN, reachingAssertions, --budget, visitedPhis);
 
         // If phiRange is not yet set, set it to the first edgeRange
         // else merge it with the new edgeRange. Example: [10..100] U [50..150] = [10..150]
@@ -864,7 +875,8 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
         return Compiler::AssertVisit::Abort;
     };
 
-    if (comp->optVisitReachingAssertions(num, visitor) == Compiler::AssertVisit::Continue && !phiRange.IsUndef())
+    if (comp->optVisitReachingAssertionsWorker(num, visitor, *visitedPhis) == Compiler::AssertVisit::Continue &&
+        !phiRange.IsUndef())
     {
         assert(phiRange.IsConstantRange());
         result = phiRange;

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -776,6 +776,13 @@ private:
     typedef JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, Range*>      RangeMap;
     typedef JitHashTable<GenTree*, JitPtrKeyFuncs<GenTree>, BasicBlock*> SearchPath;
 
+    // Cheaper version of TryGetRange that is based only on incoming assertions.
+    static Range GetRangeFromAssertionsWorker(Compiler*                        comp,
+                                              ValueNum                         num,
+                                              ASSERT_VALARG_TP                 assertions,
+                                              int                              budget,
+                                              ValueNumStore::SmallValueNumSet* visited);
+
     int GetArrLength(ValueNum vn);
 
     // Check whether the computed range is within 0 and upper bounds. This function

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -766,7 +766,11 @@ public:
     bool TryGetRange(BasicBlock* block, GenTree* expr, Range* pRange);
 
     // Cheaper version of TryGetRange that is based only on incoming assertions.
-    static Range GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VALARG_TP assertions, int budget = 10);
+    static Range GetRangeFromAssertions(Compiler*                        comp,
+                                        ValueNum                         num,
+                                        ASSERT_VALARG_TP                 assertions,
+                                        int                              budget      = 10,
+                                        ValueNumStore::SmallValueNumSet* visitedPhis = nullptr);
 
     // Compute the range from the given type
     static Range GetRangeFromType(var_types type);


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/111309

Optimize redundant range/argument checks for spans inside loops.

```cs
int Sum(ReadOnlySpan<int> data)
{
    Vector128<int> sum = default;
    while (data.Length >= Vector128<int>.Count)
    {
        sum += Vector128.Create(data);
        data = data.Slice(Vector128<int>.Count);
    }
    int result = Vector128.Sum(sum);
    foreach (var t in data)
        result += t;
    return result;
}
```

### Codegen diff
```diff
 G_M38854_IG02:
        mov      rax, bword ptr [rcx]
        mov      ecx, dword ptr [rcx+0x08]
        vxorps   xmm0, xmm0, xmm0
        cmp      ecx, 4
        jl       SHORT G_M38854_IG04
 G_M38854_IG03:
-       cmp      ecx, 4
-       jl       SHORT G_M38854_IG09
        vpaddd   xmm0, xmm0, xmmword ptr [rax]
        add      rax, 16
        add      ecx, -4
        cmp      ecx, 4
        jge      SHORT G_M38854_IG03
 G_M38854_IG04:
        vpsrldq  xmm1, xmm0, 8
        vpaddd   xmm0, xmm1, xmm0
        vpsrldq  xmm1, xmm0, 4
        vpaddd   xmm0, xmm1, xmm0
        vmovd    edx, xmm0
        test     ecx, ecx
        je       SHORT G_M38854_IG07
 G_M38854_IG05:
        xor      r8d, r8d
 G_M38854_IG06:
        add      edx, dword ptr [rax+r8]
        add      r8, 4
        dec      ecx
        jne      SHORT G_M38854_IG06
 G_M38854_IG07:
        mov      eax, edx
 G_M38854_IG08:
-       add      rsp, 40
        ret
-G_M38854_IG09:
-       mov      ecx, 6
-       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException(int)]
-       int3
-; Total bytes of code 113
+; Total bytes of code 79
```

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1389976&view=results)