### PR TITLE
Skip cross-bitness cDAC dump tests until ClrMD supports it

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -142,6 +142,18 @@ public abstract class DumpTestBase : IDisposable
 
         if (_dumpInfo is not null)
         {
+            // Cross-bitness dump reading is not yet supported when a 32-bit host
+            // tries to read a 64-bit dump (see microsoft/clrmd#1423).
+            // The reverse (64-bit host reading 32-bit dump) works fine.
+            bool isDump64Bit = _dumpInfo.Arch is "x64" or "arm64" or "riscv64" or "loongarch64";
+            bool isHost64Bit = IntPtr.Size == 8;
+            if (isDump64Bit && !isHost64Bit)
+            {
+                throw new SkipTestException(
+                    $"32-bit host cannot read 64-bit dumps: dump is {_dumpInfo.Arch}. " +
+                    $"See microsoft/clrmd#1423.");
+            }
+
             foreach (SkipOnOSAttribute attr in method.GetCustomAttributes<SkipOnOSAttribute>())
             {
                 if (attr.IncludeOnly is not null)


### PR DESCRIPTION
## Summary

Skip cDAC dump tests when the host pointer size doesn't match the dump's architecture (e.g., 32-bit host reading 64-bit dumps). Cross-bitness dump reading is not yet supported by ClrMD due to `ClrDataAddress` truncation issues being fixed in microsoft/clrmd#1423.

## Changes

- **DumpTestBase.cs**: Added cross-bitness check in `EvaluateSkipAttributes`. When `IntPtr.Size` doesn't match the dump architecture from `dump-info.json`, the test is skipped with a clear message referencing the upstream fix.

## Impact

This prevents confusing test failures on x86 Helix legs when they attempt to load x64 dumps (and vice versa). Once microsoft/clrmd#1423 is merged and the ClrMD package is updated, this skip can be removed.