### PR TITLE
Remove stale comment on ClientWebSocket._state

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
@@ -11,7 +11,6 @@ namespace System.Net.WebSockets
 {
     public sealed partial class ClientWebSocket : WebSocket
     {
-        /// <summary>This is really an InternalState value, but Interlocked doesn't support operations on values of enum types.</summary>
         private InternalState _state;
         private WebSocketHandle? _innerWebSocket;
 


### PR DESCRIPTION
Removes a stale XML doc comment on ClientWebSocket._state.
The comment explained _state being an int because Interlocked didn't support enum types, both changed in #104558 (the class constraint was removed and _staor te became InternalState), making the comment obsolete.