### PR TITLE
Replace Enum.HasFlag with bitwise operations in WebSockets

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -324,8 +324,8 @@ namespace System.Net.WebSockets
                 return ValueTask.FromException(exc);
             }
 
-            bool endOfMessage = messageFlags.HasFlag(WebSocketMessageFlags.EndOfMessage);
-            bool disableCompression = messageFlags.HasFlag(WebSocketMessageFlags.DisableCompression);
+            bool endOfMessage = (messageFlags & WebSocketMessageFlags.EndOfMessage) != 0;
+            bool disableCompression = (messageFlags & WebSocketMessageFlags.DisableCompression) != 0;
             MessageOpcode opcode;
 
             if (_lastSendWasFragment)

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
@@ -60,7 +60,7 @@ namespace System.Net.WebSockets
 
         public virtual ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken = default)
         {
-            return SendAsync(buffer, messageType, messageFlags.HasFlag(WebSocketMessageFlags.EndOfMessage), cancellationToken);
+            return SendAsync(buffer, messageType, (messageFlags & WebSocketMessageFlags.EndOfMessage) != 0, cancellationToken);
         }
 
         private async ValueTask SendWithArrayPoolAsync(

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketStateHelper.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketStateHelper.cs
@@ -16,7 +16,7 @@ namespace System.Net.WebSockets
         /// <summary>Valid states to be in when calling CloseAsync.</summary>
         internal const ManagedWebSocketStates ValidCloseStates = ManagedWebSocketStates.Open | ManagedWebSocketStates.CloseReceived | ManagedWebSocketStates.CloseSent;
 
-        internal static bool IsValidSendState(WebSocketState state) => ValidSendStates.HasFlag(ToFlag(state));
+        internal static bool IsValidSendState(WebSocketState state) => (ValidSendStates & ToFlag(state)) != 0;
 
         internal static void ThrowIfInvalidState(WebSocketState currentState, bool isDisposed, Exception? innerException, ManagedWebSocketStates validStates)
         {


### PR DESCRIPTION
  ## Summary

  Replaces four `Enum.HasFlag` calls in `System.Net.WebSockets` with the bitwise `(value & flag) != 0` idiom used
  throughout the rest of the repo.

  This follows the explicit guidance from @stephentoub in a prior review on this same file (#107662):

  > We generally prefer to avoid using HasFlag, even though the JIT does optimize away the boxing in tier 1.

  See the [original review comment](https://github.com/dotnet/runtime/pull/107662#discussion_r1752921815). 

That PR removed one `HasFlag` usage in `WebSocketStateHelper.cs`; this PR finishes the job by replacing the remaining
  occurrences across the library.

  It also brings internal consistency to `WebSocketStateHelper.cs`.
  `ThrowIfInvalidState` already uses the bitwise form `(state & validStates) == 0` a few lines below the previous `IsValidSendState` implementation.

  No behavior changes.

  ## Changes

  | File | Change |
  |---|---|
  | `WebSocketStateHelper.cs` | `IsValidSendState`, now matches the bitwise form already used by `ThrowIfInvalidState`
  in the same file |
  | `ManagedWebSocket.cs` | `endOfMessage` / `disableCompression` checks in `SendAsync` |
  | `WebSocket.cs` | `SendAsync` virtual overload's `endOfMessage` check |