### PR TITLE
Propagate sync-faulted FlushAsync exceptions through the WebSocket er…

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -510,15 +510,16 @@ namespace System.Net.WebSockets
                 if (writeTask.IsCompleted)
                 {
                     writeTask.GetAwaiter().GetResult();
-                    ValueTask flushTask = new ValueTask(_stream.FlushAsync());
+                    Task flushTask = _stream.FlushAsync();
                     if (flushTask.IsCompleted)
                     {
-                        return flushTask;
+                        flushTask.GetAwaiter().GetResult();
+                        return ValueTask.CompletedTask;
                     }
                     else
                     {
                         releaseSendBufferAndSemaphore = false;
-                        return WaitForWriteTaskAsync(flushTask, shouldFlush: false);
+                        return WaitForWriteTaskAsync(new ValueTask(flushTask), shouldFlush: false);
                     }
                 }
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTestStream.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTestStream.cs
@@ -86,6 +86,12 @@ namespace System.Net.WebSockets.Tests
         /// </summary>
         public bool IgnoreCancellationToken { get; set; }
 
+        /// <summary>
+        /// If set, causes FlushAsync to return a synchronously-faulted Task with this exception.
+        /// Used to exercise sync-completion-faulted code paths in the WebSocket send flow.
+        /// </summary>
+        public Exception? FlushException { get; set; }
+
         public override bool CanRead => true;
 
         public override bool CanSeek => false;
@@ -225,6 +231,15 @@ namespace System.Net.WebSockets.Tests
         }
 
         public override void Flush() { }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            if (FlushException is not null)
+            {
+                return Task.FromException(FlushException);
+            }
+            return base.FlushAsync(cancellationToken);
+        }
 
         public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -183,6 +183,23 @@ namespace System.Net.WebSockets.Tests
         }
 
         [Fact]
+        public async Task SendAsync_FlushAsyncSyncFaulted_WrapsExceptionInWebSocketException()
+        {
+            var underlying = new IOException("flush failed");
+            using var stream = new WebSocketTestStream { FlushException = underlying };
+            using WebSocket ws = WebSocket.CreateFromStream(
+                stream, isServer: false, subProtocol: null, keepAliveInterval: Timeout.InfiniteTimeSpan);
+
+            var buffer = new ArraySegment<byte>(new byte[] { 1, 2, 3 });
+
+            WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(
+                () => ws.SendAsync(buffer, WebSocketMessageType.Binary, endOfMessage: true, CancellationToken.None));
+
+            Assert.Equal(WebSocketError.ConnectionClosedPrematurely, ex.WebSocketErrorCode);
+            Assert.Same(underlying, ex.InnerException);
+        }
+
+        [Fact]
         public async Task ReceiveAsync_ServerUnmaskedFrame_ThrowsWebSocketException()
         {
             byte[] frame = { 0x81, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F };


### PR DESCRIPTION
 ## Summary

  When `ManagedWebSocket.SendFrameLockAcquiredNonCancelableAsync` runs with a synchronously-completed write and
  `FlushAsync` returns a synchronously-faulted `Task`, the original code wraps that `Task` in a `ValueTask` and returns
  it directly to the caller. Awaiting callers then observe the raw stream exception (e.g. `IOException`,
  `SocketException`, `ObjectDisposedException`) instead of the `WebSocketException` wrapper that every other error path
  in the send flow produces.

  This PR calls `flushTask.GetAwaiter().GetResult()` inline on the completed `Task`, so the exception is thrown inside
  the method's existing `try/catch` block, which maps it to `WebSocketException(ConnectionClosedPrematurely)` just like
   `WaitForWriteTaskAsync` does for the asynchronous completion paths.

  ## Behavior change

  This is a deliberate, behavior-visible change on one specific timing path.

  **Before:** On a sync-completed write + sync-faulted flush, callers see the original stream exception unchanged.

  **After:** On a sync-completed write + sync-faulted flush, callers see
  `WebSocketException(WebSocketError.ConnectionClosedPrematurely)` wrapping the original exception as `InnerException`,
   matching the behavior of the other three error paths in the same method.

  ### Error-wrapping map, for reference

  | Path | Wrapping layer (before) | Wrapping layer (after) |
  |---|---|---|
  | Synchronous throw (e.g., `WriteFrameToSendBuffer` fails) | outer `try/catch` → `WebSocketException` | unchanged |
  | Sync-completed write + **sync-faulted flush** | **none (raw exception)** | **outer `try/catch` → `WebSocketException`** |
  | Sync-completed write + async flush | `WaitForWriteTaskAsync` → `WebSocketException` | unchanged |
  | Async write | `WaitForWriteTaskAsync` → `WebSocketException` | unchanged |

  ## Risk assessment

  Any caller written against the contract "errors from a `WebSocket.SendAsync` surface as `WebSocketException`" was
  already silently broken on this specific path. This PR closes that gap. Callers explicitly catching the raw exception
  types on this path (unusual) would see a different exception after this change.