### PR TITLE
Improve SignalHandler_CanDisposeInHandler robustness and fault artifacts generation

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -193,7 +193,7 @@ namespace System.Diagnostics.Tests
             const string PosixSignalRegistrationCreatedMessage = "PosixSignalRegistration created.";
             const string PosixSignalHandlerStartedMessage = "PosixSignalRegistration handler started.";
             const string PosixSignalHandlerDisposedMessage = "PosixSignalRegistration disposed.";
-            const int UnterminatedExitCode = -1;
+            const int UnterminatedExitCode = 1;
 
             // Process operations timeout cascading:
             // WaitInMS * 1: Remote process wait for second signal after unregistering exercised signal handler

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -196,10 +196,11 @@ namespace System.Diagnostics.Tests
             const int UnterminatedExitCode = -1;
 
             // Process operations timeout cascading:
-            // WaitInMS * 1: Remote process wait for second signal after unregistering exercised signal handler
-            // WaitInMS * 2: RemoteExecutor Timeout, collects data and makes dump if not exited gracefully before
+            // WaitInMS * 1: Remote process wait for first signal that unregisters the exercised signal handler
+            // WaitInMS * 2: Remote process may additionally wait for a second signal that should terminate it
+            // WaitInMS * 3: RemoteExecutor timeout, leaving slack for process startup, signal delivery, and teardown
 
-            var remoteInvokeOptions = new RemoteInvokeOptions { CheckExitCode = false, TimeOut = WaitInMS * 2 };
+            var remoteInvokeOptions = new RemoteInvokeOptions { CheckExitCode = false, TimeOut = WaitInMS * 3 };
             remoteInvokeOptions.StartInfo.RedirectStandardOutput = true;
             if (OperatingSystem.IsWindows())
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -10,6 +10,7 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
@@ -194,14 +195,23 @@ namespace System.Diagnostics.Tests
             const string PosixSignalHandlerDisposedMessage = "PosixSignalRegistration disposed.";
             const int UnterminatedExitCode = -1;
 
-            var remoteInvokeOptions = new RemoteInvokeOptions { CheckExitCode = false };
+            // Process operations timeout cascading:
+            // WaitInMS * 1: Remote process wait for second signal after unregistering exercised signal handler
+            // WaitInMS * 2: RemoteExecutor Timeout, collects data and makes dump if not exited gracefully before
+
+            var remoteInvokeOptions = new RemoteInvokeOptions { CheckExitCode = false, TimeOut = WaitInMS * 2 };
             remoteInvokeOptions.StartInfo.RedirectStandardOutput = true;
             if (OperatingSystem.IsWindows())
             {
                 remoteInvokeOptions.StartInfo.CreateNewProcessGroup = true;
+                remoteInvokeOptions.CheckExitCode = true;
+                remoteInvokeOptions.ExpectedExitCode = unchecked((int)0xC000013A); // STATUS_CONTROL_C_EXIT
             }
 
-            using RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(
+            bool remoteHandleDisposed = false;
+            ExceptionDispatchInfo testException = null;
+            ExceptionDispatchInfo disposeException = null;
+            RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(
                 (signalStr) =>
                 {
                     PosixSignal expectedSignal = Enum.Parse<PosixSignal>(signalStr);
@@ -238,7 +248,6 @@ namespace System.Diagnostics.Tests
                 arg: $"{signal}",
                 remoteInvokeOptions);
 
-
             try
             {
                 AssertRemoteProcessStandardOutputLine(remoteHandle, PosixSignalRegistrationCreatedMessage, WaitInMS);
@@ -260,25 +269,46 @@ namespace System.Diagnostics.Tests
                     SendSignal(signal, remoteHandle.Process);
                 }
 
-                Assert.True(remoteHandle.Process.WaitForExit(WaitInMS));
-                Assert.True(remoteHandle.Process.StandardOutput.EndOfStream);
+                // For Windows, we prefer more feature rich termination and status checking in remoteHandle.Dispose()
+                // However on other platforms, exit code is platform dependent, so we check manually.
+                if (!OperatingSystem.IsWindows())
+                {
+                    Assert.True(remoteHandle.Process.WaitForExit(WaitInMS));
 
-                if (OperatingSystem.IsWindows())
-                {
-                    Assert.Equal(unchecked((int)0xC000013A), remoteHandle.Process.ExitCode); // STATUS_CONTROL_C_EXIT
-                }
-                else
-                {
-                    // Signal numbers are platform dependent, so we can't check exact exit code
                     Assert.NotEqual(0, remoteHandle.Process.ExitCode);
                     Assert.NotEqual(UnterminatedExitCode, remoteHandle.Process.ExitCode);
+                    Assert.NotEqual(RemoteExecutor.SuccessExitCode, remoteHandle.Process.ExitCode);
                 }
+
+                remoteHandleDisposed = true;
+                remoteHandle.Dispose();
+            }
+            catch (Exception ex)
+            {
+                testException = ExceptionDispatchInfo.Capture(ex);
             }
             finally
             {
-                // If sending the signal fails or process did not exit on its own, we want to kill the process ASAP
-                // to prevent RemoteExecutor's timeout from hiding it.
-                remoteHandle.Process.Kill();
+                if (!remoteHandleDisposed)
+                {
+                    try
+                    {
+                        remoteHandle.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        disposeException = ExceptionDispatchInfo.Capture(ex);
+                    }
+                }
+            }
+            // test exception is more important, exception at dispose could be consequence of it
+            if (testException is not null)
+            {
+                testException.Throw();
+            }
+            if (disposeException is not null)
+            {
+                disposeException.Throw();
             }
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -208,7 +208,7 @@ namespace System.Diagnostics.Tests
                 remoteInvokeOptions.ExpectedExitCode = unchecked((int)0xC000013A); // STATUS_CONTROL_C_EXIT
             }
 
-            bool remoteHandleDisposed = false;
+            bool remoteHandleDisposeAttemped = false;
             ExceptionDispatchInfo testException = null;
             ExceptionDispatchInfo disposeException = null;
             RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(
@@ -280,7 +280,7 @@ namespace System.Diagnostics.Tests
                     Assert.NotEqual(RemoteExecutor.SuccessExitCode, remoteHandle.Process.ExitCode);
                 }
 
-                remoteHandleDisposed = true;
+                remoteHandleDisposeAttemped = true;
                 remoteHandle.Dispose();
             }
             catch (Exception ex)
@@ -289,7 +289,7 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                if (!remoteHandleDisposed)
+                if (!remoteHandleDisposeAttemped)
                 {
                     try
                     {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -208,7 +208,7 @@ namespace System.Diagnostics.Tests
                 remoteInvokeOptions.ExpectedExitCode = unchecked((int)0xC000013A); // STATUS_CONTROL_C_EXIT
             }
 
-            bool remoteHandleDisposeAttemped = false;
+            bool remoteHandleDisposeAttempted = false;
             ExceptionDispatchInfo testException = null;
             ExceptionDispatchInfo disposeException = null;
             RemoteInvokeHandle remoteHandle = RemoteExecutor.Invoke(
@@ -280,7 +280,7 @@ namespace System.Diagnostics.Tests
                     Assert.NotEqual(RemoteExecutor.SuccessExitCode, remoteHandle.Process.ExitCode);
                 }
 
-                remoteHandleDisposeAttemped = true;
+                remoteHandleDisposeAttempted = true;
                 remoteHandle.Dispose();
             }
             catch (Exception ex)
@@ -289,7 +289,7 @@ namespace System.Diagnostics.Tests
             }
             finally
             {
-                if (!remoteHandleDisposeAttemped)
+                if (!remoteHandleDisposeAttempted)
                 {
                     try
                     {


### PR DESCRIPTION
Refactor `SignalHandler_CanDisposeInHandler` test which I added ~month ago as part of #124893. Refactored test utilize `RemoteInvokeHandle.Dipose()` to wait for process exiting and contains better fault logging and hang process dumping. Should be useful for investigation of test flakiness explained in #125953.