### PR TITLE
Skip CallEntryPoint in debugger single-step to prevent false stop

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8079,11 +8079,11 @@ bool DebuggerStepper::TriggerSingleStep(Thread *thread, const BYTE *ip)
     StackTraceTicket ticket(ip);
     info.GetStackInfo(ticket, GetThread(), LEAF_MOST_FRAME, NULL);
 
-    // This is a special case where we return from a managed method back to the runtime entrypoint
-    // (Environment.CallEntryPoint) or an interop stub.  These are not interesting frames for the
-    // debugger — single-stepping into them should be treated like stepping into native code.
-    // Disable the single step and enable trace call / method enter so the stepper can catch
-    // the next interesting transition or, if stepping out through Environment.CallEntryPoint,
+    // This is a special case where we return from a managed method back to the helper that invokes
+    // the main program entrypoint (Environment.CallEntryPoint) or an interop stub.  These are not
+    // interesting frames for the debugger - single-stepping into them should be treated like stepping
+    // into native code. Disable the single step and enable trace call / method enter so the stepper can
+    // catch the next interesting transition or, if stepping out through Environment.CallEntryPoint,
     // let the process exit naturally.
     if (fd == g_pEnvironmentCallEntryPointMethodDesc || fd->IsInteropStub())
     {

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8079,14 +8079,15 @@ bool DebuggerStepper::TriggerSingleStep(Thread *thread, const BYTE *ip)
     StackTraceTicket ticket(ip);
     info.GetStackInfo(ticket, GetThread(), LEAF_MOST_FRAME, NULL);
 
-    // This is a special case where we return from a managed method back to an interop stub.  This can
-    // only happen if there's no more managed method frames closer to the root and we want to perform
-    // a step out, or if we step-next off the end of a method called by an interop stub.  In either case,
-    // we'll get a single step in an interop stub, which we want to ignore.  We also want to enable trace
-    // call here, just in case this stub is about to call the managed target (in the reverse interop case).
-    if (fd->IsInteropStub())
+    // This is a special case where we return from a managed method back to the runtime entrypoint
+    // (Environment.CallEntryPoint) or an interop stub.  These are not interesting frames for the
+    // debugger — single-stepping into them should be treated like stepping into native code.
+    // Disable the single step and enable trace call / method enter so the stepper can catch
+    // the next interesting transition or, if stepping out through Environment.CallEntryPoint,
+    // let the process exit naturally.
+    if (fd == g_pEnvironmentCallEntryPointMethodDesc || fd->IsInteropStub())
     {
-        LOG((LF_CORDB,LL_INFO10000, "DS::TSS: not in managed code, Returning false (case 0)!\n"));
+        LOG((LF_CORDB,LL_INFO10000, "DS::TSS: in runtime entrypoint or interop stub, Returning false (case 0)!\n"));
         if (this->GetDCType() == DEBUGGER_CONTROLLER_STEPPER)
         {
             EnableTraceCall(info.m_activeFrame.fp);

--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -8087,7 +8087,7 @@ bool DebuggerStepper::TriggerSingleStep(Thread *thread, const BYTE *ip)
     // let the process exit naturally.
     if (fd == g_pEnvironmentCallEntryPointMethodDesc || fd->IsInteropStub())
     {
-        LOG((LF_CORDB,LL_INFO10000, "DS::TSS: in runtime entrypoint or interop stub, Returning false (case 0)!\n"));
+        LOG((LF_CORDB,LL_INFO10000, "DS::TSS: in CallEntryPoint or interop stub, Returning false (case 0)!\n"));
         if (this->GetDCType() == DEBUGGER_CONTROLLER_STEPPER)
         {
             EnableTraceCall(info.m_activeFrame.fp);


### PR DESCRIPTION
When stepping next at the last line of Main, the debugger lands in the managed Environment.CallEntryPoint which stops the debuggee in a frame with no source info rather than the process simply exiting.

Extend the existing IsInteropStub check in TriggerSingleStep to also recognize g_pEnvironmentCallEntryPointMethodDesc. When the single-step lands there, disable it and let the process exit naturally, matching the previous behavior when the return landed in native code.

Found with internal VS debugger testing.