### PR TITLE
JIT: Disallow using float callee saves in x64 functions with patchpoints

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -985,8 +985,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
 #endif // TARGET_AMD64 || TARGET_ARM64
 
 #ifdef TARGET_AMD64
-    // On x64 the OSR method does not restore float registers from tier0 frame,
-    // so disallow using float callee saves in the tier0 method.
+    // On x64 the OSR method does not restore float/mask registers from the
+    // tier0 frame, so disallow using those in the tier0 method.
     if (m_compiler->doesMethodHavePatchpoints() || m_compiler->doesMethodHavePartialCompilationPatchpoints())
     {
 #if defined(UNIX_AMD64_ABI)
@@ -996,6 +996,7 @@ LinearScan::LinearScan(Compiler* theCompiler)
         availableFloatRegs &= ~RBM_FLT_CALLEE_SAVED.GetFloatRegSet();
         availableDoubleRegs &= ~RBM_FLT_CALLEE_SAVED.GetFloatRegSet();
 #endif // UNIX_AMD64_ABI
+        availableMaskRegs &= ~RBM_MSK_CALLEE_SAVED;
     }
 #endif
 

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -985,8 +985,8 @@ LinearScan::LinearScan(Compiler* theCompiler)
 #endif // TARGET_AMD64 || TARGET_ARM64
 
 #ifdef TARGET_AMD64
-    // On xarch the OSR method does not restore float registers from tier0
-    // frame, so disallow using float callee saves in the tier0 method.
+    // On x64 the OSR method does not restore float registers from tier0 frame,
+    // so disallow using float callee saves in the tier0 method.
     if (m_compiler->doesMethodHavePatchpoints() || m_compiler->doesMethodHavePartialCompilationPatchpoints())
     {
 #if defined(UNIX_AMD64_ABI)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -984,6 +984,21 @@ LinearScan::LinearScan(Compiler* theCompiler)
     }
 #endif // TARGET_AMD64 || TARGET_ARM64
 
+#ifdef TARGET_AMD64
+    // On xarch the OSR method does not restore float registers from tier0
+    // frame, so disallow using float callee saves in the tier0 method.
+    if (m_compiler->doesMethodHavePatchpoints() || m_compiler->doesMethodHavePartialCompilationPatchpoints())
+    {
+#if defined(UNIX_AMD64_ABI)
+        availableFloatRegs &= ~RBM_FLT_CALLEE_SAVED;
+        availableDoubleRegs &= ~RBM_FLT_CALLEE_SAVED;
+#else
+        availableFloatRegs &= ~RBM_FLT_CALLEE_SAVED.GetFloatRegSet();
+        availableDoubleRegs &= ~RBM_FLT_CALLEE_SAVED.GetFloatRegSet();
+#endif // UNIX_AMD64_ABI
+    }
+#endif
+
 #if defined(TARGET_AMD64)
     if (evexIsSupported)
     {


### PR DESCRIPTION
We do not restore these in the OSR methods so using these registers currently relies on the unwinder. We will have transitioning that does not use the unwinder soon so just disable using these registers. Since patchpoints only appear in tier0 methods it is not a big deal to avoid using these registers.