### PR TITLE
Disable the new S.DS.Protocols local tests on Mono

### DIFF
--- a/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
+++ b/src/libraries/System.DirectoryServices.Protocols/tests/DirectoryServicesProtocolsTests.cs
@@ -121,6 +121,7 @@ namespace System.DirectoryServices.Protocols.Tests
 #endif
     }
 
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/127070", TestRuntimes.Mono)]
     [ConditionalClass(typeof(DirectoryServicesTestHelpers), nameof(DirectoryServicesTestHelpers.IsWindowsOrLibLdapIsInstalled))]
     public sealed partial class DirectoryServicesProtocolsTests_Local : DirectoryServicesProtocolsTests<DirectoryServicesProtocolsTests_Local.LocalCapabilities>
     {


### PR DESCRIPTION
The new tests are intermittently failing on Mono.
It's most likely a resource starvation on low-powered legs, but since these tests are just to accelerate dev inner loop just limit them to running in CoreCLR.

Mitigates impact from #127070.