### PR TITLE
Fix WebSocket close single-consumer violation 

### DIFF
--- a/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
+++ b/src/libraries/System.Net.WebSockets.Client/tests/CloseTest.cs
@@ -422,9 +422,13 @@ namespace System.Net.WebSockets.Client.Tests
 
                 await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
 
-                // There is a race condition in the above.  If the ReceiveAsync receives the sent close message from the server,
-                // then it will complete successfully and the socket will close successfully.  If the CloseAsync receive the sent
-                // close message from the server, then the receive async will end up getting aborted along with the socket.
+                // The outcome depends on timing. Two outcomes are acceptable:
+                //   1. The pending ReceiveAsync picks up the server's close frame cleanly: it completes with a Close
+                //      message and the socket transitions to Closed.
+                //   2. The close handshake triggers an internal Abort (e.g. WaitForServerToCloseConnectionAsync
+                //      times out because the server doesn't close TCP within its 1s window): state becomes Aborted,
+                //      the parked receive's stream read fails, and ReceiveAsyncPrivate translates the exception to
+                //      OperationCanceledException because of the Aborted state.
                 try
                 {
                     await t;

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -82,8 +82,6 @@ namespace System.Net.WebSockets
         private bool _sentCloseFrame;
         /// <summary>Whether we've ever received a close frame.</summary>
         private bool _receivedCloseFrame;
-        /// <summary>0 if <see cref="WaitForServerToCloseConnectionAsync"/> has not been invoked yet; 1 otherwise.</summary>
-        private int _waitedForServerClose;
         /// <summary>The reason for the close, as sent by the server, or null if not yet closed.</summary>
         private WebSocketCloseStatus? _closeStatus;
         /// <summary>A description of the close reason as sent by the server, or null if not yet closed.</summary>
@@ -410,10 +408,10 @@ namespace System.Net.WebSockets
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
-            return CloseOutputAsyncCore(closeStatus, statusDescription, cancellationToken);
+            return CloseOutputAsyncCore(closeStatus, statusDescription, enterReceiveMutex: true, cancellationToken: cancellationToken);
         }
 
-        private async Task CloseOutputAsyncCore(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+        private async Task CloseOutputAsyncCore(WebSocketCloseStatus closeStatus, string? statusDescription, bool enterReceiveMutex, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
@@ -424,7 +422,7 @@ namespace System.Net.WebSockets
             // Polite EOF wait under the receive mutex; avoids racing the receive loop on the stream.
             if (!_isServer && _receivedCloseFrame)
             {
-                await WaitForServerToCloseConnectionAsync(enterMutex: true, cancellationToken).ConfigureAwait(false);
+                await WaitForServerToCloseConnectionAsync(enterReceiveMutex, cancellationToken).ConfigureAwait(false);
             }
 
             // If we already received a close frame, since we've now also sent one, we're now closed.
@@ -1147,11 +1145,6 @@ namespace System.Net.WebSockets
 
                 Debug.Assert(_receiveMutex.IsHeld, $"Expected {nameof(_receiveMutex)} to be held");
 
-                if (Interlocked.CompareExchange(ref _waitedForServerClose, 1, 0) != 0)
-                {
-                    return;
-                }
-
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
                 // Per RFC 6455 7.1.1, try to let the server close the connection.  We give it up to a second.
@@ -1160,19 +1153,12 @@ namespace System.Net.WebSockets
                 // to try to get the server to close first.
                 ValueTask<int> finalReadTask = _stream.ReadAsync(_receiveBuffer, cancellationToken);
 
-                if (finalReadTask.IsCompletedSuccessfully)
-                {
-                    finalReadTask.GetAwaiter().GetResult();
-                }
-                else
-                {
-                    const int WaitForCloseTimeoutMs = 1_000; // arbitrary amount of time to give the server (same duration as .NET Framework)
-                    task = finalReadTask.AsTask();
+                const int WaitForCloseTimeoutMs = 1_000; // arbitrary amount of time to give the server
+                task = finalReadTask.AsTask();
 
 #pragma warning disable CA2016 // Token was already provided to the ReadAsync
-                    await task.WaitAsync(TimeSpan.FromMilliseconds(WaitForCloseTimeoutMs)).ConfigureAwait(false);
+                await task.WaitAsync(TimeSpan.FromMilliseconds(WaitForCloseTimeoutMs)).ConfigureAwait(false);
 #pragma warning restore CA2016
-                }
             }
             catch
             {
@@ -1305,24 +1291,10 @@ namespace System.Net.WebSockets
 
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this, errorMessage);
 
-            // Caller holds _receiveMutex; bypass CloseOutputAsync to avoid re-entering it for the EOF wait.
+            // Caller holds _receiveMutex; don't re-enter it for the EOF wait.
             if (!_sentCloseFrame)
             {
-                await SendCloseFrameAsync(closeStatus, string.Empty, default).ConfigureAwait(false);
-
-                if (!_isServer && _receivedCloseFrame)
-                {
-                    await WaitForServerToCloseConnectionAsync(enterMutex: false, default).ConfigureAwait(false);
-                }
-
-                lock (StateUpdateLock)
-                {
-                    Debug.Assert(_sentCloseFrame);
-                    if (_receivedCloseFrame)
-                    {
-                        DisposeCore();
-                    }
-                }
+                await CloseOutputAsyncCore(closeStatus, string.Empty, enterReceiveMutex: false, cancellationToken: default).ConfigureAwait(false);
             }
 
             // Dump our receive buffer; we're in a bad state to do any further processing

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -82,6 +82,8 @@ namespace System.Net.WebSockets
         private bool _sentCloseFrame;
         /// <summary>Whether we've ever received a close frame.</summary>
         private bool _receivedCloseFrame;
+        /// <summary>0 if <see cref="WaitForServerToCloseConnectionAsync"/> has not been invoked yet; 1 otherwise.</summary>
+        private int _waitedForServerClose;
         /// <summary>The reason for the close, as sent by the server, or null if not yet closed.</summary>
         private WebSocketCloseStatus? _closeStatus;
         /// <summary>A description of the close reason as sent by the server, or null if not yet closed.</summary>
@@ -1123,9 +1125,18 @@ namespace System.Net.WebSockets
             }
         }
 
-        /// <summary>Issues a read on the stream to wait for EOF.</summary>
+        /// <summary>Issues a read on the stream to wait for EOF. Idempotent across call sites.</summary>
         private async ValueTask WaitForServerToCloseConnectionAsync(CancellationToken cancellationToken)
         {
+            // Called from both the receive and the send path. In rare concurrent Close + Receive
+            // scenarios both paths can observe the close handshake as complete and would otherwise
+            // both issue a stream read (violating most Stream implementations' single-consumer invariant).
+            // The flag guarantees that only the first invocation performs the wait; the other is a no-op.
+            if (Interlocked.CompareExchange(ref _waitedForServerClose, 1, 0) != 0)
+            {
+                return;
+            }
+
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
             // Per RFC 6455 7.1.1, try to let the server close the connection.  We give it up to a second.

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -421,6 +421,12 @@ namespace System.Net.WebSockets
 
             await SendCloseFrameAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
 
+            // Polite EOF wait under the receive mutex; avoids racing the receive loop on the stream.
+            if (!_isServer && _receivedCloseFrame)
+            {
+                await WaitForServerToCloseConnectionAsync(enterMutex: true, cancellationToken).ConfigureAwait(false);
+            }
+
             // If we already received a close frame, since we've now also sent one, we're now closed.
             lock (StateUpdateLock)
             {
@@ -1121,50 +1127,67 @@ namespace System.Net.WebSockets
 
             if (!_isServer && _sentCloseFrame)
             {
-                await WaitForServerToCloseConnectionAsync(cancellationToken).ConfigureAwait(false);
+                await WaitForServerToCloseConnectionAsync(enterMutex: false, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        /// <summary>Issues a read on the stream to wait for EOF. Idempotent across call sites.</summary>
-        private async ValueTask WaitForServerToCloseConnectionAsync(CancellationToken cancellationToken)
+        /// <summary>Issues a read on the stream to wait for EOF, optionally acquiring <see cref="_receiveMutex"/> first.</summary>
+        private async ValueTask WaitForServerToCloseConnectionAsync(bool enterMutex, CancellationToken cancellationToken)
         {
-            // Called from both the receive and the send path. In rare concurrent Close + Receive
-            // scenarios both paths can observe the close handshake as complete and would otherwise
-            // both issue a stream read (violating most Stream implementations' single-consumer invariant).
-            // The flag guarantees that only the first invocation performs the wait; the other is a no-op.
-            if (Interlocked.CompareExchange(ref _waitedForServerClose, 1, 0) != 0)
+            bool mutexEntered = false;
+            Task? task = null;
+            try
             {
-                return;
-            }
-
-            if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
-
-            // Per RFC 6455 7.1.1, try to let the server close the connection.  We give it up to a second.
-            // We simply issue a read and don't care what we get back; we could validate that we don't get
-            // additional data, but at this point we're about to close the connection and we're just stalling
-            // to try to get the server to close first.
-            ValueTask<int> finalReadTask = _stream.ReadAsync(_receiveBuffer, cancellationToken);
-
-            if (finalReadTask.IsCompletedSuccessfully)
-            {
-                finalReadTask.GetAwaiter().GetResult();
-            }
-            else
-            {
-                const int WaitForCloseTimeoutMs = 1_000; // arbitrary amount of time to give the server (same duration as .NET Framework)
-                Task task = finalReadTask.AsTask();
-
-                try
+                if (enterMutex)
                 {
+                    await _receiveMutex.EnterAsync(cancellationToken).ConfigureAwait(false);
+                    mutexEntered = true;
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.MutexEntered(_receiveMutex);
+                }
+
+                Debug.Assert(_receiveMutex.IsHeld, $"Expected {nameof(_receiveMutex)} to be held");
+
+                if (Interlocked.CompareExchange(ref _waitedForServerClose, 1, 0) != 0)
+                {
+                    return;
+                }
+
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
+
+                // Per RFC 6455 7.1.1, try to let the server close the connection.  We give it up to a second.
+                // We simply issue a read and don't care what we get back; we could validate that we don't get
+                // additional data, but at this point we're about to close the connection and we're just stalling
+                // to try to get the server to close first.
+                ValueTask<int> finalReadTask = _stream.ReadAsync(_receiveBuffer, cancellationToken);
+
+                if (finalReadTask.IsCompletedSuccessfully)
+                {
+                    finalReadTask.GetAwaiter().GetResult();
+                }
+                else
+                {
+                    const int WaitForCloseTimeoutMs = 1_000; // arbitrary amount of time to give the server (same duration as .NET Framework)
+                    task = finalReadTask.AsTask();
+
 #pragma warning disable CA2016 // Token was already provided to the ReadAsync
                     await task.WaitAsync(TimeSpan.FromMilliseconds(WaitForCloseTimeoutMs)).ConfigureAwait(false);
 #pragma warning restore CA2016
                 }
-                catch
+            }
+            catch
+            {
+                if (task is not null)
                 {
-                    // Eat any resulting exceptions. We were going to close the connection, anyway.
                     LogExceptions(task);
-                    Abort();
+                }
+                Abort();
+            }
+            finally
+            {
+                if (mutexEntered)
+                {
+                    _receiveMutex.Exit();
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.MutexExited(_receiveMutex);
                 }
             }
         }
@@ -1278,12 +1301,28 @@ namespace System.Net.WebSockets
         private async ValueTask CloseWithReceiveErrorAndThrowAsync(
             WebSocketCloseStatus closeStatus, WebSocketError error, string? errorMessage = null, Exception? innerException = null)
         {
+            Debug.Assert(_receiveMutex.IsHeld, $"Caller should hold the {nameof(_receiveMutex)}");
+
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this, errorMessage);
 
-            // Close the connection if it hasn't already been closed
+            // Caller holds _receiveMutex; bypass CloseOutputAsync to avoid re-entering it for the EOF wait.
             if (!_sentCloseFrame)
             {
-                await CloseOutputAsync(closeStatus, string.Empty, default).ConfigureAwait(false);
+                await SendCloseFrameAsync(closeStatus, string.Empty, default).ConfigureAwait(false);
+
+                if (!_isServer && _receivedCloseFrame)
+                {
+                    await WaitForServerToCloseConnectionAsync(enterMutex: false, default).ConfigureAwait(false);
+                }
+
+                lock (StateUpdateLock)
+                {
+                    Debug.Assert(_sentCloseFrame);
+                    if (_receivedCloseFrame)
+                    {
+                        DisposeCore();
+                    }
+                }
             }
 
             // Dump our receive buffer; we're in a bad state to do any further processing
@@ -1502,6 +1541,12 @@ namespace System.Net.WebSockets
                     }
                 }
 
+                // Polite EOF wait under the receive mutex; avoids racing the receive loop on the stream.
+                if (!_isServer && _receivedCloseFrame)
+                {
+                    await WaitForServerToCloseConnectionAsync(enterMutex: true, cancellationToken).ConfigureAwait(false);
+                }
+
                 // We're closed.  Close the connection and update the status.
                 lock (StateUpdateLock)
                 {
@@ -1570,11 +1615,6 @@ namespace System.Net.WebSockets
                 }
 
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this, $"State transition from {state} to {_state}");
-            }
-
-            if (!_isServer && _receivedCloseFrame)
-            {
-                await WaitForServerToCloseConnectionAsync(cancellationToken).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #121157 and the likely related #117267 tracking the same assertion.

Serializes the client-side RFC 6455 7.1.1 EOF wait behind `_receiveMutex` so the close path cannot issue a transport read while a pending receive is still reading from the same stream. This avoids the `Http2Stream.TryReadFromBuffer` `Debug.Assert(!_hasWaiter)` failure under concurrent `CloseAsync` plus pending `ReceiveAsync` scenarios over HTTP/2 (RFC 8441).

## Root cause

`WaitForServerToCloseConnectionAsync` issues a `_stream.ReadAsync` for the RFC 6455 7.1.1 "client waits for server TCP close" step.

There are two ways the close handshake can reach that wait:

1. The receive loop observes the peer close frame in `HandleReceivedCloseAsync`. This path already runs while `_receiveMutex` is held.
2. The send-side close path sends our close frame after a peer close frame has already been observed. Previously this happened from `SendCloseFrameAsync`, which does not hold `_receiveMutex`.

A CAS-only guard avoids two completed calls to `WaitForServerToCloseConnectionAsync`, but it does not cover the wider race where the receive loop has already set `_receivedCloseFrame` and is still reading or parsing the close payload. In that window, `SendCloseFrameAsync` could observe `_receivedCloseFrame` and issue the EOF wait as a second read on the transport.

Over HTTP/1.1 the behavior is still wrong but historically tolerated by error handling. Over HTTP/2, `Http2Stream.Http2ReadWriteStream` enforces a single-consumer read invariant and can trip `Debug.Assert(!_hasWaiter)`.

The supported scenario is called out in the class-level thread-safety contract:

```csharp
/// - It's acceptable to have a pending ReceiveAsync while
///   CloseOutputAsync or CloseAsync is called.
```

## Fix

Move the EOF wait out of `SendCloseFrameAsync` and into callers that can coordinate with the receive side:

- `HandleReceivedCloseAsync` still calls `WaitForServerToCloseConnectionAsync` while already holding `_receiveMutex`.
- `CloseAsyncPrivate` and `CloseOutputAsyncCore` acquire `_receiveMutex` before performing the EOF wait.
- `CloseWithReceiveErrorAndThrowAsync` already runs under `_receiveMutex`, so it bypasses `CloseOutputAsyncCore` and calls `SendCloseFrameAsync` directly to avoid re-entering the receive mutex.
- `_waitedForServerClose` remains as a one-shot guard so the EOF wait is not repeated sequentially if more than one close path reaches the completed handshake state.

## Behavior preserved

- RFC 6455 7.1.1 "client waits for server TCP close" still runs at most once for a completed client close handshake.
- No public API change.
- No intended observable state-machine change.

## Test-side comment clarification

The test that exercises this contract, `RunClient_CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates` in `CloseTest.cs`, had a stale comment that misattributed where `OperationCanceledException` comes from in the abort branch. The comment now describes the acceptable outcomes and where the exception originates: `ReceiveAsyncPrivate` translates a stream exception to `OperationCanceledException` when `_state == Aborted`.

No test logic is changed.

## Note for reviewers about work item visibility

I'm a community contributor and do not have access to the work-item logs for #121157 / #117267. I identified the likely failing path by reading the code:

- The stack trace in #121157 narrows the failure to `WaitForServerToCloseConnectionAsync` running under `Http2Stream`.
- Combined with the "HTTP/2 WebSocket tests under Helix" context and the class-level thread-safety doc, the test `CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates` under the `CloseTest_*_Http2Loopback` classes matches the scenario.

If a reviewer can confirm from the actual work-item logs that this test is the one triggering the assertion, I'll reference the run in this PR.

## Local verification

Before the review update:

- Full libraries build (`./build.cmd -subset libs -c Release`): clean.
- `System.Net.WebSockets.Client.Tests` build: clean.
- Targeted test runs:
  - `CloseTest_Invoker_Http2Loopback.CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates` (both `useSsl` values)
  - `CloseTest_HttpClient_Http2Loopback.CloseAsync_DuringConcurrentReceiveAsync_ExpectedStates` (both `useSsl` values)
  - Full `CloseTest*` regression run (no new failures)

The latest receive-mutex follow-up was reviewed locally but not re-run.