### PR TITLE
[cDAC] Implement GetCompilerFlags for cDAC

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -18,9 +18,10 @@ internal readonly struct Loader_1 : ILoader
 
     private enum ModuleFlags_1 : uint
     {
-        Tenured = 0x1,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
-        EditAndContinue = 0x8, // Edit and Continue is enabled for this module
-        ReflectionEmit = 0x40,    // Reflection.Emit was used to create this module
+        Tenured = 0x1,                  // Set once we know for sure the Module will not be freed until the appdomain itself exits
+        JitOptimizationDisabled = 0x2,  // Cached flag: JIT optimizations are disabled
+        EditAndContinue = 0x8,          // Edit and Continue is enabled for this module
+        ReflectionEmit = 0x40,          // Reflection.Emit was used to create this module
     }
 
     private const uint DebuggerInfoMask = 0x0000FC00;
@@ -366,6 +367,8 @@ internal readonly struct Loader_1 : ILoader
         ModuleFlags flags = default;
         if (runtimeFlags.HasFlag(ModuleFlags_1.Tenured))
             flags |= ModuleFlags.Tenured;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.JitOptimizationDisabled))
+            flags |= ModuleFlags.JitOptimizationDisabled;
         if (runtimeFlags.HasFlag(ModuleFlags_1.EditAndContinue))
             flags |= ModuleFlags.EditAndContinue;
         if (runtimeFlags.HasFlag(ModuleFlags_1.ReflectionEmit))

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -237,11 +237,11 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         {
             Contracts.ILoader loader = _target.Contracts.Loader;
             Contracts.ModuleHandle handle = loader.GetModuleHandleFromAssemblyPtr(new TargetPointer(vmAssembly));
-            Contracts.DebuggerAssemblyControlFlags flags = loader.GetDebuggerInfoBits(handle);
-            *pfAllowJITOpts = (flags & Contracts.DebuggerAssemblyControlFlags.DACF_ALLOW_JIT_OPTS) != 0
+            Contracts.ModuleFlags flags = loader.GetFlags(handle);
+            *pfAllowJITOpts = (flags & Contracts.ModuleFlags.JitOptimizationDisabled) == 0
                 ? Interop.BOOL.TRUE
                 : Interop.BOOL.FALSE;
-            *pfEnableEnC = (flags & Contracts.DebuggerAssemblyControlFlags.DACF_ENC_ENABLED) != 0
+            *pfEnableEnC = (flags & Contracts.ModuleFlags.EditAndContinue) != 0
                 ? Interop.BOOL.TRUE
                 : Interop.BOOL.FALSE;
         }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -229,7 +229,42 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetAddressType(address, pRetVal) : HResults.E_NOTIMPL;
 
     public int GetCompilerFlags(ulong vmAssembly, Interop.BOOL* pfAllowJITOpts, Interop.BOOL* pfEnableEnC)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetCompilerFlags(vmAssembly, pfAllowJITOpts, pfEnableEnC) : HResults.E_NOTIMPL;
+    {
+        *pfAllowJITOpts = Interop.BOOL.FALSE;
+        *pfEnableEnC = Interop.BOOL.FALSE;
+        int hr = HResults.S_OK;
+        try
+        {
+            Contracts.ILoader loader = _target.Contracts.Loader;
+            Contracts.ModuleHandle handle = loader.GetModuleHandleFromAssemblyPtr(new TargetPointer(vmAssembly));
+            Contracts.DebuggerAssemblyControlFlags flags = loader.GetDebuggerInfoBits(handle);
+            *pfAllowJITOpts = (flags & Contracts.DebuggerAssemblyControlFlags.DACF_ALLOW_JIT_OPTS) != 0
+                ? Interop.BOOL.TRUE
+                : Interop.BOOL.FALSE;
+            *pfEnableEnC = (flags & Contracts.DebuggerAssemblyControlFlags.DACF_ENC_ENABLED) != 0
+                ? Interop.BOOL.TRUE
+                : Interop.BOOL.FALSE;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL allowJITOptsLocal;
+            Interop.BOOL enableEnCLocal;
+            int hrLocal = _legacy.GetCompilerFlags(vmAssembly, &allowJITOptsLocal, &enableEnCLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                Debug.Assert(*pfAllowJITOpts == allowJITOptsLocal, $"cDAC: {*pfAllowJITOpts}, DAC: {allowJITOptsLocal}");
+                Debug.Assert(*pfEnableEnC == enableEnCLocal, $"cDAC: {*pfEnableEnC}, DAC: {enableEnCLocal}");
+            }
+        }
+#endif
+        return hr;
+    }
 
     public int SetCompilerFlags(ulong vmAssembly, Interop.BOOL fAllowJitOpts, Interop.BOOL fEnableEnC)
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.SetCompilerFlags(vmAssembly, fAllowJitOpts, fEnableEnC) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/tests/LoaderTests.cs
+++ b/src/native/managed/cdac/tests/LoaderTests.cs
@@ -716,14 +716,12 @@ public unsafe class LoaderTests
     {
         foreach (var arch in new MockTarget.StdArch())
         {
-            // Both flags set
-            yield return [DebuggerAllowJitOptsPriv | DebuggerEncEnabledPriv, Interop.BOOL.TRUE, Interop.BOOL.TRUE, arch[0]];
-            // No flags set
-            yield return [0u, Interop.BOOL.FALSE, Interop.BOOL.FALSE, arch[0]];
-            // Only AllowJITOpts
-            yield return [DebuggerAllowJitOptsPriv, Interop.BOOL.TRUE, Interop.BOOL.FALSE, arch[0]];
-            // Only EnC enabled
-            yield return [DebuggerEncEnabledPriv, Interop.BOOL.FALSE, Interop.BOOL.TRUE, arch[0]];
+            yield return [IsJitOptimizationDisabled | IsEditAndContinue, Interop.BOOL.FALSE, Interop.BOOL.TRUE, arch[0]];
+            yield return [0u, Interop.BOOL.TRUE, Interop.BOOL.FALSE, arch[0]];
+            yield return [IsJitOptimizationDisabled, Interop.BOOL.FALSE, Interop.BOOL.FALSE, arch[0]];
+            yield return [IsEditAndContinue, Interop.BOOL.TRUE, Interop.BOOL.TRUE, arch[0]];
+            // Debugger allows JIT opts but profiler disables them (IS_JIT_OPTIMIZATION_DISABLED wins)
+            yield return [DebuggerAllowJitOptsPriv | IsJitOptimizationDisabled, Interop.BOOL.FALSE, Interop.BOOL.FALSE, arch[0]];
         }
     }
 

--- a/src/native/managed/cdac/tests/LoaderTests.cs
+++ b/src/native/managed/cdac/tests/LoaderTests.cs
@@ -711,4 +711,44 @@ public unsafe class LoaderTests
         uint rawFlags = target.Read<uint>(moduleAddr + (ulong)flagsOffset);
         Assert.True((rawFlags & IsEditAndContinue) != 0, "IS_EDIT_AND_CONTINUE should be set when DACF_ENC_ENABLED is explicitly requested");
     }
+
+    public static IEnumerable<object[]> GetCompilerFlagsData()
+    {
+        foreach (var arch in new MockTarget.StdArch())
+        {
+            // Both flags set
+            yield return [DebuggerAllowJitOptsPriv | DebuggerEncEnabledPriv, Interop.BOOL.TRUE, Interop.BOOL.TRUE, arch[0]];
+            // No flags set
+            yield return [0u, Interop.BOOL.FALSE, Interop.BOOL.FALSE, arch[0]];
+            // Only AllowJITOpts
+            yield return [DebuggerAllowJitOptsPriv, Interop.BOOL.TRUE, Interop.BOOL.FALSE, arch[0]];
+            // Only EnC enabled
+            yield return [DebuggerEncEnabledPriv, Interop.BOOL.FALSE, Interop.BOOL.TRUE, arch[0]];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(GetCompilerFlagsData))]
+    public void GetCompilerFlags(uint rawFlags, Interop.BOOL expectedAllowJITOpts, Interop.BOOL expectedEnableEnC, MockTarget.Architecture arch)
+    {
+        var targetBuilder = new TestPlaceholderTarget.Builder(arch);
+        MockLoaderBuilder loader = new(targetBuilder.MemoryBuilder);
+
+        MockLoaderModule module = loader.AddModule(flags: rawFlags);
+        ulong assemblyAddr = module.Assembly;
+
+        var target = targetBuilder
+            .AddTypes(CreateContractTypes(loader))
+            .AddContract<ILoader>(version: "c1")
+            .Build();
+
+        DacDbiImpl dbi = new(target, legacyObj: null);
+
+        Interop.BOOL allowJITOpts;
+        Interop.BOOL enableEnC;
+        int hr = dbi.GetCompilerFlags(assemblyAddr, &allowJITOpts, &enableEnC);
+        Assert.Equal(HResults.S_OK, hr);
+        Assert.Equal(expectedAllowJITOpts, allowJITOpts);
+        Assert.Equal(expectedEnableEnC, enableEnC);
+    }
 }


### PR DESCRIPTION
## Summary
Implement `GetCompilerFlags` in cDAC `DacDbiImpl` using `ILoader.GetFlags` to read cached result bits (`JitOptimizationDisabled`, `EditAndContinue`) matching native DAC behavior.

## Changes
- `DacDbiImpl.cs` - `GetCompilerFlags` implementation
- `Loader_1.cs` - Add `JitOptimizationDisabled` to `ModuleFlags_1` and `GetFlags()` mapping
- `LoaderTests.cs` - Add 20 test cases covering all flag combinations plus profiler-override scenario