### PR TITLE
Update socket infinite time span test

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -402,25 +402,15 @@ namespace System.Net.Sockets.Tests
         [Fact]
         public void SelectPoll_InfiniteTimeSpan_Ok()
         {
-            using (Socket host = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                host.Bind(new IPEndPoint(IPAddress.Loopback, 0));
-                host.Listen(1);
-                Task accept = host.AcceptAsync();
+                var list = new List<Socket> { s };
 
-                using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
-                {
-                    s.Connect(new IPEndPoint(IPAddress.Loopback, ((IPEndPoint)host.LocalEndPoint).Port));
-
-                    var list = new List<Socket>();
-                    list.Add(s);
-
-                    // should be writable
-                    Socket.Select(null, list, null, Timeout.InfiniteTimeSpan);
-                    Socket.Select(null, list, null, -1);
-                    s.Poll(Timeout.InfiniteTimeSpan, SelectMode.SelectWrite);
-                    s.Poll(-1, SelectMode.SelectWrite);
-                }
+                // should be writable
+                Socket.Select(null, list, null, Timeout.InfiniteTimeSpan);
+                Socket.Select(null, list, null, -1);
+                s.Poll(Timeout.InfiniteTimeSpan, SelectMode.SelectWrite);
+                s.Poll(-1, SelectMode.SelectWrite);
             }
         }
 

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -404,13 +404,16 @@ namespace System.Net.Sockets.Tests
         {
             using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp))
             {
-                var list = new List<Socket> { s };
-
                 // should be writable
+                var list = new List<Socket> { s };
                 Socket.Select(null, list, null, Timeout.InfiniteTimeSpan);
+                Assert.Equal(new[] { s }, list);
+
                 Socket.Select(null, list, null, -1);
-                s.Poll(Timeout.InfiniteTimeSpan, SelectMode.SelectWrite);
-                s.Poll(-1, SelectMode.SelectWrite);
+                Assert.Equal(new[] { s }, list);
+
+                Assert.True(s.Poll(Timeout.InfiniteTimeSpan, SelectMode.SelectWrite));
+                Assert.True(s.Poll(-1, SelectMode.SelectWrite));
             }
         }
 


### PR DESCRIPTION
Since TCP connections sometimes fail on android platforms (https://github.com/dotnet/runtime/issues/122493) and the goal of this test is just to check infinite time span arguments are valid, use a UDP connection instead.

Fixes #121717.