### PR TITLE
Fix x86 DAC stack walk regression from Environment.CallEntryPoint skip

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -308,12 +308,12 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::UnwindStackWalkFrame(StackWalkHan
                         continue;
                     }
 
-                    // Skip the runtime helper that invokes the main program entrypoint, the debuggers do not want to see it.
-                    // Environment.CallEntryPoint
-                    if (pMD == g_pEnvironmentCallEntryPointMethodDesc)
-                    {
-                        continue;
-                    }
+                    // Note: Environment.CallEntryPoint is NOT skipped here with continue.
+                    // On x86, GetFrameWorker() unwinds one frame ahead to compute the frame pointer
+                    // (see rsstackwalk.cpp). If we skip this frame, the unwind lands on the wrong
+                    // frame, producing an incorrect frame pointer for the caller (e.g., Main).
+                    // Instead, we let it be enumerated; GetStackWalkCurrentFrameInfo classifies it
+                    // as kRuntimeEntryPointFrame and GetFrameWorker returns S_FALSE to hide it.
 
                     fIsAtEndOfStack = FALSE;
                 }

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -297,24 +297,12 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::UnwindStackWalkFrame(StackWalkHan
                 }
                 else if (pIter->GetFrameState() == StackFrameIterator::SFITER_FRAMELESS_METHOD)
                 {
-                    MethodDesc *pMD = pIter->m_crawl.GetFunction();
-                    MethodTable *pMT = pMD->GetMethodTable();
-
-                    // Skip the exception handling managed code, the debugger clients are not supposed to see them
-                    // EH.DispatchEx, EH.RhThrowEx, EH.RhThrowHwEx, ExceptionServices.InternalCalls.SfiInit, ExceptionServices.InternalCalls.SfiNext
-                    // and System.Runtime.StackFrameIterator.*
-                    if (pMT == g_pEHClass || pMT == g_pExceptionServicesInternalCallsClass || pMT == g_pStackFrameIteratorClass)
-                    {
-                        continue;
-                    }
-
-                    // Note: Environment.CallEntryPoint is NOT skipped here with continue.
-                    // On x86, GetFrameWorker() unwinds one frame ahead to compute the frame pointer
-                    // (see rsstackwalk.cpp). If we skip this frame, the unwind lands on the wrong
-                    // frame, producing an incorrect frame pointer for the caller (e.g., Main).
-                    // Instead, we let it be enumerated; GetStackWalkCurrentFrameInfo classifies it
-                    // as kRuntimeEntryPointFrame and GetFrameWorker returns S_FALSE to hide it.
-
+                    // Runtime-internal frames (exception handling helpers, entry point, etc.) are NOT
+                    // skipped here with continue. On x86, GetFrameWorker() unwinds one frame ahead to
+                    // compute the frame pointer (see rsstackwalk.cpp). Skipping frames here would cause
+                    // the unwind to land on the wrong frame, producing incorrect frame pointers.
+                    // Instead, GetStackWalkCurrentFrameInfo classifies these frames and GetFrameWorker
+                    // returns S_FALSE to hide them from debugger clients.
                     fIsAtEndOfStack = FALSE;
                 }
                 else
@@ -425,7 +413,8 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackWalkCurrentFrameInfo(Stac
                     {
                         MethodDesc *pMD = pIter->m_crawl.GetFunction();
                         // EH.DispatchEx, EH.RhThrowEx, EH.RhThrowHwEx, ExceptionServices.InternalCalls.SfiInit, ExceptionServices.InternalCalls.SfiNext
-                        if (pMD->GetMethodTable() == g_pEHClass || pMD->GetMethodTable() == g_pExceptionServicesInternalCallsClass)
+                        // and System.Runtime.StackFrameIterator.*
+                        if (pMD->GetMethodTable() == g_pEHClass || pMD->GetMethodTable() == g_pExceptionServicesInternalCallsClass || pMD->GetMethodTable() == g_pStackFrameIteratorClass)
                         {
                             ftResult = kManagedExceptionHandlingCodeFrame;
                         }


### PR DESCRIPTION
Found using internal VS testing, any DBI stack walk on x86 where Environment.CallEntryPoint is on the stack would produce wrong frame pointers for the frames below it (like Main).  This resulted in ICorDebugStackWalk enumeration on that thread would fail.  It only affects x86 because that's the only architecture where GetFrameWorker unwinds one frame ahead to compute the frame pointer. On x64/arm64, the frame pointer is obtained directly without that extra unwind, so the continue skip is harmless there.

The fix is to avoid skipping Environment.CallEntryPoint in UnwindStackWalkFrame.  The frame is still hidden from debugger UI via kRuntimeEntryPointFrame classification and S_FALSE return in GetFrameWorker.