### PR TITLE
Fix .NETFramework build breaks

### DIFF
--- a/eng/TraversalSdk.AfterTargets.targets
+++ b/eng/TraversalSdk.AfterTargets.targets
@@ -19,11 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(FilterTraversalProjectReferences)' == 'true'">
-    <!-- Override the Traversal SDK setting as filtering relies on the TargetFrameworkProperties being fetched
-         and don't flow the BuildTargetFramework property down. -->
+    <!-- Override the Traversal SDK setting as filtering relies on the TargetFrameworkProperties being fetched. -->
     <ProjectReference Update="@(ProjectReference)"
-                      SkipGetTargetFrameworkProperties="false"
-                      UndefineProperties="%(UndefineProperties);BuildTargetFramework"  />
+                      SkipGetTargetFrameworkProperties="false"  />
   </ItemGroup>
 
 </Project>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -123,13 +123,16 @@
   </Target>
 
   <!-- Skip the PNSE doc-source self-reference when the local NetCoreApp ref pack hasn't been built
-       (e.g. in NET481-only legs); doc enrichment from the sibling TFM is optional in that case. -->
+       (e.g. in NET481-only legs); doc enrichment from the sibling TFM is optional in that case.
+       Mirror the FrameworkList.xml sentinel from eng/targetingpacks.targets, checking both the
+       normal ref-pack location and the bootstrap layout location. -->
   <Target Name="AddProjectReferenceToPNSEDocSource"
           DependsOnTargets="GetPNSEDocTargetFramework"
           BeforeTargets="PrepareForBuild"
           Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and
                     '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
-                    Exists('$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml')">
+                    (Exists('$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml') or
+                     ('$(UseBootstrapLayout)' == 'true' and Exists('$(BootstrapRefPackDir)\data\FrameworkList.xml')))">
     
     <Error Condition="'$(PNSEDocTargetFramework)' == ''"
            Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'PNSEDocTargetFramework' to the desired target framework." />

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -122,17 +122,13 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Skip the PNSE doc-source self-reference when the local NetCoreApp ref pack hasn't been built
-       (e.g. in NET481-only legs); doc enrichment from the sibling TFM is optional in that case.
-       Mirror the FrameworkList.xml sentinel from eng/targetingpacks.targets, checking both the
-       normal ref-pack location and the bootstrap layout location. -->
+  <!-- Skip the PNSE doc-source self-reference when not building a .NETCoreApp vertical. -->
   <Target Name="AddProjectReferenceToPNSEDocSource"
           DependsOnTargets="GetPNSEDocTargetFramework"
           BeforeTargets="PrepareForBuild"
           Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and
                     '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
-                    (Exists('$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml') or
-                     ('$(UseBootstrapLayout)' == 'true' and Exists('$(BootstrapRefPackDir)\data\FrameworkList.xml')))">
+                    ('$(BuildTargetFramework)' == '' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')">
     
     <Error Condition="'$(PNSEDocTargetFramework)' == ''"
            Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'PNSEDocTargetFramework' to the desired target framework." />

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -122,11 +122,14 @@
     </PropertyGroup>
   </Target>
 
+  <!-- Skip the PNSE doc-source self-reference when the local NetCoreApp ref pack hasn't been built
+       (e.g. in NET481-only legs); doc enrichment from the sibling TFM is optional in that case. -->
   <Target Name="AddProjectReferenceToPNSEDocSource"
           DependsOnTargets="GetPNSEDocTargetFramework"
           BeforeTargets="PrepareForBuild"
           Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and
-                    '$(UseCompilerGeneratedDocXmlFile)' == 'true'">
+                    '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
+                    Exists('$(MicrosoftNetCoreAppRefPackDataDir)FrameworkList.xml')">
     
     <Error Condition="'$(PNSEDocTargetFramework)' == ''"
            Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'PNSEDocTargetFramework' to the desired target framework." />

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ErrObjectTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ErrObjectTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.VisualBasic.Tests
             Assert.Equal("", errObj.Source);
 #if NET
             Marshal.SetLastPInvokeError(42);
-#endif
             Assert.Equal(42, errObj.LastDllError);
+#endif
             Assert.Equal(0, errObj.Number);
             Assert.Equal("", errObj.Description);
             Assert.Null(errObj.GetException());

--- a/src/libraries/Microsoft.VisualBasic.Core/tests/ErrObjectTests.cs
+++ b/src/libraries/Microsoft.VisualBasic.Core/tests/ErrObjectTests.cs
@@ -28,7 +28,9 @@ namespace Microsoft.VisualBasic.Tests
             Assert.Equal(0, errObj.HelpContext);
             Assert.Equal("", errObj.HelpFile);
             Assert.Equal("", errObj.Source);
+#if NET
             Marshal.SetLastPInvokeError(42);
+#endif
             Assert.Equal(42, errObj.LastDllError);
             Assert.Equal(0, errObj.Number);
             Assert.Equal("", errObj.Description);


### PR DESCRIPTION
When `UseCompilerGeneratedDocXmlFile` is `true` (the default) and a library is a PNSE assembly, `eng/intellisense.targets` adds a self-referencing `ProjectReference` with `SetTargetFramework=net11.0` to pull enriched XML docs from the non-PNSE sibling build. In the NET481 build leg the local targeting pack (`FrameworkList.xml`) is never produced, so the inner `net11.0` build fails with:

> The shared framework must be built before the local targeting pack can be consumed.

This became visible after #124365 removed `<UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>` from `System.Reflection.Context`, activating the PNSE doc-source path for the first time in that project.

### Fix

Disable `AddProjectReferenceToPNSEDocSource` when doing a vertical build that is not for .NETCore.

This also fixes a build break in VB tests that was introduced while the NETFx build was broken.

### Verification

Tested locally by building vertical builds for NETFx, Net11,  and packages.  Ran netfx tests for modified VB.Core library

Fixes #127007

