### PR TITLE
Fix flaky CounterSampleCalculator_ElapsedTime test

### DIFF
--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections;
-using System.Collections.Specialized;
 using Xunit;
 
 namespace System.Diagnostics.Tests
@@ -18,15 +16,15 @@ namespace System.Diagnostics.Tests
             PerformanceCounter counterSample = CreateCounter(categoryName, PerformanceCounterType.ElapsedTime);
 
             counterSample.RawValue = Stopwatch.GetTimestamp();
-            DateTime Start = DateTime.Now;
+            long startTicks = Stopwatch.GetTimestamp();
             Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
 
             System.Threading.Thread.Sleep(500);
 
             var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
-            var dateTimeVal = DateTime.Now.Subtract(Start).TotalSeconds;
+            var elapsed = (double)(Stopwatch.GetTimestamp() - startTicks) / Stopwatch.Frequency;
             Helpers.DeleteCategory(categoryName);
-            Assert.True(Math.Abs(dateTimeVal - counterVal) < .3);
+            Assert.True(Math.Abs(elapsed - counterVal) < .3);
         }
 
         public static PerformanceCounter CreateCounter(string categoryName, PerformanceCounterType counterType)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -15,16 +15,21 @@ namespace System.Diagnostics.Tests
 
             PerformanceCounter counterSample = CreateCounter(categoryName, PerformanceCounterType.ElapsedTime);
 
-            long startTimestamp = Stopwatch.GetTimestamp();
-            counterSample.RawValue = startTimestamp;
-            Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
+            // Timing comparisons can be flaky under CI load, so retry.
+            RetryHelper.Execute(() =>
+            {
+                long startTimestamp = Stopwatch.GetTimestamp();
+                counterSample.RawValue = startTimestamp;
+                Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
 
-            System.Threading.Thread.Sleep(500);
+                System.Threading.Thread.Sleep(500);
 
-            var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
-            var elapsed = (double)(Stopwatch.GetTimestamp() - startTimestamp) / Stopwatch.Frequency;
+                var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
+                var elapsed = (double)(Stopwatch.GetTimestamp() - startTimestamp) / Stopwatch.Frequency;
+                Assert.True(Math.Abs(elapsed - counterVal) < .3, $"Expected elapsed ({elapsed:F3}s) and counterVal ({counterVal:F3}s) to be within 0.3s");
+            }, maxAttempts: 3);
+
             Helpers.DeleteCategory(categoryName);
-            Assert.True(Math.Abs(elapsed - counterVal) < .3);
         }
 
         public static PerformanceCounter CreateCounter(string categoryName, PerformanceCounterType counterType)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Xunit;
+using Xunit.Sdk;
 
 namespace System.Diagnostics.Tests
 {
@@ -15,21 +16,27 @@ namespace System.Diagnostics.Tests
 
             PerformanceCounter counterSample = CreateCounter(categoryName, PerformanceCounterType.ElapsedTime);
 
-            // Timing comparisons can be flaky under CI load, so retry.
-            RetryHelper.Execute(() =>
+            try
             {
-                long startTimestamp = Stopwatch.GetTimestamp();
-                counterSample.RawValue = startTimestamp;
-                Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
+                // Timing comparisons can be flaky under CI load, so retry.
+                RetryHelper.Execute(() =>
+                {
+                    long startTimestamp = Stopwatch.GetTimestamp();
+                    counterSample.RawValue = startTimestamp;
+                    Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
 
-                System.Threading.Thread.Sleep(500);
+                    System.Threading.Thread.Sleep(500);
 
-                var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
-                var elapsed = (double)(Stopwatch.GetTimestamp() - startTimestamp) / Stopwatch.Frequency;
-                Assert.True(Math.Abs(elapsed - counterVal) < .3, $"Expected elapsed ({elapsed:F3}s) and counterVal ({counterVal:F3}s) to be within 0.3s");
-            }, maxAttempts: 3);
-
-            Helpers.DeleteCategory(categoryName);
+                    var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
+                    var elapsed = (double)(Stopwatch.GetTimestamp() - startTimestamp) / Stopwatch.Frequency;
+                    Assert.True(Math.Abs(elapsed - counterVal) < .3, $"Expected elapsed ({elapsed:F3}s) and counterVal ({counterVal:F3}s) to be within 0.3s");
+                }, maxAttempts: 3, retryWhen: e => e is XunitException);
+            }
+            finally
+            {
+                counterSample.Dispose();
+                Helpers.DeleteCategory(categoryName);
+            }
         }
 
         public static PerformanceCounter CreateCounter(string categoryName, PerformanceCounterType counterType)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs
@@ -15,14 +15,14 @@ namespace System.Diagnostics.Tests
 
             PerformanceCounter counterSample = CreateCounter(categoryName, PerformanceCounterType.ElapsedTime);
 
-            counterSample.RawValue = Stopwatch.GetTimestamp();
-            long startTicks = Stopwatch.GetTimestamp();
+            long startTimestamp = Stopwatch.GetTimestamp();
+            counterSample.RawValue = startTimestamp;
             Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
 
             System.Threading.Thread.Sleep(500);
 
             var counterVal = Helpers.RetryOnAllPlatforms(() => counterSample.NextValue());
-            var elapsed = (double)(Stopwatch.GetTimestamp() - startTicks) / Stopwatch.Frequency;
+            var elapsed = (double)(Stopwatch.GetTimestamp() - startTimestamp) / Stopwatch.Frequency;
             Helpers.DeleteCategory(categoryName);
             Assert.True(Math.Abs(elapsed - counterVal) < .3);
         }


### PR DESCRIPTION
I got this on an unrelated PR.

> [!NOTE]
> This PR was authored with assistance from Copilot CLI.

The `CounterSampleCalculator_ElapsedTime` test occasionally fails in CI (0.01% rate) because it compares elapsed time measured by two different clock sources: QPC (via the perf counter infrastructure) and `DateTime.Now` (over system clock, updated by periodic interrupt). Under CI load, the gap between `Stopwatch.GetTimestamp()` and `DateTime.Now` on consecutive lines can exceed the 0.3s tolerance.

```
Assert.True() Failure
Expected: True
Actual:   False
   at System.Diagnostics.Tests.CounterSampleCalculatorTests.CounterSampleCalculator_ElapsedTime() in /_/src/libraries/System.Diagnostics.PerformanceCounter/tests/CounterSampleCalculatorTests.cs:line 29
```

Fix by using `Stopwatch` for both measurements so they share the same clock source (QPC). Can't use `.GetElapsedTime()` as that wasn't in .NET Framework.
