### PR TITLE
Fix map/virtual.cpp on OpenBSD

### DIFF
--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -1581,11 +1581,11 @@ void ExecutableMemoryAllocator::TryReserveInitialMemory()
 
     int32_t sizeOfAllocation = MaxExecutableMemorySizeNearCoreClr;
     int32_t initialReserveLimit = -1;
-    #if !defined(TARGET_OPENBSD)
+#ifdef RLIMIT_AS
     int addressSpace = RLIMIT_AS;
-    #else
+#else
     int addressSpace = RLIMIT_DATA;
-    #endif
+#endif
     rlimit addressSpaceLimit;
     if ((getrlimit(addressSpace, &addressSpaceLimit) == 0) && (addressSpaceLimit.rlim_cur != RLIM_INFINITY))
     {

--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -716,7 +716,7 @@ VIRTUALCommitMemory(
 
     nProtect = W32toUnixAccessControl(flProtect);
     pRetVal = (void *) StartBoundary;
-    
+
 #ifndef TARGET_WASM
     // Commit the pages
     if (mprotect((void *) StartBoundary, MemSize, nProtect) != 0)
@@ -1581,8 +1581,13 @@ void ExecutableMemoryAllocator::TryReserveInitialMemory()
 
     int32_t sizeOfAllocation = MaxExecutableMemorySizeNearCoreClr;
     int32_t initialReserveLimit = -1;
+    #if !defined(TARGET_OPENBSD)
+    int addressSpace = RLIMIT_AS;
+    #else
+    int addressSpace = RLIMIT_DATA;
+    #endif
     rlimit addressSpaceLimit;
-    if ((getrlimit(RLIMIT_AS, &addressSpaceLimit) == 0) && (addressSpaceLimit.rlim_cur != RLIM_INFINITY))
+    if ((getrlimit(addressSpace, &addressSpaceLimit) == 0) && (addressSpaceLimit.rlim_cur != RLIM_INFINITY))
     {
         // By default reserve max 20% of the available virtual address space
         rlim_t initialExecMemoryPerc = 20;


### PR DESCRIPTION
OpenBSD doesn't have `RLIMIT_AS` but [RLIMIT_DATA](https://man.openbsd.org/getrlimit#RLIMIT_DATA) can be used instead.

Looks like some whitespace snuck into this file in the past and the `.editorconfig` settings in the repository have cleaned it up on save. I can revert the whitespace changes if needed.

Contributes to #124911.