### PR TITLE
perf: specialize Task.WhenAny for 3 and 4 tasks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -6629,6 +6629,16 @@ namespace System.Threading.Tasks
                 return WhenAny(tasks[0], tasks[1]);
             }
 
+            if (tasks.Length == 3)
+            {
+                return WhenAny(tasks[0], tasks[1], tasks[2]);
+            }
+
+            if (tasks.Length == 4)
+            {
+                return WhenAny(tasks[0], tasks[1], tasks[2], tasks[3]);
+            }
+
             if (tasks.IsEmpty)
             {
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Task_MultiTaskContinuation_EmptyTaskList, ExceptionArgument.tasks);
@@ -6756,6 +6766,211 @@ namespace System.Threading.Tasks
                     {
                         task2.RemoveContinuation(this);
                     }
+
+                    bool success = TrySetResult((TTask)completingTask);
+                    Debug.Assert(success, "Only one task should have gotten to this point, and thus this must be successful.");
+                }
+            }
+
+            public bool InvokeMayRunArbitraryCode => true;
+        }
+
+        private static Task<TTask> WhenAny<TTask>(TTask task1, TTask task2, TTask task3) where TTask : Task
+        {
+            ArgumentNullException.ThrowIfNull(task1);
+            ArgumentNullException.ThrowIfNull(task2);
+            ArgumentNullException.ThrowIfNull(task3);
+
+            return
+                task1.IsCompleted ? FromResult(task1) :
+                task2.IsCompleted ? FromResult(task2) :
+                task3.IsCompleted ? FromResult(task3) :
+                new ThreeTaskWhenAnyPromise<TTask>(task1, task2, task3);
+        }
+
+        /// <summary>A promise type used by WhenAny to wait on exactly three tasks.</summary>
+        /// <typeparam name="TTask">Specifies the type of the task.</typeparam>
+        /// <remarks>
+        /// This has essentially the same logic as <see cref="TaskFactory.CompleteOnInvokePromise{TTask}"/>, but optimized
+        /// for three tasks rather than any number.
+        /// </remarks>
+        private sealed class ThreeTaskWhenAnyPromise<TTask> : Task<TTask>, ITaskCompletionAction where TTask : Task
+        {
+            private TTask? _task1, _task2, _task3;
+
+            /// <summary>Instantiate the promise and register it with each task as a completion action.</summary>
+            public ThreeTaskWhenAnyPromise(TTask task1, TTask task2, TTask task3)
+            {
+                Debug.Assert(task1 != null && task2 != null && task3 != null);
+                _task1 = task1;
+                _task2 = task2;
+                _task3 = task3;
+
+                if (TplEventSource.Log.IsEnabled())
+                {
+                    TplEventSource.Log.TraceOperationBegin(this.Id, "Task.WhenAny", 0);
+                }
+
+                if (s_asyncDebuggingEnabled)
+                {
+                    AddToActiveTasks(this);
+                }
+
+                task1.AddCompletionAction(this);
+                task2.AddCompletionAction(this);
+                task3.AddCompletionAction(this);
+
+                if (task1.IsCompleted)
+                {
+                    // If task1 has already completed, Invoke may have tried to remove the continuation from
+                    // each task before task2 and task3 added the continuation, in which case they're now referencing the
+                    // already completed continuation.  To deal with that race condition, explicitly check
+                    // and remove the continuation here.
+                    task2.RemoveContinuation(this);
+                    task3.RemoveContinuation(this);
+                }
+                else if (task2.IsCompleted)
+                {
+                    task3.RemoveContinuation(this);
+                }
+            }
+
+            /// <summary>Completes this task when one of the constituent tasks completes.</summary>
+            public void Invoke(Task completingTask)
+            {
+                Task? task1;
+                if ((task1 = Interlocked.Exchange(ref _task1, null)) != null)
+                {
+                    Task? task2 = _task2;
+                    Task? task3 = _task3;
+                    _task2 = null;
+                    _task3 = null;
+
+                    Debug.Assert(task1 != null && task2 != null && task3 != null);
+
+                    if (TplEventSource.Log.IsEnabled())
+                    {
+                        TplEventSource.Log.TraceOperationRelation(this.Id, CausalityRelation.Choice);
+                        TplEventSource.Log.TraceOperationEnd(this.Id, AsyncCausalityStatus.Completed);
+                    }
+
+                    if (s_asyncDebuggingEnabled)
+                    {
+                        RemoveFromActiveTasks(this);
+                    }
+
+                    if (!task1.IsCompleted) task1.RemoveContinuation(this);
+                    if (!task2.IsCompleted) task2.RemoveContinuation(this);
+                    if (!task3.IsCompleted) task3.RemoveContinuation(this);
+
+                    bool success = TrySetResult((TTask)completingTask);
+                    Debug.Assert(success, "Only one task should have gotten to this point, and thus this must be successful.");
+                }
+            }
+
+            public bool InvokeMayRunArbitraryCode => true;
+        }
+
+        private static Task<TTask> WhenAny<TTask>(TTask task1, TTask task2, TTask task3, TTask task4) where TTask : Task
+        {
+            ArgumentNullException.ThrowIfNull(task1);
+            ArgumentNullException.ThrowIfNull(task2);
+            ArgumentNullException.ThrowIfNull(task3);
+            ArgumentNullException.ThrowIfNull(task4);
+
+            return
+                task1.IsCompleted ? FromResult(task1) :
+                task2.IsCompleted ? FromResult(task2) :
+                task3.IsCompleted ? FromResult(task3) :
+                task4.IsCompleted ? FromResult(task4) :
+                new FourTaskWhenAnyPromise<TTask>(task1, task2, task3, task4);
+        }
+
+        /// <summary>A promise type used by WhenAny to wait on exactly four tasks.</summary>
+        /// <typeparam name="TTask">Specifies the type of the task.</typeparam>
+        /// <remarks>
+        /// This has essentially the same logic as <see cref="TaskFactory.CompleteOnInvokePromise{TTask}"/>, but optimized
+        /// for four tasks rather than any number.
+        /// </remarks>
+        private sealed class FourTaskWhenAnyPromise<TTask> : Task<TTask>, ITaskCompletionAction where TTask : Task
+        {
+            private TTask? _task1, _task2, _task3, _task4;
+
+            /// <summary>Instantiate the promise and register it with each task as a completion action.</summary>
+            public FourTaskWhenAnyPromise(TTask task1, TTask task2, TTask task3, TTask task4)
+            {
+                Debug.Assert(task1 != null && task2 != null && task3 != null && task4 != null);
+                _task1 = task1;
+                _task2 = task2;
+                _task3 = task3;
+                _task4 = task4;
+
+                if (TplEventSource.Log.IsEnabled())
+                {
+                    TplEventSource.Log.TraceOperationBegin(this.Id, "Task.WhenAny", 0);
+                }
+
+                if (s_asyncDebuggingEnabled)
+                {
+                    AddToActiveTasks(this);
+                }
+
+                task1.AddCompletionAction(this);
+                task2.AddCompletionAction(this);
+                task3.AddCompletionAction(this);
+                task4.AddCompletionAction(this);
+
+                if (task1.IsCompleted)
+                {
+                    // If task1 has already completed, Invoke may have tried to remove the continuation from
+                    // each task before task2, task3 and task4 added the continuation, in which case they're now referencing the
+                    // already completed continuation.  To deal with that race condition, explicitly check
+                    // and remove the continuation here.
+                    task2.RemoveContinuation(this);
+                    task3.RemoveContinuation(this);
+                    task4.RemoveContinuation(this);
+                }
+                else if (task2.IsCompleted)
+                {
+                    task3.RemoveContinuation(this);
+                    task4.RemoveContinuation(this);
+                }
+                else if (task3.IsCompleted)
+                {
+                    task4.RemoveContinuation(this);
+                }
+            }
+
+            /// <summary>Completes this task when one of the constituent tasks completes.</summary>
+            public void Invoke(Task completingTask)
+            {
+                Task? task1;
+                if ((task1 = Interlocked.Exchange(ref _task1, null)) != null)
+                {
+                    Task? task2 = _task2;
+                    Task? task3 = _task3;
+                    Task? task4 = _task4;
+                    _task2 = null;
+                    _task3 = null;
+                    _task4 = null;
+
+                    Debug.Assert(task1 != null && task2 != null && task3 != null && task4 != null);
+
+                    if (TplEventSource.Log.IsEnabled())
+                    {
+                        TplEventSource.Log.TraceOperationRelation(this.Id, CausalityRelation.Choice);
+                        TplEventSource.Log.TraceOperationEnd(this.Id, AsyncCausalityStatus.Completed);
+                    }
+
+                    if (s_asyncDebuggingEnabled)
+                    {
+                        RemoveFromActiveTasks(this);
+                    }
+
+                    if (!task1.IsCompleted) task1.RemoveContinuation(this);
+                    if (!task2.IsCompleted) task2.RemoveContinuation(this);
+                    if (!task3.IsCompleted) task3.RemoveContinuation(this);
+                    if (!task4.IsCompleted) task4.RemoveContinuation(this);
 
                     bool success = TrySetResult((TTask)completingTask);
                     Debug.Assert(success, "Only one task should have gotten to this point, and thus this must be successful.");


### PR DESCRIPTION
Mirrors the existing TwoTaskWhenAnyPromise pattern to eliminate the Task[] defensive-copy allocation for Count=3 and Count=4. Count>=5 unchanged.

Closes #126748

## Benchmarks

```

BenchmarkDotNet v0.16.0-nightly.20260320.467, Windows 11 (10.0.26200.8246/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700KF 3.40GHz, 1 CPU, 24 logical and 16 physical cores
Memory: 63.72 GB Total, 53.5 GB Available
.NET SDK 11.0.100-preview.3.26170.106
  [Host]     : .NET 11.0.0 (11.0.0-preview.3.26170.106, 11.0.26.17106), X64 RyuJIT x86-64-v3
  Job-UHUKNN : .NET 11.0.0 (11.0.0-dev, 42.42.42.42424), X64 RyuJIT x86-64-v3
  Job-SVDRLY : .NET 11.0.0 (11.0.0-dev, 42.42.42.42424), X64 RyuJIT x86-64-v3


```
| Method                 | Job        | Toolchain                                                                                                            | Count | Mean      | Error    | StdDev   | Ratio | Allocated | Alloc Ratio |
|----------------------- |----------- |--------------------------------------------------------------------------------------------------------------------- |------ |----------:|---------:|---------:|------:|----------:|------------:|
| **AllCompleted**           | **Job-UHUKNN** | **\runtime-baseline\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe** | **3**     |  **43.07 ns** | **0.447 ns** | **0.396 ns** |  **1.00** |     **136 B** |        **1.00** |
| AllCompleted           | Job-SVDRLY | \runtime\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe          | 3     |  10.39 ns | 0.107 ns | 0.100 ns |  0.24 |      72 B |        0.53 |
|                        |            |                                                                                                                      |       |           |          |          |       |           |             |
| AllPendingThenComplete | Job-UHUKNN | \runtime-baseline\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe | 3     | 147.30 ns | 0.941 ns | 0.881 ns |  1.00 |     584 B |        1.00 |
| AllPendingThenComplete | Job-SVDRLY | \runtime\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe          | 3     | 131.14 ns | 0.867 ns | 0.811 ns |  0.89 |     544 B |        0.93 |
|                        |            |                                                                                                                      |       |           |          |          |       |           |             |
| **AllCompleted**           | **Job-UHUKNN** | **\runtime-baseline\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe** | **4**     |  **44.30 ns** | **0.173 ns** | **0.161 ns** |  **1.00** |     **144 B** |        **1.00** |
| AllCompleted           | Job-SVDRLY | \runtime\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe          | 4     |  10.08 ns | 0.102 ns | 0.090 ns |  0.23 |      72 B |        0.50 |
|                        |            |                                                                                                                      |       |           |          |          |       |           |             |
| AllPendingThenComplete | Job-UHUKNN | \runtime-baseline\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe | 4     | 178.93 ns | 0.897 ns | 0.796 ns |  1.00 |     736 B |        1.00 |
| AllPendingThenComplete | Job-SVDRLY | \runtime\artifacts\bin\testhost\net11.0-windows-Release-x64\shared\Microsoft.NETCore.App\11.0.0\corerun.exe          | 4     | 171.51 ns | 0.694 ns | 0.649 ns |  0.96 |     696 B |        0.95 |


## Benchmark code

```csharp
[MemoryDiagnoser(false)]
public class Perf_WhenAny
{
    [Params(3, 4)]
    public int Count;

    private Task[] _completed = default!;

    [GlobalSetup]
    public void Setup()
    {
        _completed = new Task[Count];
        for (int i = 0; i < Count; i++)
        {
            _completed[i] = Task.CompletedTask;
        }
    }

    [Benchmark]
    public Task AllCompleted() => WhenAnyNoInlining(_completed);

    [Benchmark]
    [MethodImpl(MethodImplOptions.NoInlining)]
    public object AllPendingThenComplete()
    {
        var sources = new TaskCompletionSource<int>[Count];
        var tasks = new Task<int>[Count];
        for (int i = 0; i < Count; i++)
        {
            sources[i] = new TaskCompletionSource<int>();
            tasks[i] = sources[i].Task;
        }

        object result = WhenAnyNoInlining(tasks);
        sources[0].SetResult(0);
        return result;
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    public Task WhenAnyNoInlining(Task[] tasks) => Task.WhenAny(tasks);
}