### PR TITLE
Fix trimming warnings in System.Diagnostics.Process tests

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -391,8 +391,7 @@ namespace System.Diagnostics.Tests
             // To mimic this behaviour, we can't use Environment.SetEnvironmentVariable here as it's case-insensitive on Windows.
             // We also can't use p.StartInfo.Environment as it's comparer is set to OrdinalIgnoreCAse.
             // But we can overwrite it using reflection to mimic the CreateProcess behaviour and avoid having this test call CreateProcess directly.
-            p.StartInfo.Environment
-                .GetType()
+            Type.GetType("System.Collections.Specialized.DictionaryWrapper, System.Diagnostics.Process")!
                 .GetField("_contents", Reflection.BindingFlags.NonPublic | Reflection.BindingFlags.Instance)
                 .SetValue(p.StartInfo.Environment, envVars);
 

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -960,8 +960,7 @@ namespace System.Diagnostics.Tests
 
         private static IDictionary GetWaitStateDictionary(bool childDictionary)
         {
-            Assembly assembly = typeof(Process).Assembly;
-            Type waitStateType = assembly.GetType("System.Diagnostics.ProcessWaitState");
+            Type waitStateType = Type.GetType("System.Diagnostics.ProcessWaitState, System.Diagnostics.Process")!;
             FieldInfo dictionaryField = waitStateType.GetField(childDictionary ? "s_childProcessWaitStates" : "s_processWaitStates", BindingFlags.NonPublic | BindingFlags.Static);
             return (IDictionary)dictionaryField.GetValue(null);
         }
@@ -974,7 +973,8 @@ namespace System.Diagnostics.Tests
 
         private static int GetWaitStateReferenceCount(object waitState)
         {
-            FieldInfo referenCountField = waitState.GetType().GetField("_outstandingRefCount", BindingFlags.NonPublic | BindingFlags.Instance);
+            FieldInfo referenCountField = Type.GetType("System.Diagnostics.ProcessWaitState, System.Diagnostics.Process")!
+                .GetField("_outstandingRefCount", BindingFlags.NonPublic | BindingFlags.Instance);
             return (int)referenCountField.GetValue(waitState);
         }
 

--- a/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
+++ b/src/libraries/System.Diagnostics.Process/tests/System.Diagnostics.Process.Tests.csproj
@@ -5,8 +5,6 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-android;$(NetCoreAppCurrent)-maccatalyst</TargetFrameworks>
     <IgnoreForCI Condition="'$(TargetOS)' == 'browser'">true</IgnoreForCI>
-    <!-- https://github.com/dotnet/runtime/issues/126862 -->
-    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
   </PropertyGroup>
   <!-- DesignTimeBuild requires all the TargetFramework Derived Properties to not be present in the first property group. -->
   <PropertyGroup>


### PR DESCRIPTION
Replace obj.GetType().GetField(...) and assembly.GetType(...) with Type.GetType("FullName, AssemblyName") patterns that the trim analyzer can statically analyze. Re-enable the trim analyzer in the test project.