### PR TITLE
Mark Continuation field accessors as `AggressiveInlining`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -111,6 +111,7 @@ namespace System.Runtime.CompilerServices
 
         // See note in ContinuationFlags above for the computation of these offsets.
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public unsafe object GetContinuationContext()
         {
             const uint mask = (1u << (int)ContinuationFlags.ContinuationContextIndexNumBits) - 1;
@@ -120,6 +121,7 @@ namespace System.Runtime.CompilerServices
             return Unsafe.As<byte, object>(ref Unsafe.Add(ref data, (DataOffset - PointerSize) + index * PointerSize));
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool HasException()
         {
             const uint mask = (1u << (int)ContinuationFlags.ExceptionIndexNumBits) - 1;
@@ -135,6 +137,7 @@ namespace System.Runtime.CompilerServices
             Unsafe.As<byte, Exception>(ref Unsafe.Add(ref data, (DataOffset - PointerSize) + index * PointerSize)) = ex;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ref byte GetResultStorageOrNull()
         {
             const uint mask = (1u << (int)ContinuationFlags.ResultIndexNumBits) - 1;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -128,6 +128,7 @@ namespace System.Runtime.CompilerServices
             return ((uint)Flags & (mask << (int)ContinuationFlags.ExceptionIndexFirstBit)) != 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void SetException(Exception ex)
         {
             const uint mask = (1u << (int)ContinuationFlags.ExceptionIndexNumBits) - 1;


### PR DESCRIPTION
The intrinsic-heavy code appears big to the JIT, but in reality expands to just a handful of instructions. These were not getting inlined before.