### PR TITLE
Fix AsyncInstrumentation to honor s_asyncDebuggingEnabled

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -107,6 +107,15 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsUninitialized(s_activeFlags))
                 {
+                    // The debugger may have set Task.s_asyncDebuggingEnabled directly via ICorDebug
+                    // before any ETW session is established. In that case, s_asyncDebuggerActiveFlags
+                    // will still be Disabled because OnEventCommand was never called. Honor the
+                    // debugger's request by enabling default flags when s_asyncDebuggingEnabled is set.
+                    if (s_asyncDebuggerActiveFlags == Flags.Disabled && Task.s_asyncDebuggingEnabled)
+                    {
+                        s_asyncDebuggerActiveFlags = DefaultFlags | Flags.AsyncDebugger;
+                    }
+
                     s_activeFlags = s_asyncProfilerActiveFlags | s_asyncDebuggerActiveFlags;
                 }
 


### PR DESCRIPTION
When the debugger sets Task.s_asyncDebuggingEnabled directly via ICorDebug (SetManagedTaskEtwEventsEnabled), the AsyncInstrumentation flags system added by PR #126091 was not aware of this. The new flags only got set via ETW OnEventCommand, so non-ETW RuntimeAsync configs had s_asyncDebuggerActiveFlags stuck at Disabled, preventing NotifyDebuggerOfRuntimeAsyncState from being called.

Fix: In InitializeFlags(), check Task.s_asyncDebuggingEnabled as a fallback when s_asyncDebuggerActiveFlags is still Disabled. This ensures the debugger's request is honored regardless of whether ETW events have been enabled.