### PR TITLE
Fix flaky RegularExpressionAttribute timeout test

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/RegularExpressionAttributeTests.cs
@@ -78,7 +78,7 @@ namespace System.ComponentModel.DataAnnotations.Tests
         public static void Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException()
         {
             RegularExpressionAttribute attribute = new RegularExpressionAttribute("(a[ab]+)+$") { MatchTimeoutInMilliseconds = 1 };
-            Assert.Throws<RegexMatchTimeoutException>(() => attribute.Validate("aaaaaaaaaaaaaaaaaaaaaaaaaaaa>", new ValidationContext(new object())));
+            Assert.Throws<RegexMatchTimeoutException>(() => attribute.Validate(new string('a', 100) + ">", new ValidationContext(new object())));
         }
 
         [Fact]


### PR DESCRIPTION
Fix flaky RegularExpressionAttribute timeout test

Rare CI failure in `RegularExpressionAttributeTests.Validate_MatchingTimesOut_ThrowsRegexMatchTimeoutException`:

```
Assert.Throws() Failure: Exception type was not an exact match
Expected: typeof(System.Text.RegularExpressions.RegexMatchTimeoutException)
Actual:   typeof(System.ComponentModel.DataAnnotations.ValidationException)
---- System.ComponentModel.DataAnnotations.ValidationException : The field Object must match the regular expression '(a[ab]+)+$'.
```

The test uses pattern `(a[ab]+)+$` with a 1ms timeout, expecting catastrophic backtracking to cause a `RegexMatchTimeoutException`. The input was a hardcoded 28-character string (`"aaaaaaaaaaaaaaaaaaaaaaaaaaaa>"`). With regex engine improvements, the backtracking sometimes completes within the 1ms timeout window before the timeout check fires. When that happens, `IsValid()` returns `false` (no match) and `Validate()` wraps it as a `ValidationException` instead of the expected `RegexMatchTimeoutException`.

The fix increases the input length from 28 to 100 characters (`new string('a', 100) + ">"`), making the exponential backtracking work (O(2^n)) large enough that the 1ms timeout is reliably exceeded.

> [!NOTE]
> This change was AI-generated with GitHub Copilot.
