### PR TITLE
Fix x64 data breakpoint handling after CORINFO_HELP_ARRADDR_ST inlining

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -9709,7 +9709,8 @@ bool DebuggerContinuableExceptionBreakpoint::SendEvent(Thread *thread, bool fIpC
             {
                 LOG((LF_CORDB, LL_INFO10000, "D::DDBP: HIT DATA BREAKPOINT INSIDE WRITE BARRIER...\n"));
                 DebuggerDataBreakpoint *pDataBreakpoint = new (interopsafe) DebuggerDataBreakpoint(thread);
-                pDataBreakpoint->AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE*)GetIP(&contextToAdjust), FramePointer::MakeFramePointer(GetFP(&contextToAdjust)), true, DPT_DEFAULT_TRACE_TYPE);
+                // Use LEAF_MOST_FRAME to bypass the frame pointer check in MatchPatch.
+                pDataBreakpoint->AddAndActivateNativePatchForAddress((CORDB_ADDRESS_TYPE*)GetIP(&contextToAdjust), LEAF_MOST_FRAME, true, DPT_DEFAULT_TRACE_TYPE);
             }
             else
             {

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5491,6 +5491,46 @@ AdjustContextForJITHelpers(
         if (IsIPInMarkedJitHelper(ip))
         {
             Thread::VirtualUnwindToFirstManagedCallFrame(pContext);
+
+            // After unwinding from the native write barrier to the first managed frame, check
+            // whether that frame is a managed helper that itself called the write barrier and
+            // keep unwinding until we reach user code.
+            //
+            // CastHelpers.StelemRef (CORINFO_HELP_ARRADDR_ST) and its callees StelemRef_Helper
+            // and StelemRef_Helper_NoCacheLookup all call RuntimeHelpers.WriteBarrier. The call
+            // chain can be up to 3 levels deep:
+            //   user -> StelemRef -> StelemRef_Helper -> StelemRef_Helper_NoCacheLookup -> WriteBarrier
+            //
+            // Prior to the change that inlined CORINFO_HELP_ARRADDR_ST, StelemRef tail-called
+            // the write barrier so its frame was already destroyed and the unwind went directly
+            // to user code. With a regular call, the StelemRef family frames remain on the stack.
+            //
+            // We identify these helpers by their MethodTable (CastHelpers class), which is stable
+            // across tiered recompilation.
+            static MethodTable* s_pCastHelpersMT = nullptr;
+            while (true)
+            {
+                PCODE currentIP = GetIP(pContext);
+                if (!ExecutionManager::IsManagedCode(currentIP))
+                    break;
+
+                EECodeInfo codeInfo(currentIP);
+                if (!codeInfo.IsValid())
+                    break;
+
+                MethodDesc* pMD = codeInfo.GetMethodDesc();
+                if (pMD == nullptr)
+                    break;
+
+                if (s_pCastHelpersMT == nullptr)
+                    s_pCastHelpersMT = CoreLibBinder::GetExistingClass(CLASS__CASTHELPERS);
+
+                if (pMD->GetMethodTable() != s_pCastHelpersMT)
+                    break;
+
+                Thread::VirtualUnwindCallFrame(pContext);
+            }
+
             return TRUE;
         }
 #else

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -5491,46 +5491,6 @@ AdjustContextForJITHelpers(
         if (IsIPInMarkedJitHelper(ip))
         {
             Thread::VirtualUnwindToFirstManagedCallFrame(pContext);
-
-            // After unwinding from the native write barrier to the first managed frame, check
-            // whether that frame is a managed helper that itself called the write barrier and
-            // keep unwinding until we reach user code.
-            //
-            // CastHelpers.StelemRef (CORINFO_HELP_ARRADDR_ST) and its callees StelemRef_Helper
-            // and StelemRef_Helper_NoCacheLookup all call RuntimeHelpers.WriteBarrier. The call
-            // chain can be up to 3 levels deep:
-            //   user -> StelemRef -> StelemRef_Helper -> StelemRef_Helper_NoCacheLookup -> WriteBarrier
-            //
-            // Prior to the change that inlined CORINFO_HELP_ARRADDR_ST, StelemRef tail-called
-            // the write barrier so its frame was already destroyed and the unwind went directly
-            // to user code. With a regular call, the StelemRef family frames remain on the stack.
-            //
-            // We identify these helpers by their MethodTable (CastHelpers class), which is stable
-            // across tiered recompilation.
-            static MethodTable* s_pCastHelpersMT = nullptr;
-            while (true)
-            {
-                PCODE currentIP = GetIP(pContext);
-                if (!ExecutionManager::IsManagedCode(currentIP))
-                    break;
-
-                EECodeInfo codeInfo(currentIP);
-                if (!codeInfo.IsValid())
-                    break;
-
-                MethodDesc* pMD = codeInfo.GetMethodDesc();
-                if (pMD == nullptr)
-                    break;
-
-                if (s_pCastHelpersMT == nullptr)
-                    s_pCastHelpersMT = CoreLibBinder::GetExistingClass(CLASS__CASTHELPERS);
-
-                if (pMD->GetMethodTable() != s_pCastHelpersMT)
-                    break;
-
-                Thread::VirtualUnwindCallFrame(pContext);
-            }
-
             return TRUE;
         }
 #else


### PR DESCRIPTION
After #126547, the WriteBarrier FCall was converted from native (FCall) to managed.  This affected the debugger's unwind logic for data breakpoint handling (AdjustContextForJITHelpersForDebugger) resulting in the debugger to unwind into  the JIT helper (CastHelpers.StelemRef) rather than user code.  

The fix adds a loop after the initial unwind that checks whether the landed-on frame belongs to the CastHelpers
class and continues unwinding until it reaches user code. This only affects x64 data breakpoints, as x86 does a raw single-frame stack pop (restores EIP from ESP) rather than VirtualUnwindToFirstManagedCallFrame, so it was unaffected.  ARM64 does not support data breakpoints.