### PR TITLE
Make PrepareTrimConfiguration a public extension point

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -3,7 +3,7 @@
   <Target Name="_ComputeIlcCompileInputs"
           Condition="'$(BuildingFrameworkLibrary)' != 'true'"
           BeforeTargets="ComputeIlcCompileInputs"
-          DependsOnTargets="$(IlcDynamicBuildPropertyDependencies);_ComputeAssembliesToCompileToNative;_PrepareTrimConfiguration">
+          DependsOnTargets="$(IlcDynamicBuildPropertyDependencies);_ComputeAssembliesToCompileToNative;PrepareTrimConfiguration">
 
     <ItemGroup>
       <_IlcManagedInputAssemblies Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.PostprocessAssembly)' == 'true'" />
@@ -24,7 +24,7 @@
     The SDK typically sequences this target in the publish pipeline as:
       ComputeResolvedFilesToPublishList -> ILLink (when RunILLink is true) -> NativeCompile -> ...
 
-    This gives us a clean, explicit position after trim configuration (_PrepareTrimConfiguration),
+    This gives us a clean, explicit position after trim configuration (PrepareTrimConfiguration),
     regardless of whether ILLink itself runs.
     ============================================================
   -->
@@ -84,7 +84,7 @@
   <UsingTask TaskName="ComputeManagedAssembliesToCompileToNative" AssemblyFile="$(IlcBuildTasksPath)" />
   <Target Name="_ComputeAssembliesToCompileToNative"
           DependsOnTargets="$(IlcDynamicBuildPropertyDependencies);_ComputeAssembliesToPostprocessOnPublish"
-          BeforeTargets="_PrepareTrimConfiguration">
+          BeforeTargets="PrepareTrimConfiguration">
 
     <Warning Condition="Exists($(UserRuntimeConfig))" Text="The published project has a runtimeconfig.template.json that is not supported by PublishAot. Move the configuration to the project file using RuntimeHostConfigurationOption." />
     <!-- Fail with descriptive error message for common mistake. -->

--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -195,7 +195,7 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                     _PrepareTrimConfiguration
+                     PrepareTrimConfiguration
 
     Set up shared trim configuration properties and metadata on ResolvedFileToPublish.
     This target is shared between ILLink and ILC (NativeAOT). It sets default values for
@@ -203,11 +203,15 @@ Copyright (c) .NET Foundation. All rights reserved.
     and _TrimmerFeatureSettings, and applies TrimmerSingleWarn metadata to
     ResolvedFileToPublish items for the intermediate assembly and project references.
 
+    This is a public extension point. Other targets may hook into it via
+    BeforeTargets="PrepareTrimConfiguration" to add RuntimeHostConfigurationOption items
+    that will be included in _TrimmerFeatureSettings for both ILLink and ILC.
+
     Consumers that need trim metadata on ResolvedFileToPublish should depend on this target.
     Metadata set here flows to ManagedAssemblyToLink via _ComputeManagedAssemblyToLink (which
     depends on this target), since ComputeManagedAssemblies preserves metadata from its inputs.
    -->
-   <Target Name="_PrepareTrimConfiguration"
+   <Target Name="PrepareTrimConfiguration"
            DependsOnTargets="_ComputeAssembliesToPostprocessOnPublish">
 
     <!-- Set up TrimMode. -->
@@ -335,7 +339,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <UsingTask TaskName="ComputeManagedAssemblies" AssemblyFile="$(ILLinkTasksAssembly)" Condition="'$(ILLinkTasksAssembly)' != ''" TaskFactory="TaskHostFactory" />
-  <Target Name="_ComputeManagedAssemblyToLink" DependsOnTargets="_PrepareTrimConfiguration">
+  <Target Name="_ComputeManagedAssemblyToLink" DependsOnTargets="PrepareTrimConfiguration">
 
     <!-- NB: There should not be non-managed assemblies in this list, but we still give the ILLink a chance to
          further refine this list. It currently drops C++/CLI assemblies in ComputeManageAssemblies. -->

--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -204,8 +204,9 @@ Copyright (c) .NET Foundation. All rights reserved.
     ResolvedFileToPublish items for the intermediate assembly and project references.
 
     This is a public extension point. Other targets may hook into it via
-    BeforeTargets="PrepareTrimConfiguration" to add RuntimeHostConfigurationOption items
-    that will be included in _TrimmerFeatureSettings for both ILLink and ILC.
+    BeforeTargets="PrepareTrimConfiguration" to add RuntimeHostConfigurationOption items.
+    Only items with Trim="true" metadata will be included in _TrimmerFeatureSettings
+    for both ILLink and ILC.
 
     Consumers that need trim metadata on ResolvedFileToPublish should depend on this target.
     Metadata set here flows to ManagedAssemblyToLink via _ComputeManagedAssemblyToLink (which


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from AI.

## Summary

Rename `_PrepareTrimConfiguration` to `PrepareTrimConfiguration` so that external SDKs can hook `BeforeTargets="PrepareTrimConfiguration"` to add `RuntimeHostConfigurationOption` items before they are snapshotted into `_TrimmerFeatureSettings`.

## Problem

PR #124801 extracted the `RuntimeHostConfigurationOption` → `_TrimmerFeatureSettings` conversion from `PrepareForILLink` into a new internal target `_PrepareTrimConfiguration`. This target runs as a transitive dependency of `PrepareForILLink` (via `_ComputeManagedAssemblyToLink`), so it executes *before* `BeforeTargets="PrepareForILLink"` hooks fire.

MAUI adds its feature switches (e.g. `IsHybridWebViewSupported`) via `BeforeTargets="PrepareForILLink"`. After #124801, these items arrive after `_PrepareTrimConfiguration` has already snapshotted `RuntimeHostConfigurationOption` into `_TrimmerFeatureSettings`. As a result, ILC never receives `--feature` flags for MAUI's switches on Android NativeAOT (where `RunILLink=true`), causing spurious IL3050 warnings.

## Fix

Make `PrepareTrimConfiguration` a public target so SDKs have a stable, intentional hook point for adding feature switch configuration that flows to both ILLink and ILC. MAUI (and other SDKs) can then use `BeforeTargets="PrepareTrimConfiguration"` to add their `RuntimeHostConfigurationOption` items before the snapshot.

## Verified

Tested with a MAUI Android NativeAOT app:
- **Before**: `--feature:Microsoft.Maui.RuntimeFeature.IsHybridWebViewSupported=false` missing from ILC rsp → IL3050 emitted
- **After**: `--feature` flag present → IL3050 suppressed by FeatureGuard

Fixes #127017

cc @sbomer @simonrozsival