### PR TITLE
Fixes some theoretical races and retentions in AsyncOperation and ManualResetValueTaskSource

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -53,10 +53,7 @@ namespace System.Threading.Tasks.Sources
             // The outer user always ensures that the state is not accessed across
             // the reset point when implementing Rent/Return operations.
             _version++;
-            Debug.Assert(_continuation == null || IsCompleted);
             _continuation = null;
-            Debug.Assert(_continuationState == null);
-            Debug.Assert(_capturedContext == null);
             _continuationState = null;
             _capturedContext = null;
             _error = null;
@@ -232,9 +229,7 @@ namespace System.Threading.Tasks.Sources
                 ThrowHelper.ThrowInvalidOperationException();
             }
 
-            Action<object?>? continuation =
-                Volatile.Read(ref _continuation) ??
-                Interlocked.CompareExchange(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel, null);
+            Action<object?>? continuation = Interlocked.Exchange(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel);
 
             if (continuation is not null)
             {
@@ -242,10 +237,6 @@ namespace System.Threading.Tasks.Sources
                 _continuationState = null;
                 object? context = _capturedContext;
                 _capturedContext = null;
-                // NB: this write must happen after setting result/error, but
-                //     _continuation is set to not-null via CAS after setting result/error,
-                //     and this write is after that.
-                _continuation = ManualResetValueTaskSourceCoreShared.s_sentinel;
 
                 if (context is null)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -34,8 +34,6 @@ namespace System.Threading.Tasks.Sources
         private TResult? _result;
         /// <summary>The current version of this value, used to help prevent misuse.</summary>
         private short _version;
-        /// <summary>Whether the current operation has completed.</summary>
-        private bool _completed;
         /// <summary>Whether to force continuations to run asynchronously.</summary>
         private bool _runContinuationsAsynchronously;
 
@@ -51,13 +49,18 @@ namespace System.Threading.Tasks.Sources
         public void Reset()
         {
             // Reset/update state for the next use/await of this instance.
+            // Order of assignments is unimportant here.
+            // The outer user always ensures that the state is not accessed across
+            // reset point by when implementing Rent/Return operations.
             _version++;
+            Debug.Assert(_continuation == null || IsCompleted);
             _continuation = null;
+            Debug.Assert(_continuationState == null);
+            Debug.Assert(_capturedContext == null);
             _continuationState = null;
             _capturedContext = null;
             _error = null;
             _result = default;
-            _completed = false;
         }
 
         /// <summary>Completes with a successful result.</summary>
@@ -79,13 +82,16 @@ namespace System.Threading.Tasks.Sources
         /// <summary>Gets the operation version.</summary>
         public short Version => _version;
 
+        /// <summary>Gets whether the operation has completed.</summary>
+        internal bool IsCompleted => ReferenceEquals(Volatile.Read(ref _continuation), ManualResetValueTaskSourceCoreShared.s_sentinel);
+
         /// <summary>Gets the status of the operation.</summary>
         /// <param name="token">Opaque value that was provided to the <see cref="ValueTask"/>'s constructor.</param>
         public ValueTaskSourceStatus GetStatus(short token)
         {
             ValidateToken(token);
             return
-                Volatile.Read(ref _continuation) is null || !_completed ? ValueTaskSourceStatus.Pending :
+                !IsCompleted ? ValueTaskSourceStatus.Pending :
                 _error is null ? ValueTaskSourceStatus.Succeeded :
                 _error.SourceException is OperationCanceledException ? ValueTaskSourceStatus.Canceled :
                 ValueTaskSourceStatus.Faulted;
@@ -96,7 +102,7 @@ namespace System.Threading.Tasks.Sources
         [StackTraceHidden]
         public TResult GetResult(short token)
         {
-            if (token != _version || !_completed || _error is not null)
+            if (token != _version || !IsCompleted || _error is not null)
             {
                 ThrowForFailedGetResult();
             }
@@ -125,6 +131,17 @@ namespace System.Threading.Tasks.Sources
             }
             ValidateToken(token);
 
+            // We need to store the state before the CompareExchange, so that if it completes immediately
+            // after the CompareExchange, it'll find the state already stored.  If someone misuses this
+            // and schedules multiple continuations erroneously, we could end up using the wrong state.
+            // Make a best-effort attempt to catch such misuse.
+            if (_continuationState is not null)
+            {
+                ThrowHelper.ThrowInvalidOperationException();
+            }
+            _continuationState = state;
+
+            Debug.Assert(_capturedContext is null);
             if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) != 0)
             {
                 _capturedContext = ExecutionContext.Capture();
@@ -151,35 +168,36 @@ namespace System.Threading.Tasks.Sources
                 }
             }
 
-            // We need to set the continuation state before we swap in the delegate, so that
-            // if there's a race between this and SetResult/Exception and SetResult/Exception
-            // sees the _continuation as non-null, it'll be able to invoke it with the state
-            // stored here.  However, this also means that if this is used incorrectly (e.g.
-            // awaited twice concurrently), _continuationState might get erroneously overwritten.
-            // To minimize the chances of that, we check preemptively whether _continuation
-            // is already set to something other than the completion sentinel.
-            object? storedContinuation = _continuation;
-            if (storedContinuation is null)
+            // Try to set the provided continuation into _continuation.  If this succeeds, that means the operation
+            // has not yet completed, and the completer will be responsible for invoking the callback.  If this fails,
+            // that means the operation has already completed, and we must invoke the callback, but because we're still
+            // inside the awaiter's OnCompleted method and we want to avoid possible stack dives, we must invoke
+            // the continuation asynchronously rather than synchronously.
+            Action<object?>? prevContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
+            if (prevContinuation is null)
             {
-                _continuationState = state;
-                storedContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
-                if (storedContinuation is null)
-                {
-                    // Operation hadn't already completed, so we're done. The continuation will be
-                    // invoked when SetResult/Exception is called at some later point.
-                    return;
-                }
+                // Operation hadn't already completed, so we're done. The continuation will be
+                // invoked when SetResult/Exception is called at some later point.
+                return;
             }
 
-            // Operation already completed, so we need to queue the supplied callback.
-            // At this point the storedContinuation should be the sentinal; if it's not, the instance was misused.
-            Debug.Assert(storedContinuation is not null, $"{nameof(storedContinuation)} is null");
-            if (!ReferenceEquals(storedContinuation, ManualResetValueTaskSourceCoreShared.s_sentinel))
+            // Queue the continuation.  We always queue here, even if !RunContinuationsAsynchronously, in order
+            // to avoid stack diving; this path happens in the rare race when we're setting up to await and the
+            // object is completed after the awaiter.IsCompleted but before the awaiter.OnCompleted.
+
+            // We no longer need the stored values as we will be passing the state when queuing directly
+            _continuationState = null;
+            object? capturedContext = _capturedContext;
+            _capturedContext = null;
+
+            // If the set failed because there's already a delegate in _continuation, but that delegate is
+            // something other than the completion sentinel, something went wrong, which should only happen if
+            // the instance was erroneously used, likely to hook up multiple continuations.
+            if (!ReferenceEquals(prevContinuation, ManualResetValueTaskSourceCoreShared.s_sentinel))
             {
                 ThrowHelper.ThrowInvalidOperationException();
             }
 
-            object? capturedContext = _capturedContext;
             switch (capturedContext)
             {
                 case null:
@@ -209,11 +227,10 @@ namespace System.Threading.Tasks.Sources
         /// <summary>Signals that the operation has completed.  Invoked after the result or error has been set.</summary>
         private void SignalCompletion()
         {
-            if (_completed)
+            if (IsCompleted)
             {
                 ThrowHelper.ThrowInvalidOperationException();
             }
-            _completed = true;
 
             Action<object?>? continuation =
                 Volatile.Read(ref _continuation) ??

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -225,6 +225,7 @@ namespace System.Threading.Tasks.Sources
                 _continuationState = null;
                 object? context = _capturedContext;
                 _capturedContext = null;
+                _continuation = ManualResetValueTaskSourceCoreShared.s_sentinel;
 
                 if (context is null)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -242,7 +242,10 @@ namespace System.Threading.Tasks.Sources
                 _continuationState = null;
                 object? context = _capturedContext;
                 _capturedContext = null;
-                Volatile.Write(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel);
+                // NB: this write must happen after setting result/error, but
+                //     _continuation is set to not-null via CAS after setting result/error,
+                //     and this write is after that.
+                _continuation = ManualResetValueTaskSourceCoreShared.s_sentinel;
 
                 if (context is null)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -51,7 +51,7 @@ namespace System.Threading.Tasks.Sources
             // Reset/update state for the next use/await of this instance.
             // Order of assignments is unimportant here.
             // The outer user always ensures that the state is not accessed across
-            // reset point by when implementing Rent/Return operations.
+            // the reset point when implementing Rent/Return operations.
             _version++;
             Debug.Assert(_continuation == null || IsCompleted);
             _continuation = null;
@@ -242,7 +242,7 @@ namespace System.Threading.Tasks.Sources
                 _continuationState = null;
                 object? context = _capturedContext;
                 _capturedContext = null;
-                _continuation = ManualResetValueTaskSourceCoreShared.s_sentinel;
+                Volatile.Write(ref _continuation, ManualResetValueTaskSourceCoreShared.s_sentinel);
 
                 if (context is null)
                 {

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -491,6 +491,8 @@ namespace System.Threading.Channels
         internal virtual void ClearRetainedState()
         {
             _error = null;
+            Debug.Assert((object?)Next == null);
+            Debug.Assert((object?)Previous == null);
             Debug.Assert(_continuationState == null);
             Debug.Assert(_capturedContext == null);
         }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -139,7 +139,7 @@ namespace System.Threading.Channels
 #endif
 
         /// <summary>Gets whether the operation has completed.</summary>
-        internal bool IsCompleted => ReferenceEquals(_continuation, s_completedSentinel);
+        internal bool IsCompleted => ReferenceEquals(Volatile.Read(ref _continuation), s_completedSentinel);
 
         /// <summary>Completes the operation with a failed state and the specified error.</summary>
         /// <param name="exception">The error.</param>
@@ -267,12 +267,13 @@ namespace System.Threading.Channels
             Debug.Assert(_continuation is not null);
 
             object? ctx = _capturedContext;
+            _capturedContext = null;
+
             ExecutionContext? ec =
                 ctx is null ? null :
                 ctx as ExecutionContext ??
                 (ctx as CapturedSchedulerAndExecutionContext)?._executionContext;
 
-            _capturedContext = null;
             if (ec is null)
             {
                 Action<object?> c = _continuation!;
@@ -359,43 +360,52 @@ namespace System.Threading.Channels
             // inside the awaiter's OnCompleted method and we want to avoid possible stack dives, we must invoke
             // the continuation asynchronously rather than synchronously.
             Action<object?>? prevContinuation = Interlocked.CompareExchange(ref _continuation, continuation, null);
-            if (prevContinuation is not null)
+            if (prevContinuation is null)
             {
-                // If the set failed because there's already a delegate in _continuation, but that delegate is
-                // something other than s_completedSentinel, something went wrong, which should only happen if
-                // the instance was erroneously used, likely to hook up multiple continuations.
-                Debug.Assert(IsCompleted, $"Expected IsCompleted");
-                if (!ReferenceEquals(prevContinuation, s_completedSentinel))
-                {
-                    Debug.Assert(prevContinuation != s_availableSentinel, "Continuation was the available sentinel.");
-                    ThrowMultipleContinuations();
-                }
+                // Operation hadn't already completed, so we're done. The continuation will be
+                // invoked when SetResult/Exception is called at some later point.
+                return;
+            }
 
-                // Queue the continuation.  We always queue here, even if !RunContinuationsAsynchronously, in order
-                // to avoid stack diving; this path happens in the rare race when we're setting up to await and the
-                // object is completed after the awaiter.IsCompleted but before the awaiter.OnCompleted.
-                if (_capturedContext is null)
+            // Queue the continuation.  We always queue here, even if !RunContinuationsAsynchronously, in order
+            // to avoid stack diving; this path happens in the rare race when we're setting up to await and the
+            // object is completed after the awaiter.IsCompleted but before the awaiter.OnCompleted.
+
+            // We no longer need the stored values as we will be passing the state when queuing directly
+            _continuationState = null;
+            object? capturedContext = _capturedContext;
+            _capturedContext = null;
+
+            // If the set failed because there's already a delegate in _continuation, but that delegate is
+            // something other than the completion sentinel, something went wrong, which should only happen if
+            // the instance was erroneously used, likely to hook up multiple continuations.
+            Debug.Assert(prevContinuation != s_availableSentinel, "Continuation was the available sentinel.");
+            Debug.Assert(IsCompleted, $"Expected IsCompleted");
+            if (!ReferenceEquals(prevContinuation, s_completedSentinel))
+            {
+                ThrowMultipleContinuations();
+            }
+
+            if (capturedContext is null)
+            {
+                ChannelUtilities.UnsafeQueueUserWorkItem(continuation, state);
+            }
+            else if (sc is not null)
+            {
+                sc.Post(static s =>
                 {
-                    ChannelUtilities.UnsafeQueueUserWorkItem(continuation, state);
-                }
-                else if (sc is not null)
-                {
-                    sc.Post(static s =>
-                    {
-                        var t = (KeyValuePair<Action<object?>, object?>)s!;
-                        t.Key(t.Value);
-                    }, new KeyValuePair<Action<object?>, object?>(continuation, state));
-                }
-                else if (ts is not null)
-                {
-                    Debug.Assert(ts is not null);
-                    Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
-                }
-                else
-                {
-                    Debug.Assert(_capturedContext is ExecutionContext);
-                    ChannelUtilities.QueueUserWorkItem(continuation, state);
-                }
+                    var t = (KeyValuePair<Action<object?>, object?>)s!;
+                    t.Key(t.Value);
+                }, new KeyValuePair<Action<object?>, object?>(continuation, state));
+            }
+            else if (ts is not null)
+            {
+                Task.Factory.StartNew(continuation, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach, ts);
+            }
+            else
+            {
+                Debug.Assert(capturedContext is ExecutionContext);
+                ChannelUtilities.QueueUserWorkItem(continuation, state);
             }
         }
 
@@ -470,10 +480,19 @@ namespace System.Threading.Channels
 
             if (_pooled)
             {
-                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
+                ClearRetainedState();
+                // enable reuse only after fetching all needed data
+                Volatile.Write(ref _continuation, s_availableSentinel);
             }
 
             error?.Throw();
+        }
+
+        internal virtual void ClearRetainedState()
+        {
+            _error = null;
+            Debug.Assert(_continuationState == null);
+            Debug.Assert(_capturedContext == null);
         }
     }
 
@@ -515,11 +534,19 @@ namespace System.Threading.Channels
 
             if (_pooled)
             {
-                Volatile.Write(ref _continuation, s_availableSentinel); // only after fetching all needed data
+                ClearRetainedState();
+                // enable reuse only after fetching all needed data
+                Volatile.Write(ref _continuation, s_availableSentinel);
             }
 
             error?.Throw();
             return result!;
+        }
+
+        internal override void ClearRetainedState()
+        {
+            base.ClearRetainedState();
+            _result = default;
         }
 
         /// <summary>Attempts to take ownership of the pooled instance.</summary>
@@ -529,10 +556,6 @@ namespace System.Threading.Channels
             Debug.Assert(_pooled, "Should only be used for pooled objects");
             if (ReferenceEquals(Interlocked.CompareExchange(ref _continuation, null, s_availableSentinel), s_availableSentinel))
             {
-                _continuationState = null;
-                _result = default;
-                _error = null;
-                _capturedContext = null;
                 return true;
             }
 


### PR DESCRIPTION
Possibly fixes: #127234  
- Completion asserts because it sees `AsyncOperation` in already completed state, very rarely on ARM64. Seems like an ordering issue, since it is on ARM64. 
I see one case where it seems we miss a fence. Not sure if it is related. The actual failure is very hard to repro on purpose.

Possibly fixes: #126735 
- Test observes object rooting on runtime async.

While logically runtime async captures the same state, there are some implementation details like in the `{_continuation, _continuationState}` tuple, the continuation may retain less, but _state_ may retain more, compared to regular async. There are code paths that clear continuation, but do not clear the state, thus can observe the difference. 
We should fix that regardless, even if #126735 is caused by something else.

The main idea is that continuation/state are needed only until the continuation runs. Retaining longer than that in poolable/reusable containers (i.e. until container is reused) can potentially lead to observable issues like last used connection not disposing/closing if no further activity in the app. 

Same applies to the captured context - as soon as we do not need it, it would not hurt to clear fields holding to the context. No problem was observed due to this, but just in case...

This PR also makes AsyncOperation and ManualResetValueTaskSource to be slightly more similar. Mostly by using the completion sentinel as the only way to signal completion + some minor tweaks, cross-copying comments,...