### PR TITLE
[NET] Add Video sub-class to MediaTypeNames with common video MIME types

### DIFF
--- a/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
+++ b/src/libraries/System.Net.Mail/ref/System.Net.Mail.cs
@@ -384,6 +384,14 @@ namespace System.Net.Mime
             public const string Rtf = "text/rtf";
             public const string Xml = "text/xml";
         }
+        public static partial class Video
+        {
+            public const string Mp4 = "video/mp4";
+            public const string Mpeg = "video/mpeg";
+            public const string Ogg = "video/ogg";
+            public const string QuickTime = "video/quicktime";
+            public const string Webm = "video/webm";
+        }
     }
     public static partial class MediaTypeMap
     {

--- a/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mime/MediaTypeNames.cs
@@ -165,5 +165,24 @@ namespace System.Net.Mime
             /// <summary>Specifies that the <see cref="MediaTypeNames.Text"/> data is in XML format.</summary>
             public const string Xml = "text/xml";
         }
+
+        /// <summary>Specifies the kind of video data in an email message attachment.</summary>
+        public static class Video
+        {
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Video"/> data is in MP4 format.</summary>
+            public const string Mp4 = "video/mp4";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Video"/> data is in MPEG format.</summary>
+            public const string Mpeg = "video/mpeg";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Video"/> data is in Ogg format.</summary>
+            public const string Ogg = "video/ogg";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Video"/> data is in QuickTime format.</summary>
+            public const string QuickTime = "video/quicktime";
+
+            /// <summary>Specifies that the <see cref="MediaTypeNames.Video"/> data is in WebM format.</summary>
+            public const string Webm = "video/webm";
+        }
     }
 }

--- a/src/libraries/System.Net.Mail/tests/Unit/MediaTypeNamesVideoTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Unit/MediaTypeNamesVideoTest.cs
@@ -1,0 +1,21 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Net.Mime.Tests
+{
+    public class MediaTypeNamesVideoTest
+    {
+        [Theory]
+        [InlineData(MediaTypeNames.Video.Mp4, "video/mp4")]
+        [InlineData(MediaTypeNames.Video.Mpeg, "video/mpeg")]
+        [InlineData(MediaTypeNames.Video.Ogg, "video/ogg")]
+        [InlineData(MediaTypeNames.Video.QuickTime, "video/quicktime")]
+        [InlineData(MediaTypeNames.Video.Webm, "video/webm")]
+        public void VideoMediaTypeNames_MatchExpectedValues(string actual, string expected)
+        {
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Mail/tests/Unit/System.Net.Mail.Unit.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="MailAddressTests\MailAddressEncodeTest.cs" />
     <Compile Include="MailAddressTests\MailAddressParserTest.cs" />
     <Compile Include="MailAddressTests\MailAddressParsingTest.cs" />
+    <Compile Include="MediaTypeNamesVideoTest.cs" />
     <Compile Include="MessageTests\MessageEncodeHeadersTest.cs" />
     <Compile Include="MessageTests\MessageHeaderBehaviorTest.cs" />
     <Compile Include="MessageTests\ReplyToListTest.cs" />


### PR DESCRIPTION
Add MediaTypeNames.Video with five commonly-used video container format constants: Mp4, Mpeg, Ogg, QuickTime, and Webm. These are the most widely used video MIME types in web applications and are already mapped in MediaTypeMap. Codec-specific types (H264, VP8, etc.) are excluded as they are rarely used as HTTP Content-Type headers.

Fixes #124392