### PR TITLE
[QUIC] Add QuicStream.Priority property

### DIFF
--- a/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
+++ b/src/libraries/System.Net.Quic/ref/System.Net.Quic.cs
@@ -114,6 +114,7 @@ namespace System.Net.Quic
     public sealed partial class QuicStream : System.IO.Stream
     {
         internal QuicStream() { }
+        public const byte DefaultPriority = (byte)127;
         public override bool CanRead { get { throw null; } }
         public override bool CanSeek { get { throw null; } }
         public override bool CanTimeout { get { throw null; } }
@@ -121,6 +122,7 @@ namespace System.Net.Quic
         public long Id { get { throw null; } }
         public override long Length { get { throw null; } }
         public override long Position { get { throw null; } set { } }
+        public byte Priority { get { throw null; } set { } }
         public System.Threading.Tasks.Task ReadsClosed { get { throw null; } }
         public override int ReadTimeout { get { throw null; } set { } }
         public System.Net.Quic.QuicStreamType Type { get { throw null; } }

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -120,12 +120,21 @@ public sealed partial class QuicStream
 
     private long _id = -1;
     private readonly QuicStreamType _type;
+    private byte _priority = DefaultPriority;
 
     /// <summary>
     /// Provided via <see cref="StartAsync(Action{QuicStreamType}, CancellationToken)" /> from <see cref="QuicConnection" /> so that <see cref="QuicStream"/> can decrement its available stream count field.
     /// When <see cref="HandleEventStartComplete(ref START_COMPLETE_DATA)">START_COMPLETE</see> arrives it gets invoked and unset back to <c>null</c> to not to hold any unintended reference to <see cref="QuicConnection"/>.
     /// </summary>
     private Action<QuicStreamType>? _decrementStreamCapacity;
+
+    /// <summary>
+    /// The default value of <see cref="Priority"/>, which is the middle of the <see cref="byte"/> range.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="byte.MinValue"/> represents the lowest priority and <see cref="byte.MaxValue"/> represents the highest priority.
+    /// </remarks>
+    public const byte DefaultPriority = 0x7F;
 
     /// <summary>
     /// Stream id, see <see href="https://www.rfc-editor.org/rfc/rfc9000.html#name-stream-types-and-identifier" />.
@@ -136,6 +145,27 @@ public sealed partial class QuicStream
     /// Stream type, see <see href="https://www.rfc-editor.org/rfc/rfc9000.html#name-stream-types-and-identifier" />.
     /// </summary>
     public QuicStreamType Type => _type;
+
+    /// <summary>
+    /// Gets or sets the stream priority, see <see href="https://www.rfc-editor.org/rfc/rfc9000.html#name-stream-prioritization">RFC 9000: Stream Prioritization</see>.
+    /// </summary>
+    /// <remarks>
+    /// <para>Priority only affects the order of data sent on the wire relative to other streams on the same connection.
+    /// <see cref="byte.MinValue"/> represents the lowest priority and <see cref="byte.MaxValue"/> represents the highest.
+    /// The default value is <see cref="DefaultPriority"/>.</para>
+    /// </remarks>
+    /// <value>The priority level for this stream. The default value is <see cref="DefaultPriority"/>.</value>
+    public byte Priority
+    {
+        get => _priority;
+        set
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            SetMsQuicParameter(_handle, QUIC_PARAM_STREAM_PRIORITY, (ushort)((value << 8) | 0xFF));
+            _priority = value;
+        }
+    }
 
     /// <summary>
     /// A <see cref="Task"/> that will get completed once reading side has been closed.

--- a/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
+++ b/src/libraries/System.Net.Quic/tests/FunctionalTests/QuicStreamTests.cs
@@ -1553,5 +1553,96 @@ namespace System.Net.Quic.Tests
                 }
             }
         }
+
+        [Fact]
+        public async Task Priority_DefaultValue()
+        {
+            await RunClientServer(
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptInboundStreamAsync();
+                    Assert.Equal(QuicStream.DefaultPriority, stream.Priority);
+                },
+                clientFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                    Assert.Equal(QuicStream.DefaultPriority, stream.Priority);
+                    stream.CompleteWrites();
+                }
+            );
+        }
+
+        [Theory]
+        [InlineData(byte.MinValue)]
+        [InlineData(1)]
+        [InlineData(QuicStream.DefaultPriority)]
+        [InlineData(byte.MaxValue)]
+        public async Task Priority_SetGet(byte priority)
+        {
+            await RunClientServer(
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptInboundStreamAsync();
+                    byte[] buffer = new byte[1];
+                    await ReadAll(stream, buffer);
+                },
+                clientFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                    stream.Priority = priority;
+                    Assert.Equal(priority, stream.Priority);
+                    await stream.WriteAsync(new byte[] { 42 }, completeWrites: true);
+                }
+            );
+        }
+
+        [Fact]
+        public async Task Priority_SetMultipleTimes()
+        {
+            await RunClientServer(
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptInboundStreamAsync();
+                    byte[] buffer = new byte[1];
+                    await ReadAll(stream, buffer);
+                },
+                clientFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+
+                    stream.Priority = byte.MaxValue;
+                    Assert.Equal(byte.MaxValue, stream.Priority);
+
+                    stream.Priority = byte.MinValue;
+                    Assert.Equal(byte.MinValue, stream.Priority);
+
+                    stream.Priority = QuicStream.DefaultPriority;
+                    Assert.Equal(QuicStream.DefaultPriority, stream.Priority);
+
+                    await stream.WriteAsync(new byte[] { 42 }, completeWrites: true);
+                }
+            );
+        }
+
+        [Fact]
+        public async Task Priority_ThrowsAfterDispose()
+        {
+            await RunClientServer(
+                serverFunction: async connection =>
+                {
+                    await using QuicStream stream = await connection.AcceptInboundStreamAsync();
+                    byte[] buffer = new byte[1];
+                    await ReadAll(stream, buffer);
+                },
+                clientFunction: async connection =>
+                {
+                    QuicStream stream = await connection.OpenOutboundStreamAsync(QuicStreamType.Bidirectional);
+                    await stream.WriteAsync(new byte[] { 42 }, completeWrites: true);
+                    await stream.DisposeAsync();
+
+                    Assert.Throws<ObjectDisposedException>(() => stream.Priority = byte.MaxValue);
+                }
+            );
+        }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.

Implements the API-approved design from #90281.

## Changes

Adds a settable `Priority` property (`byte`) and a `DefaultPriority` constant (`0x7F`) to `QuicStream`, per the [approved API shape](https://github.com/dotnet/runtime/issues/90281#issuecomment-4290641129):

```csharp
namespace System.Net.Quic;

public partial class QuicStream
{
    public const byte DefaultPriority = 0x7F;
    public byte Priority { get; set; }
}
```

- **Getter** returns the cached field value (no P/Invoke).
- **Setter** calls `SetMsQuicParameter(QUIC_PARAM_STREAM_PRIORITY, (ushort)((value << 8) | 0xFF))` to translate the byte range to MsQuic's ushort range.
- Throws `ObjectDisposedException` after disposal.

## Tests

Four new tests in `QuicStreamTests.cs`:
- `Priority_DefaultValue` — both client/server streams default to `0x7F`
- `Priority_SetGet` (Theory) — roundtrip for min, 1, default, max values
- `Priority_SetMultipleTimes` — changing priority multiple times
- `Priority_ThrowsAfterDispose` — `ObjectDisposedException` after disposal

All existing and new tests pass.

Fixes #90281