### PR TITLE
[browser] Make WASM framework asset CopyToOutputDirectory configurable

### DIFF
--- a/eng/testing/tests.browser.targets
+++ b/eng/testing/tests.browser.targets
@@ -51,6 +51,10 @@
     <UseSystemResourceKeys Condition="'$(UseSystemResourceKeys)' == ''">false</UseSystemResourceKeys>
     <EventSourceSupport Condition="'$(EventSourceSupport)' == ''">true</EventSourceSupport>
     <NullabilityInfoContextSupport Condition="'$(NullabilityInfoContextSupport)' == ''">true</NullabilityInfoContextSupport>
+
+    <!-- Library tests run directly from bin/ without the static web assets middleware,
+         so copy framework files to the output directory. See https://github.com/dotnet/runtime/issues/127257. -->
+    <_WasmFrameworkCopyToOutputDirectory>PreserveNewest</_WasmFrameworkCopyToOutputDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(RuntimeFlavor)' == 'CoreCLR'">
     <WasmTestSupport>true</WasmTestSupport>

--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -354,6 +354,12 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_WasmBuildWebcilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil'))</_WasmBuildWebcilPath>
       <_WasmBuildTmpWebcilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil'))</_WasmBuildTmpWebcilPath>
+      <!-- Controls whether WASM framework/webcil static web assets are copied to bin/wwwroot/_framework/
+           at build time. Defaults to 'Never' (assets stay in obj/fx/ and are served via the static web
+           assets middleware). Set to 'PreserveNewest' to copy them to the output directory — this is
+           required for scenarios that run the app from bin/ without the static web assets middleware
+           (e.g. in-tree library tests). -->
+      <_WasmFrameworkCopyToOutputDirectory Condition="'$(_WasmFrameworkCopyToOutputDirectory)' == ''">Never</_WasmFrameworkCopyToOutputDirectory>
     </PropertyGroup>
 
     <ConvertDllsToWebcil Candidates="@(_BuildAssetsCandidates)" IntermediateOutputPath="$(_WasmBuildTmpWebcilPath)" OutputPath="$(_WasmBuildWebcilPath)" IsEnabled="$(_WasmEnableWebcil)" WebcilVersion="$(_WasmWebcilVersion)">
@@ -387,7 +393,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       SourceType="Computed"
       AssetKind="Build"
       AssetRole="Primary"
-      CopyToOutputDirectory="Never"
+      CopyToOutputDirectory="$(_WasmFrameworkCopyToOutputDirectory)"
       CopyToPublishDirectory="Never"
       FingerprintCandidates="$(_WasmFingerprintAssets)"
       FingerprintPatterns="@(FingerprintPatterns);@(_WasmFingerprintPatterns)"
@@ -406,7 +412,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       SourceType="Framework"
       AssetKind="Build"
       AssetRole="Primary"
-      CopyToOutputDirectory="Never"
+      CopyToOutputDirectory="$(_WasmFrameworkCopyToOutputDirectory)"
       CopyToPublishDirectory="Never"
       FingerprintCandidates="$(_WasmFingerprintAssets)"
       FingerprintPatterns="@(FingerprintPatterns);@(_WasmFingerprintPatterns)"
@@ -435,7 +441,7 @@ Copyright (c) .NET Foundation. All rights reserved.
          during dotnet run — they are not copied to bin/wwwroot/_framework/ at build time. -->
     <ItemGroup>
       <_WasmMaterializedFrameworkAssets Update="@(_WasmMaterializedFrameworkAssets)"
-        AssetMode="All" CopyToOutputDirectory="Never" />
+        AssetMode="All" CopyToOutputDirectory="$(_WasmFrameworkCopyToOutputDirectory)" />
       <WasmStaticWebAsset Include="@(_WasmMaterializedFrameworkAssets)" />
     </ItemGroup>
 


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.

## Summary

Fixes the library-tests regression from #126407 tracked in #127257.

#126407 switched the WASM framework / webcil static web asset `CopyToOutputDirectory` from `PreserveNewest` to `Never`, which is correct for `dotnet run` (static web assets middleware serves files out of `obj/fx/`). But library tests in this repo run the app directly from `bin/` without the middleware, so the framework files are missing and loading `dotnet.*.js` fails.

## Changes

- **`Microsoft.NET.Sdk.WebAssembly.Browser.targets`**: introduce a private MSBuild property `_WasmFrameworkCopyToOutputDirectory` (default `Never`) and route the three `CopyToOutputDirectory` values through it (Computed/webcil assets, Framework assets, and the post-`UpdatePackageStaticWebAssets` item update).
- **`eng/testing/tests.browser.targets`**: set `_WasmFrameworkCopyToOutputDirectory` to `PreserveNewest` so library tests copy framework assets to the output directory as before.

Default behavior for regular `dotnet run` / Blazor WASM scenarios is unchanged.