### PR TITLE
[cDAC] Add Apple to RuntimeInfoOperatingSystem

### DIFF
--- a/docs/design/datacontracts/RuntimeInfo.md
+++ b/docs/design/datacontracts/RuntimeInfo.md
@@ -21,6 +21,8 @@ public enum RuntimeInfoOperatingSystem : uint
     Unknown = 0,
     Win,
     Unix,
+    Browser,
+    Apple,
 }
 ```
 
@@ -49,6 +51,12 @@ Global variables used:
 
 The contract implementation returns the architecture and operating system global values parsed as the
 respective enum case-insensitively. If these globals are not available, the contract returns Unknown.
+
+`Apple` covers all Apple platforms (macOS, iOS, tvOS, MacCatalyst) — i.e. any target where the
+runtime is compiled with `TARGET_APPLE` defined. It is distinct from `Unix` so that consumers which
+need to apply Apple-specific ABI or platform rules (for example, the Apple ARM64 stack-argument
+alignment) can detect the target reliably. Apple platforms are still POSIX and will behave like
+`Unix` for the purposes of any `GetTargetOperatingSystem() != Windows` check.
 
 ### Reader versioning scheme
 

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -1311,6 +1311,11 @@ CDAC_GLOBALS_BEGIN()
 #error Handle 'Browser' define
 #endif // Browser
 CDAC_GLOBAL_STRING(OperatingSystem, Browser)
+#elif defined(TARGET_APPLE)
+#ifdef Apple
+#error Handle 'Apple' define
+#endif // Apple
+CDAC_GLOBAL_STRING(OperatingSystem, Apple)
 #elif defined(TARGET_UNIX)
 #ifdef Unix
 #error Handle 'Unix' define

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeInfo.cs
@@ -27,6 +27,7 @@ public enum RuntimeInfoOperatingSystem : uint
     Windows,
     Unix,
     Browser,
+    Apple,
 }
 
 public interface IRuntimeInfo : IContract

--- a/src/native/managed/cdac/tests/DumpTests/RuntimeInfoDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/RuntimeInfoDumpTests.cs
@@ -52,7 +52,8 @@ public class RuntimeInfoDumpTests : DumpTestBase
         RuntimeInfoOperatingSystem expected = DumpMetadata.Os switch
         {
             "windows" => RuntimeInfoOperatingSystem.Windows,
-            "linux" or "osx" or "freebsd" => RuntimeInfoOperatingSystem.Unix,
+            "osx" => RuntimeInfoOperatingSystem.Apple,
+            "linux" or "freebsd" => RuntimeInfoOperatingSystem.Unix,
             _ => RuntimeInfoOperatingSystem.Unknown,
         };
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with AI (Copilot CLI) assistance.

## Summary

Adds a dedicated `Apple` value to `RuntimeInfoOperatingSystem` so the cDAC can distinguish Apple platforms (macOS / iOS / tvOS / MacCatalyst) from other Unix targets. The native data descriptor emits the new `Apple` string whenever `TARGET_APPLE` is defined, checked before the generic `TARGET_UNIX` arm.

Fixes #127282.

## Motivation

`CallingConventionInfo` in #126408 needs to set `IsAppleArm64ABI` only on Apple platforms, because Apple ARM64 uses different stack-argument alignment than Linux ARM64 (natural alignment for primitives, 4-byte alignment for float HFAs, vs. Linux's uniform 8-byte slots). With today's enum collapsing everything non-Windows/non-Browser into `Unix`, that check cannot be expressed and `IsAppleArm64ABI` is effectively hardcoded.

## Changes

- **`src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeInfo.cs`** — add `Apple` to the enum.
- **`src/coreclr/vm/datadescriptor/datadescriptor.inc`** — emit `CDAC_GLOBAL_STRING(OperatingSystem, Apple)` when `TARGET_APPLE` is defined, before the `TARGET_UNIX` arm. Follows the existing `#ifdef` guard pattern.
- **`docs/design/datacontracts/RuntimeInfo.md`** — document the new value and clarify that `Apple` is still POSIX for `!= Windows` checks.
- **`src/native/managed/cdac/tests/DumpTests/RuntimeInfoDumpTests.cs`** — map dump metadata `"osx"` to `Apple` (was `Unix`); `"linux"`/`"freebsd"` stay `Unix`.

## Compatibility

The enum is parsed via `Enum.TryParse(ignoreCase: true)`:

- **Old runtime + new cDAC**: old runtimes still emit `"Unix"` on macOS, so dumps look identical to today.
- **New runtime + old cDAC**: old cDACs fail to parse `"Apple"` and return `Unknown`; every production check is `== Windows` / `!= Windows`, which is unaffected.

No `RuntimeInfo` contract version bump is needed — V1 is defined in terms of parsing, not the specific token set.

## Where the enum is used

All usages are inside `src/native/managed/cdac`; an org-wide GitHub search found no references outside `dotnet/runtime` and the `dotnet/dotnet` VMR mirror, and `dotnet/diagnostics` has zero references.

**Definition**
- `Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeInfo.cs` — enum + `IRuntimeInfo.GetTargetOperatingSystem()`.

**Production (parser + consumers)**
- `Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeInfo_1.cs` — `Enum.TryParse(ignoreCase: true)` of the `OperatingSystem` global, fallback to `Unknown`.
- `Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs` — `!= Windows`.
- `…/StackWalk/Context/AMD64/AMD64Unwinder.cs` (2 sites) — `!= Windows` → `_unixAMD64ABI`, and a `Debug.Assert(... == Windows)` on the Windows-only path.
- `…/StackWalk/Context/X86/X86Unwinder.cs` — `!= Windows`.

**Tests**
- `tests/RuntimeInfoTests.cs` — theory data auto-generated from the enum; picks up `Apple` automatically.
- `tests/DumpTests/RuntimeInfoDumpTests.cs` — dump-metadata → enum map (updated by this PR).

## Call-site audit

All current `GetTargetOperatingSystem()` consumers compare against `Windows`, not `Unix`, so adding `Apple` changes no runtime behavior:

| Site | Check |
|------|-------|
| `AMD64Unwinder.cs:34` | `!= Windows` → sets `_unixAMD64ABI`. Apple x64 is Unix AMD64 ABI ✓ |
| `AMD64Unwinder.cs:853` | `Debug.Assert(... == Windows)` on Windows path ✓ |
| `X86Unwinder.cs:37` | `!= Windows` (x86 has no Apple target) ✓ |
| `SOSDacImpl.cs:745` | `!= Windows` ✓ |

Follow-up in #126408 will flip `IsAppleArm64ABI = os == Unix` to `os == Apple`.

## Testing

- `Microsoft.Diagnostics.DataContractReader.Tests` — all 1751 tests pass, including the auto-generated `"apple"` round-trip case in `RuntimeInfoTests.GetTargetOperatingSystemTest`.
- Dump test mapping updated so existing macOS dump configs validate against `Apple`.
- The native `datadescriptor.inc` change is a preprocessor-only addition following the existing pattern and is inert on non-Apple builds.
