### PR TITLE
Fix copy-paste bugs in PrecodeMachineDescriptor StubPrecode block

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/PrecodeMachineDescriptor.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/PrecodeMachineDescriptor.cs
@@ -43,7 +43,7 @@ internal sealed class PrecodeMachineDescriptor : IData<PrecodeMachineDescriptor>
 
         if (type.Fields.ContainsKey(nameof(StubPrecodeSize)))
         {
-            StubPrecodeSize = target.ReadField<byte>(address, type, nameof(FixupStubPrecodeSize));
+            StubPrecodeSize = target.ReadField<byte>(address, type, nameof(StubPrecodeSize));
             StubBytes = new byte[StubPrecodeSize.Value];
             target.ReadBuffer(address + (ulong)type.Fields[nameof(StubBytes)].Offset, StubBytes);
             StubIgnoredBytes = new byte[StubPrecodeSize.Value];
@@ -52,8 +52,8 @@ internal sealed class PrecodeMachineDescriptor : IData<PrecodeMachineDescriptor>
         else
         {
             StubPrecodeSize = null;
-            FixupBytes = null;
-            FixupIgnoredBytes = null;
+            StubBytes = null;
+            StubIgnoredBytes = null;
         }
 
         PInvokeImportPrecodeType = MaybeGetPrecodeType(target, address, nameof(PInvokeImportPrecodeType));


### PR DESCRIPTION
Fix two copy-paste bugs in `PrecodeMachineDescriptor` introduced in #115746 when the `StubPrecode` block was created by duplicating the `FixupStubPrecode` block:

1. `ReadField` used `nameof(FixupStubPrecodeSize)` instead of `nameof(StubPrecodeSize)` — causing `StubPrecodeSize` to read the wrong field value from the data descriptor
2. The `else` branch nulled `FixupBytes`/`FixupIgnoredBytes` instead of `StubBytes`/`StubIgnoredBytes` — potentially corrupting the Fixup precode data that was correctly initialized by the block above

Both bugs affect `PrecodeStubs_3` (contract version 3) which relies on `StubBytes`/`StubIgnoredBytes` for byte-pattern precode identification in `TryGetKnownPrecodeType`.

> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.