### PR TITLE
Fixup CodeFragmentHeap block allocation reporting

### DIFF
--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2213,7 +2213,6 @@ TaggedMemAllocPtr CodeFragmentHeap::RealAllocAlignedMem(size_t  dwRequestedSize
         if (dwSize < SMALL_BLOCK_THRESHOLD)
             dwSize = 4 * SMALL_BLOCK_THRESHOLD;
         pMem = ExecutionManager::GetEEJitManager()->AllocCodeFragmentBlock(dwSize, dwAlignment, m_pAllocator, m_kind);
-        ReportStubBlock(pMem, dwSize, m_kind);
     }
 
     SIZE_T dwExtra = (BYTE *)ALIGN_UP(pMem, dwAlignment) - (BYTE *)pMem;
@@ -2226,6 +2225,8 @@ TaggedMemAllocPtr CodeFragmentHeap::RealAllocAlignedMem(size_t  dwRequestedSize
         AddBlock((BYTE *)pMem + dwExtra + dwRequestedSize, dwRemaining);
         dwSize -= dwRemaining;
     }
+
+    ReportStubBlock(pMem, dwSize, m_kind);
 
     TaggedMemAllocPtr tmap;
     tmap.m_pMem             = pMem;

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -34,7 +34,7 @@ bool PerfMap::s_ShowOptimizationTiers = false;
 bool PerfMap::s_GroupStubsOfSameType = false;
 bool PerfMap::s_IndividualAllocationStubReporting = false;
 
-unsigned PerfMap::s_StubsMapped = 0;
+volatile LONG PerfMap::s_StubsMapped = 0;
 CrstStatic PerfMap::s_csPerfMap;
 
 bool PerfMapLowGranularityStubs()
@@ -437,7 +437,7 @@ void PerfMap::LogStubs(const char* stubType, const char* stubOwner, PCODE pCode,
         }
         else
         {
-            name.Printf("stub<%d> %s<%s>", ++(s_StubsMapped), stubType, stubOwner);
+            name.Printf("stub<%d> %s<%s>", InterlockedIncrement(&s_StubsMapped), stubType, stubOwner);
         }
         SString line;
         line.Printf(FMT_CODE_ADDR " %x %s\n", pCode, codeSize, name.GetUTF8());

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -37,8 +37,8 @@ private:
     static bool s_GroupStubsOfSameType;
     static bool s_IndividualAllocationStubReporting;
 
-    // Set to true if an error is encountered when writing to the file.
-    static unsigned s_StubsMapped;
+    // Counter for generating unique stub names when s_GroupStubsOfSameType is false.
+    static volatile LONG s_StubsMapped;
 
     static CrstStatic s_csPerfMap;
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/122274 fixed up some cases where block allocations produced code, but try to do a read of uncommitted memory. This change just makes it such that block records have the right size for range identification.

After this the settings provide the following expectations:

```
   DOTNET_PerfMapEnabled
     0 (default)  Disabled
     1            Perfmap text file + jitdump
     2            Jitdump only
     3            Perfmap text file only

   DOTNET_PerfMapShowOptimizationTiers
     0                 No tier info in symbol names
     1 (default)  Show optimization tiers in symbol names

   DOTNET_PerfMapStubGranularity
     Controls how stubs are reported. Bit 0 controls naming,
     bit 1 controls individual allocation site reporting.

     0 (default)  Grouped names, block-level only
                  Name format: "stub Type<Owner>"
                  Block stubs: perfmap yes, jitdump yes (no disassembly)
                  IndividualWithinBlock: not reported

     1            Unique names, block-level only
                  Name format: "stub<N> Type<Owner>"
                  Block stubs: perfmap yes, jitdump yes (no disassembly)
                  IndividualWithinBlock: not reported

     2            Grouped names, individual alloc sites
                  Name format: "stub Type<Owner>"
                  Block stubs: not reported
                  IndividualWithinBlock: perfmap yes, jitdump yes

     3            Unique names, individual alloc sites
                  Name format: "stub<N> Type<Owner>"
                  Block stubs: not reported
                  IndividualWithinBlock: perfmap yes, jitdump yes

     Individual stubs (e.g. write barriers) are always reported
     with full disassembly regardless of granularity setting.
```