### PR TITLE
Remove unnecessary _featureCheckValues cache from ILLink

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -3164,19 +3164,8 @@ namespace Mono.Linker.Steps
             if (method == null)
                 return null;
 
-            var methodAction = Annotations.GetAction(method);
-            if (methodAction is MethodAction.ConvertToStub)
-            {
-                // CodeRewriterStep may request the stubbed value for any preserved method
-                // with the action ConvertToStub. Ensure we have precomputed any stub value that may be needed by
-                // CodeRewriterStep. This ensures sweeping doesn't change the stub value (which can be determined by
-                // FeatureGuardAttribute or FeatureSwitchDefinitionAttribute that might have been removed).
-                Annotations.TryGetMethodStubValue(method, out _);
-            }
-
-            if (methodAction == MethodAction.Nothing)
+            if (Annotations.GetAction(method) == MethodAction.Nothing)
                 Annotations.SetAction(method, MethodAction.Parse);
-
 
             // Use the original reason as it's important to correctly generate warnings
             // the updated reason is only useful for better tracking of dependencies.

--- a/src/tools/illink/src/linker/Linker/MemberActionStore.cs
+++ b/src/tools/illink/src/linker/Linker/MemberActionStore.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared;
 using Mono.Cecil;
@@ -13,14 +12,12 @@ namespace Mono.Linker
     {
         public SubstitutionInfo PrimarySubstitutionInfo { get; }
         private readonly Dictionary<AssemblyDefinition, SubstitutionInfo?> _embeddedXmlInfos;
-        private readonly Dictionary<MethodDefinition, bool> _featureCheckValues;
         readonly LinkContext _context;
 
         public MemberActionStore(LinkContext context)
         {
             PrimarySubstitutionInfo = new SubstitutionInfo();
             _embeddedXmlInfos = new Dictionary<AssemblyDefinition, SubstitutionInfo?>();
-            _featureCheckValues = new Dictionary<MethodDefinition, bool>();
             _context = context;
         }
 
@@ -73,9 +70,6 @@ namespace Mono.Linker
 
         internal bool TryGetFeatureCheckValue(MethodDefinition method, out bool value)
         {
-            if (_featureCheckValues.TryGetValue(method, out value))
-                return true;
-
             value = false;
 
             if (!method.IsStatic)
@@ -98,10 +92,7 @@ namespace Mono.Linker
                 // If there's a FeatureSwitchDefinition, don't continue looking for FeatureGuard.
                 // We don't want to infer feature switch settings from FeatureGuard.
                 if (_context.FeatureSettings.TryGetValue(switchName, out value))
-                {
-                    _featureCheckValues[method] = value;
                     return true;
-                }
                 return false;
             }
 
@@ -118,17 +109,13 @@ namespace Mono.Linker
                     switch (featureType.Name)
                     {
                         case "RequiresUnreferencedCodeAttribute":
-                            _featureCheckValues[method] = value;
                             return true;
                         case "RequiresDynamicCodeAttribute":
                             if (_context.FeatureSettings.TryGetValue(
                                     "System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported",
                                     out bool isDynamicCodeSupported)
                                 && !isDynamicCodeSupported)
-                            {
-                                _featureCheckValues[method] = value;
                                 return true;
-                            }
                             break;
                     }
                 }


### PR DESCRIPTION
Now that CodeRewriterStep runs before SweepStep (#127090), the `_featureCheckValues` cache in `MemberActionStore` and the eager pre-computation in `MarkStep` are no longer needed.

The cache was added in #104995 to preserve feature attribute values before they could be swept away. With the step reordering, attributes are still present when `CodeRewriterStep` processes them.

This cleanup was suggested in https://github.com/dotnet/runtime/pull/127090#discussion_r3118235567

> *This content was created with assistance from AI.*