### PR TITLE
Fix CounterGroup timer to use Stopwatch instead of DateTime.UtcNow

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -143,10 +143,10 @@ namespace System.Diagnostics.Tracing
 
 #region Timer Processing
 
-        private long _timeStampSinceCollectionStarted;
+        private long _baseTimestamp;
+        private TimeSpan _timeSinceCollectionStarted;
         private TimeSpan _pollingInterval;
-        private long _pollingIntervalSwTicks;
-        private long _nextPollingTimeStamp;
+        private TimeSpan _nextPollingOffset;
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
@@ -156,13 +156,12 @@ namespace System.Diagnostics.Tracing
             if (_pollingInterval == TimeSpan.Zero || interval < _pollingInterval)
             {
                 _pollingInterval = interval;
-                _pollingIntervalSwTicks = _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
                 // Schedule IncrementingPollingCounter reset and synchronously reset other counters
                 HandleCountersReset();
 
-                long now = Stopwatch.GetTimestamp();
-                _timeStampSinceCollectionStarted = now;
-                _nextPollingTimeStamp = now + _pollingIntervalSwTicks;
+                _baseTimestamp = Stopwatch.GetTimestamp();
+                _timeSinceCollectionStarted = TimeSpan.Zero;
+                _nextPollingOffset = _pollingInterval;
 
                 // Create the polling thread and init all the shared state if needed
                 if (s_pollingThread == null)
@@ -192,7 +191,6 @@ namespace System.Diagnostics.Tracing
         {
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
             _pollingInterval = TimeSpan.Zero;
-            _pollingIntervalSwTicks = 0;
             s_counterGroupEnabledList?.Remove(this);
 
             if (s_needsResetIncrementingPollingCounters.Count > 0)
@@ -231,14 +229,14 @@ namespace System.Diagnostics.Tracing
         {
             if (_eventSource.IsEnabled())
             {
-                long now;
+                TimeSpan nowOffset;
                 TimeSpan elapsed;
                 TimeSpan pollingInterval;
                 DiagnosticCounter[] counters;
                 lock (s_counterGroupLock)
                 {
-                    now = Stopwatch.GetTimestamp();
-                    elapsed = Stopwatch.GetElapsedTime(_timeStampSinceCollectionStarted, now);
+                    nowOffset = Stopwatch.GetElapsedTime(_baseTimestamp);
+                    elapsed = nowOffset - _timeSinceCollectionStarted;
                     pollingInterval = _pollingInterval;
                     counters = new DiagnosticCounter[_counters.Count];
                     _counters.CopyTo(counters);
@@ -264,8 +262,8 @@ namespace System.Diagnostics.Tracing
 
                 lock (s_counterGroupLock)
                 {
-                    _timeStampSinceCollectionStarted = now;
-                    TimeSpan delta = Stopwatch.GetElapsedTime(_nextPollingTimeStamp, now);
+                    _timeSinceCollectionStarted = nowOffset;
+                    TimeSpan delta = nowOffset - _nextPollingOffset;
                     if (delta < _pollingInterval)
                     {
                         delta = _pollingInterval;
@@ -273,7 +271,8 @@ namespace System.Diagnostics.Tracing
 
                     if (_pollingInterval > TimeSpan.Zero)
                     {
-                        _nextPollingTimeStamp += (long)Math.Ceiling(delta / _pollingInterval) * _pollingIntervalSwTicks;
+                        long missed = (delta.Ticks + _pollingInterval.Ticks - 1) / _pollingInterval.Ticks;
+                        _nextPollingOffset += new TimeSpan(missed * _pollingInterval.Ticks);
                     }
                 }
             }
@@ -304,8 +303,8 @@ namespace System.Diagnostics.Tracing
                     sleepEvent = s_pollingThreadSleepEvent;
                     foreach (CounterGroup counterGroup in s_counterGroupEnabledList!)
                     {
-                        long now = Stopwatch.GetTimestamp();
-                        TimeSpan timeUntilNextPoll = Stopwatch.GetElapsedTime(now, counterGroup._nextPollingTimeStamp);
+                        TimeSpan nowOffset = Stopwatch.GetElapsedTime(counterGroup._baseTimestamp);
+                        TimeSpan timeUntilNextPoll = counterGroup._nextPollingOffset - nowOffset;
                         if (timeUntilNextPoll < TimeSpan.FromMilliseconds(1))
                         {
                             onTimers.Add(counterGroup);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.Versioning;
 using System.Threading;
 
@@ -142,9 +143,9 @@ namespace System.Diagnostics.Tracing
 
 #region Timer Processing
 
-        private DateTime _timeStampSinceCollectionStarted;
+        private long _timeStampSinceCollectionStarted;
         private int _pollingIntervalInMilliseconds;
-        private DateTime _nextPollingTimeStamp;
+        private long _nextPollingTimeStamp;
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
@@ -156,8 +157,9 @@ namespace System.Diagnostics.Tracing
                 // Schedule IncrementingPollingCounter reset and synchronously reset other counters
                 HandleCountersReset();
 
-                _timeStampSinceCollectionStarted = DateTime.UtcNow;
-                _nextPollingTimeStamp = DateTime.UtcNow + new TimeSpan(0, 0, (int)pollingIntervalInSeconds);
+                long now = Stopwatch.GetTimestamp();
+                _timeStampSinceCollectionStarted = now;
+                _nextPollingTimeStamp = now + (long)(Stopwatch.Frequency * pollingIntervalInSeconds);
 
                 // Create the polling thread and init all the shared state if needed
                 if (s_pollingThread == null)
@@ -225,14 +227,14 @@ namespace System.Diagnostics.Tracing
         {
             if (_eventSource.IsEnabled())
             {
-                DateTime now;
+                long now;
                 TimeSpan elapsed;
                 int pollingIntervalInMilliseconds;
                 DiagnosticCounter[] counters;
                 lock (s_counterGroupLock)
                 {
-                    now = DateTime.UtcNow;
-                    elapsed = now - _timeStampSinceCollectionStarted;
+                    now = Stopwatch.GetTimestamp();
+                    elapsed = Stopwatch.GetElapsedTime(_timeStampSinceCollectionStarted, now);
                     pollingIntervalInMilliseconds = _pollingIntervalInMilliseconds;
                     counters = new DiagnosticCounter[_counters.Count];
                     _counters.CopyTo(counters);
@@ -259,10 +261,17 @@ namespace System.Diagnostics.Tracing
                 lock (s_counterGroupLock)
                 {
                     _timeStampSinceCollectionStarted = now;
-                    TimeSpan delta = now - _nextPollingTimeStamp;
-                    delta = _pollingIntervalInMilliseconds > delta.TotalMilliseconds ? TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds) : delta;
+                    long intervalTicks = (long)((double)Stopwatch.Frequency * _pollingIntervalInMilliseconds / 1000);
+                    long delta = now - _nextPollingTimeStamp;
+                    if (delta < intervalTicks)
+                    {
+                        delta = intervalTicks;
+                    }
+
                     if (_pollingIntervalInMilliseconds > 0)
-                        _nextPollingTimeStamp += TimeSpan.FromMilliseconds(_pollingIntervalInMilliseconds * Math.Ceiling(delta.TotalMilliseconds / _pollingIntervalInMilliseconds));
+                    {
+                        _nextPollingTimeStamp += (long)(intervalTicks * Math.Ceiling((double)delta / intervalTicks));
+                    }
                 }
             }
         }
@@ -292,13 +301,13 @@ namespace System.Diagnostics.Tracing
                     sleepEvent = s_pollingThreadSleepEvent;
                     foreach (CounterGroup counterGroup in s_counterGroupEnabledList!)
                     {
-                        DateTime now = DateTime.UtcNow;
-                        if (counterGroup._nextPollingTimeStamp < now + new TimeSpan(0, 0, 0, 0, 1))
+                        long now = Stopwatch.GetTimestamp();
+                        if (counterGroup._nextPollingTimeStamp < now + Stopwatch.Frequency / 1000)
                         {
                             onTimers.Add(counterGroup);
                         }
 
-                        int millisecondsTillNextPoll = (int)((counterGroup._nextPollingTimeStamp - now).TotalMilliseconds);
+                        int millisecondsTillNextPoll = (int)Stopwatch.GetElapsedTime(now, counterGroup._nextPollingTimeStamp).TotalMilliseconds;
                         millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
                         sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -93,7 +93,7 @@ namespace System.Diagnostics.Tracing
 
                 Debug.Assert((s_counterGroupEnabledList == null && !_eventSource.IsEnabled())
                                 || (_eventSource.IsEnabled() && s_counterGroupEnabledList!.Contains(this))
-                                || (_pollingIntervalInMilliseconds == 0 && !s_counterGroupEnabledList!.Contains(this))
+                                || (_pollingInterval == TimeSpan.Zero && !s_counterGroupEnabledList!.Contains(this))
                                 || (!_eventSource.IsEnabled() && !s_counterGroupEnabledList!.Contains(this)));
             }
         }
@@ -144,22 +144,23 @@ namespace System.Diagnostics.Tracing
 #region Timer Processing
 
         private long _timeStampSinceCollectionStarted;
-        private int _pollingIntervalInMilliseconds;
+        private TimeSpan _pollingInterval;
         private long _nextPollingTimeStamp;
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
             Debug.Assert(pollingIntervalInSeconds > 0);
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
-            if (_pollingIntervalInMilliseconds == 0 || pollingIntervalInSeconds * 1000 < _pollingIntervalInMilliseconds)
+            TimeSpan interval = TimeSpan.FromSeconds(pollingIntervalInSeconds);
+            if (_pollingInterval == TimeSpan.Zero || interval < _pollingInterval)
             {
-                _pollingIntervalInMilliseconds = (int)(pollingIntervalInSeconds * 1000);
+                _pollingInterval = interval;
                 // Schedule IncrementingPollingCounter reset and synchronously reset other counters
                 HandleCountersReset();
 
                 long now = Stopwatch.GetTimestamp();
                 _timeStampSinceCollectionStarted = now;
-                _nextPollingTimeStamp = now + (long)(Stopwatch.Frequency * pollingIntervalInSeconds);
+                _nextPollingTimeStamp = now + _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
 
                 // Create the polling thread and init all the shared state if needed
                 if (s_pollingThread == null)
@@ -188,7 +189,7 @@ namespace System.Diagnostics.Tracing
         private void DisableTimer()
         {
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
-            _pollingIntervalInMilliseconds = 0;
+            _pollingInterval = TimeSpan.Zero;
             s_counterGroupEnabledList?.Remove(this);
 
             if (s_needsResetIncrementingPollingCounters.Count > 0)
@@ -229,13 +230,13 @@ namespace System.Diagnostics.Tracing
             {
                 long now;
                 TimeSpan elapsed;
-                int pollingIntervalInMilliseconds;
+                TimeSpan pollingInterval;
                 DiagnosticCounter[] counters;
                 lock (s_counterGroupLock)
                 {
                     now = Stopwatch.GetTimestamp();
                     elapsed = Stopwatch.GetElapsedTime(_timeStampSinceCollectionStarted, now);
-                    pollingIntervalInMilliseconds = _pollingIntervalInMilliseconds;
+                    pollingInterval = _pollingInterval;
                     counters = new DiagnosticCounter[_counters.Count];
                     _counters.CopyTo(counters);
                 }
@@ -255,22 +256,21 @@ namespace System.Diagnostics.Tracing
                     // written to the old session or the new session. The behavior change is not being treated as a
                     // significant problem to address for now, but we can come back and address it if it turns out to
                     // be an actual issue.
-                    counter.WritePayload((float)elapsed.TotalSeconds, pollingIntervalInMilliseconds);
+                    counter.WritePayload((float)elapsed.TotalSeconds, (int)pollingInterval.TotalMilliseconds);
                 }
 
                 lock (s_counterGroupLock)
                 {
                     _timeStampSinceCollectionStarted = now;
-                    long intervalTicks = (long)((double)Stopwatch.Frequency * _pollingIntervalInMilliseconds / 1000);
-                    long delta = now - _nextPollingTimeStamp;
-                    if (delta < intervalTicks)
+                    TimeSpan delta = Stopwatch.GetElapsedTime(_nextPollingTimeStamp, now);
+                    if (delta < _pollingInterval)
                     {
-                        delta = intervalTicks;
+                        delta = _pollingInterval;
                     }
 
-                    if (_pollingIntervalInMilliseconds > 0)
+                    if (_pollingInterval > TimeSpan.Zero)
                     {
-                        _nextPollingTimeStamp += (long)(intervalTicks * Math.Ceiling((double)delta / intervalTicks));
+                        _nextPollingTimeStamp += (long)Math.Ceiling(delta / _pollingInterval) * _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
                     }
                 }
             }
@@ -302,13 +302,13 @@ namespace System.Diagnostics.Tracing
                     foreach (CounterGroup counterGroup in s_counterGroupEnabledList!)
                     {
                         long now = Stopwatch.GetTimestamp();
-                        if (counterGroup._nextPollingTimeStamp < now + Stopwatch.Frequency / 1000)
+                        TimeSpan timeUntilNextPoll = Stopwatch.GetElapsedTime(now, counterGroup._nextPollingTimeStamp);
+                        if (timeUntilNextPoll < TimeSpan.FromMilliseconds(1))
                         {
                             onTimers.Add(counterGroup);
                         }
 
-                        int millisecondsTillNextPoll = (int)Stopwatch.GetElapsedTime(now, counterGroup._nextPollingTimeStamp).TotalMilliseconds;
-                        millisecondsTillNextPoll = Math.Max(1, millisecondsTillNextPoll);
+                        int millisecondsTillNextPoll = Math.Max(1, (int)timeUntilNextPoll.TotalMilliseconds);
                         sleepDurationInMilliseconds = Math.Min(sleepDurationInMilliseconds, millisecondsTillNextPoll);
                     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -145,6 +145,7 @@ namespace System.Diagnostics.Tracing
 
         private long _timeStampSinceCollectionStarted;
         private TimeSpan _pollingInterval;
+        private long _pollingIntervalSwTicks;
         private long _nextPollingTimeStamp;
 
         private void EnableTimer(float pollingIntervalInSeconds)
@@ -155,12 +156,13 @@ namespace System.Diagnostics.Tracing
             if (_pollingInterval == TimeSpan.Zero || interval < _pollingInterval)
             {
                 _pollingInterval = interval;
+                _pollingIntervalSwTicks = _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
                 // Schedule IncrementingPollingCounter reset and synchronously reset other counters
                 HandleCountersReset();
 
                 long now = Stopwatch.GetTimestamp();
                 _timeStampSinceCollectionStarted = now;
-                _nextPollingTimeStamp = now + _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
+                _nextPollingTimeStamp = now + _pollingIntervalSwTicks;
 
                 // Create the polling thread and init all the shared state if needed
                 if (s_pollingThread == null)
@@ -190,6 +192,7 @@ namespace System.Diagnostics.Tracing
         {
             Debug.Assert(Monitor.IsEntered(s_counterGroupLock));
             _pollingInterval = TimeSpan.Zero;
+            _pollingIntervalSwTicks = 0;
             s_counterGroupEnabledList?.Remove(this);
 
             if (s_needsResetIncrementingPollingCounters.Count > 0)
@@ -270,7 +273,7 @@ namespace System.Diagnostics.Tracing
 
                     if (_pollingInterval > TimeSpan.Zero)
                     {
-                        _nextPollingTimeStamp += (long)Math.Ceiling(delta / _pollingInterval) * _pollingInterval.Ticks * Stopwatch.Frequency / TimeSpan.TicksPerSecond;
+                        _nextPollingTimeStamp += (long)Math.Ceiling(delta / _pollingInterval) * _pollingIntervalSwTicks;
                     }
                 }
             }


### PR DESCRIPTION
## Background

`DateTime.UtcNow` can jump due to NTP sync, causing elapsed time reported to EventCounter subscribers to be incorrect for that interval — affecting rate calculations like requests/sec in monitoring dashboards. Stopwatch is monotonic and not subject to clock adjustments.

`CounterGroup` is only directly referenced from `DiagnosticCounter`. `DiagnosticCounter` is the base class of `EventCounter`, `PollingCounter`, `IncrementingPollingCounter`, `IncrementingEventCounter`, so they all are affected.