### PR TITLE
[SRM] Optimize building the blob heap.

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetCoreAppPrevious);$(NetCoreAppMinimum);netstandard2.0;$(NetFrameworkMinimum)</TargetFrameworks>
@@ -49,6 +49,7 @@ The System.Reflection.Metadata library is built-in as part of the shared framewo
     <Compile Include="System\Reflection\Metadata\BlobWriterImpl.cs" />
     <Compile Include="System\Reflection\Metadata\BlobBuilder.cs" />
     <Compile Include="System\Reflection\Metadata\BlobBuilder.Enumerators.cs" />
+    <Compile Include="System\Reflection\Metadata\BlobBuilder.Segment.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\DecimalUtilities.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EnumerableExtensions.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\CustomAttributeDecoder.cs" />

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Hash.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Hash.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Immutable;
-
 namespace System.Reflection.Internal
 {
     internal static class Hash
@@ -40,13 +38,20 @@ namespace System.Reflection.Internal
         /// </summary>
         /// <param name="data">The sequence of bytes</param>
         /// <returns>The FNV-1a hash of <paramref name="data"/></returns>
-        internal static int GetFNVHashCode(ReadOnlySpan<byte> data)
-        {
-            int hashCode = Hash.FnvOffsetBias;
+        internal static int GetFNVHashCode(ReadOnlySpan<byte> data) => AccumulateFNVHashCode(FnvOffsetBias, data);
 
+        /// <summary>
+        /// Compute the FNV-1a hash of a sequence of bytes
+        /// See http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+        /// </summary>
+        /// <param name="hashCode">The current hash code</param>
+        /// <param name="data">The sequence of bytes</param>
+        /// <returns>The updated hash code</returns>
+        internal static int AccumulateFNVHashCode(int hashCode, ReadOnlySpan<byte> data)
+        {
             for (int i = 0; i < data.Length; i++)
             {
-                hashCode = unchecked((hashCode ^ data[i]) * Hash.FnvPrime);
+                hashCode = unchecked((hashCode ^ data[i]) * FnvPrime);
             }
 
             return hashCode;

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
@@ -40,9 +40,9 @@ namespace System.Reflection.Metadata
                 // calling Expand() will move it to the last chunk, so we need to call it twice.
                 if (FreeBytes == 0)
                 {
-                    Expand(chunkSize, alwaysAppendBuffer: true);
+                    Expand(chunkSize, writingSegments: true);
                 }
-                Expand(chunkSize, alwaysAppendBuffer: true);
+                Expand(chunkSize, writingSegments: true);
                 Debug.Assert(CanWriteSegment && _nextOrPrevious.FreeBytes >= minimumSize);
             }
         }
@@ -111,7 +111,7 @@ namespace System.Reflection.Metadata
         private Segment FinishSegment(BlobBuilder startChunk, int startOffset, int size)
         {
             Debug.Assert(CanWriteSegment);
-            CheckInvariants();
+            CheckInvariants(writingSegments: true);
             return new Segment(startChunk, startOffset, size);
         }
 
@@ -152,6 +152,71 @@ namespace System.Reflection.Metadata
                 WriteForSegment(chunk.Span);
             }
             return FinishSegment(startChunk, startOffset, builder.Count);
+        }
+
+        /// <summary>
+        /// Performs necessary adjustments to the <see cref="BlobBuilder"/> after writing <see cref="Segment"/>-
+        /// addressable data to it.
+        /// </summary>
+        /// <remarks>
+        /// This method must be called before linking a <see cref="BlobBuilder"/> that has had <see cref="Segment"/>-
+        /// addressable data written to it, and invalidates previously returned <see cref="Segment"/>s.
+        /// </remarks>
+        internal void FinishWritingSegments()
+        {
+            Debug.Assert(IsHead);
+            if (_nextOrPrevious == this || Length > 0)
+            {
+                return;
+            }
+
+            BlobBuilder lastChunk = _nextOrPrevious;
+            BlobBuilder firstChunk = lastChunk._nextOrPrevious;
+            BlobBuilder penultimateChunk = firstChunk;
+            while (penultimateChunk._nextOrPrevious != lastChunk)
+            {
+                penultimateChunk = penultimateChunk._nextOrPrevious;
+            }
+            bool twoChunks = firstChunk == lastChunk;
+
+            // We have:
+            // [First]->[]->[Penultimate]->[Last] <- [this (empty)]
+            //    ^__________________________|
+            // And want to turn it into this:
+            // [First]->[]->[Penultimate] <- [Last]
+            //    ^_______________|
+            // Degenerate cases:
+            // [First == Penultimate == Last] <- [this (empty)]
+            //    ^______________________|
+            // [First == Penultimate] <- [Last] <- [this (empty)]
+            //   ^_________________________|
+
+            // Swap buffers of last and head chunks, and free the last chunk:
+            byte[] lastBuffer = lastChunk._buffer;
+            int lastLength = lastChunk.Length; // don't copy the frozen flag
+            lastChunk._buffer = _buffer;
+            lastChunk._length = _length;
+            _buffer = lastBuffer;
+            _length = (uint)lastLength;
+            lastChunk.ClearAndFreeChunk();
+            // Relink chunks:
+            if (twoChunks)
+            {
+                // If there are only two chunks, turn this into a single-chunk BlobBuilder.
+                _nextOrPrevious = this;
+                PreviousLength = 0;
+            }
+            else
+            {
+                // If there are more than two chunks, set the penultimate chunk as the new last chunk.
+                // This handles the case of First == Penultimate as well.
+                _nextOrPrevious = penultimateChunk;
+                penultimateChunk._nextOrPrevious = firstChunk;
+                PreviousLength = penultimateChunk.Count;
+            }
+
+            // The standard set of invariants should now hold.
+            CheckInvariants();
         }
 
         /// <summary>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
@@ -1,0 +1,345 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Reflection.Internal;
+
+namespace System.Reflection.Metadata
+{
+    public partial class BlobBuilder
+    {
+        /// <summary>
+        /// Returns whether the <see cref="BlobBuilder"/> is in a state where <see cref="Segment"/>-addressible
+        /// data can be written to it.
+        /// </summary>
+        /// <remarks>
+        /// This is true if the blob builder contains more than one chunk, the head chunk is empty, and the
+        /// previous chunk has some minimum free space.
+        /// </remarks>
+        /// <seealso cref="EnsureCanWriteSegment"/>
+        private bool CanWriteSegment => _nextOrPrevious != this && Length == 0 && _nextOrPrevious.FreeBytes > 0;
+
+        // TODO: Move the cunking logic to the main BlobBuilder.cs file, and use it everywhere in BlobBuilder.
+        // https://github.com/dotnet/runtime/issues/100418
+        internal const int DefaultMaxChunkSize = 8192;
+
+        private int NextChunkLength => Math.Max(MinChunkSize, Math.Min(Count, DefaultMaxChunkSize));
+
+        /// <summary>
+        /// Brings the <see cref="BlobBuilder"/> into a state where <see cref="Segment"/>-addressible
+        /// data can be written to it.
+        /// </summary>
+        /// <seealso cref="CanWriteSegment"/>
+        private void EnsureCanWriteSegment(int minimumSize = 1)
+        {
+            Debug.Assert(minimumSize > 0);
+            if (!CanWriteSegment || _nextOrPrevious.FreeBytes < minimumSize)
+            {
+                int chunkSize = NextChunkLength;
+                // We need to have some free space in the last chunk. If the head chunk is full,
+                // calling Expand() will move it to the last chunk, so we need to call it twice.
+                if (FreeBytes == 0)
+                {
+                    Expand(chunkSize, alwaysAppendBuffer: true);
+                }
+                Expand(chunkSize, alwaysAppendBuffer: true);
+                Debug.Assert(CanWriteSegment && _nextOrPrevious.FreeBytes >= minimumSize);
+            }
+        }
+
+        private void AddLengthForSegment(int length)
+        {
+            Debug.Assert(length > 0);
+            Debug.Assert(CanWriteSegment && _nextOrPrevious.FreeBytes >= length);
+            _nextOrPrevious.AddLength(length);
+            PreviousLength += length;
+        }
+
+        /// <summary>
+        /// Starts writing <see cref="Segment"/>-addressible data to the <see cref="BlobBuilder"/>.
+        /// </summary>
+        /// <param name="startChunk">The first chunk of the segment.</param>
+        /// <param name="startOffset">The offset to the first byte within the first chunk of the segment.</param>
+        private void StartSegment(out BlobBuilder startChunk, out int startOffset)
+        {
+            Debug.Assert(IsHead);
+            EnsureCanWriteSegment();
+            startChunk = _nextOrPrevious;
+            startOffset = startChunk.Length;
+        }
+
+        /// <summary>
+        /// Writes a compressed integer to the <see cref="BlobBuilder"/>. This method should be preferred
+        /// over <see cref="WriteCompressedInteger"/> when the <see cref="BlobBuilder"/> is used to create
+        /// <see cref="Segment"/>s.
+        /// </summary>
+        /// <param name="value">The integer to write.</param>
+        private void WriteCompressedIntegerForSegment(int value)
+        {
+            EnsureCanWriteSegment(minimumSize: sizeof(int));
+            Span<byte> writeBuffer = _nextOrPrevious.RemainingSpan;
+            int written = BlobWriterImpl.WriteCompressedInteger(writeBuffer, unchecked((uint)value));
+            AddLengthForSegment(written);
+        }
+
+        /// <summary>
+        /// Writes a buffer to the <see cref="BlobBuilder"/>, ensuring that its content can be accessed from
+        /// a <see cref="Segment"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="StartSegment"/> must be called before calling this method.
+        /// </remarks>
+        private void WriteForSegment(ReadOnlySpan<byte> buffer)
+        {
+            Debug.Assert(CanWriteSegment);
+            int expectedCount = Count + buffer.Length;
+            while (!buffer.IsEmpty)
+            {
+                Span<byte> writeBuffer = _nextOrPrevious.RemainingSpan;
+                int bytesToWrite = Math.Min(writeBuffer.Length, buffer.Length);
+                buffer.Slice(0, bytesToWrite).CopyTo(writeBuffer);
+                buffer = buffer.Slice(bytesToWrite);
+                AddLengthForSegment(bytesToWrite);
+                EnsureCanWriteSegment();
+            }
+            Debug.Assert(Count == expectedCount);
+        }
+
+        /// <summary>
+        /// Finishes creation of a <see cref="Segment"/>.
+        /// </summary>
+        private Segment FinishSegment(BlobBuilder startChunk, int startOffset, int size)
+        {
+            Debug.Assert(CanWriteSegment);
+            CheckInvariants();
+            return new Segment(startChunk, startOffset, size);
+        }
+
+        /// <summary>
+        /// Writes a buffer to the <see cref="BlobBuilder"/> and returns a <see cref="Segment"/> over
+        /// the written data.
+        /// </summary>
+        /// <param name="buffer">The buffer to write.</param>
+        /// <param name="prependCompressedSize">Whether to prepend <paramref name="buffer"/>'s size as
+        /// a compressed integer. The bytes of the size will not be included in the <see cref="Segment"/>.</param>
+        internal Segment WriteSegment(ReadOnlySpan<byte> buffer, bool prependCompressedSize = false)
+        {
+            if (prependCompressedSize)
+            {
+                WriteCompressedIntegerForSegment(buffer.Length);
+            }
+            StartSegment(out BlobBuilder startChunk, out int startOffset);
+            WriteForSegment(buffer);
+            return FinishSegment(startChunk, startOffset, buffer.Length);
+        }
+
+        /// <summary>
+        /// Writes the contents of a <see cref="BlobBuilder"/> to the <see cref="BlobBuilder"/> and
+        /// returns a <see cref="Segment"/> over the written data.
+        /// </summary>
+        /// <param name="builder">The <see cref="BlobBuilder"/> to write.</param>
+        /// <param name="prependCompressedSize">Whether to prepend <paramref name="builder"/>'s size as
+        /// a compressed integer. The bytes of the size will not be included in the <see cref="Segment"/>.</param>
+        internal Segment WriteSegment(BlobBuilder builder, bool prependCompressedSize = false)
+        {
+            if (prependCompressedSize)
+            {
+                WriteCompressedIntegerForSegment(builder.Count);
+            }
+            StartSegment(out BlobBuilder startChunk, out int startOffset);
+            foreach (BlobBuilder chunk in builder.GetChunks())
+            {
+                WriteForSegment(chunk.Span);
+            }
+            return FinishSegment(startChunk, startOffset, builder.Count);
+        }
+
+        /// <summary>
+        /// Represents a contiguous region of data in a <see cref="BlobBuilder"/>.
+        /// </summary>
+        /// <seealso cref="WriteSegment(ReadOnlySpan{byte}, bool)"/>
+        /// <seealso cref="WriteSegment(BlobBuilder, bool)"/>
+        [DebuggerDisplay("Count = {Count}")]
+        internal readonly struct Segment(BlobBuilder builder, int offset, int size)
+        {
+            private readonly BlobBuilder _builder = builder;
+            private readonly int _offset = offset;
+
+            public int Count { get; } = size;
+
+            public Chunks GetChunks() => new Chunks(this);
+
+            public bool ContentEquals(ReadOnlySpan<byte> other)
+            {
+                if (Count != other.Length)
+                {
+                    return false;
+                }
+
+                foreach (ReadOnlySpan<byte> chunk in GetChunks())
+                {
+                    if (!chunk.SequenceEqual(other.Slice(0, chunk.Length)))
+                    {
+                        return false;
+                    }
+                    other = other.Slice(chunk.Length);
+                }
+
+                return true;
+            }
+
+            public bool ContentEquals(BlobBuilder other)
+            {
+                if (Count != other.Count)
+                {
+                    return false;
+                }
+
+                Chunks leftEnumerator = GetChunks();
+                BlobBuilder.Chunks rightEnumerator = other.GetChunks();
+                int leftStart = 0;
+                int rightStart = 0;
+
+                bool leftContinues = leftEnumerator.MoveNext();
+                bool rightContinues = rightEnumerator.MoveNext();
+
+                while (leftContinues && rightContinues)
+                {
+                    Debug.Assert(leftStart == 0 || rightStart == 0);
+
+                    ReadOnlySpan<byte> left = leftEnumerator.Current;
+                    ReadOnlySpan<byte> right = rightEnumerator.Current.Span;
+
+                    int minLength = Math.Min(left.Length - leftStart, right.Length - rightStart);
+                    if (!left.Slice(leftStart, minLength).SequenceEqual(right.Slice(rightStart, minLength)))
+                    {
+                        return false;
+                    }
+
+                    leftStart += minLength;
+                    rightStart += minLength;
+
+                    // nothing remains in left chunk to compare:
+                    if (leftStart == left.Length)
+                    {
+                        leftContinues = leftEnumerator.MoveNext();
+                        leftStart = 0;
+                    }
+
+                    // nothing remains in left chunk to compare:
+                    if (rightStart == right.Length)
+                    {
+                        rightContinues = rightEnumerator.MoveNext();
+                        rightStart = 0;
+                    }
+                }
+
+                return leftContinues == rightContinues;
+            }
+
+#if NET
+            public bool ContentEquals(Segment other)
+            {
+                if (Count != other.Count)
+                {
+                    return false;
+                }
+
+                Chunks leftEnumerator = GetChunks();
+                Chunks rightEnumerator = other.GetChunks();
+                int leftStart = 0;
+                int rightStart = 0;
+
+                bool leftContinues = leftEnumerator.MoveNext();
+                bool rightContinues = rightEnumerator.MoveNext();
+
+                while (leftContinues && rightContinues)
+                {
+                    Debug.Assert(leftStart == 0 || rightStart == 0);
+
+                    ReadOnlySpan<byte> left = leftEnumerator.Current;
+                    ReadOnlySpan<byte> right = rightEnumerator.Current;
+
+                    int minLength = Math.Min(left.Length - leftStart, right.Length - rightStart);
+                    if (!left.Slice(leftStart, minLength).SequenceEqual(right.Slice(rightStart, minLength)))
+                    {
+                        return false;
+                    }
+
+                    leftStart += minLength;
+                    rightStart += minLength;
+
+                    // nothing remains in left chunk to compare:
+                    if (leftStart == left.Length)
+                    {
+                        leftContinues = leftEnumerator.MoveNext();
+                        leftStart = 0;
+                    }
+
+                    // nothing remains in left chunk to compare:
+                    if (rightStart == right.Length)
+                    {
+                        rightContinues = rightEnumerator.MoveNext();
+                        rightStart = 0;
+                    }
+                }
+
+                return leftContinues == rightContinues;
+            }
+#endif
+
+            public int GetContentFNVHashCode()
+            {
+                int hash = Hash.FnvOffsetBias;
+                foreach (ReadOnlySpan<byte> chunk in GetChunks())
+                {
+                    hash = Hash.AccumulateFNVHashCode(hash, chunk);
+                }
+                return hash;
+            }
+
+            public struct Chunks
+            {
+                private BlobBuilder _current;
+                private int _chunkOffset, _chunkLength;
+                private int _remaining;
+                private int _steps;
+
+                internal Chunks(Segment segment)
+                {
+                    _current = segment._builder;
+                    _chunkOffset = segment._offset;
+                    _chunkLength = Math.Min(segment.Count, _current.Length - _chunkOffset);
+                    _remaining = segment.Count - _chunkLength;
+                }
+
+                public readonly ReadOnlySpan<byte> Current => _current.Span.Slice(_chunkOffset, _chunkLength);
+
+                public bool MoveNext()
+                {
+                    if (_remaining == 0 && _steps != 0)
+                    {
+                        // If the segment was empty, return an empty chunk, to match BlobBuilder.GetChunks().
+                        return false;
+                    }
+                    switch (_steps++)
+                    {
+                        case 0:
+                            // The enumerator is already initialized to the first chunk, so do nothing the first time MoveNext is called.
+                            return true;
+                        case 1:
+                            // Chunks after the first one start at their beginning.
+                            _chunkOffset = 0;
+                            break;
+                    }
+                    _current = _current._nextOrPrevious;
+                    _chunkLength = Math.Min(_remaining, _current.Length);
+                    _remaining -= _chunkLength;
+                    return true;
+                }
+
+                public readonly Chunks GetEnumerator() => this;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
@@ -9,7 +9,7 @@ namespace System.Reflection.Metadata
     public partial class BlobBuilder
     {
         /// <summary>
-        /// Returns whether the <see cref="BlobBuilder"/> is in a state where <see cref="Segment"/>-addressible
+        /// Returns whether the <see cref="BlobBuilder"/> is in a state where <see cref="Segment"/>-addressable
         /// data can be written to it.
         /// </summary>
         /// <remarks>
@@ -26,7 +26,7 @@ namespace System.Reflection.Metadata
         private int NextChunkLength => Math.Max(MinChunkSize, Math.Min(Count, DefaultMaxChunkSize));
 
         /// <summary>
-        /// Brings the <see cref="BlobBuilder"/> into a state where <see cref="Segment"/>-addressible
+        /// Brings the <see cref="BlobBuilder"/> into a state where <see cref="Segment"/>-addressable
         /// data can be written to it.
         /// </summary>
         /// <seealso cref="CanWriteSegment"/>
@@ -56,7 +56,7 @@ namespace System.Reflection.Metadata
         }
 
         /// <summary>
-        /// Starts writing <see cref="Segment"/>-addressible data to the <see cref="BlobBuilder"/>.
+        /// Starts writing <see cref="Segment"/>-addressable data to the <see cref="BlobBuilder"/>.
         /// </summary>
         /// <param name="startChunk">The first chunk of the segment.</param>
         /// <param name="startOffset">The offset to the first byte within the first chunk of the segment.</param>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.Segment.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Metadata
         /// <seealso cref="EnsureCanWriteSegment"/>
         private bool CanWriteSegment => _nextOrPrevious != this && Length == 0 && _nextOrPrevious.FreeBytes > 0;
 
-        // TODO: Move the cunking logic to the main BlobBuilder.cs file, and use it everywhere in BlobBuilder.
+        // TODO: Move the chunking logic to the main BlobBuilder.cs file, and use it everywhere in BlobBuilder.
         // https://github.com/dotnet/runtime/issues/100418
         internal const int DefaultMaxChunkSize = 8192;
 
@@ -226,7 +226,7 @@ namespace System.Reflection.Metadata
                         leftStart = 0;
                     }
 
-                    // nothing remains in left chunk to compare:
+                    // nothing remains in right chunk to compare:
                     if (rightStart == right.Length)
                     {
                         rightContinues = rightEnumerator.MoveNext();
@@ -276,7 +276,7 @@ namespace System.Reflection.Metadata
                         leftStart = 0;
                     }
 
-                    // nothing remains in left chunk to compare:
+                    // nothing remains in right chunk to compare:
                     if (rightStart == right.Length)
                     {
                         rightContinues = rightEnumerator.MoveNext();
@@ -319,7 +319,7 @@ namespace System.Reflection.Metadata
                 {
                     if (_remaining == 0 && _steps != 0)
                     {
-                        // If the segment was empty, return an empty chunk, to match BlobBuilder.GetChunks().
+                        // The segment has been fully enumerated, including the case where it was empty.
                         return false;
                     }
                     switch (_steps++)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -30,7 +30,16 @@ namespace System.Reflection.Metadata
         //
         // In this case the content represented is a sequence (1,2,3,4).
         // This structure optimizes for append write operations and sequential enumeration from the start of the chain.
-        // Data can only be written to the head node. Other nodes are "frozen".
+        // Usually, data can only be written to the head node and other nodes are "frozen".
+        //
+        // However, when using the Segment APIs, we write to the last node, creating additional nodes if necessary.
+        // Data in a segment cannot reside in the head node, because you cannot link to it from a previous node.
+        // Writing to the last node satisfies this requirement, and also minimizes changes to the existing writing
+        // paths, which write to the head node as always.
+        // This means that alternating between regular and segment writes will lead to gaps in the buffers, but the
+        // Segment APIs are not public, and this is not an expected use case.
+        // Blob builders used for writing segments will always have an empty head node, but that memory does not go
+        // to waste as more data get written, and if the builder is linked, it gets freed normally.
         private BlobBuilder _nextOrPrevious;
         private BlobBuilder FirstChunk => _nextOrPrevious._nextOrPrevious;
 
@@ -51,6 +60,7 @@ namespace System.Reflection.Metadata
         private int Length => (int)(_length & ~IsFrozenMask);
         private uint FrozenLength => _length | IsFrozenMask;
         private Span<byte> Span => _buffer.AsSpan(0, Length);
+        private Span<byte> RemainingSpan => _buffer.AsSpan(Length);
 
         public BlobBuilder(int capacity = DefaultChunkSize)
         {
@@ -133,7 +143,15 @@ namespace System.Reflection.Metadata
                 int totalLength = 0;
                 foreach (var chunk in GetChunks())
                 {
-                    Debug.Assert(chunk.IsHead || chunk.Length > 0);
+                    if (!chunk.IsHead && chunk == _nextOrPrevious)
+                    {
+                        // The last chunk can be empty if we are writing segments.
+                        Debug.Assert(chunk.Length >= 0);
+                    }
+                    else
+                    {
+                        Debug.Assert(chunk.IsHead || (chunk.Length > 0));
+                    }
                     totalLength += chunk.Length;
                 }
 
@@ -260,6 +278,20 @@ namespace System.Reflection.Metadata
             return leftContinues == rightContinues;
         }
 
+        internal int GetContentFNVHashCode()
+        {
+            if (!IsHead)
+            {
+                Throw.InvalidOperationBuilderAlreadyLinked();
+            }
+            int hashCode = Hash.FnvOffsetBias;
+            foreach (BlobBuilder chunk in GetChunks())
+            {
+                hashCode = Hash.AccumulateFNVHashCode(hashCode, chunk.Span);
+            }
+            return hashCode;
+        }
+
         /// <exception cref="InvalidOperationException">Content is not available, the builder has been linked with another one.</exception>
         public byte[] ToArray()
         {
@@ -316,19 +348,6 @@ namespace System.Reflection.Metadata
         {
             byte[]? array = ToArray(start, byteCount);
             return ImmutableCollectionsMarshal.AsImmutableArray(array);
-        }
-
-        internal bool TryGetSpan(out ReadOnlySpan<byte> buffer)
-        {
-            if (_nextOrPrevious == this)
-            {
-                // If the blob builder has one chunk, we can just return it and avoid copies.
-                buffer = Span;
-                return true;
-            }
-
-            buffer = default;
-            return false;
         }
 
         /// <exception cref="ArgumentNullException"><paramref name="destination"/> is null.</exception>
@@ -520,7 +539,7 @@ namespace System.Reflection.Metadata
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void Expand(int newLength)
+        private void Expand(int newLength, bool alwaysAppendBuffer = false)
         {
             // TODO: consider converting the last chunk to a smaller one if there is too much empty space left
 
@@ -540,9 +559,10 @@ namespace System.Reflection.Metadata
 
             var newBuffer = newChunk._buffer;
 
-            if (_length == 0)
+            if (_length == 0 && !alwaysAppendBuffer)
             {
                 // If the first write into an empty buffer needs more space than the buffer provides, swap the buffers.
+                // We don't want this when writing a segment.
                 newChunk._buffer = _buffer;
                 _buffer = newBuffer;
             }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -129,7 +129,7 @@ namespace System.Reflection.Metadata
         }
 
         [Conditional("DEBUG")]
-        private void CheckInvariants()
+        private void CheckInvariants(bool writingSegments = false)
         {
             Debug.Assert(_buffer != null);
             Debug.Assert(Length >= 0 && Length <= _buffer.Length);
@@ -143,14 +143,14 @@ namespace System.Reflection.Metadata
                 int totalLength = 0;
                 foreach (var chunk in GetChunks())
                 {
-                    if (!chunk.IsHead && chunk == _nextOrPrevious)
+                    if (!writingSegments)
                     {
-                        // The last chunk can be empty if we are writing segments.
-                        Debug.Assert(chunk.Length >= 0);
+                        Debug.Assert(chunk.IsHead || chunk.Length > 0);
                     }
                     else
                     {
-                        Debug.Assert(chunk.IsHead || (chunk.Length > 0));
+                        // The last chunk can be empty if we are writing segments.
+                        Debug.Assert(chunk.IsHead || chunk.Length > 0 || chunk == _nextOrPrevious);
                     }
                     totalLength += chunk.Length;
                 }
@@ -539,7 +539,7 @@ namespace System.Reflection.Metadata
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        private void Expand(int newLength, bool alwaysAppendBuffer = false)
+        private void Expand(int newLength, bool writingSegments = false)
         {
             // TODO: consider converting the last chunk to a smaller one if there is too much empty space left
 
@@ -559,10 +559,10 @@ namespace System.Reflection.Metadata
 
             var newBuffer = newChunk._buffer;
 
-            if (_length == 0 && !alwaysAppendBuffer)
+            if (_length == 0 && !writingSegments)
             {
                 // If the first write into an empty buffer needs more space than the buffer provides, swap the buffers.
-                // We don't want this when writing a segment.
+                // We don't want this when writing segments.
                 newChunk._buffer = _buffer;
                 _buffer = newBuffer;
             }
@@ -593,7 +593,7 @@ namespace System.Reflection.Metadata
                 _length = 0;
             }
 
-            CheckInvariants();
+            CheckInvariants(writingSegments);
         }
 
         /// <summary>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -267,7 +267,7 @@ namespace System.Reflection.Metadata
                     leftStart = 0;
                 }
 
-                // nothing remains in left chunk to compare:
+                // nothing remains in right chunk to compare:
                 if (rightStart == right.Length)
                 {
                     rightContinues = rightEnumerator.MoveNext();

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriterImpl.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobWriterImpl.cs
@@ -32,6 +32,33 @@ namespace System.Reflection.Metadata
             return 4;
         }
 
+        internal static int WriteCompressedInteger(Span<byte> buffer, uint value)
+        {
+            unchecked
+            {
+                if (value <= SingleByteCompressedIntegerMaxValue)
+                {
+                    buffer[0] = (byte)value;
+                    return sizeof(byte);
+                }
+                else if (value <= TwoByteCompressedIntegerMaxValue)
+                {
+                    BinaryPrimitives.WriteUInt16BigEndian(buffer, (ushort)(0x8000 | value));
+                    return sizeof(ushort);
+                }
+                else if (value <= MaxCompressedIntegerValue)
+                {
+                    BinaryPrimitives.WriteUInt32BigEndian(buffer, 0xc0000000 | value);
+                    return sizeof(uint);
+                }
+                else
+                {
+                    Throw.ValueArgumentOutOfRange();
+                    return 0;
+                }
+            }
+        }
+
         internal static void WriteCompressedInteger(ref BlobWriter writer, uint value)
         {
             unchecked

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
@@ -102,5 +102,7 @@ namespace System.Reflection.Metadata.Ecma335
 #endif
 
         public int Count => _dictionary.Count;
+
+        public void Clear() => _dictionary.Clear();
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Internal;
 #if NET
@@ -12,64 +11,56 @@ using System.Runtime.InteropServices;
 namespace System.Reflection.Metadata.Ecma335
 {
     [DebuggerDisplay("Count = {Count}")]
-    internal readonly struct BlobDictionary
+    internal readonly struct BlobDictionary(BlobBuilder builder, int capacity = 0)
     {
-        private readonly Dictionary<int, KeyValuePair<ImmutableArray<byte>, BlobHandle>> _dictionary;
+#if NET
+        private readonly Dictionary<BlobBuilder.Segment, BlobHandle> _dictionary = new(capacity, new Comparer(builder));
+
+        public BlobHandle GetOrAdd<T>(T key, BlobHandle value) where T : notnull, allows ref struct
+        {
+            // Always use the alternate lookup; we do not support directly adding segments.
+            ref BlobHandle entry =
+                ref CollectionsMarshal.GetValueRefOrAddDefault(_dictionary.GetAlternateLookup<T>(), key, out bool exists);
+
+            if (!exists)
+            {
+                entry = value;
+            }
+
+            return entry;
+        }
+
+        private sealed class Comparer(BlobBuilder builder) : IEqualityComparer<BlobBuilder.Segment>, IAlternateEqualityComparer<ReadOnlySpan<byte>, BlobBuilder.Segment>, IAlternateEqualityComparer<BlobBuilder, BlobBuilder.Segment>
+        {
+            public BlobBuilder.Segment Create(ReadOnlySpan<byte> alternate) => builder.WriteSegment(alternate, prependCompressedSize: true);
+            public BlobBuilder.Segment Create(BlobBuilder alternate) => builder.WriteSegment(alternate, prependCompressedSize: true);
+
+            public bool Equals(BlobBuilder.Segment x, BlobBuilder.Segment y) => x.ContentEquals(y);
+            public bool Equals(ReadOnlySpan<byte> alternate, BlobBuilder.Segment other) => other.ContentEquals(alternate);
+            public bool Equals(BlobBuilder alternate, BlobBuilder.Segment other) => other.ContentEquals(alternate);
+            public int GetHashCode(BlobBuilder.Segment obj) => obj.GetContentFNVHashCode();
+            public int GetHashCode(ReadOnlySpan<byte> alternate) => Hash.GetFNVHashCode(alternate);
+            public int GetHashCode(BlobBuilder alternate) => alternate.GetContentFNVHashCode();
+        }
+#else
+        private readonly BlobBuilder _builder = builder;
+
+        private readonly Dictionary<int, KeyValuePair<BlobBuilder.Segment, BlobHandle>> _dictionary = new(capacity);
 
         // A simple LCG. Constants taken from
         // https://github.com/imneme/pcg-c/blob/83252d9c23df9c82ecb42210afed61a7b42402d7/include/pcg_variants.h#L276-L284
         private static int GetNextDictionaryKey(int dictionaryKey) =>
             (int)((uint)dictionaryKey * 747796405 + 2891336453);
 
-#if NET
-        private unsafe ref KeyValuePair<ImmutableArray<byte>, BlobHandle> GetValueRefOrAddDefault(ReadOnlySpan<byte> key, out bool exists)
+        public BlobHandle GetOrAdd(BlobBuilder key, BlobHandle value)
         {
-            int dictionaryKey = Hash.GetFNVHashCode(key);
-            while (true)
-            {
-                ref var entry = ref CollectionsMarshal.GetValueRefOrAddDefault(_dictionary, dictionaryKey, out exists);
-                if (!exists || entry.Key.AsSpan().SequenceEqual(key))
-                {
-#pragma warning disable CS9082 // Local is returned by reference but was initialized to a value that cannot be returned by reference
-                    // In .NET 6 the assembly of GetValueRefOrAddDefault was compiled with earlier ref safety rules
-                    // and caused an error, which was turned into a warning because of unsafe and was suppressed.
-                    return ref entry;
-#pragma warning restore CS9082
-                }
-                dictionaryKey = GetNextDictionaryKey(dictionaryKey);
-            }
-        }
-
-        public BlobHandle GetOrAdd(ReadOnlySpan<byte> key, ImmutableArray<byte> immutableKey, BlobHandle value, out bool exists)
-        {
-            ref var entry = ref GetValueRefOrAddDefault(key, out exists);
-            if (exists)
-            {
-                return entry.Value;
-            }
-
-            // If we are given an immutable array, do not allocate a new one.
-            if (immutableKey.IsDefault)
-            {
-                immutableKey = key.ToImmutableArray();
-            }
-            else
-            {
-                Debug.Assert(immutableKey.AsSpan().SequenceEqual(key));
-            }
-
-            entry = new(immutableKey, value);
-            return value;
-        }
-#else
-        public BlobHandle GetOrAdd(ReadOnlySpan<byte> key, ImmutableArray<byte> immutableKey, BlobHandle value, out bool exists)
-        {
-            int dictionarykey = Hash.GetFNVHashCode(key);
-            KeyValuePair<ImmutableArray<byte>, BlobHandle> entry;
+            int dictionarykey = key.GetContentFNVHashCode();
+            KeyValuePair<BlobBuilder.Segment, BlobHandle> entry;
+            bool exists;
             while (true)
             {
                 if (!(exists = _dictionary.TryGetValue(dictionarykey, out entry))
-                    || entry.Key.AsSpan().SequenceEqual(key))
+                    || entry.Key.ContentEquals(key))
                 {
                     break;
                 }
@@ -81,29 +72,35 @@ namespace System.Reflection.Metadata.Ecma335
                 return entry.Value;
             }
 
-            // If we are given an immutable array, do not allocate a new one.
-            if (immutableKey.IsDefault)
+            _dictionary.Add(dictionarykey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
+            return value;
+        }
+
+        public BlobHandle GetOrAdd(ReadOnlySpan<byte> key, BlobHandle value)
+        {
+            int dictionarykey = Hash.GetFNVHashCode(key);
+            KeyValuePair<BlobBuilder.Segment, BlobHandle> entry;
+            bool exists;
+            while (true)
             {
-                immutableKey = key.ToImmutableArray();
-            }
-            else
-            {
-                Debug.Assert(immutableKey.AsSpan().SequenceEqual(key));
+                if (!(exists = _dictionary.TryGetValue(dictionarykey, out entry))
+                    || entry.Key.ContentEquals(key))
+                {
+                    break;
+                }
+                dictionarykey = GetNextDictionaryKey(dictionarykey);
             }
 
-            _dictionary.Add(dictionarykey, new(immutableKey, value));
+            if (exists)
+            {
+                return entry.Value;
+            }
+
+            _dictionary.Add(dictionarykey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
             return value;
         }
 #endif
 
-        public BlobDictionary(int capacity = 0)
-        {
-            _dictionary = new(capacity);
-        }
-
         public int Count => _dictionary.Count;
-
-        public Dictionary<int, KeyValuePair<ImmutableArray<byte>, BlobHandle>>.Enumerator GetEnumerator() =>
-            _dictionary.GetEnumerator();
     }
 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/BlobDictionary.cs
@@ -54,17 +54,17 @@ namespace System.Reflection.Metadata.Ecma335
 
         public BlobHandle GetOrAdd(BlobBuilder key, BlobHandle value)
         {
-            int dictionarykey = key.GetContentFNVHashCode();
+            int dictionaryKey = key.GetContentFNVHashCode();
             KeyValuePair<BlobBuilder.Segment, BlobHandle> entry;
             bool exists;
             while (true)
             {
-                if (!(exists = _dictionary.TryGetValue(dictionarykey, out entry))
+                if (!(exists = _dictionary.TryGetValue(dictionaryKey, out entry))
                     || entry.Key.ContentEquals(key))
                 {
                     break;
                 }
-                dictionarykey = GetNextDictionaryKey(dictionarykey);
+                dictionaryKey = GetNextDictionaryKey(dictionaryKey);
             }
 
             if (exists)
@@ -72,23 +72,23 @@ namespace System.Reflection.Metadata.Ecma335
                 return entry.Value;
             }
 
-            _dictionary.Add(dictionarykey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
+            _dictionary.Add(dictionaryKey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
             return value;
         }
 
         public BlobHandle GetOrAdd(ReadOnlySpan<byte> key, BlobHandle value)
         {
-            int dictionarykey = Hash.GetFNVHashCode(key);
+            int dictionaryKey = Hash.GetFNVHashCode(key);
             KeyValuePair<BlobBuilder.Segment, BlobHandle> entry;
             bool exists;
             while (true)
             {
-                if (!(exists = _dictionary.TryGetValue(dictionarykey, out entry))
+                if (!(exists = _dictionary.TryGetValue(dictionaryKey, out entry))
                     || entry.Key.ContentEquals(key))
                 {
                     break;
                 }
-                dictionarykey = GetNextDictionaryKey(dictionarykey);
+                dictionaryKey = GetNextDictionaryKey(dictionaryKey);
             }
 
             if (exists)
@@ -96,7 +96,7 @@ namespace System.Reflection.Metadata.Ecma335
                 return entry.Value;
             }
 
-            _dictionary.Add(dictionarykey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
+            _dictionary.Add(dictionaryKey, new(_builder.WriteSegment(key, prependCompressedSize: true), value));
             return value;
         }
 #endif

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -617,6 +617,10 @@ namespace System.Reflection.Metadata.Ecma335
             WriteAligned(stringHeap, builder);
             WriteAligned(_userStringBuilder, builder);
             WriteAligned(_guidBuilder, builder);
+            // FinishWritingSegments will invalidate the segments in the dictionary,
+            // so we need to clear it first.
+            _blobs.Clear();
+            _blobBuilder.FinishWritingSegments();
             WriteAligned(_blobBuilder, builder);
         }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -42,9 +42,9 @@ namespace System.Reflection.Metadata.Ecma335
         private int _stringHeapCapacity = 4 * 1024;
 
         // #Blob heap
-        private readonly BlobDictionary _blobs = new BlobDictionary(1024);
+        private readonly BlobDictionary _blobs;
+        private readonly HeapBlobBuilder _blobBuilder = new HeapBlobBuilder(1024);
         private readonly int _blobHeapStartOffset;
-        private int _blobHeapSize;
 
         // #GUID heap
         private readonly Dictionary<Guid, GuidHandle> _guids = new Dictionary<Guid, GuidHandle>();
@@ -116,8 +116,8 @@ namespace System.Reflection.Metadata.Ecma335
             // beginning of the delta blob.
             _userStringBuilder.WriteByte(0);
 
-            _blobs.GetOrAdd(ReadOnlySpan<byte>.Empty, ImmutableArray<byte>.Empty, default, out _);
-            _blobHeapSize = 1;
+            _blobs = new BlobDictionary(_blobBuilder, 32);
+            _ = _blobs.GetOrAdd((ReadOnlySpan<byte>)[], default);
 
             // When EnC delta is applied #US, #String and #Blob heaps are appended.
             // Thus indices of strings and blobs added to this generation are offset
@@ -150,8 +150,7 @@ namespace System.Reflection.Metadata.Ecma335
             switch (heap)
             {
                 case HeapIndex.Blob:
-                    // Not useful to set capacity.
-                    // By the time the blob heap is serialized we know the exact size we need.
+                    _blobBuilder.SetCapacity(byteCount);
                     break;
 
                 case HeapIndex.Guid:
@@ -191,12 +190,7 @@ namespace System.Reflection.Metadata.Ecma335
                 Throw.ArgumentNull(nameof(value));
             }
 
-            if (value.TryGetSpan(out ReadOnlySpan<byte> buffer))
-            {
-                return GetOrAddBlob(buffer);
-            }
-
-            return GetOrAddBlob(value.ToImmutableArray());
+            return GetOrAddBlobImpl(value);
         }
 
         /// <summary>
@@ -215,17 +209,34 @@ namespace System.Reflection.Metadata.Ecma335
             return GetOrAddBlob(new ReadOnlySpan<byte>(value));
         }
 
-        private BlobHandle GetOrAddBlob(ReadOnlySpan<byte> value, ImmutableArray<byte> immutableValue = default)
+        private BlobHandle GetOrAddBlob(ReadOnlySpan<byte> value) => GetOrAddBlobImpl(value);
+
+#if NET
+        private BlobHandle GetOrAddBlobImpl<T>(T value)
+            where T : notnull, allows ref struct
         {
-            BlobHandle nextHandle = BlobHandle.FromOffset(_blobHeapStartOffset + _blobHeapSize);
-            BlobHandle handle = _blobs.GetOrAdd(value, immutableValue, nextHandle, out bool exists);
-            if (!exists)
-            {
-                _blobHeapSize += BlobWriterImpl.GetCompressedIntegerSize(value.Length) + value.Length;
-            }
+            BlobHandle nextHandle = BlobHandle.FromOffset(_blobHeapStartOffset + _blobBuilder.Count);
+            BlobHandle handle = _blobs.GetOrAdd(value, nextHandle);
 
             return handle;
         }
+#else
+        private BlobHandle GetOrAddBlobImpl(ReadOnlySpan<byte> value)
+        {
+            BlobHandle nextHandle = BlobHandle.FromOffset(_blobHeapStartOffset + _blobBuilder.Count);
+            BlobHandle handle = _blobs.GetOrAdd(value, nextHandle);
+
+            return handle;
+        }
+
+        private BlobHandle GetOrAddBlobImpl(BlobBuilder value)
+        {
+            BlobHandle nextHandle = BlobHandle.FromOffset(_blobHeapStartOffset + _blobBuilder.Count);
+            BlobHandle handle = _blobs.GetOrAdd(value, nextHandle);
+
+            return handle;
+        }
+#endif
 
         /// <summary>
         /// Adds specified blob to Blob heap, if it's not there already.
@@ -240,7 +251,7 @@ namespace System.Reflection.Metadata.Ecma335
                 Throw.ArgumentNull(nameof(value));
             }
 
-            return GetOrAddBlob(value.AsSpan(), value);
+            return GetOrAddBlob(value.AsSpan());
         }
 
         /// <summary>
@@ -606,33 +617,7 @@ namespace System.Reflection.Metadata.Ecma335
             WriteAligned(stringHeap, builder);
             WriteAligned(_userStringBuilder, builder);
             WriteAligned(_guidBuilder, builder);
-            WriteAlignedBlobHeap(builder);
-        }
-
-        private void WriteAlignedBlobHeap(BlobBuilder builder)
-        {
-            int alignment = BitArithmetic.Align(_blobHeapSize, 4) - _blobHeapSize;
-
-            var writer = new BlobWriter(builder.ReserveBytes(_blobHeapSize + alignment));
-
-            // Perf consideration: With large heap the following loop may cause a lot of cache misses
-            // since the order of entries in _blobs dictionary depends on the hash of the array values,
-            // which is not correlated to the heap index. If we observe such issue we should order
-            // the entries by heap position before running this loop.
-
-            int startOffset = _blobHeapStartOffset;
-            foreach (var entry in _blobs)
-            {
-                int heapOffset = entry.Value.Value.GetHeapOffset();
-                var blob = entry.Value.Key;
-
-                writer.Offset = (heapOffset == 0) ? 0 : heapOffset - startOffset;
-                writer.WriteCompressedInteger(blob.Length);
-                writer.WriteBytes(blob);
-            }
-
-            writer.Offset = _blobHeapSize;
-            writer.WriteBytes(0, alignment);
+            WriteAligned(_blobBuilder, builder);
         }
 
         private static void WriteAligned(BlobBuilder source, BlobBuilder target)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.cs
@@ -22,7 +22,7 @@ namespace System.Reflection.Metadata.Ecma335
             var heapSizes = ImmutableArray.Create(
                 _userStringBuilder.Count,
                 stringHeapBuilder.Count,
-                _blobHeapSize,
+                _blobBuilder.Count,
                 _guidBuilder.Count);
 
             var sizes = new MetadataSizes(GetRowCounts(), externalRowCounts, heapSizes, metadataVersionByteCount, isStandaloneDebugMetadata);


### PR DESCRIPTION
### Background

When building the blob heap, `MetadataBuilder` keeps track of the blobs added, to avoid adding them multiple times. In the beginning, this was happening using a `Dictionary<ImmutableArray<byte>, BlobHandle>` and a custom comparer that compared the keys by value. This approach had the disadvantage of always allocating an `ImmutableArray<byte>` when you called `GetOrAddBlob` with anything except an immutable array. #81059 improved this situation and eliminated most allocations when the blob already exists. However, there are several optimization opportunities in how we build the blob heap:

* We still get an allocation when we call `GetOrAddBlob` with a multi-chunk `BlobBuilder`, even if the blob already existed.
* Adding a new blob to the heap still ends up making an allocation.
* Unlike other heap types, the blob heap gets written in random order, which requires [allocating a contiguous memory block as large as the size of the entire blob heap](https://github.com/dotnet/runtime/blob/20f699e11f3ddfa60ef484bbe13fdd6ea8867b95/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs#L616). This subverts `BlobBuilder`'s pooling and chunking facilities, and leads to an LOH allocation.

This PR fixes all of the above.

### Changes

Instead of keeping track of each blob as an `ImmutableArray<byte>` and writing the blob heap at the end, we write the blob heap to a `BlobBuilder` as each blob gets added, and keep track of each blob by its position within that `BlobBuilder`.

In order to do that, `BlobBuilder` was extended to support writing data that can be later referenced using a `BlobBuilder.Segment` struct. This is an internal-only functionality that slightly alters some invariants of `BlobBuilder`, but is invisible to external consumers. `Segment`-addressible buffers are written in chunks of increasingly sized buffers up to 8K bytes, matching the behavior of `StringBuilder`. This chunking logic will be user-configurable and expanded to all `BlobBuilder` APIs as part of #100418.

Afterwards, `BlobDictionary` was updated to use `BlobBuilder.Segment` as its key type, and append to the `BlobBuilder` to get a segment when a blob does not already exist. Also, the modern .NET implementation of `BlobDictionary` was significantly simplified by making use of the `AlternateLookup` API.

### TODO

- [x] Benchmark