### PR TITLE
Handle nullable-unwrapped generic parameter values

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/DiagnosticContext.cs
@@ -47,8 +47,12 @@ namespace ILLink.Shared.TrimAnalysis
         {
             Debug.Assert(Location != null);
 
-            if (actualValue is NullableValueWithDynamicallyAccessedMembers nv)
-                actualValue = nv.UnderlyingTypeValue;
+            actualValue = actualValue switch
+            {
+                NullableValueWithDynamicallyAccessedMembers nv => nv.UnderlyingTypeValue,
+                NullableUnwrappedGenericParameterValue ng => ng.GenericParameter,
+                _ => actualValue,
+            };
 
             ISymbol symbol = actualValue switch
             {

--- a/src/tools/illink/src/ILLink.Shared/Annotations.cs
+++ b/src/tools/illink/src/ILLink.Shared/Annotations.cs
@@ -94,6 +94,7 @@ namespace ILLink.Shared
                 // but it is a breaking change for other UnderlyingTypeValues.
                 // https://github.com/dotnet/runtime/issues/93800
                 NullableValueWithDynamicallyAccessedMembers { UnderlyingTypeValue: FieldValue or MethodReturnValue } nullable => nullable.UnderlyingTypeValue,
+                NullableUnwrappedGenericParameterValue unwrappedGenericParam => unwrappedGenericParam.GenericParameter,
                 _ => source
             };
             DiagnosticId diagnosticId = (source, target) switch

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -1024,6 +1024,7 @@ namespace ILLink.Shared.TrimAnalysis
                                     : MultiValueLattice.Top, // This returns null at runtime, so return empty value
                             NullableSystemTypeValue nullableSystemType => nullableSystemType.UnderlyingTypeValue,
                             NullableValueWithDynamicallyAccessedMembers nullableDamValue => nullableDamValue.UnderlyingTypeValue,
+                            GenericParameterValue genericParam => new NullableUnwrappedGenericParameterValue(genericParam),
                             ValueWithDynamicallyAccessedMembers damValue => damValue,
                             _ => annotatedMethodReturnValue
                         });

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using ILLink.Shared.DataFlow;
+using ILLink.Shared.TypeSystemProxy;
+
+// This is needed due to NativeAOT which doesn't enable nullable globally yet
+#nullable enable
+
+namespace ILLink.Shared.TrimAnalysis
+{
+    /// <summary>
+    /// This represents a typeof of a generic parameter that was unwrapped with Nullable.GetUnderlyingType.
+    /// </summary>
+    internal sealed record NullableUnwrappedGenericParameterValue : ValueWithDynamicallyAccessedMembers
+    {
+        public NullableUnwrappedGenericParameterValue(in GenericParameterValue genericParameter)
+        {
+            GenericParameter = genericParameter;
+        }
+
+        public readonly GenericParameterValue GenericParameter;
+
+        public override DynamicallyAccessedMemberTypes DynamicallyAccessedMemberTypes => GenericParameter.DynamicallyAccessedMemberTypes;
+        public override IEnumerable<string> GetDiagnosticArgumentsForAnnotationMismatch()
+            => GenericParameter.GetDiagnosticArgumentsForAnnotationMismatch();
+
+        public override SingleValue DeepCopy() => this; // This value is immutable
+
+        public override string ToString() => this.ValueToString(GenericParameter, "Nullable-unwrapped");
+    }
+}

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
@@ -2,10 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
-using ILLink.Shared.TypeSystemProxy;
 
 // This is needed due to NativeAOT which doesn't enable nullable globally yet
 #nullable enable

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/NullableUnwrappedGenericParameterValue.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using ILLink.Shared.DataFlow;
 
 // This is needed due to NativeAOT which doesn't enable nullable globally yet

--- a/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
+++ b/src/tools/illink/src/ILLink.Shared/TrimAnalysis/RequireDynamicallyAccessedMembersAction.cs
@@ -25,15 +25,22 @@ namespace ILLink.Shared.TrimAnalysis
 
             foreach (var uniqueValue in value.AsEnumerable())
             {
+                GenericParameterValue? maybeGenericParam = uniqueValue switch
+                {
+                    GenericParameterValue gpv => gpv,
+                    NullableUnwrappedGenericParameterValue nug => nug.GenericParameter,
+                    _ => null
+                };
+
                 if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
-                    && uniqueValue is GenericParameterValue genericParam
-                    && genericParam.GenericParameter.HasDefaultConstructorConstraint())
+                    && maybeGenericParam is not null
+                    && maybeGenericParam.GenericParameter.HasDefaultConstructorConstraint())
                 {
                     // We allow a new() constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicParameterlessConstructor
                 }
                 else if (targetValue.DynamicallyAccessedMemberTypes == DynamicallyAccessedMemberTypes.PublicFields
-                    && uniqueValue is GenericParameterValue maybeEnumConstrainedGenericParam
-                    && maybeEnumConstrainedGenericParam.GenericParameter.HasEnumConstraint())
+                    && maybeGenericParam is not null
+                    && maybeGenericParam.GenericParameter.HasEnumConstraint())
                 {
                     // We allow a System.Enum constraint on a generic parameter to satisfy DynamicallyAccessedMemberTypes.PublicFields
                 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
@@ -26,6 +26,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
                 TestRecognizedIntrinsic();
                 TestRecognizedGenericIntrinsic<object>();
+                TestNullableCornerCase<int?>();
                 TestRecognizedConstraint();
                 TestUnknownOwningType();
                 TestUnknownArgument();
@@ -34,6 +35,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             public static void TestRecognizedIntrinsic() => typeof(Gen<>).MakeGenericType(typeof(object));
 
             public static void TestRecognizedGenericIntrinsic<T>() => typeof(Gen<>).MakeGenericType(typeof(T));
+
+            [ExpectedWarning("IL3050", nameof(Type.MakeGenericType), Tool.Analyzer | Tool.NativeAot, "NativeAOT-specific warning")]
+            public static void TestNullableCornerCase<T>() => typeof(Gen<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T)));
 
             public static void TestRecognizedConstraint() => typeof(GenConstrained<>).MakeGenericType(GrabUnknownType());
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/MakeGenericDataflowIntrinsics.cs
@@ -27,6 +27,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
                 TestRecognizedIntrinsic();
                 TestRecognizedGenericIntrinsic<object>();
                 TestNullableCornerCase<int?>();
+                TestNullableCornerCaseClassConstraint<object>();
+                TestNullableCornerCaseEnumConstraint<DayOfWeek>();
                 TestRecognizedConstraint();
                 TestUnknownOwningType();
                 TestUnknownArgument();
@@ -38,6 +40,12 @@ namespace Mono.Linker.Tests.Cases.DataFlow
 
             [ExpectedWarning("IL3050", nameof(Type.MakeGenericType), Tool.Analyzer | Tool.NativeAot, "NativeAOT-specific warning")]
             public static void TestNullableCornerCase<T>() => typeof(Gen<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T)));
+
+            [ExpectedWarning("IL3050", nameof(Type.MakeGenericType), Tool.Analyzer | Tool.NativeAot, "NativeAOT-specific warning")]
+            public static void TestNullableCornerCaseClassConstraint<T>() where T : class => typeof(Gen<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T)));
+
+            [ExpectedWarning("IL3050", nameof(Type.MakeGenericType), Tool.Analyzer | Tool.NativeAot, "NativeAOT-specific warning")]
+            public static void TestNullableCornerCaseEnumConstraint<T>() where T : Enum => typeof(Gen<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T)));
 
             public static void TestRecognizedConstraint() => typeof(GenConstrained<>).MakeGenericType(GrabUnknownType());
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/NullableAnnotations.cs
@@ -67,6 +67,9 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             MakeGenericTypeWithKnowAndUnknownArray();
             RequiresOnNullableMakeGenericType.Test();
 
+            NewConstraintThroughNullableGetUnderlyingType<TestType>();
+            EnumConstraintThroughNullableGetUnderlyingType<DayOfWeek>();
+
             // Prevents optimizing away 'as Type' conversion.
             PreserveSystemType();
         }
@@ -403,6 +406,21 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         static void PreserveSystemType()
         {
             typeof(Type).RequiresNonPublicConstructors();
+        }
+
+        [Kept]
+        static void NewConstraintThroughNullableGetUnderlyingType<
+            [KeptGenericParamAttributes(GenericParameterAttributes.DefaultConstructorConstraint)]
+        T
+        >() where T : new()
+        {
+            Nullable.GetUnderlyingType(typeof(T)).RequiresPublicParameterlessConstructor();
+        }
+
+        [Kept]
+        static void EnumConstraintThroughNullableGetUnderlyingType<T>() where T : Enum
+        {
+            Nullable.GetUnderlyingType(typeof(T)).RequiresPublicFields();
         }
     }
 }


### PR DESCRIPTION
Introduce NullableUnwrappedGenericParameterValue to represent a typeof(T) that was unwrapped via Nullable.GetUnderlyingType.

This fixes an issue where `typeof(Gen<>).MakeGenericType(Nullable.GetUnderlyingType(typeof(T)))` would make ILC precompile `Gen<T>`, not produce a warning, and then fail at runtime because we actually need `Gen<Nullable<T>>`.

Cc @dotnet/illink 