### PR TITLE
Adopt RuntimeFeature.IsMultithreadingSupported for CoreCLR PlatformDetection

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Reflection;
 
 namespace TestLibrary
 {
@@ -106,35 +105,7 @@ namespace TestLibrary
         public static bool IsWasi => OperatingSystem.IsWasi();
         public static bool IsWasm => IsBrowser || IsWasi;
         public static bool IsNotMultithreadingSupported => !IsMultithreadingSupported;
-
-        // TODO-WASM: https://github.com/dotnet/runtime/issues/124748
-        // this is compiled with 11.0.0-preview.1.26104.118\ref
-        // which doesn't have the RuntimeFeature.IsMultithreadingSupported API yet.
-        // after we update to a newer ref, we should use RuntimeFeature.IsMultithreadingSupported directly.
-        // public static bool IsMultithreadingSupported => RuntimeFeature.IsMultithreadingSupported;
-        public static bool IsMultithreadingSupported { get; } = GetIsMultithreadingSupported();
-
-        private static bool GetIsMultithreadingSupported()
-        {
-            if (!IsWasm)
-                return true;
-
-            try
-            {
-                Type runtimeFeatureType = typeof(System.Runtime.CompilerServices.RuntimeFeature);
-
-                PropertyInfo isMultithreadingSupportedProperty = runtimeFeatureType.GetProperty("IsMultithreadingSupported", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-                if (isMultithreadingSupportedProperty != null)
-                {
-                    return (bool)isMultithreadingSupportedProperty.GetValue(null);
-                }
-            }
-            catch
-            {
-                // if any of the reflection calls fail, assume multithreading is not supported.
-            }
-            return false;
-        }
+        public static bool IsMultithreadingSupported => RuntimeFeature.IsMultithreadingSupported;
 
         private static bool IsEnvironmentVariableTrue(string variableName)
         {


### PR DESCRIPTION
Replace the reflection-based workaround in `src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs` with a direct `RuntimeFeature.IsMultithreadingSupported` call, now that the ref assemblies (SDK 11.0.100-preview.3) include the API.

- Removed `GetIsMultithreadingSupported()` reflection helper
- Removed unused `using System.Reflection`
- Removed TODO comment

Fixes #124748