### PR TITLE
Remove `NOTIFY_SOCKET` clear side effect from `SystemdNotifier` ctor

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdHostBuilderExtensions.cs
@@ -115,7 +115,17 @@ namespace Microsoft.Extensions.Hosting
             // systemd-style integration (for example, when NOTIFY_SOCKET is set or the process
             // is detected as a systemd service).
 #pragma warning disable CA1416 // Validate platform compatibility
-            services.AddSingleton<ISystemdNotifier, SystemdNotifier>();
+            services.AddSingleton<ISystemdNotifier>(_ =>
+            {
+                // Construct the notifier first so it reads (and normalizes) NOTIFY_SOCKET, then
+                // clear the env var so child processes don't inherit it and accidentally notify
+                // the parent's service manager. Done inside the DI factory so SystemdNotifier
+                // construction stays lazy and the env var is only mutated when hosting is
+                // actually wired up.
+                var notifier = new SystemdNotifier();
+                Environment.SetEnvironmentVariable(SystemdConstants.NotifySocket, null);
+                return notifier;
+            });
             services.AddSingleton<IHostLifetime, SystemdLifetime>();
 #pragma warning restore CA1416 // Validate platform compatibility
 

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/src/SystemdNotifier.cs
@@ -65,11 +65,6 @@ namespace Microsoft.Extensions.Hosting.Systemd
                 return null;
             }
 
-            // Because this method is called on Notifier construction, the envvar is cleared when the Host is built
-            // (IHostLifetime depends on ISystemdNotifier). This prevents child processes from inheriting the socket
-            // and interfering with service manager notifications.
-            Environment.SetEnvironmentVariable(SystemdConstants.NotifySocket, null);
-
             // Support abstract socket paths.
             if (socketPath[0] == '@')
             {


### PR DESCRIPTION
Move the `NOTIFY_SOCKET` clear out of `SystemdNotifier.GetNotifySocketPath` and into the `ISystemdNotifier` DI factory in `AddSystemdLifetime`. The public parameterless ctor is now a pure read; the env var is only mutated when hosting is actually wired up, and notifier construction stays lazy (DI resolves it during `Host` build via `IHostLifetime`).

Follow-up from #125520.