### PR TITLE
Fix locale collation for build.sh

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -175,7 +175,7 @@ useNinja=true
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
-actInt=($(comm -12 <(printf '%s\n' "${actions[@]/#/-}" | sort) <(printf '%s\n' "${@/#--/-}" | sort)))
+actInt=($(LC_ALL=C comm -12 <(printf '%s\n' "${actions[@]/#/-}" | LC_ALL=C sort) <(printf '%s\n' "${@/#--/-}" | LC_ALL=C sort)))
 firstArgumentChecked=0
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
`comm` is sensitive to collation rules. When invoking `comm` in the build script, force the locale collation to `C` so `sort` and `comm` behave consistently regardless of what the system behavior is.

Fixes #127334