### PR TITLE
[browser] Fix DateTime marshalling to be timezone-independent

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.DateTime.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/src/System/Runtime/InteropServices/JavaScript/Marshaling/JSMarshalerArgument.DateTime.cs
@@ -107,7 +107,7 @@ namespace System.Runtime.InteropServices.JavaScript
         public void ToJS(DateTime value)
         {
             slot.Type = MarshalerType.DateTime;
-            slot.DoubleValue = new DateTimeOffset(value).ToUnixTimeMilliseconds();
+            slot.DoubleValue = new DateTimeOffset(value.Ticks, TimeSpan.Zero).ToUnixTimeMilliseconds();
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace System.Runtime.InteropServices.JavaScript
             if (value.HasValue)
             {
                 slot.Type = MarshalerType.DateTime;
-                slot.DoubleValue = new DateTimeOffset(value.Value).ToUnixTimeMilliseconds();
+                slot.DoubleValue = new DateTimeOffset(value.Value.Ticks, TimeSpan.Zero).ToUnixTimeMilliseconds();
             }
             else
             {

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System.Runtime.InteropServices.JavaScript.Tests.csproj
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System.Runtime.InteropServices.JavaScript.Tests.csproj
@@ -7,6 +7,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TestRuntime>true</TestRuntime>
     <WasmXHarnessArgs>$(WasmXHarnessArgs) --engine-arg=--expose-gc --web-server-use-cop</WasmXHarnessArgs>
+    <WasmXHarnessMonoArgs>$(WasmXHarnessMonoArgs) --setenv=TZ=Europe/Berlin</WasmXHarnessMonoArgs>
     <EnableAggressiveTrimming>true</EnableAggressiveTrimming>
     <PublishTrimmed>true</PublishTrimmed>
     <DefineConstants Condition="'$(WasmEnableThreads)' == 'true'">$(DefineConstants);FEATURE_WASM_MANAGED_THREADS</DefineConstants>


### PR DESCRIPTION
## Problem

`ToJS(DateTime)` used `new DateTimeOffset(value)` which applies the **local timezone offset** when `DateTime.Kind` is `Unspecified` or `Local`. The `ToManaged` side always returns `.UtcDateTime` (offset=0). This asymmetry causes the roundtripped `DateTime` to shift by the local UTC offset.

With Emscripten 3.1.56, the WASM environment effectively ignored the `TZ` environment variable, so local time always equaled UTC — masking the bug. Emscripten 5.0.6 correctly processes `TZ`, exposing the issue on any machine with a non-UTC timezone.

### Failing tests (CET/CEST, +02:00)

- `DateTimeMaxValueBoundaryCondition` — 1h shift (CET for Dec 31)
- `DateTimeMarshallingLosesMicrosecondComponentPrecisionLoss` — 2h shift (CEST for Apr 1)
- `DateTimeMinValueBoundaryCondition` — `ArgumentOutOfRangeException` (MinValue + offset underflows year 0)
- `JsExportFuncOfDateTime_Argument_OverflowNETDateTime` — MaxValue+60s no longer overflows
- `JsExportFunctionDateTimeDateTime` — `DateTime.Now` roundtrip loses offset hours

## Fix

Replace `new DateTimeOffset(value)` with `new DateTimeOffset(value.Ticks, TimeSpan.Zero)` in both `ToJS(DateTime)` and `ToJS(DateTime?)`. This reinterprets ticks as UTC, matching the `ToManaged` side which already returns `.UtcDateTime`.

The `DateTimeOffset` overloads are unaffected — `ToUnixTimeMilliseconds()` already accounts for the stored offset.

### Before (broken in non-UTC timezone)

```
C# ToJS:    new DateTimeOffset(20:00 local, +02:00) → epoch for 18:00 UTC
JS:         new Date(epoch) → 18:00 UTC internally
C# ToManaged: FromUnixTimeMilliseconds(...).UtcDateTime → 18:00 (clock value shifted!)
```

### After (timezone-independent)

```
C# ToJS:    new DateTimeOffset(20:00 ticks, +00:00) → epoch for 20:00 UTC
JS:         new Date(epoch) → 20:00 UTC internally
C# ToManaged: FromUnixTimeMilliseconds(...).UtcDateTime → 20:00 (clock value preserved)
```

## Test coverage

Added `TZ=Europe/Berlin` to `WasmXHarnessMonoArgs` in the test csproj so CI (which runs in UTC) exercises the same non-UTC code paths as local development.
