### PR TITLE
Move CHECK_IR before morph global

### DIFF
--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -1987,6 +1987,36 @@ void Compiler::compSetProcessor()
 
     opts.preferredVectorByteLength = preferredVectorBitWidth / BITS_PER_BYTE;
 
+    if (info.compClassHnd != NO_CLASS_HANDLE)
+    {
+        const char* namespaceName;
+        const char* className = getClassNameFromMetadata(info.compClassHnd, &namespaceName);
+
+        if ((strcmp(namespaceName, "System.Numerics") == 0) && (strcmp(className, "Vector`1") == 0))
+        {
+            uint32_t const classSize = info.compCompHnd->getClassSize(info.compClassHnd);
+
+            instructionSetFlags.RemoveInstructionSet(InstructionSet_VectorT128);
+            instructionSetFlags.RemoveInstructionSet(InstructionSet_VectorT256);
+            instructionSetFlags.RemoveInstructionSet(InstructionSet_VectorT512);
+
+            switch (classSize)
+            {
+                case 16:
+                    instructionSetFlags.AddInstructionSet(InstructionSet_VectorT128);
+                    break;
+
+                case 32:
+                    instructionSetFlags.AddInstructionSet(InstructionSet_VectorT256);
+                    break;
+
+                case 64:
+                    instructionSetFlags.AddInstructionSet(InstructionSet_VectorT512);
+                    break;
+            }
+        }
+    }
+
     // Only one marker ISA should have been passed in, and it should now be cleared.
     assert(!instructionSetFlags.HasInstructionSet(InstructionSet_Vector128) &&
            !instructionSetFlags.HasInstructionSet(InstructionSet_Vector256) &&
@@ -2022,6 +2052,8 @@ void Compiler::compSetProcessor()
     instructionSetFlags.AddInstructionSet(InstructionSet_Vector128);
 #endif // TARGET_ARM64
 
+    instructionSetFlags.Set64BitInstructionSetVariants();
+    instructionSetFlags = EnsureInstructionSetFlagsAreValid(instructionSetFlags);
     assert(instructionSetFlags.Equals(EnsureInstructionSetFlagsAreValid(instructionSetFlags)));
     opts.setSupportedISAs(instructionSetFlags);
 
@@ -4571,6 +4603,9 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
     fgStress64RsltMul();
 #endif // DEBUG
 
+    // Enable IR checks before global morph so the post-phase check runs on morphed IR.
+    activePhaseChecks |= PhaseChecks::CHECK_IR;
+
     // Morph the trees in all the blocks of the method
     //
     unsigned const preMorphBBCount = fgBBcount;
@@ -4591,8 +4626,6 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
         compCurBB = nullptr;
 #endif // DEBUG
 
-        // Enable IR checks
-        activePhaseChecks |= PhaseChecks::CHECK_IR;
     };
     DoPhase(this, PHASE_POST_MORPH, postMorphPhase);
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -1191,6 +1191,43 @@ var_types Compiler::impNormStructType(CORINFO_CLASS_HANDLE structHnd, var_types*
 
         if (structSizeMightRepresentSIMDType(originalSize))
         {
+            const char* namespaceName = nullptr;
+            const char* className     = info.compCompHnd->getClassNameFromMetadata(structHnd, &namespaceName);
+
+            if (isNumericsNamespace(namespaceName) && (strcmp(className, "Vector`1") == 0))
+            {
+                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT128);
+                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT256);
+                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT512);
+                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT128);
+                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT256);
+                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT512);
+                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT128);
+                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT256);
+                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT512);
+
+                switch (originalSize)
+                {
+                    case 16:
+                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT128);
+                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT128);
+                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT128);
+                        break;
+
+                    case 32:
+                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT256);
+                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT256);
+                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT256);
+                        break;
+
+                    case 64:
+                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT512);
+                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT512);
+                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT512);
+                        break;
+                }
+            }
+
             unsigned int sizeBytes;
             var_types    simdBaseType = getBaseTypeAndSizeOfSIMDType(structHnd, &sizeBytes);
             if (simdBaseType != TYP_UNDEF)

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -10835,6 +10835,46 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                             }
 
                             uint32_t size = getVectorTByteLength();
+
+                            if (isVectorT)
+                            {
+                                CORINFO_CLASS_HANDLE const vectorClass = info.compCompHnd->getMethodClass(method);
+                                uint32_t const             classSize   = info.compCompHnd->getClassSize(vectorClass);
+
+                                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT128);
+                                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT256);
+                                opts.compSupportsISA.RemoveInstructionSet(InstructionSet_VectorT512);
+                                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT128);
+                                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT256);
+                                opts.compSupportsISAReported.RemoveInstructionSet(InstructionSet_VectorT512);
+                                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT128);
+                                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT256);
+                                opts.compSupportsISAExactly.RemoveInstructionSet(InstructionSet_VectorT512);
+
+                                switch (classSize)
+                                {
+                                    case 16:
+                                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT128);
+                                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT128);
+                                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT128);
+                                        size = 16;
+                                        break;
+
+                                    case 32:
+                                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT256);
+                                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT256);
+                                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT256);
+                                        size = 32;
+                                        break;
+
+                                    case 64:
+                                        opts.compSupportsISA.AddInstructionSet(InstructionSet_VectorT512);
+                                        opts.compSupportsISAReported.AddInstructionSet(InstructionSet_VectorT512);
+                                        opts.compSupportsISAExactly.AddInstructionSet(InstructionSet_VectorT512);
+                                        size = 64;
+                                        break;
+                                }
+                            }
 #ifdef TARGET_ARM64
                             assert((size == 16) || (size == SIZE_UNKNOWN));
 #else


### PR DESCRIPTION
Not sold on the need for these size updates, or (if needed) the way they're implemented