### PR TITLE
Fix sporadic AccessViolation in compressed single-file apps on Apple Silicon

### DIFF
--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -922,10 +922,9 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
 
     CopyMemory(base, (void*)GetBase(), sizeOfHeaders);
 
-    DWORD oldProtection;
+    DWORD oldProtection; // PAL layer doesn't properly set the previous protection, so we don't try to validate it here.
     if (!ClrVirtualProtect((void*)base, sizeOfHeaders, PAGE_READONLY, &oldProtection))
         ThrowLastError();
-    _ASSERTE(oldProtection == PAGE_READWRITE);
 
     // Commit and copy each section with its desired protection.
     for (IMAGE_SECTION_HEADER* section = sectionStart; section < sectionEnd; section++)

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -929,9 +929,12 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // Commit and copy each section with its desired protection.
     for (IMAGE_SECTION_HEADER* section = sectionStart; section < sectionEnd; section++)
     {
+        DWORD virtualSize = VAL32(section->Misc.VirtualSize);
+        if (virtualSize == 0)
+            continue;
+
         bool isExec = (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
         BYTE* sectionBase = (BYTE*)base + VAL32(section->VirtualAddress);
-        DWORD virtualSize = VAL32(section->Misc.VirtualSize);
         DWORD copySize = min(VAL32(section->SizeOfRawData), virtualSize);
 
         if (ClrVirtualAlloc(sectionBase, virtualSize, MEM_COMMIT, isExec ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE) == NULL)

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -877,17 +877,29 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
 #endif // FEATURE_ENABLE_NO_ADDRESS_SPACE_RANDOMIZATION
 
     DWORD allocationType = MEM_RESERVE | MEM_COMMIT;
+    DWORD initialProtection = PAGE_READWRITE;
 #if defined(HOST_UNIX) && defined(FEATURE_DYNAMIC_CODE_COMPILED)
     // Tell PAL to use the executable memory allocator to satisfy this request for virtual memory.
     // This is required on MacOS and otherwise will allow us to place native R2R code close to the
     // coreclr library and thus improve performance by avoiding jump stubs in managed code.
     allocationType |= MEM_RESERVE_EXECUTABLE;
 #endif
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+    // On Apple Silicon, allocating the image region as plain PAGE_READWRITE and then promoting
+    // executable sections to PAGE_EXECUTE_READ via mprotect has been observed to
+    // intermittently leave pages non-executable at the kernel level. This manifests as sporadic
+    // AccessViolationException crashes.
+    //
+    // Avoid the unreliable transition - reserve the whole region as PAGE_NOACCESS first, then
+    // commit each section directly with its final protection.
+    allocationType &= ~MEM_COMMIT;
+    initialProtection = PAGE_NOACCESS;
+#endif
 
     COUNT_T allocSize = ALIGN_UP(this->GetVirtualSize(), g_SystemInfo.dwAllocationGranularity);
-    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, allocationType, PAGE_READWRITE);
+    LPVOID base = ClrVirtualAlloc(preferredBase, allocSize, allocationType, initialProtection);
     if (base == NULL && preferredBase != NULL)
-        base = ClrVirtualAlloc(NULL, allocSize, allocationType, PAGE_READWRITE);
+        base = ClrVirtualAlloc(NULL, allocSize, allocationType, initialProtection);
 
     if (base == NULL)
         ThrowLastError();
@@ -895,15 +907,60 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // when loading by copying we have only one part to free.
     m_imageParts[0] = AllocatedPart(base);
 
+    IMAGE_SECTION_HEADER* sectionStart = IMAGE_FIRST_SECTION(FindNTHeaders());
+    IMAGE_SECTION_HEADER* sectionEnd = sectionStart + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
+
+#if defined(HOST_OSX) && defined(HOST_ARM64)
+    _ASSERTE((allocationType & MEM_COMMIT) == 0);
+    _ASSERTE(initialProtection != PAGE_READWRITE);
+
+    DWORD sizeOfHeaders = VAL32(FindNTHeaders()->OptionalHeader.SizeOfHeaders);
+
+    // Commit and copy headers, then apply read-only protection.
+    if (ClrVirtualAlloc(base, sizeOfHeaders, MEM_COMMIT, PAGE_READWRITE) == NULL)
+        ThrowLastError();
+
+    CopyMemory(base, (void*)GetBase(), sizeOfHeaders);
+
+    DWORD oldProtection;
+    if (!ClrVirtualProtect((void*)base, sizeOfHeaders, PAGE_READONLY, &oldProtection))
+        ThrowLastError();
+    _ASSERTE(oldProtection == PAGE_READWRITE);
+
+    // Commit and copy each section with its desired protection.
+    for (IMAGE_SECTION_HEADER* section = sectionStart; section < sectionEnd; section++)
+    {
+        bool isExec = (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
+        BYTE* sectionBase = (BYTE*)base + VAL32(section->VirtualAddress);
+        DWORD virtualSize = VAL32(section->Misc.VirtualSize);
+        DWORD copySize = min(VAL32(section->SizeOfRawData), virtualSize);
+
+        if (ClrVirtualAlloc(sectionBase, virtualSize, MEM_COMMIT, isExec ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE) == NULL)
+            ThrowLastError();
+
+        if (isExec)
+            PAL_JitWriteProtect(true);
+
+        CopyMemory(sectionBase, (BYTE*)GetBase() + VAL32(section->PointerToRawData), copySize);
+
+        if (isExec)
+        {
+            PAL_JitWriteProtect(false);
+        }
+        else if ((section->Characteristics & IMAGE_SCN_MEM_WRITE) == 0)
+        {
+            DWORD oldProt;
+            if (!ClrVirtualProtect(sectionBase, virtualSize, PAGE_READONLY, &oldProt))
+                ThrowLastError();
+        }
+    }
+#else
     // We're going to copy everything first, and write protect what we need to later.
 
     // First, copy headers
     CopyMemory(base, (void*)GetBase(), VAL32(FindNTHeaders()->OptionalHeader.SizeOfHeaders));
 
     // Now, copy all sections to appropriate virtual address
-
-    IMAGE_SECTION_HEADER* sectionStart = IMAGE_FIRST_SECTION(FindNTHeaders());
-    IMAGE_SECTION_HEADER* sectionEnd = sectionStart + VAL16(FindNTHeaders()->FileHeader.NumberOfSections);
 
     IMAGE_SECTION_HEADER* section = sectionStart;
     while (section < sectionEnd)
@@ -928,13 +985,9 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
     // Finally, apply proper protection to copied sections
     for (section = sectionStart; section < sectionEnd; section++)
     {
-        DWORD executableProtection = PAGE_EXECUTE_READ;
-#if defined(HOST_OSX) && defined(HOST_ARM64)
-        executableProtection = PAGE_EXECUTE_READWRITE;
-#endif
         // Add appropriate page protection.
         DWORD newProtection = section->Characteristics & IMAGE_SCN_MEM_EXECUTE ?
-            executableProtection :
+            PAGE_EXECUTE_READ :
             section->Characteristics & IMAGE_SCN_MEM_WRITE ?
             PAGE_READWRITE :
             PAGE_READONLY;
@@ -946,6 +999,7 @@ void* FlatImageLayout::LoadImageByCopyingParts(SIZE_T* m_imageParts) const
             ThrowLastError();
         }
     }
+#endif // defined(HOST_OSX) && defined(HOST_ARM64)
 
     return base;
 }

--- a/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
+++ b/src/installer/tests/AppHost.Bundle.Tests/AppLaunch.cs
@@ -110,6 +110,24 @@ namespace AppHost.Bundle.Tests
             }
         }
 
+        // Regression test: on macOS Apple Silicon, compressed self-contained single-file
+        // apps intermittently hit an AccessViolationException based on how we load images.
+        // This was observed via concurrent child process launches, so this test launches
+        // multiple child processes in parallel as a regression test.
+        [Fact]
+        [PlatformSpecific(TestPlatforms.OSX)]
+        public void SelfContained_Compressed_SpawnsChildren()
+        {
+            string singleFile = sharedTestState.SelfContainedApp.Bundle(BundleOptions.EnableCompression);
+
+            Command.Create(singleFile, "launch_self")
+                .CaptureStdErr()
+                .CaptureStdOut()
+                .Execute()
+                .Should().Pass()
+                .And.HaveStdOutContaining("Hello World!");
+        }
+
         [Theory(
             SkipType = typeof(Binaries.CetCompat),
             SkipUnless = nameof(Binaries.CetCompat.IsSupported),

--- a/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
+++ b/src/installer/tests/Assets/Projects/HelloWorld/Program.cs
@@ -2,9 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Loader;
+using System.Threading.Tasks;
 
 namespace HelloWorld
 {
@@ -53,6 +56,24 @@ namespace HelloWorld
                     // Disable core dumps - test is intentionally crashing
                     Utilities.CoreDump.Disable();
                     throw new Exception("Goodbye World!");
+                case "launch_self":
+                    // Launch copies of this app in parallel.
+                    // When run via dotnet <app_dll>, GetCommandLineArgs[0] is the managed
+                    // dll - forward it so the child knows what to launch.
+                    string fileName = Environment.ProcessPath!;
+                    string entry = Environment.GetCommandLineArgs()[0];
+                    bool forwardEntry = entry != Environment.ProcessPath;
+
+                    var tasks = Enumerable.Range(0, 5).Select(_ => Task.Run(() =>
+                    {
+                        var startInfo = new ProcessStartInfo { FileName = fileName };
+                        if (forwardEntry)
+                            startInfo.ArgumentList.Add(entry);
+                        using var process = Process.Start(startInfo)!;
+                        process.WaitForExit();
+                    })).ToArray();
+                    Task.WaitAll(tasks);
+                    break;
                 default:
                     break;
             }


### PR DESCRIPTION
> [!NOTE]
> This pull request was generated with AI assistance (GitHub Copilot CLI).

Fixes #123324.

cc @dotnet/appmodel @AaronRobinsonMSFT 

## Problem

On macOS Apple Silicon (observed on macOS 15), compressed self-contained single-file apps intermittently hit `AccessViolationException` crashes.  With the repro provided in the issue, the failure rate was roughly 75% in a local run.

`FlatImageLayout::LoadImageByCopyingParts` allocates the image region with `MEM_RESERVE_EXECUTABLE` (which maps to `MAP_JIT` on macOS) as `PAGE_READWRITE`, copies in all section bytes, then promotes executable sections to `PAGE_EXECUTE_READWRITE` via a second `mprotect`. On Apple Silicon, this `RW → RWX` transition on MAP_JIT memory has been observed to intermittently succeed at the API level but leave pages non-executable at the kernel level, producing the sporadic AVs.

## Fix

On Apple Silicon (`HOST_OSX && HOST_ARM64`), avoid the unreliable transition: reserve the whole image region as `PAGE_NOACCESS` up front, then commit each section directly with its final runtime protection (`PAGE_EXECUTE_READWRITE` for exec, `PAGE_READWRITE` otherwise), copying executable content under `PAL_JitWriteProtect`. The `PROT_NONE → RWX` direction via a fresh commit is reliable; the problematic `RW → RWX` transition no longer occurs. Read-only sections are still downgraded from `PAGE_READWRITE` to `PAGE_READONLY` after the copy, which is a W-removing transition and is not implicated in the original bug.

The non-Apple-Silicon code path is unchanged.

## Testing

New test: `AppHost.Bundle.Tests.AppLaunch.SelfContained_Compressed_SpawnsChildren` (OSX-only). Adds a `launch_self` option to the `HelloWorld` test asset that spawns 5 copies of itself in parallel, and asserts the parent runs to completion.

Local validation on Apple Silicon:

- Without fix: parent crash with `AccessViolationException` in ~74% of trials at N=5 children (rises to ~98% at N≥12).
- With fix: 0 failures across 50+ trials at N=5.
