### PR TITLE
[browser][coreCLR] Support interpreter code resolution on portable entrypoint platforms

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5605,11 +5605,11 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), methodDesc));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode()));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode(), methodDesc));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode()));
     }
 
     DebugInfoRequest request;
@@ -5664,11 +5664,11 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), methodDesc));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode()));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode(), methodDesc));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode()));
     }
 
     DebugInfoRequest request;

--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5425,7 +5425,7 @@ ClrDataAccess::RawGetMethodName(
     MethodDesc* methodDesc = NULL;
 
     {
-        EECodeInfo codeInfo(GetInterpreterCodeFromInterpreterPrecodeIfPresent(TO_TADDR(address)));
+        EECodeInfo codeInfo(GetInterpreterCodeFromEntryPointIfPresent(TO_TADDR(address)));
         if (codeInfo.IsValid())
         {
             if (displacement)
@@ -5605,11 +5605,11 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode()));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), methodDesc));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(methodDesc->GetNativeCode()));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode(), methodDesc));
     }
 
     DebugInfoRequest request;
@@ -5664,11 +5664,11 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode()));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), methodDesc));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(methodDesc->GetNativeCode()));
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(methodDesc->GetNativeCode(), methodDesc));
     }
 
     DebugInfoRequest request;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1316,7 +1316,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_AD
 
         EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
         {
-            codeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(codeAddr);
+            codeAddr = GetInterpreterCodeFromEntryPointIfPresent(codeAddr);
         }
         EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
 

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -911,7 +911,7 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
 void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, NativeCodeVersion activeCodeVersion, DacpReJitData * pReJitData)
 {
     pReJitData->rejitID = nativeCodeVersion.GetILCodeVersion().GetVersionId();
-    pReJitData->NativeCodeAddr = GetInterpreterCodeFromEntryPointIfPresent(nativeCodeVersion.GetNativeCode(), nativeCodeVersion.GetMethodDesc());
+    pReJitData->NativeCodeAddr = GetInterpreterCodeFromEntryPointIfPresent(nativeCodeVersion.GetNativeCode());
 
     if (nativeCodeVersion != activeCodeVersion)
     {
@@ -1021,7 +1021,7 @@ HRESULT ClrDataAccess::GetMethodDescData(
         if (!requestedNativeCodeVersion.IsNull() && requestedNativeCodeVersion.GetNativeCode() != (PCODE)NULL)
         {
             methodDescData->bHasNativeCode = TRUE;
-            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), pMD)));
+            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode())));
         }
         else
         {
@@ -1245,7 +1245,7 @@ HRESULT ClrDataAccess::GetTieredVersions(
         int count = 0;
         for (NativeCodeVersionIterator iter = nativeCodeVersions.Begin(); iter != nativeCodeVersions.End(); iter++)
         {
-            TADDR pNativeCode = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent((*iter).GetNativeCode(), pMD));
+            TADDR pNativeCode = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent((*iter).GetNativeCode()));
             nativeCodeAddrs[count].NativeCodeAddr = pNativeCode;
             PTR_NativeCodeVersionNode pNode = (*iter).AsNode();
             nativeCodeAddrs[count].NativeCodeVersionNodePtr = PTR_CDADDR(pNode);

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -911,7 +911,7 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
 void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, NativeCodeVersion activeCodeVersion, DacpReJitData * pReJitData)
 {
     pReJitData->rejitID = nativeCodeVersion.GetILCodeVersion().GetVersionId();
-    pReJitData->NativeCodeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCodeVersion.GetNativeCode());
+    pReJitData->NativeCodeAddr = GetInterpreterCodeFromEntryPointIfPresent(nativeCodeVersion.GetNativeCode(), nativeCodeVersion.GetMethodDesc());
 
     if (nativeCodeVersion != activeCodeVersion)
     {
@@ -1021,7 +1021,7 @@ HRESULT ClrDataAccess::GetMethodDescData(
         if (!requestedNativeCodeVersion.IsNull() && requestedNativeCodeVersion.GetNativeCode() != (PCODE)NULL)
         {
             methodDescData->bHasNativeCode = TRUE;
-            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode())));
+            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent(requestedNativeCodeVersion.GetNativeCode(), pMD)));
         }
         else
         {
@@ -1245,7 +1245,7 @@ HRESULT ClrDataAccess::GetTieredVersions(
         int count = 0;
         for (NativeCodeVersionIterator iter = nativeCodeVersions.Begin(); iter != nativeCodeVersions.End(); iter++)
         {
-            TADDR pNativeCode = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent((*iter).GetNativeCode()));
+            TADDR pNativeCode = PCODEToPINSTR(GetInterpreterCodeFromEntryPointIfPresent((*iter).GetNativeCode(), pMD));
             nativeCodeAddrs[count].NativeCodeAddr = pNativeCode;
             PTR_NativeCodeVersionNode pNode = (*iter).AsNode();
             nativeCodeAddrs[count].NativeCodeVersionNodePtr = PTR_CDADDR(pNode);

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -2060,7 +2060,7 @@ void DebuggerMethodInfo::CreateDJIsForMethodDesc(MethodDesc * pMethodDesc)
         {
             // Some versions may not be compiled yet - skip those for now
             // if they compile later the JitCompiled callback will add a DJI to our cache at that time
-            PCODE codeAddr = GetInterpreterCodeFromEntryPointIfPresent(itr->GetNativeCode(), pMethodDesc);
+            PCODE codeAddr = GetInterpreterCodeFromEntryPointIfPresent(itr->GetNativeCode());
             LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD (%d) Native code for DJI - %p\n", ++count, codeAddr));
             if (codeAddr)
             {

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -2060,7 +2060,7 @@ void DebuggerMethodInfo::CreateDJIsForMethodDesc(MethodDesc * pMethodDesc)
         {
             // Some versions may not be compiled yet - skip those for now
             // if they compile later the JitCompiled callback will add a DJI to our cache at that time
-            PCODE codeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(itr->GetNativeCode());
+            PCODE codeAddr = GetInterpreterCodeFromEntryPointIfPresent(itr->GetNativeCode(), pMethodDesc);
             LOG((LF_CORDB, LL_INFO10000, "DMI::CDJIFMD (%d) Native code for DJI - %p\n", ++count, codeAddr));
             if (codeAddr)
             {

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4428,7 +4428,7 @@ TADDR MethodAndStartAddressToEECodeInfoPointer(MethodDesc *pMethodDesc, PCODE pN
             return dac_cast<TADDR>(pInterpCode);
         }
     }
-#endif
+#endif // defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
 
     return start;
 }

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4417,9 +4417,7 @@ TADDR MethodAndStartAddressToEECodeInfoPointer(MethodDesc *pMethodDesc, PCODE pN
         return 0;
     }
 
-    start = GetInterpreterCodeFromEntryPointIfPresent(start, pNativeCodeStartAddress ? NULL : pMethodDesc);
-
-    return start;
+    return GetInterpreterCodeFromEntryPointIfPresent(start);
 }
 
 /****************************************************************************/

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4417,7 +4417,20 @@ TADDR MethodAndStartAddressToEECodeInfoPointer(MethodDesc *pMethodDesc, PCODE pN
         return 0;
     }
 
-    return GetInterpreterCodeFromInterpreterPrecodeIfPresent(start);
+    start = GetInterpreterCodeFromInterpreterPrecodeIfPresent(start);
+
+#if defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
+    if (pNativeCodeStartAddress == (PCODE)0)
+    {
+        PTR_InterpByteCodeStart pInterpCode = pMethodDesc->GetInterpreterCode();
+        if (pInterpCode != NULL)
+        {
+            return dac_cast<TADDR>(pInterpCode);
+        }
+    }
+#endif
+
+    return start;
 }
 
 /****************************************************************************/

--- a/src/coreclr/vm/eventtrace.cpp
+++ b/src/coreclr/vm/eventtrace.cpp
@@ -4417,18 +4417,7 @@ TADDR MethodAndStartAddressToEECodeInfoPointer(MethodDesc *pMethodDesc, PCODE pN
         return 0;
     }
 
-    start = GetInterpreterCodeFromInterpreterPrecodeIfPresent(start);
-
-#if defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
-    if (pNativeCodeStartAddress == (PCODE)0)
-    {
-        PTR_InterpByteCodeStart pInterpCode = pMethodDesc->GetInterpreterCode();
-        if (pInterpCode != NULL)
-        {
-            return dac_cast<TADDR>(pInterpCode);
-        }
-    }
-#endif // defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
+    start = GetInterpreterCodeFromEntryPointIfPresent(start, pNativeCodeStartAddress ? NULL : pMethodDesc);
 
     return start;
 }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1631,7 +1631,7 @@ public:
     PCODE GetCodeForInterpreterOrJitted()
     {
         WRAPPER_NO_CONTRACT;
-        return GetInterpreterCodeFromEntryPointIfPresent(GetNativeCode(), this);
+        return GetInterpreterCodeFromEntryPointIfPresent(GetNativeCode());
     }
 
     // Returns GetNativeCode() if it exists, but also checks to see if there

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1631,7 +1631,7 @@ public:
     PCODE GetCodeForInterpreterOrJitted()
     {
         WRAPPER_NO_CONTRACT;
-        return GetInterpreterCodeFromInterpreterPrecodeIfPresent(GetNativeCode());
+        return GetInterpreterCodeFromEntryPointIfPresent(GetNativeCode(), this);
     }
 
     // Returns GetNativeCode() if it exists, but also checks to see if there

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -959,7 +959,7 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
 
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
 
-TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pMethodDesc)
+TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint)
 {
     CONTRACTL {
         NOTHROW;
@@ -967,13 +967,26 @@ TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pM
         SUPPORTS_DAC;
     } CONTRACTL_END;
 
-#if defined(FEATURE_INTERPRETER) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
+#ifdef FEATURE_INTERPRETER
     if (entryPoint == (TADDR)NULL)
     {
         return (TADDR)NULL;
     }
 
     RangeSection * pRS = ExecutionManager::FindCodeRange(entryPoint, ExecutionManager::GetScanFlags());
+
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+    if (pRS == NULL)
+    {
+        // Address not in any code range - this is a portable entry point.
+        MethodDesc* pMD = PortableEntryPoint::GetMethodDesc((PCODE)entryPoint);
+        PTR_InterpByteCodeStart pInterpCode = pMD->GetInterpreterCode();
+        if (pInterpCode != NULL)
+        {
+            entryPoint = dac_cast<TADDR>(pInterpCode);
+        }
+    }
+#else // !FEATURE_PORTABLE_ENTRYPOINTS
     if (pRS != NULL && pRS->_flags & RangeSection::RANGE_SECTION_RANGELIST)
     {
         if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
@@ -984,16 +997,8 @@ TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pM
             }
         }
     }
-#elif defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
-    if (pMethodDesc != NULL)
-    {
-        PTR_InterpByteCodeStart pInterpCode = pMethodDesc->GetInterpreterCode();
-        if (pInterpCode != NULL)
-        {
-            return dac_cast<TADDR>(pInterpCode);
-        }
-    }
-#endif
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
+#endif // FEATURE_INTERPRETER
 
     return entryPoint;
 }

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -959,32 +959,41 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
 
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
 
-TADDR GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub)
+TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pMethodDesc)
 {
     CONTRACTL {
         NOTHROW;
         GC_NOTRIGGER;
         SUPPORTS_DAC;
     } CONTRACTL_END;
-    
+
 #if defined(FEATURE_INTERPRETER) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
-    if (codePointerMaybeInterpreterStub == (TADDR)NULL)
+    if (entryPoint == (TADDR)NULL)
     {
         return (TADDR)NULL;
     }
 
-    RangeSection * pRS = ExecutionManager::FindCodeRange(codePointerMaybeInterpreterStub, ExecutionManager::GetScanFlags());
+    RangeSection * pRS = ExecutionManager::FindCodeRange(entryPoint, ExecutionManager::GetScanFlags());
     if (pRS != NULL && pRS->_flags & RangeSection::RANGE_SECTION_RANGELIST)
     {
         if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
         {
-            if (dac_cast<PTR_StubPrecode>(PCODEToPINSTR(codePointerMaybeInterpreterStub))->GetType() == PRECODE_INTERPRETER)
+            if (dac_cast<PTR_StubPrecode>(PCODEToPINSTR(entryPoint))->GetType() == PRECODE_INTERPRETER)
             {
-                codePointerMaybeInterpreterStub = (dac_cast<PTR_InterpreterPrecode>(PCODEToPINSTR(codePointerMaybeInterpreterStub)))->GetData()->ByteCodeAddr;
+                entryPoint = (dac_cast<PTR_InterpreterPrecode>(PCODEToPINSTR(entryPoint)))->GetData()->ByteCodeAddr;
             }
+        }
+    }
+#elif defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)
+    if (pMethodDesc != NULL)
+    {
+        PTR_InterpByteCodeStart pInterpCode = pMethodDesc->GetInterpreterCode();
+        if (pInterpCode != NULL)
+        {
+            return dac_cast<TADDR>(pInterpCode);
         }
     }
 #endif
 
-    return codePointerMaybeInterpreterStub;
+    return entryPoint;
 }

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -864,6 +864,7 @@ extern InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
 
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 
+class MethodDesc;
 TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pMethodDesc = NULL);
 
 #endif // __PRECODE_H__

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -864,6 +864,6 @@ extern InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
 
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 
-TADDR GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub);
+TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pMethodDesc = NULL);
 
 #endif // __PRECODE_H__

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -864,7 +864,6 @@ extern InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
 
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 
-class MethodDesc;
-TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint, MethodDesc* pMethodDesc = NULL);
+TADDR GetInterpreterCodeFromEntryPointIfPresent(TADDR entryPoint);
 
 #endif // __PRECODE_H__

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -809,7 +809,9 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
 #ifdef FEATURE_INTERPRETER
         if (isInterpreterCode)
         {
-            // If this is interpreter code, we need to get the native code start address from the interpreter Precode
+            // If this is interpreter code, get the native code start address from the
+            // interpreter entrypoint data: PortableEntryPoint interpreter data when
+            // FEATURE_PORTABLE_ENTRYPOINTS is enabled, otherwise the interpreter Precode.
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
             InterpByteCodeStart* interpreterCode = (InterpByteCodeStart*)PortableEntryPoint::GetInterpreterData(pCode);
 #else // !FEATURE_PORTABLE_ENTRYPOINTS

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -810,8 +810,12 @@ PCODE MethodDesc::JitCompileCodeLockedEventWrapper(PrepareCodeConfig* pConfig, J
         if (isInterpreterCode)
         {
             // If this is interpreter code, we need to get the native code start address from the interpreter Precode
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+            InterpByteCodeStart* interpreterCode = (InterpByteCodeStart*)PortableEntryPoint::GetInterpreterData(pCode);
+#else // !FEATURE_PORTABLE_ENTRYPOINTS
             InterpreterPrecode* pPrecode = InterpreterPrecode::FromEntryPoint(pCode);
             InterpByteCodeStart* interpreterCode = dac_cast<InterpByteCodeStart*>(pPrecode->GetData()->ByteCodeAddr);
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
             pNativeCodeStartAddress = PINSTRToPCODE(dac_cast<TADDR>(interpreterCode));
         }
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2544,7 +2544,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
             // Check to see if the entrypoint is into the interpreter. If so, grab the interpreter codes from the stub and put that directly
             // into the MethodDesc
             TADDR functionAddress = GetOrCreatePrecode()->GetTarget();
-            TADDR byteCodeStartOrFunctionAddress = GetInterpreterCodeFromInterpreterPrecodeIfPresent(functionAddress);
+            TADDR byteCodeStartOrFunctionAddress = GetInterpreterCodeFromEntryPointIfPresent(functionAddress);
             if (byteCodeStartOrFunctionAddress != functionAddress)
             {
                 // Then we must have an InterpByteCodeStart


### PR DESCRIPTION
## Summary

Generalizes `GetInterpreterCodeFromInterpreterPrecodeIfPresent` (renamed to `GetInterpreterCodeFromEntryPointIfPresent`) to resolve interpreter bytecode addresses on platforms that use `FEATURE_PORTABLE_ENTRYPOINTS` (e.g., browser WASM) where `InterpreterPrecode` does not exist.

## Motivation

The sampling profiler does not work on WASM because the EventPipe code paths that resolve instruction pointers (IPs) to method information assume the traditional `InterpreterPrecode` mechanism. On WASM, CoreCLR uses portable entrypoints (`FEATURE_PORTABLE_ENTRYPOINTS`) instead of interpreter precodes, so the existing code silently returns wrong or zero addresses, causing the profiler to fail to attribute samples to managed methods.

Split from https://github.com/dotnet/runtime/pull/126324 for smaller reviews

## Changes

### Renamed function with new signature
- `GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR)` → `GetInterpreterCodeFromEntryPointIfPresent(TADDR, MethodDesc*)`
- The new `pMethodDesc` parameter (defaulting to `NULL`) enables resolution on portable entrypoint platforms via `MethodDesc::GetInterpreterCode()`.

### New portable entrypoint code path (`precode.cpp`)
Added `#elif defined(FEATURE_INTERPRETER) && defined(FEATURE_PORTABLE_ENTRYPOINTS)` branch:
- When `pMethodDesc` is provided, calls `pMethodDesc->GetInterpreterCode()` to get the `InterpByteCodeStart` pointer directly from the MethodDesc, bypassing the precode entirely.
- Falls through to returning the original entry point when `pMethodDesc` is NULL or no interpreter code exists.

### Portable entrypoint handling in `prestub.cpp`
Added `#ifdef FEATURE_PORTABLE_ENTRYPOINTS` branch in `JitCompileCodeLockedEventWrapper` to use `PortableEntryPoint::GetInterpreterData(pCode)` instead of `InterpreterPrecode::FromEntryPoint(pCode)` when extracting the `InterpByteCodeStart` for ETW method-jitted events.

### Caller updates (DAC/debugger/ETW)
All callers updated to pass the new `MethodDesc*` parameter where available:
- `daccess.cpp` — `GetMethodVarInfo`, `GetMethodNativeMap`, `RawGetMethodName`
- `dacdbiimpl.cpp` — `GetNativeCodeInfoForAddr`
- `request.cpp` — `CopyNativeCodeVersionToReJitData`, `GetMethodDescData`, `GetTieredVersions`
- `functioninfo.cpp` — `CreateDJIsForMethodDesc`
- `eventtrace.cpp` — `MethodAndStartAddressToEECodeInfoPointer` (passes `NULL` when a specific code address was provided, `pMethodDesc` otherwise)
- `method.hpp` — `GetCodeForInterpreterOrJitted`
