### PR TITLE
Use safe Span.Slice loop pattern in HashCode.AddBytes

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -45,7 +45,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 #pragma warning disable CA1066 // Implement IEquatable when overriding Object.Equals
 
@@ -335,17 +334,17 @@ namespace System
                 {
                     case 1:
                         Debug.Assert(value.Length >= sizeof(int));
-                        Add(MemoryMarshal.Read<int>(value));
+                        Add(BitConverter.ToInt32(value));
                         value = value.Slice(sizeof(int));
                         goto case 2;
                     case 2:
                         Debug.Assert(value.Length >= sizeof(int));
-                        Add(MemoryMarshal.Read<int>(value));
+                        Add(BitConverter.ToInt32(value));
                         value = value.Slice(sizeof(int));
                         goto case 3;
                     case 3:
                         Debug.Assert(value.Length >= sizeof(int));
-                        Add(MemoryMarshal.Read<int>(value));
+                        Add(BitConverter.ToInt32(value));
                         value = value.Slice(sizeof(int));
                         break;
                 }
@@ -354,10 +353,10 @@ namespace System
             // With the queue clear, we add sixteen bytes at a time until the input has fewer than sixteen bytes remaining.
             while (value.Length >= sizeof(int) * 4)
             {
-                _v1 = Round(_v1, MemoryMarshal.Read<uint>(value));
-                _v2 = Round(_v2, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 1)));
-                _v3 = Round(_v3, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 2)));
-                _v4 = Round(_v4, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 3)));
+                _v1 = Round(_v1, BitConverter.ToUInt32(value));
+                _v2 = Round(_v2, BitConverter.ToUInt32(value.Slice(sizeof(int) * 1)));
+                _v3 = Round(_v3, BitConverter.ToUInt32(value.Slice(sizeof(int) * 2)));
+                _v4 = Round(_v4, BitConverter.ToUInt32(value.Slice(sizeof(int) * 3)));
 
                 _length += 4;
                 value = value.Slice(sizeof(int) * 4);
@@ -367,7 +366,7 @@ namespace System
             // Add four bytes at a time until the input has fewer than four bytes remaining.
             while (value.Length >= sizeof(int))
             {
-                Add(MemoryMarshal.Read<int>(value));
+                Add(BitConverter.ToInt32(value));
                 value = value.Slice(sizeof(int));
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/HashCode.cs
@@ -317,9 +317,6 @@ namespace System
         /// </remarks>
         public void AddBytes(ReadOnlySpan<byte> value)
         {
-            ref byte pos = ref MemoryMarshal.GetReference(value);
-            ref byte end = ref Unsafe.Add(ref pos, value.Length);
-
             if (value.Length < (sizeof(int) * 4))
             {
                 goto Small;
@@ -337,55 +334,47 @@ namespace System
                 switch (_length % 4)
                 {
                     case 1:
-                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
-                        Add(Unsafe.ReadUnaligned<int>(ref pos));
-                        pos = ref Unsafe.Add(ref pos, sizeof(int));
+                        Debug.Assert(value.Length >= sizeof(int));
+                        Add(MemoryMarshal.Read<int>(value));
+                        value = value.Slice(sizeof(int));
                         goto case 2;
                     case 2:
-                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
-                        Add(Unsafe.ReadUnaligned<int>(ref pos));
-                        pos = ref Unsafe.Add(ref pos, sizeof(int));
+                        Debug.Assert(value.Length >= sizeof(int));
+                        Add(MemoryMarshal.Read<int>(value));
+                        value = value.Slice(sizeof(int));
                         goto case 3;
                     case 3:
-                        Debug.Assert(Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int));
-                        Add(Unsafe.ReadUnaligned<int>(ref pos));
-                        pos = ref Unsafe.Add(ref pos, sizeof(int));
+                        Debug.Assert(value.Length >= sizeof(int));
+                        Add(MemoryMarshal.Read<int>(value));
+                        value = value.Slice(sizeof(int));
                         break;
                 }
             }
 
             // With the queue clear, we add sixteen bytes at a time until the input has fewer than sixteen bytes remaining.
-            // We first have to round the end pointer to the nearest 16-byte block from the offset. This makes the loop's condition simpler.
-            ref byte blockEnd = ref Unsafe.Subtract(ref end, Unsafe.ByteOffset(ref pos, ref end) % (sizeof(int) * 4));
-            while (Unsafe.IsAddressLessThan(ref pos, ref blockEnd))
+            while (value.Length >= sizeof(int) * 4)
             {
-                Debug.Assert(Unsafe.ByteOffset(ref pos, ref blockEnd) >= (sizeof(int) * 4));
-                uint v1 = Unsafe.ReadUnaligned<uint>(ref pos);
-                _v1 = Round(_v1, v1);
-                uint v2 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref pos, sizeof(int) * 1));
-                _v2 = Round(_v2, v2);
-                uint v3 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref pos, sizeof(int) * 2));
-                _v3 = Round(_v3, v3);
-                uint v4 = Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref pos, sizeof(int) * 3));
-                _v4 = Round(_v4, v4);
+                _v1 = Round(_v1, MemoryMarshal.Read<uint>(value));
+                _v2 = Round(_v2, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 1)));
+                _v3 = Round(_v3, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 2)));
+                _v4 = Round(_v4, MemoryMarshal.Read<uint>(value.Slice(sizeof(int) * 3)));
 
                 _length += 4;
-                pos = ref Unsafe.Add(ref pos, sizeof(int) * 4);
+                value = value.Slice(sizeof(int) * 4);
             }
 
         Small:
             // Add four bytes at a time until the input has fewer than four bytes remaining.
-            while (Unsafe.ByteOffset(ref pos, ref end) >= sizeof(int))
+            while (value.Length >= sizeof(int))
             {
-                Add(Unsafe.ReadUnaligned<int>(ref pos));
-                pos = ref Unsafe.Add(ref pos, sizeof(int));
+                Add(MemoryMarshal.Read<int>(value));
+                value = value.Slice(sizeof(int));
             }
 
             // Add the remaining bytes a single byte at a time.
-            while (Unsafe.IsAddressLessThan(ref pos, ref end))
+            foreach (byte b in value)
             {
-                Add((int)pos);
-                pos = ref Unsafe.Add(ref pos, 1);
+                Add((int)b);
             }
         }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot (AI-generated content).

Rewrites `HashCode.AddBytes` to use the safe loop pattern:

```cs
while (value.Length >= sizeof(int) * 4)
{
    _v1 = Round(_v1, BitConverter.ToUInt32(value));
    _v2 = Round(_v2, BitConverter.ToUInt32(value.Slice(sizeof(int) * 1)));
    _v3 = Round(_v3, BitConverter.ToUInt32(value.Slice(sizeof(int) * 2)));
    _v4 = Round(_v4, BitConverter.ToUInt32(value.Slice(sizeof(int) * 3)));

    _length += 4;
    value = value.Slice(sizeof(int) * 4);
}
```

This replaces `Unsafe.ReadUnaligned` / `Unsafe.Add(ref, off)` / `Unsafe.IsAddressLessThan` based pointer walking with `BitConverter.ToInt32`/`ToUInt32` and `ReadOnlySpan<byte>.Slice` over the input span (the queue-flush switch and the 4-byte / 1-byte tail loops are converted in the same way).

The JIT recognizes this exact loop shape (`while (data.Length >= CONST) { ...; data = data.Slice(CONST); }`) and elides the bounds checks, so the resulting codegen is equivalent to the previous unsafe form.

### Codegen diff

https://www.diffchecker.com/JhXDl9Eg/
