### PR TITLE
Disable trim and AOT analyzers in iOS test project

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/Hybrid/System.Runtime.IOS.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/Hybrid/System.Runtime.IOS.Tests.csproj
@@ -5,6 +5,9 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <HybridGlobalization>true</HybridGlobalization>
+    <!-- https://github.com/dotnet/runtime/issues/126862 -->
+    <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
+    <EnableAotAnalyzer>false</EnableAotAnalyzer>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This should fix extra-platforms. Enabling these analyzers is new, not all tests are clean.