### PR TITLE
[cDAC] Add diagnostic logging to GetMethodTableName assertion

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -51,6 +52,36 @@ internal static class DebugExtensions
                 _ => cdacHr == dacHr,
             };
             Debug.Assert(match, $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})");
+        }
+
+        [Conditional("DEBUG")]
+        internal static unsafe void ValidateOutputStringBuffer(
+            char* cdacBuffer,
+            uint* cdacNeeded,
+            char[] dacBuffer,
+            uint dacNeeded,
+            uint count,
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            string location = $"{Path.GetFileName(filePath)}:{lineNumber}";
+
+            if (cdacNeeded is not null && *cdacNeeded != dacNeeded)
+            {
+                int cdacLen = (int)Math.Min(*cdacNeeded, count);
+                string cdacStr = cdacBuffer is not null && cdacLen > 0 ? new string(cdacBuffer, 0, cdacLen - 1) : "<null>";
+                string dacStr = dacNeeded > 0 ? new string(dacBuffer, 0, (int)dacNeeded - 1) : "<empty>";
+                Trace.TraceWarning($"Output buffer pNeeded mismatch ({location}) - cDAC: {*cdacNeeded} (\"{cdacStr}\"), DAC: {dacNeeded} (\"{dacStr}\")");
+            }
+            else if (cdacBuffer is not null && dacNeeded > 0 && count >= dacNeeded)
+            {
+                var cdacSpan = new ReadOnlySpan<char>(cdacBuffer, (int)dacNeeded - 1);
+                var dacSpan = new ReadOnlySpan<char>(dacBuffer, 0, (int)dacNeeded - 1);
+                if (!cdacSpan.SequenceEqual(dacSpan))
+                {
+                    Trace.TraceWarning($"Output buffer content mismatch ({location}) - cDAC: \"{new string(cdacBuffer, 0, (int)dacNeeded - 1)}\", DAC: \"{new string(dacBuffer, 0, (int)dacNeeded - 1)}\"");
+                }
+            }
         }
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -2995,6 +2995,13 @@ public sealed unsafe partial class SOSDacImpl
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
+                if (pNeeded != null && *pNeeded != neededLocal)
+                {
+                    string cdacStr = mtName is not null && count > 0 ? new string(mtName, 0, (int)System.Math.Min(*pNeeded, count) - 1) : "<null>";
+                    string dacStr = neededLocal > 0 ? new string(mtNameLocal, 0, (int)neededLocal - 1) : "<empty>";
+                    System.Console.Error.WriteLine($"CDAC_MISMATCH GetMethodTableName MT=0x{(ulong)mt:X} pNeeded: cDAC={*pNeeded} DAC={neededLocal} cDAC_name=\"{cdacStr}\" DAC_name=\"{dacStr}\"");
+                    System.Console.Error.Flush();
+                }
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
                 Debug.Assert(mtName == null || new ReadOnlySpan<char>(mtNameLocal, 0, (int)neededLocal - 1).SequenceEqual(new string(mtName)));
             }


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Add \Console.Error.WriteLine\ diagnostic output before the \Debug.Assert\ in \GetMethodTableName\ to capture the mismatched type names when the cDAC and legacy DAC produce different results. The stderr output survives the process crash and appears in CI test logs.

## Problem

The \SOS.WebApp3\ test has been crashing in all \untime-diagnostics\ PR builds since April 24 with:
\\\
Assertion failed: pNeeded == null || *pNeeded == neededLocal
   at SOSDacImpl.GetMethodTableName(...)
\\\

The assertion fires during \!timerinfo\ when the cDAC's \TypeNameBuilder\ produces a different type name than the legacy DAC's \TypeString\ for some method table. The assertion doesn't include the actual names, making diagnosis impossible.

## Changes

- **SOSDacImpl.cs**: Added stderr logging before the assertion that prints the MT address, both pNeeded values, and both type name strings with a \CDAC_MISMATCH\ prefix
- **DebugExtensions.cs**: Added \ValidateOutputStringBuffer\ helper for future soft-fail conversion

## Purpose

This is a **diagnostic PR** to identify the exact type causing the mismatch. Once identified, a follow-up PR will fix the root cause in \TypeNameBuilder\.