### PR TITLE
[APIScan] Remove unused KiUserExceptionDispatcher check in debugger patch skip (Bug 2822252)

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -4729,43 +4729,6 @@ TP_RESULT DebuggerPatchSkip::TriggerExceptionHook(Thread *thread, CONTEXT * cont
 
         if (IsSingleStep(exception->ExceptionCode))
         {
-#ifndef TARGET_UNIX
-            // Check if the current IP is anywhere near the exception dispatcher logic.
-            // If it is, ignore the exception, as the real exception is coming next.
-            static FARPROC pExcepDispProc = NULL;
-
-            if (!pExcepDispProc)
-            {
-                HMODULE hNtDll = WszGetModuleHandle(W("ntdll.dll"));
-
-                if (hNtDll != NULL)
-                {
-                    pExcepDispProc = GetProcAddress(hNtDll, "KiUserExceptionDispatcher");
-
-                    if (!pExcepDispProc)
-                        pExcepDispProc = (FARPROC)(size_t)(-1);
-                }
-                else
-                    pExcepDispProc = (FARPROC)(size_t)(-1);
-            }
-
-            _ASSERTE(pExcepDispProc != NULL);
-
-            if ((size_t)pExcepDispProc != (size_t)(-1))
-            {
-                LPVOID pExcepDispEntryPoint = pExcepDispProc;
-
-                if ((size_t)GetIP(context) > (size_t)pExcepDispEntryPoint &&
-                    (size_t)GetIP(context) <= ((size_t)pExcepDispEntryPoint + MAX_INSTRUCTION_LENGTH * 2 + 1))
-                {
-                    LOG((LF_CORDB, LL_INFO10000,
-                         "Bypass instruction not redirected. Landed in exception dispatcher.\n"));
-
-                    return (TPR_IGNORE_AND_STOP);
-                }
-            }
-#endif // TARGET_UNIX
-
             // If the IP is close to the skip patch start, or if we were skipping over a call, then assume the IP needs
             // adjusting.
             if (m_instrAttrib.m_fIsCall ||


### PR DESCRIPTION
## APIScan Compliance Fix

**Bug**: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2822252
**Issue Type**: DocumentationNotFound
**Binary**: coreclr.dll
**Branch**: release/8.0

### Problem

APIScan reports a `documentationnotfound` finding for `coreclr.dll` calling `ntdll.dll!KiUserExceptionDispatcher`. The call originates in `DebuggerPatchSkip::TriggerExceptionHook` (`src/coreclr/debug/ee/controller.cpp:4743`), where the debugger's breakpoint patch-skip mechanism uses `GetProcAddress` to resolve `KiUserExceptionDispatcher` from `ntdll.dll` to check whether the current IP is near the NT exception dispatcher entry point.

`KiUserExceptionDispatcher` is an internal NT kernel callback — it has no public documentation on learn.microsoft.com, causing APIScan to flag it.

### Fix

Remove the entire `#ifndef TARGET_UNIX` / `#endif // TARGET_UNIX` block (37 lines) that performed the `KiUserExceptionDispatcher` check. This code was dead — the check was never triggered in practice. The remaining single-step handling logic (IP adjustment for skip patch area) is sufficient.

### Precedent

This change backports commit `8a2cc6d6fdf2eeea783af49b1e470fbe2c564ee7` from `main`, originally merged via PR #91230 ("Code cleanup: remove unused code in debugger patch skip logic") on 2023-08-29.

The precedent PR was authored by Tom McDonald and discussed in APIScan email threads by Susan Lester (Feb 8, 2024) and Stefan Hirtbach (Feb 21, 2024), who confirmed the .NET Core removal resolved the issue for v-next. This 8.0 servicing branch did not receive the backport.

### Validation

⚠️ CI validation required — this PR was generated by the APIScan Copilot Skill and has not been build-tested locally.

### Generated by

APIScan Copilot Skill (ProducePR utility)