### PR TITLE
[cDAC] Fix GetMethodTableName empty type name mismatch

### DIFF
--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -143,7 +143,7 @@ extends:
                 artifactName: 'TestResults_cDAC_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
               displayName: 'Publish Test Results and SOS Logs'
               continueOnError: true
-              condition: failed()
+              condition: always()
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -197,7 +197,7 @@ extends:
                 artifactName: 'TestResults_cDAC_no_fallback_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
               displayName: 'Publish Test Results and SOS Logs'
               continueOnError: true
-              condition: failed()
+              condition: always()
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -250,7 +250,7 @@ extends:
                 artifactName: 'TestResults_DAC_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
               displayName: 'Publish Test Results and SOS Logs'
               continueOnError: true
-              condition: failed()
+              condition: always()
 
     #
     # cDAC Dump Tests — Build, generate dumps, and run tests on Helix (single-leg mode)

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1939,7 +1939,11 @@ ClrDataAccess::GetMethodTableName(CLRDATA_ADDRESS mt, unsigned int count, _Inout
 
             if (s.IsEmpty())
             {
-                hr = E_OUTOFMEMORY;
+                if (pNeeded)
+                    *pNeeded = 1;
+
+                if (mtName && count)
+                    mtName[0] = 0;
             }
             else
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -51,6 +52,36 @@ internal static class DebugExtensions
                 _ => cdacHr == dacHr,
             };
             Debug.Assert(match, $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})");
+        }
+
+        [Conditional("DEBUG")]
+        internal static unsafe void ValidateOutputStringBuffer(
+            char* cdacBuffer,
+            uint* cdacNeeded,
+            char[] dacBuffer,
+            uint dacNeeded,
+            uint count,
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            string location = $"{Path.GetFileName(filePath)}:{lineNumber}";
+
+            if (cdacNeeded is not null && *cdacNeeded != dacNeeded)
+            {
+                int cdacLen = (int)Math.Min(*cdacNeeded, count);
+                string cdacStr = cdacBuffer is not null && cdacLen > 0 ? new string(cdacBuffer, 0, cdacLen - 1) : "<null>";
+                string dacStr = dacNeeded > 0 ? new string(dacBuffer, 0, (int)dacNeeded - 1) : "<empty>";
+                Trace.TraceWarning($"Output buffer pNeeded mismatch ({location}) - cDAC: {*cdacNeeded} (\"{cdacStr}\"), DAC: {dacNeeded} (\"{dacStr}\")");
+            }
+            else if (cdacBuffer is not null && dacNeeded > 0 && count >= dacNeeded)
+            {
+                var cdacSpan = new ReadOnlySpan<char>(cdacBuffer, (int)dacNeeded - 1);
+                var dacSpan = new ReadOnlySpan<char>(dacBuffer, 0, (int)dacNeeded - 1);
+                if (!cdacSpan.SequenceEqual(dacSpan))
+                {
+                    Trace.TraceWarning($"Output buffer content mismatch ({location}) - cDAC: \"{new string(cdacBuffer, 0, (int)dacNeeded - 1)}\", DAC: \"{new string(dacBuffer, 0, (int)dacNeeded - 1)}\"");
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Problem

The `SOS.WebApp3` test has been crashing in all `runtime-diagnostics` PR builds since April 24 with a `Debug.Assert` failure in `GetMethodTableName`.

### Root Cause

Commit c835d0fc4f8 ("Change heap dumps to use HEAP2 as the default") removed explicit enumeration of `m_pAvailableParamTypes`, `m_pInstMethodHashTable`, and per-type/method `EnumMemoryRegions` from `Module::EnumMemoryRegions` for heap dumps. HEAP2 relies solely on `LoaderAllocator` heap enumeration, but generic instantiation lookup tables aren't fully captured by raw heap page enumeration. This causes some type names to be unresolvable from HEAP2 dumps.

When `TypeString::AppendType` can't resolve a type name (produces empty string), the native DAC was returning `E_OUTOFMEMORY` while the cDAC returned `S_OK` with `pNeeded=1`. The `#if DEBUG` validation caught this mismatch and crashed.

### What this PR fixes

1. **request.cpp**: Fix the native DAC to write an empty string with `pNeeded=1` instead of returning `E_OUTOFMEMORY` — an empty type name is not an OOM condition. Both DACs now agree on `S_OK` with empty string.

2. **runtime-diagnostics.yml**: Changed "Publish Test Results and SOS Logs" from `condition: failed()` to `condition: always()` for all three SOS test jobs, so diagnostic output is accessible for passing runs.

3. **DebugExtensions.cs**: Added `ValidateOutputStringBuffer` helper for future use in converting output buffer assertions to soft-fail.

### Follow-up needed

The HEAP2 dump regression should be addressed separately. The removed code from `ceeload.cpp` (`m_pAvailableParamTypes`, `m_pInstMethodHashTable`, and per-MethodTable/MethodDesc enumeration) needs to be partially restored to ensure generic instantiation type names are resolvable from heap dumps. cc @hoyosjs
