### PR TITLE
Use safe spans in BigInteger RightShiftSelf

### DIFF
--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Numerics
@@ -115,46 +114,48 @@ namespace System.Numerics
             {
                 carry = bits[^1] >> back;
 
-                ref nuint start = ref MemoryMarshal.GetReference(bits);
-                int offset = bits.Length;
+                Span<nuint> remaining = bits;
 
                 // Each vector load needs one extra element below it to source the carry bits
                 // that shift in from the lower limbs, hence the +1 minimum.
-                while (Vector512.IsHardwareAccelerated && offset >= Vector512<nuint>.Count + 1)
+                while (Vector512.IsHardwareAccelerated && remaining.Length >= Vector512<nuint>.Count + 1)
                 {
-                    Vector512<nuint> current = Vector512.LoadUnsafe(ref start, (nuint)(offset - Vector512<nuint>.Count)) << shift;
-                    Vector512<nuint> carries = Vector512.LoadUnsafe(ref start, (nuint)(offset - (Vector512<nuint>.Count + 1))) >> back;
+                    int offset = remaining.Length - Vector512<nuint>.Count;
+                    Vector512<nuint> current = Vector512.Create(remaining.Slice(offset)) << shift;
+                    Vector512<nuint> carries = Vector512.Create(remaining.Slice(offset - 1)) >> back;
 
                     Vector512<nuint> newValue = current | carries;
 
-                    Vector512.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector512<nuint>.Count));
-                    offset -= Vector512<nuint>.Count;
+                    newValue.CopyTo(remaining.Slice(offset));
+                    remaining = remaining.Slice(0, offset);
                 }
 
-                while (Vector256.IsHardwareAccelerated && offset >= Vector256<nuint>.Count + 1)
+                while (Vector256.IsHardwareAccelerated && remaining.Length >= Vector256<nuint>.Count + 1)
                 {
-                    Vector256<nuint> current = Vector256.LoadUnsafe(ref start, (nuint)(offset - Vector256<nuint>.Count)) << shift;
-                    Vector256<nuint> carries = Vector256.LoadUnsafe(ref start, (nuint)(offset - (Vector256<nuint>.Count + 1))) >> back;
+                    int offset = remaining.Length - Vector256<nuint>.Count;
+                    Vector256<nuint> current = Vector256.Create(remaining.Slice(offset)) << shift;
+                    Vector256<nuint> carries = Vector256.Create(remaining.Slice(offset - 1)) >> back;
 
                     Vector256<nuint> newValue = current | carries;
 
-                    Vector256.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector256<nuint>.Count));
-                    offset -= Vector256<nuint>.Count;
+                    newValue.CopyTo(remaining.Slice(offset));
+                    remaining = remaining.Slice(0, offset);
                 }
 
-                while (Vector128.IsHardwareAccelerated && offset >= Vector128<nuint>.Count + 1)
+                while (Vector128.IsHardwareAccelerated && remaining.Length >= Vector128<nuint>.Count + 1)
                 {
-                    Vector128<nuint> current = Vector128.LoadUnsafe(ref start, (nuint)(offset - Vector128<nuint>.Count)) << shift;
-                    Vector128<nuint> carries = Vector128.LoadUnsafe(ref start, (nuint)(offset - (Vector128<nuint>.Count + 1))) >> back;
+                    int offset = remaining.Length - Vector128<nuint>.Count;
+                    Vector128<nuint> current = Vector128.Create(remaining.Slice(offset)) << shift;
+                    Vector128<nuint> carries = Vector128.Create(remaining.Slice(offset - 1)) >> back;
 
                     Vector128<nuint> newValue = current | carries;
 
-                    Vector128.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector128<nuint>.Count));
-                    offset -= Vector128<nuint>.Count;
+                    newValue.CopyTo(remaining.Slice(offset));
+                    remaining = remaining.Slice(0, offset);
                 }
 
                 nuint carry2 = 0;
-                for (int i = 0; i < offset; i++)
+                for (int i = 0; i < remaining.Length; i++)
                 {
                     nuint value = carry2 | bits[i] << shift;
                     carry2 = bits[i] >> back;
@@ -189,43 +190,43 @@ namespace System.Numerics
             {
                 carry = bits[0] << back;
 
-                ref nuint start = ref MemoryMarshal.GetReference(bits);
-                int offset = 0;
+                Span<nuint> remaining = bits;
 
-                while (Vector512.IsHardwareAccelerated && bits.Length - offset >= Vector512<nuint>.Count + 1)
+                while (Vector512.IsHardwareAccelerated && remaining.Length >= Vector512<nuint>.Count + 1)
                 {
-                    Vector512<nuint> current = Vector512.LoadUnsafe(ref start, (nuint)offset) >> shift;
-                    Vector512<nuint> carries = Vector512.LoadUnsafe(ref start, (nuint)(offset + 1)) << back;
+                    Vector512<nuint> current = Vector512.Create(remaining) >> shift;
+                    Vector512<nuint> carries = Vector512.Create(remaining.Slice(1)) << back;
 
                     Vector512<nuint> newValue = current | carries;
 
-                    Vector512.StoreUnsafe(newValue, ref start, (nuint)offset);
-                    offset += Vector512<nuint>.Count;
+                    newValue.CopyTo(remaining);
+                    remaining = remaining.Slice(Vector512<nuint>.Count);
                 }
 
-                while (Vector256.IsHardwareAccelerated && bits.Length - offset >= Vector256<nuint>.Count + 1)
+                while (Vector256.IsHardwareAccelerated && remaining.Length >= Vector256<nuint>.Count + 1)
                 {
-                    Vector256<nuint> current = Vector256.LoadUnsafe(ref start, (nuint)offset) >> shift;
-                    Vector256<nuint> carries = Vector256.LoadUnsafe(ref start, (nuint)(offset + 1)) << back;
+                    Vector256<nuint> current = Vector256.Create(remaining) >> shift;
+                    Vector256<nuint> carries = Vector256.Create(remaining.Slice(1)) << back;
 
                     Vector256<nuint> newValue = current | carries;
 
-                    Vector256.StoreUnsafe(newValue, ref start, (nuint)offset);
-                    offset += Vector256<nuint>.Count;
+                    newValue.CopyTo(remaining);
+                    remaining = remaining.Slice(Vector256<nuint>.Count);
                 }
 
-                while (Vector128.IsHardwareAccelerated && bits.Length - offset >= Vector128<nuint>.Count + 1)
+                while (Vector128.IsHardwareAccelerated && remaining.Length >= Vector128<nuint>.Count + 1)
                 {
-                    Vector128<nuint> current = Vector128.LoadUnsafe(ref start, (nuint)offset) >> shift;
-                    Vector128<nuint> carries = Vector128.LoadUnsafe(ref start, (nuint)(offset + 1)) << back;
+                    Vector128<nuint> current = Vector128.Create(remaining) >> shift;
+                    Vector128<nuint> carries = Vector128.Create(remaining.Slice(1)) << back;
 
                     Vector128<nuint> newValue = current | carries;
 
-                    Vector128.StoreUnsafe(newValue, ref start, (nuint)offset);
-                    offset += Vector128<nuint>.Count;
+                    newValue.CopyTo(remaining);
+                    remaining = remaining.Slice(Vector128<nuint>.Count);
                 }
 
                 nuint carry2 = 0;
+                int offset = bits.Length - remaining.Length;
                 for (int i = bits.Length - 1; i >= offset; i--)
                 {
                     nuint value = carry2 | bits[i] >> shift;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -185,63 +185,50 @@ namespace System.Numerics
 
             int back = BitsPerLimb - shift;
 
-            if (Vector128.IsHardwareAccelerated)
+            carry = bits[0] << back;
+
+            Span<nuint> remaining = bits;
+
+            while (Vector512.IsHardwareAccelerated && remaining.Length >= Vector512<nuint>.Count + 1)
             {
-                carry = bits[0] << back;
+                Vector512<nuint> current = Vector512.Create(remaining) >> shift;
+                Vector512<nuint> carries = Vector512.Create(remaining.Slice(1)) << back;
 
-                Span<nuint> remaining = bits;
+                Vector512<nuint> newValue = current | carries;
 
-                while (Vector512.IsHardwareAccelerated && remaining.Length >= Vector512<nuint>.Count + 1)
-                {
-                    Vector512<nuint> current = Vector512.Create(remaining) >> shift;
-                    Vector512<nuint> carries = Vector512.Create(remaining.Slice(1)) << back;
-
-                    Vector512<nuint> newValue = current | carries;
-
-                    newValue.CopyTo(remaining);
-                    remaining = remaining.Slice(Vector512<nuint>.Count);
-                }
-
-                while (Vector256.IsHardwareAccelerated && remaining.Length >= Vector256<nuint>.Count + 1)
-                {
-                    Vector256<nuint> current = Vector256.Create(remaining) >> shift;
-                    Vector256<nuint> carries = Vector256.Create(remaining.Slice(1)) << back;
-
-                    Vector256<nuint> newValue = current | carries;
-
-                    newValue.CopyTo(remaining);
-                    remaining = remaining.Slice(Vector256<nuint>.Count);
-                }
-
-                while (Vector128.IsHardwareAccelerated && remaining.Length >= Vector128<nuint>.Count + 1)
-                {
-                    Vector128<nuint> current = Vector128.Create(remaining) >> shift;
-                    Vector128<nuint> carries = Vector128.Create(remaining.Slice(1)) << back;
-
-                    Vector128<nuint> newValue = current | carries;
-
-                    newValue.CopyTo(remaining);
-                    remaining = remaining.Slice(Vector128<nuint>.Count);
-                }
-
-                nuint carry2 = 0;
-                int offset = bits.Length - remaining.Length;
-                for (int i = bits.Length - 1; i >= offset; i--)
-                {
-                    nuint value = carry2 | bits[i] >> shift;
-                    carry2 = bits[i] << back;
-                    bits[i] = value;
-                }
+                newValue.CopyTo(remaining);
+                remaining = remaining.Slice(Vector512<nuint>.Count);
             }
-            else
+
+            while (Vector256.IsHardwareAccelerated && remaining.Length >= Vector256<nuint>.Count + 1)
             {
-                carry = 0;
-                for (int i = bits.Length - 1; i >= 0; i--)
-                {
-                    nuint value = carry | bits[i] >> shift;
-                    carry = bits[i] << back;
-                    bits[i] = value;
-                }
+                Vector256<nuint> current = Vector256.Create(remaining) >> shift;
+                Vector256<nuint> carries = Vector256.Create(remaining.Slice(1)) << back;
+
+                Vector256<nuint> newValue = current | carries;
+
+                newValue.CopyTo(remaining);
+                remaining = remaining.Slice(Vector256<nuint>.Count);
+            }
+
+            while (Vector128.IsHardwareAccelerated && remaining.Length >= Vector128<nuint>.Count + 1)
+            {
+                Vector128<nuint> current = Vector128.Create(remaining) >> shift;
+                Vector128<nuint> carries = Vector128.Create(remaining.Slice(1)) << back;
+
+                Vector128<nuint> newValue = current | carries;
+
+                newValue.CopyTo(remaining);
+                remaining = remaining.Slice(Vector128<nuint>.Count);
+            }
+
+            nuint carry2 = 0;
+            int offset = bits.Length - remaining.Length;
+            for (int i = bits.Length - 1; i >= offset; i--)
+            {
+                nuint value = carry2 | bits[i] >> shift;
+                carry2 = bits[i] << back;
+                bits[i] = value;
             }
         }
     }

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 
 namespace System.Numerics
@@ -114,48 +115,46 @@ namespace System.Numerics
             {
                 carry = bits[^1] >> back;
 
-                Span<nuint> remaining = bits;
+                ref nuint start = ref MemoryMarshal.GetReference(bits);
+                int offset = bits.Length;
 
                 // Each vector load needs one extra element below it to source the carry bits
                 // that shift in from the lower limbs, hence the +1 minimum.
-                while (Vector512.IsHardwareAccelerated && remaining.Length >= Vector512<nuint>.Count + 1)
+                while (Vector512.IsHardwareAccelerated && offset >= Vector512<nuint>.Count + 1)
                 {
-                    int offset = remaining.Length - Vector512<nuint>.Count;
-                    Vector512<nuint> current = Vector512.Create(remaining.Slice(offset)) << shift;
-                    Vector512<nuint> carries = Vector512.Create(remaining.Slice(offset - 1)) >> back;
+                    Vector512<nuint> current = Vector512.LoadUnsafe(ref start, (nuint)(offset - Vector512<nuint>.Count)) << shift;
+                    Vector512<nuint> carries = Vector512.LoadUnsafe(ref start, (nuint)(offset - (Vector512<nuint>.Count + 1))) >> back;
 
                     Vector512<nuint> newValue = current | carries;
 
-                    newValue.CopyTo(remaining.Slice(offset));
-                    remaining = remaining.Slice(0, offset);
+                    Vector512.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector512<nuint>.Count));
+                    offset -= Vector512<nuint>.Count;
                 }
 
-                while (Vector256.IsHardwareAccelerated && remaining.Length >= Vector256<nuint>.Count + 1)
+                while (Vector256.IsHardwareAccelerated && offset >= Vector256<nuint>.Count + 1)
                 {
-                    int offset = remaining.Length - Vector256<nuint>.Count;
-                    Vector256<nuint> current = Vector256.Create(remaining.Slice(offset)) << shift;
-                    Vector256<nuint> carries = Vector256.Create(remaining.Slice(offset - 1)) >> back;
+                    Vector256<nuint> current = Vector256.LoadUnsafe(ref start, (nuint)(offset - Vector256<nuint>.Count)) << shift;
+                    Vector256<nuint> carries = Vector256.LoadUnsafe(ref start, (nuint)(offset - (Vector256<nuint>.Count + 1))) >> back;
 
                     Vector256<nuint> newValue = current | carries;
 
-                    newValue.CopyTo(remaining.Slice(offset));
-                    remaining = remaining.Slice(0, offset);
+                    Vector256.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector256<nuint>.Count));
+                    offset -= Vector256<nuint>.Count;
                 }
 
-                while (Vector128.IsHardwareAccelerated && remaining.Length >= Vector128<nuint>.Count + 1)
+                while (Vector128.IsHardwareAccelerated && offset >= Vector128<nuint>.Count + 1)
                 {
-                    int offset = remaining.Length - Vector128<nuint>.Count;
-                    Vector128<nuint> current = Vector128.Create(remaining.Slice(offset)) << shift;
-                    Vector128<nuint> carries = Vector128.Create(remaining.Slice(offset - 1)) >> back;
+                    Vector128<nuint> current = Vector128.LoadUnsafe(ref start, (nuint)(offset - Vector128<nuint>.Count)) << shift;
+                    Vector128<nuint> carries = Vector128.LoadUnsafe(ref start, (nuint)(offset - (Vector128<nuint>.Count + 1))) >> back;
 
                     Vector128<nuint> newValue = current | carries;
 
-                    newValue.CopyTo(remaining.Slice(offset));
-                    remaining = remaining.Slice(0, offset);
+                    Vector128.StoreUnsafe(newValue, ref start, (nuint)(offset - Vector128<nuint>.Count));
+                    offset -= Vector128<nuint>.Count;
                 }
 
                 nuint carry2 = 0;
-                for (int i = 0; i < remaining.Length; i++)
+                for (int i = 0; i < offset; i++)
                 {
                     nuint value = carry2 | bits[i] << shift;
                     carry2 = bits[i] >> back;

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.ShiftRot.cs
@@ -222,14 +222,11 @@ namespace System.Numerics
                 remaining = remaining.Slice(Vector128<nuint>.Count);
             }
 
-            nuint carry2 = 0;
-            int offset = bits.Length - remaining.Length;
-            for (int i = bits.Length - 1; i >= offset; i--)
+            for (int i = 0; i < remaining.Length - 1; i++)
             {
-                nuint value = carry2 | bits[i] >> shift;
-                carry2 = bits[i] << back;
-                bits[i] = value;
+                remaining[i] = (remaining[i] >> shift) | (remaining[i + 1] << back);
             }
+            remaining[remaining.Length - 1] >>= shift;
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated by GitHub Copilot.

## Summary
- Rewrite only `RightShiftSelf` to use sliced `Span<nuint>` inputs with `Vector*.Create` and `CopyTo`
- Keep `LeftShiftSelf` unchanged from `main`
- Remove the previous ref arithmetic / `LoadUnsafe` / `StoreUnsafe` pattern from the right-shift vector loop

## Validation
- `dotnet.cmd build src\libraries\System.Runtime.Numerics\src\System.Runtime.Numerics.csproj -v:minimal`
- `dotnet.cmd build /t:test src\libraries\System.Runtime.Numerics\tests\System.Runtime.Numerics.Tests.csproj -v:minimal` (3033 tests, 0 failed)


[Diffs](https://github.com/MihuBot/runtime-utils/issues/1858) - improvements.