### PR TITLE
[Wasm RyuJIT]: Fix LIR Semantics in Stackifier Output

### DIFF
--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -530,11 +530,10 @@ void Lowering::AfterLowerBlocks()
         Compiler*             m_compiler;
         ArrayStack<GenTree**> m_stack;
         unsigned              m_minimumTempLclNum;
+        unsigned              m_maximumTempLclNum;
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_unusedTempNodes           = nullptr;
         bool                  m_anyChanges                = false;
-        BitVecTraits          m_pendingReleaseTempTraits;
-        BitVec                m_pendingReleaseTemps;
 
     public:
         Stackifier(Lowering* lower)
@@ -542,9 +541,7 @@ void Lowering::AfterLowerBlocks()
             , m_compiler(lower->m_compiler)
             , m_stack(m_compiler->getAllocator(CMK_Lower))
             , m_minimumTempLclNum(m_compiler->lvaCount)
-            // initially allocate 32 temp local slots for "pending release"
-            , m_pendingReleaseTempTraits(32, m_compiler)
-            , m_pendingReleaseTemps(BitVecOps::MakeEmpty(&m_pendingReleaseTempTraits))
+            , m_maximumTempLclNum(m_compiler->lvaCount)
         {
         }
 
@@ -555,13 +552,12 @@ void Lowering::AfterLowerBlocks()
             GenTree* node    = block->lastNode();
             while (node != nullptr)
             {
-                assert(BitVecOps::IsEmpty(&m_pendingReleaseTempTraits, m_pendingReleaseTemps));
                 assert(IsDataFlowRoot(node));
                 node = StackifyTree(node);
                 // We've finished processing the current root tree, so
-                // we can release any pending temps used in stackification of the tree,
+                // we can release any temps used in stackification of the tree,
                 // since there is no more risk of interference between tree operands.
-                RemovePendingTemporaries();
+                ReleaseTemporaries();
             }
             m_lower->m_block = nullptr;
 
@@ -577,8 +573,6 @@ void Lowering::AfterLowerBlocks()
             // Simple greedy algorithm working backwards. The invariant is that the stack top must be placed right next
             // to (in normal linear order - before) the node we last stackified.
             m_stack.Push(&root);
-
-            AddTemporariesForPendingRelease(root);
 
             GenTree* lastStackified = root->gtNext;
             while (m_stack.Height() != initialDepth)
@@ -713,59 +707,32 @@ void Lowering::AfterLowerBlocks()
             return lclNum;
         }
 
-        constexpr int lvaToTempNum(unsigned lclNum)
+        unsigned TempListLength(Temporary* list)
         {
-            assert(lclNum >= m_minimumTempLclNum);
-            return lclNum - m_minimumTempLclNum;
-        }
-
-        constexpr int tmpToLvaNum(unsigned tmpNum)
-        {
-            assert(tmpNum >= 0);
-            return tmpNum + m_minimumTempLclNum;
-        }
-
-        void AddTemporariesForPendingRelease(GenTree* node)
-        {
-            // We rely in this function on the lifetime of temporaries beginning (recall this is backwards traversal)
-            // at exactly "node"'s position. This is a safe assumption, since we will already have stackified all
-            // subsequent nodes, and so any further new use of this temporary will be before this one's lifetime begins.
-            // However, we don't know precisely where the liftime ends here, because uses of locals happen at their
-            // position in tree order, and not the LIR stream. So conservatively, we wait until we've processed an
-            // entire root gentree before reusing any temporaries to avoid the possibility of reusing a temporary before
-            // its last live use in the tree order.
-
-            assert(IsDataFlowRoot(node));
-            if (!node->OperIs(GT_STORE_LCL_VAR))
+            unsigned length = 0;
+            while (list != nullptr)
             {
-                return;
+                length++;
+                list = list->Prev;
+            }
+            return length;
+        }
+
+        void ReleaseTemporaries()
+        {
+            unsigned numRemoved = 0;
+            // Recycle all available temporaries as unused nodes
+            for (int i = 0; i < TYP_COUNT; i++)
+            {
+                while (m_availableTemps[i] != nullptr)
+                {
+                    Temporary* temp = Remove(&m_availableTemps[i]);
+                    Append(&m_unusedTempNodes, temp);
+                }
             }
 
-            unsigned lclNum = node->AsLclVar()->GetLclNum();
-            if (lclNum < m_minimumTempLclNum)
+            for (unsigned lclNum = m_minimumTempLclNum; lclNum < m_compiler->lvaCount; lclNum++)
             {
-                return;
-            }
-
-            JITDUMP("Stackifier pending release of lclNum: %d temporary defined by [%06u]\n", lclNum,
-                    Compiler::dspTreeID(node));
-            EnsurePendingReleaseCapacity(lvaToTempNum(lclNum));
-            BitVecOps::AddElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, lvaToTempNum(lclNum));
-        }
-
-        void RemovePendingTemporaries()
-        {
-            // iterate through m_pendingReleaseTemps
-            BitVecOps::Iter iter(&m_pendingReleaseTempTraits, m_pendingReleaseTemps);
-            unsigned        tmpNum;
-            while (iter.NextElem(&tmpNum))
-            {
-                // remove from m_pendingReleaseTemps
-                BitVecOps::RemoveElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, tmpNum);
-
-                unsigned lclNum = tmpToLvaNum(tmpNum);
-                assert(lclNum >= m_minimumTempLclNum);
-
                 Temporary* local = Remove(&m_unusedTempNodes); // See if we have any free nodes in the pool.
                 if (local == nullptr)
                 {
@@ -776,6 +743,18 @@ void Lowering::AfterLowerBlocks()
                 JITDUMP("Temporary V%02u is now free and can be re-used\n", lclNum);
                 Append(&m_availableTemps[genActualType(m_compiler->lvaGetDesc(lclNum)->TypeGet())], local);
             }
+
+            unsigned count = 0;
+            for (int i = 0; i < TYP_COUNT; i++)
+            {
+                Temporary* temp = m_availableTemps[i];
+                while (temp != nullptr)
+                {
+                    count++;
+                    temp = temp->Prev;
+                }
+            }
+            assert(count == (m_compiler->lvaCount - m_minimumTempLclNum));
         }
 
         Temporary* Remove(Temporary** pTemps)
@@ -792,29 +771,6 @@ void Lowering::AfterLowerBlocks()
         {
             local->Prev = *pTemps;
             *pTemps     = local;
-        }
-
-        void EnsurePendingReleaseCapacity(unsigned needed)
-        {
-            if (needed < BitVecTraits::GetSize(&m_pendingReleaseTempTraits))
-            {
-                return;
-            }
-
-            unsigned     oldSize = BitVecTraits::GetSize(&m_pendingReleaseTempTraits);
-            unsigned     newSize = max(needed + 1, oldSize * 2);
-            BitVecTraits newTraits(newSize, m_compiler);
-            BitVec       newVec = BitVecOps::MakeEmpty(&newTraits);
-
-            BitVecOps::Iter iter(&m_pendingReleaseTempTraits, m_pendingReleaseTemps);
-            unsigned        elem;
-            while (iter.NextElem(&elem))
-            {
-                BitVecOps::AddElemD(&newTraits, newVec, elem);
-            }
-
-            m_pendingReleaseTempTraits = newTraits;
-            m_pendingReleaseTemps      = newVec;
         }
     };
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -550,8 +550,6 @@ void Lowering::AfterLowerBlocks()
 
         void StackifyBlock(BasicBlock* block)
         {
-
-            JITDUMP("LIR BEFORE stackification of " FMT_BB ": ", block->bbNum);
             m_anyChanges     = false;
             m_lower->m_block = block;
             GenTree* node    = block->lastNode();
@@ -560,6 +558,9 @@ void Lowering::AfterLowerBlocks()
                 assert(BitVecOps::IsEmpty(&m_pendingReleaseTempTraits, m_pendingReleaseTemps));
                 assert(IsDataFlowRoot(node));
                 node = StackifyTree(node);
+                // We've finished processing the current root tree, so
+                // we can release any pending temps used in stackification of the tree,
+                // since there is no more risk of interference between tree operands.
                 RemovePendingTemporaries();
             }
             m_lower->m_block = nullptr;
@@ -567,11 +568,6 @@ void Lowering::AfterLowerBlocks()
             JITDUMP(FMT_BB ": %s\n", block->bbNum,
                     m_anyChanges ? "stackified with some changes" : "already in WASM value stack order");
             assert((m_unusedTempNodes == nullptr) && "Some temporaries were not released");
-            if (m_anyChanges)
-            {
-                JITDUMP("LIR after stackification of " FMT_BB ": ", block->bbNum);
-                DISPRANGE(LIR::AsRange(block));
-            }
         }
 
         GenTree* StackifyTree(GenTree* root)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -582,7 +582,7 @@ void Lowering::AfterLowerBlocks()
             // to (in normal linear order - before) the node we last stackified.
             m_stack.Push(&root);
 
-            PendingReleaseTemporariesDefinedBy(root);
+            AddTemporariesForPendingRelease(root);
 
             GenTree* lastStackified = root->gtNext;
             while (m_stack.Height() != initialDepth)
@@ -729,12 +729,16 @@ void Lowering::AfterLowerBlocks()
             return tmpNum + m_minimumTempLclNum;
         }
 
-        void PendingReleaseTemporariesDefinedBy(GenTree* node)
+        void AddTemporariesForPendingRelease(GenTree* node)
         {
             // We rely in this function on the lifetime of temporaries beginning (recall this is backwards traversal)
-            // at exactly "node"'s position, and not shrinking or extending after this call. This is currently true
-            // because we never move dataflow roots, and we only begin processing them after all subsequent nodes
-            // have already been stackified and thus won't move either.
+            // at exactly "node"'s position. This is a safe assumption, since we will already have stackified all
+            // subsequent nodes, and so any further new use of this temporary will be before this one's lifetime begins.
+            // However, we don't know precisely where the liftime ends here, because uses of locals happen at their position 
+            // in tree order, and not the LIR stream. So conservatively, we wait until we've processed an entire root gentree   
+            // before reusing any temporaries to avoid the possibility of reusing a temporary before its last
+            // live use in the tree order.
+
             assert(IsDataFlowRoot(node));
             if (!node->OperIs(GT_STORE_LCL_VAR))
             {
@@ -748,7 +752,7 @@ void Lowering::AfterLowerBlocks()
             }
 
             JITDUMP("Stackifier pending release of lclNum: %d temporary defined by [%06u]\n", lclNum, Compiler::dspTreeID(node));
-            EnsureTempBitVecCapacity(lvaToTempNum(lclNum));
+            EnsurePendingReleaseCapacity(lvaToTempNum(lclNum));
             BitVecOps::AddElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, lvaToTempNum(lclNum));
         }
 
@@ -793,7 +797,7 @@ void Lowering::AfterLowerBlocks()
             *pTemps     = local;
         }
 
-        void EnsureTempBitVecCapacity(unsigned needed)
+        void EnsurePendingReleaseCapacity(unsigned needed)
         {
             if (needed < BitVecTraits::GetSize(&m_pendingReleaseTempTraits))
             {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -530,7 +530,6 @@ void Lowering::AfterLowerBlocks()
         Compiler*             m_compiler;
         ArrayStack<GenTree**> m_stack;
         unsigned              m_minimumTempLclNum;
-        unsigned              m_maximumTempLclNum;
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_unusedTempNodes           = nullptr;
         bool                  m_anyChanges                = false;
@@ -541,7 +540,6 @@ void Lowering::AfterLowerBlocks()
             , m_compiler(lower->m_compiler)
             , m_stack(m_compiler->getAllocator(CMK_Lower))
             , m_minimumTempLclNum(m_compiler->lvaCount)
-            , m_maximumTempLclNum(m_compiler->lvaCount)
         {
         }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -531,7 +531,9 @@ void Lowering::AfterLowerBlocks()
         ArrayStack<GenTree**> m_stack;
         unsigned              m_minimumTempLclNum;
         Temporary*            m_availableTemps[TYP_COUNT] = {};
+        Temporary*            m_inUseTemps[TYP_COUNT]     = {};
         Temporary*            m_unusedTempNodes           = nullptr;
+        Temporary*            m_inUseTempNodes            = nullptr;
         bool                  m_anyChanges                = false;
 
     public:
@@ -670,6 +672,8 @@ void Lowering::AfterLowerBlocks()
             *use = lclNode;
 
             JITDUMP("Replaced [%06u] with a temporary:\n", Compiler::dspTreeID(node));
+            DISPNODE(node);
+            DISPNODE(lclNode);
 
             if ((node->gtLIRFlags & LIR::Flags::MultiplyUsed) == LIR::Flags::MultiplyUsed)
             {
@@ -690,16 +694,21 @@ void Lowering::AfterLowerBlocks()
             if (local != nullptr)
             {
                 lclNum = local->LclNum;
-                Append(&m_unusedTempNodes, local); // Free the node for later recycling.
                 assert(m_compiler->lvaGetDesc(lclNum)->TypeGet() == genActualType(type));
             }
             else
             {
                 lclNum            = m_compiler->lvaGrabTemp(true DEBUGARG("Stackifier temporary"));
+                assert(lclNum >= m_minimumTempLclNum);
                 LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
                 varDsc->lvType    = genActualType(type);
-                assert(lclNum >= m_minimumTempLclNum);
+
+                // Allocate a new temporary to describe this local
+                local = new (m_compiler, CMK_Lower) Temporary();
+                local->LclNum = lclNum;
             }
+            Append(&m_inUseTemps[genActualType(type)], local);
+
             JITDUMP("Temporary V%02u is now in use\n", lclNum);
             return lclNum;
         }
@@ -713,28 +722,34 @@ void Lowering::AfterLowerBlocks()
             }
             assert(m_minimumTempLclNum < m_compiler->lvaCount);
 
-            // Recycle all available temporaries as unused nodes
+            // Reclaim all in-use temporaries
             for (int i = 0; i < TYP_COUNT; i++)
             {
-                while (m_availableTemps[i] != nullptr)
+                while (m_inUseTemps[i] != nullptr)
                 {
-                    Temporary* temp = Remove(&m_availableTemps[i]);
-                    Append(&m_unusedTempNodes, temp);
+                    Temporary* temp = Remove(&m_inUseTemps[i]);
+                    assert(temp->LclNum >= m_minimumTempLclNum);
+                    Append(&m_availableTemps[i], temp);
+                    JITDUMP("Temporary V%02u is now available\n", temp->LclNum);
                 }
             }
 
-            for (unsigned lclNum = m_minimumTempLclNum; lclNum < m_compiler->lvaCount; lclNum++)
+#ifdef DEBUG
+            unsigned count = 0;
+            // Verify that all temporaries have been reclaimed
+            for (int i = 0; i < TYP_COUNT; i++)
             {
-                Temporary* local = Remove(&m_unusedTempNodes); // See if we have any free nodes in the pool.
-                if (local == nullptr)
+                Temporary* temp = m_availableTemps[i];
+                while (temp != nullptr)
                 {
-                    local = new (m_compiler, CMK_Lower) Temporary();
+                    count++;
+                    assert(temp->LclNum >= m_minimumTempLclNum);
+                    temp = temp->Prev;
                 }
-                local->LclNum = lclNum;
-
-                JITDUMP("Temporary V%02u is now free and can be re-used\n", lclNum);
-                Append(&m_availableTemps[genActualType(m_compiler->lvaGetDesc(lclNum)->TypeGet())], local);
             }
+
+            assert(count == (m_compiler->lvaCount - m_minimumTempLclNum));
+#endif
         }
 
         Temporary* Remove(Temporary** pTemps)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -698,13 +698,13 @@ void Lowering::AfterLowerBlocks()
             }
             else
             {
-                lclNum            = m_compiler->lvaGrabTemp(true DEBUGARG("Stackifier temporary"));
+                lclNum = m_compiler->lvaGrabTemp(true DEBUGARG("Stackifier temporary"));
                 assert(lclNum >= m_minimumTempLclNum);
                 LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNum);
                 varDsc->lvType    = genActualType(type);
 
                 // Allocate a new temporary to describe this local
-                local = new (m_compiler, CMK_Lower) Temporary();
+                local         = new (m_compiler, CMK_Lower) Temporary();
                 local->LclNum = lclNum;
             }
             Append(&m_inUseTemps[genActualType(type)], local);
@@ -734,23 +734,6 @@ void Lowering::AfterLowerBlocks()
                     JITDUMP("Temporary V%02u is now available\n", temp->LclNum);
                 }
             }
-
-#ifdef DEBUG
-            unsigned count = 0;
-            // Verify that all temporaries have been reclaimed
-            for (int i = 0; i < TYP_COUNT; i++)
-            {
-                Temporary* temp = m_availableTemps[i];
-                while (temp != nullptr)
-                {
-                    count++;
-                    assert(temp->LclNum >= m_minimumTempLclNum);
-                    temp = temp->Prev;
-                }
-            }
-
-            assert(count == (m_compiler->lvaCount - m_minimumTempLclNum));
-#endif
         }
 
         Temporary* Remove(Temporary** pTemps)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -709,7 +709,13 @@ void Lowering::AfterLowerBlocks()
 
         void ReleaseTemporaries()
         {
-            unsigned numRemoved = 0;
+            if (m_minimumTempLclNum == m_compiler->lvaCount)
+            {
+                // No temporaries were created
+                return;
+            }
+            assert(m_minimumTempLclNum < m_compiler->lvaCount);
+
             // Recycle all available temporaries as unused nodes
             for (int i = 0; i < TYP_COUNT; i++)
             {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -722,6 +722,7 @@ void Lowering::AfterLowerBlocks()
             }
             assert(m_minimumTempLclNum < m_compiler->lvaCount);
 
+            JITDUMP("Releasing stackifier temporaries:\n");
             // Reclaim all in-use temporaries
             for (int i = 0; i < TYP_COUNT; i++)
             {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -533,6 +533,8 @@ void Lowering::AfterLowerBlocks()
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_unusedTempNodes           = nullptr;
         bool                  m_anyChanges                = false;
+        BitVecTraits          m_pendingReleaseTempTraits;
+        BitVec                m_pendingReleaseTemps;
 
     public:
         Stackifier(Lowering* lower)
@@ -540,24 +542,36 @@ void Lowering::AfterLowerBlocks()
             , m_compiler(lower->m_compiler)
             , m_stack(m_compiler->getAllocator(CMK_Lower))
             , m_minimumTempLclNum(m_compiler->lvaCount)
+            // initially allocate 32 temp local slots for "pending release"
+            , m_pendingReleaseTempTraits(32, m_compiler)
+            , m_pendingReleaseTemps(BitVecOps::MakeEmpty(&m_pendingReleaseTempTraits))
         {
         }
 
         void StackifyBlock(BasicBlock* block)
         {
+
+            JITDUMP("LIR BEFORE stackification of " FMT_BB ": ", block->bbNum);
             m_anyChanges     = false;
             m_lower->m_block = block;
             GenTree* node    = block->lastNode();
             while (node != nullptr)
             {
+                assert(BitVecOps::IsEmpty(&m_pendingReleaseTempTraits, m_pendingReleaseTemps));
                 assert(IsDataFlowRoot(node));
                 node = StackifyTree(node);
+                RemovePendingTemporaries();
             }
             m_lower->m_block = nullptr;
 
             JITDUMP(FMT_BB ": %s\n", block->bbNum,
                     m_anyChanges ? "stackified with some changes" : "already in WASM value stack order");
             assert((m_unusedTempNodes == nullptr) && "Some temporaries were not released");
+            if (m_anyChanges)
+            {
+                JITDUMP("LIR after stackification of " FMT_BB ": ", block->bbNum);
+                DISPRANGE(LIR::AsRange(block));
+            }
         }
 
         GenTree* StackifyTree(GenTree* root)
@@ -567,7 +581,8 @@ void Lowering::AfterLowerBlocks()
             // Simple greedy algorithm working backwards. The invariant is that the stack top must be placed right next
             // to (in normal linear order - before) the node we last stackified.
             m_stack.Push(&root);
-            ReleaseTemporariesDefinedBy(root);
+
+            PendingReleaseTemporariesDefinedBy(root);
 
             GenTree* lastStackified = root->gtNext;
             while (m_stack.Height() != initialDepth)
@@ -668,8 +683,6 @@ void Lowering::AfterLowerBlocks()
             *use = lclNode;
 
             JITDUMP("Replaced [%06u] with a temporary:\n", Compiler::dspTreeID(node));
-            DISPNODE(node);
-            DISPNODE(lclNode);
 
             if ((node->gtLIRFlags & LIR::Flags::MultiplyUsed) == LIR::Flags::MultiplyUsed)
             {
@@ -704,7 +717,19 @@ void Lowering::AfterLowerBlocks()
             return lclNum;
         }
 
-        void ReleaseTemporariesDefinedBy(GenTree* node)
+        constexpr int lvaToTempNum(unsigned lclNum)
+        {
+            assert(lclNum >= m_minimumTempLclNum);
+            return lclNum - m_minimumTempLclNum;
+        }
+
+        constexpr int tmpToLvaNum(unsigned tmpNum)
+        {
+            assert(tmpNum >= 0);
+            return tmpNum + m_minimumTempLclNum;
+        }
+
+        void PendingReleaseTemporariesDefinedBy(GenTree* node)
         {
             // We rely in this function on the lifetime of temporaries beginning (recall this is backwards traversal)
             // at exactly "node"'s position, and not shrinking or extending after this call. This is currently true
@@ -722,15 +747,34 @@ void Lowering::AfterLowerBlocks()
                 return;
             }
 
-            Temporary* local = Remove(&m_unusedTempNodes); // See if we have any free nodes in the pool.
-            if (local == nullptr)
-            {
-                local = new (m_compiler, CMK_Lower) Temporary();
-            }
-            local->LclNum = lclNum;
+            JITDUMP("Stackifier pending release of lclNum: %d temporary defined by [%06u]\n", lclNum, Compiler::dspTreeID(node));
+            EnsureTempBitVecCapacity(lvaToTempNum(lclNum));
+            BitVecOps::AddElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, lvaToTempNum(lclNum));
+        }
 
-            JITDUMP("Temporary V%02u is now free and can be re-used\n", lclNum);
-            Append(&m_availableTemps[genActualType(node->TypeGet())], local);
+        void RemovePendingTemporaries()
+        {
+            // iterate through m_pendingReleaseTemps
+            BitVecOps::Iter iter(&m_pendingReleaseTempTraits, m_pendingReleaseTemps);
+            unsigned        tmpNum;
+            while (iter.NextElem(&tmpNum))
+            {
+                // remove from m_pendingReleaseTemps
+                BitVecOps::RemoveElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, tmpNum);
+
+                unsigned lclNum = tmpToLvaNum(tmpNum);
+                assert(lclNum >= m_minimumTempLclNum);
+
+                Temporary* local = Remove(&m_unusedTempNodes); // See if we have any free nodes in the pool.
+                if (local == nullptr)
+                {
+                    local = new (m_compiler, CMK_Lower) Temporary();
+                }
+                local->LclNum = lclNum;
+
+                JITDUMP("Temporary V%02u is now free and can be re-used\n", lclNum);
+                Append(&m_availableTemps[genActualType(m_compiler->lvaGetDesc(lclNum)->TypeGet())], local);
+            }
         }
 
         Temporary* Remove(Temporary** pTemps)
@@ -747,6 +791,29 @@ void Lowering::AfterLowerBlocks()
         {
             local->Prev = *pTemps;
             *pTemps     = local;
+        }
+
+        void EnsureTempBitVecCapacity(unsigned needed)
+        {
+            if (needed < BitVecTraits::GetSize(&m_pendingReleaseTempTraits))
+            {
+                return;
+            }
+
+            unsigned     oldSize   = BitVecTraits::GetSize(&m_pendingReleaseTempTraits);
+            unsigned     newSize   = max(needed + 1, oldSize * 2);
+            BitVecTraits newTraits(newSize, m_compiler);
+            BitVec       newVec = BitVecOps::MakeEmpty(&newTraits);
+
+            BitVecOps::Iter iter(&m_pendingReleaseTempTraits, m_pendingReleaseTemps);
+            unsigned        elem;
+            while (iter.NextElem(&elem))
+            {
+                BitVecOps::AddElemD(&newTraits, newVec, elem);
+            }
+
+            m_pendingReleaseTempTraits = newTraits;
+            m_pendingReleaseTemps  = newVec;
         }
     };
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -554,7 +554,7 @@ void Lowering::AfterLowerBlocks()
             {
                 assert(IsDataFlowRoot(node));
                 node = StackifyTree(node);
-                // We don't track liveness of temporaries more precisely since introducing eairler uses
+                // We don't track liveness of temporaries more precisely since introducing earlier uses
                 // may interfere with later (by that point already inserted and stackified) stores.
                 ReleaseTemporaries();
             }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -730,10 +730,10 @@ void Lowering::AfterLowerBlocks()
             // We rely in this function on the lifetime of temporaries beginning (recall this is backwards traversal)
             // at exactly "node"'s position. This is a safe assumption, since we will already have stackified all
             // subsequent nodes, and so any further new use of this temporary will be before this one's lifetime begins.
-            // However, we don't know precisely where the liftime ends here, because uses of locals happen at their position 
-            // in tree order, and not the LIR stream. So conservatively, we wait until we've processed an entire root gentree   
-            // before reusing any temporaries to avoid the possibility of reusing a temporary before its last
-            // live use in the tree order.
+            // However, we don't know precisely where the liftime ends here, because uses of locals happen at their
+            // position in tree order, and not the LIR stream. So conservatively, we wait until we've processed an
+            // entire root gentree before reusing any temporaries to avoid the possibility of reusing a temporary before
+            // its last live use in the tree order.
 
             assert(IsDataFlowRoot(node));
             if (!node->OperIs(GT_STORE_LCL_VAR))
@@ -747,7 +747,8 @@ void Lowering::AfterLowerBlocks()
                 return;
             }
 
-            JITDUMP("Stackifier pending release of lclNum: %d temporary defined by [%06u]\n", lclNum, Compiler::dspTreeID(node));
+            JITDUMP("Stackifier pending release of lclNum: %d temporary defined by [%06u]\n", lclNum,
+                    Compiler::dspTreeID(node));
             EnsurePendingReleaseCapacity(lvaToTempNum(lclNum));
             BitVecOps::AddElemD(&m_pendingReleaseTempTraits, m_pendingReleaseTemps, lvaToTempNum(lclNum));
         }
@@ -800,8 +801,8 @@ void Lowering::AfterLowerBlocks()
                 return;
             }
 
-            unsigned     oldSize   = BitVecTraits::GetSize(&m_pendingReleaseTempTraits);
-            unsigned     newSize   = max(needed + 1, oldSize * 2);
+            unsigned     oldSize = BitVecTraits::GetSize(&m_pendingReleaseTempTraits);
+            unsigned     newSize = max(needed + 1, oldSize * 2);
             BitVecTraits newTraits(newSize, m_compiler);
             BitVec       newVec = BitVecOps::MakeEmpty(&newTraits);
 
@@ -813,7 +814,7 @@ void Lowering::AfterLowerBlocks()
             }
 
             m_pendingReleaseTempTraits = newTraits;
-            m_pendingReleaseTemps  = newVec;
+            m_pendingReleaseTemps      = newVec;
         }
     };
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -532,8 +532,7 @@ void Lowering::AfterLowerBlocks()
         unsigned              m_minimumTempLclNum;
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_inUseTemps[TYP_COUNT]     = {};
-        Temporary*            m_unusedTempNodes           = nullptr;
-        Temporary*            m_inUseTempNodes            = nullptr;
+        unsigned              m_numInUseTemps;
         bool                  m_anyChanges                = false;
 
     public:
@@ -542,6 +541,7 @@ void Lowering::AfterLowerBlocks()
             , m_compiler(lower->m_compiler)
             , m_stack(m_compiler->getAllocator(CMK_Lower))
             , m_minimumTempLclNum(m_compiler->lvaCount)
+            , m_numInUseTemps(0)
         {
         }
 
@@ -562,7 +562,6 @@ void Lowering::AfterLowerBlocks()
 
             JITDUMP(FMT_BB ": %s\n", block->bbNum,
                     m_anyChanges ? "stackified with some changes" : "already in WASM value stack order");
-            assert((m_unusedTempNodes == nullptr) && "Some temporaries were not released");
         }
 
         GenTree* StackifyTree(GenTree* root)
@@ -708,6 +707,7 @@ void Lowering::AfterLowerBlocks()
                 local->LclNum = lclNum;
             }
             Append(&m_inUseTemps[genActualType(type)], local);
+            m_numInUseTemps++;
 
             JITDUMP("Temporary V%02u is now in use\n", lclNum);
             return lclNum;
@@ -731,9 +731,12 @@ void Lowering::AfterLowerBlocks()
                     Temporary* temp = Remove(&m_inUseTemps[i]);
                     assert(temp->LclNum >= m_minimumTempLclNum);
                     Append(&m_availableTemps[i], temp);
+                    m_numInUseTemps--;
                     JITDUMP("Temporary V%02u is now available\n", temp->LclNum);
                 }
             }
+
+            assert(m_numInUseTemps == 0 && "Some temporaries are still in use");
         }
 
         Temporary* Remove(Temporary** pTemps)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -707,17 +707,6 @@ void Lowering::AfterLowerBlocks()
             return lclNum;
         }
 
-        unsigned TempListLength(Temporary* list)
-        {
-            unsigned length = 0;
-            while (list != nullptr)
-            {
-                length++;
-                list = list->Prev;
-            }
-            return length;
-        }
-
         void ReleaseTemporaries()
         {
             unsigned numRemoved = 0;
@@ -743,18 +732,6 @@ void Lowering::AfterLowerBlocks()
                 JITDUMP("Temporary V%02u is now free and can be re-used\n", lclNum);
                 Append(&m_availableTemps[genActualType(m_compiler->lvaGetDesc(lclNum)->TypeGet())], local);
             }
-
-            unsigned count = 0;
-            for (int i = 0; i < TYP_COUNT; i++)
-            {
-                Temporary* temp = m_availableTemps[i];
-                while (temp != nullptr)
-                {
-                    count++;
-                    temp = temp->Prev;
-                }
-            }
-            assert(count == (m_compiler->lvaCount - m_minimumTempLclNum));
         }
 
         Temporary* Remove(Temporary** pTemps)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -533,7 +533,7 @@ void Lowering::AfterLowerBlocks()
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_inUseTemps[TYP_COUNT]     = {};
         unsigned              m_numInUseTemps;
-        bool                  m_anyChanges                = false;
+        bool                  m_anyChanges = false;
 
     public:
         Stackifier(Lowering* lower)

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -552,9 +552,8 @@ void Lowering::AfterLowerBlocks()
             {
                 assert(IsDataFlowRoot(node));
                 node = StackifyTree(node);
-                // We've finished processing the current root tree, so
-                // we can release any temps used in stackification of the tree,
-                // since there is no more risk of interference between tree operands.
+                // We don't track liveness of temporaries more precisely since introducing eairler uses
+                // may interfere with later (by that point already inserted and stackified) stores.
                 ReleaseTemporaries();
             }
             m_lower->m_block = nullptr;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -532,8 +532,7 @@ void Lowering::AfterLowerBlocks()
         unsigned              m_minimumTempLclNum;
         Temporary*            m_availableTemps[TYP_COUNT] = {};
         Temporary*            m_inUseTemps[TYP_COUNT]     = {};
-        unsigned              m_numInUseTemps;
-        bool                  m_anyChanges = false;
+        bool                  m_anyChanges                = false;
 
     public:
         Stackifier(Lowering* lower)
@@ -541,7 +540,6 @@ void Lowering::AfterLowerBlocks()
             , m_compiler(lower->m_compiler)
             , m_stack(m_compiler->getAllocator(CMK_Lower))
             , m_minimumTempLclNum(m_compiler->lvaCount)
-            , m_numInUseTemps(0)
         {
         }
 
@@ -707,7 +705,6 @@ void Lowering::AfterLowerBlocks()
                 local->LclNum = lclNum;
             }
             Append(&m_inUseTemps[genActualType(type)], local);
-            m_numInUseTemps++;
 
             JITDUMP("Temporary V%02u is now in use\n", lclNum);
             return lclNum;
@@ -731,12 +728,9 @@ void Lowering::AfterLowerBlocks()
                     Temporary* temp = Remove(&m_inUseTemps[i]);
                     assert(temp->LclNum >= m_minimumTempLclNum);
                     Append(&m_availableTemps[i], temp);
-                    m_numInUseTemps--;
                     JITDUMP("Temporary V%02u is now available\n", temp->LclNum);
                 }
             }
-
-            assert(m_numInUseTemps == 0 && "Some temporaries are still in use");
         }
 
         Temporary* Remove(Temporary** pTemps)


### PR DESCRIPTION
This is a fix for an issue that came up in #126778, and is probably easiest to explain with a motivating example.

Consider the following case, where NOMOVE is a gentree operation we aren't allowed to move.
```
t2 = ... NOMOVE OP
t3 = ... OP
t0 = ... NOMOVE OP
t1 = ... OP
 * t3 (arg1)
 * t2 (arg2)
 * t1 (arg3)
 * t0 (target)
 CALL
```
 The stackifier will first introduce a store to put `t0` after  `t1`:
```
t2 = ... NOMOVE OP
t3 = ... OP
t0 = ... OP
    +** STORE_LCL_VAR tmp0
t1 = ... OP
t0 = LCL_VAR tmp0
 * t3 (arg1)
 * t2 (arg2)
 * t1 (arg3)
 * t0 (call target)
 CALL
```
And then recursively stackify the new STORE to tmp0, since it is a dataflow root.
*The stackifier then marks tmp0 as free here, since it IS free in linear data flow order*. Then, when the next operands to the call are
stackified, the stackifier introduces a temporary again, but reuses t0 
because we freed it. 
```
t2 = ... OP
 +** STORE_LCL_VAR tmp0
t3 = ... OP
t2 = LCL_VAR tmp0
t0 = ... OP
    +** STORE_LCL_VAR tmp0
t1 = ... OP
t0 = LCL_VAR tmp0
 * t3
 * t2
 * t1
 * t0 (target)
 CALL
```
This produces invalid LIR; there is a store to tmp0 before one of its reads (t2) is consumed.

The simplest fix is to not release temporaries for reuse until all operands of a root tree have been processed. This PR adds a free list of temps which is recycled after each root gen tree has been processed, so we won't end up with any interference between temporaries while processing gentree ops which share a parent node.