### PR TITLE
Add [NoInlining] to Marvin.ComputeHash32OrdinalIgnoreCase

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
@@ -15,6 +15,7 @@ namespace System
         /// Compute a Marvin OrdinalIgnoreCase hash and collapse it into a 32-bit hash.
         /// n.b. <paramref name="count"/> is specified as char count, not byte count.
         /// </summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public static int ComputeHash32OrdinalIgnoreCase(ref char data, int count, uint p0, uint p1)
         {
             uint ucount = (uint)count; // in chars


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

## Summary

Add `[MethodImpl(MethodImplOptions.NoInlining)]` to `Marvin.ComputeHash32OrdinalIgnoreCase`, matching the existing attribute on `Marvin.ComputeHash32`.

## Problem

The inline budget increase from 20 to 22 in #118641 caused partial inlining of the Marvin OrdinalIgnoreCase hash computation. At budget 22, the JIT has enough budget to inline `ComputeHash32OrdinalIgnoreCase` into callers, but not enough to also inline the `Block()` calls within it. This results in a worse code layout where `Marvin.Block` gets a separate Tier1 compilation rather than being fully inlined into the hash method, causing significant regressions:

- **CredentialCacheTests.GetCredential_HostPort**: up to 32% regression (notfound), 17% (name5)
- Multiple other benchmarks through `StringComparer.OrdinalIgnoreCase.GetHashCode()` paths

The byte-based `ComputeHash32` already has `[NoInlining]` to prevent this exact scenario. The char-based `ComputeHash32OrdinalIgnoreCase` was missing the same treatment.

## Fix

Single-line change: add `[MethodImpl(MethodImplOptions.NoInlining)]` to `ComputeHash32OrdinalIgnoreCase`. This ensures the hash computation stays as an opaque call while `Block()` (marked `AggressiveInlining`) is fully inlined within it.

Fix #118739