### PR TITLE
Use safe Span.Slice loop pattern in Enumerable.FillIncrementing

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/Range.cs
+++ b/src/libraries/System.Linq/src/System/Linq/Range.cs
@@ -4,8 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Numerics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace System.Linq
 {
@@ -79,33 +77,26 @@ namespace System.Linq
         /// <summary>Fills the <paramref name="destination"/> with incrementing numbers, starting from <paramref name="value"/>.</summary>
         private static void FillIncrementing<T>(Span<T> destination, T value) where T : INumber<T>
         {
-            ref T pos = ref MemoryMarshal.GetReference(destination);
-            ref T end = ref Unsafe.Add(ref pos, destination.Length);
-
             if (Vector.IsHardwareAccelerated &&
                 Vector<T>.IsSupported &&
                 destination.Length >= Vector<T>.Count)
             {
-                Vector<T> init = Vector<T>.Indices;
-                Vector<T> current = new Vector<T>(value) + init;
+                Vector<T> current = new Vector<T>(value) + Vector<T>.Indices;
                 Vector<T> increment = new Vector<T>(T.CreateTruncating(Vector<T>.Count));
 
-                ref T oneVectorFromEnd = ref Unsafe.Subtract(ref end, Vector<T>.Count);
-                do
+                while (destination.Length >= Vector<T>.Count)
                 {
-                    current.StoreUnsafe(ref pos);
+                    current.CopyTo(destination);
                     current += increment;
-                    pos = ref Unsafe.Add(ref pos, Vector<T>.Count);
+                    destination = destination.Slice(Vector<T>.Count);
                 }
-                while (Unsafe.IsAddressLessThanOrEqualTo(ref pos, ref oneVectorFromEnd));
 
                 value = current[0];
             }
 
-            while (Unsafe.IsAddressLessThan(ref pos, ref end))
+            foreach (ref T slot in destination)
             {
-                pos = value++;
-                pos = ref Unsafe.Add(ref pos, 1);
+                slot = value++;
             }
         }
     }


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot (AI-generated content).

Rewrites the vectorized fill in `Enumerable.FillIncrementing<T>` to use the safe `while (span.Length >= CONST) { ...; span = span.Slice(CONST); }` loop pattern, removing all `Unsafe.*` / `MemoryMarshal.GetReference` plumbing. JIT recognizes this shape and elides the bounds checks.

# Codegen

Small [diffs](https://github.com/MihuBot/runtime-utils/issues/1859), no new checks. No [perf impact.](https://github.com/EgorBot/Benchmarks/issues/151)