### PR TITLE
Haiku: Remove redundant PIC/PIE flags

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -492,13 +492,10 @@ endif()
 
 if(NOT CLR_CMAKE_TARGET_BROWSER AND NOT CLR_CMAKE_TARGET_WASI)
     # The default linker on Solaris also does not support PIE.
-    if(NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE_TARGET_SUNOS AND NOT CLR_CMAKE_TARGET_APPLE AND NOT MSVC)
+    # Haiku toolchains already set -pic and link everything as shared objects (-shared). -pie will clash with -shared.
+    if(NOT CLR_CMAKE_TARGET_ANDROID AND NOT CLR_CMAKE_TARGET_SUNOS AND NOT CLR_CMAKE_TARGET_HAIKU AND NOT CLR_CMAKE_TARGET_APPLE AND NOT MSVC)
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
-        if(CLR_CMAKE_TARGET_HAIKU)
-            add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-fPIC>)
-        else()
-            add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-fPIE>)
-        endif()
+        add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:-fPIE>)
         add_compile_options($<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:-fPIC>)
     endif()
 


### PR DESCRIPTION
Haiku toolchains already pass `-pic` and link everything as shared objects (`-shared`).

`-pic` is therefore redundant. `-pie` may also cause additional problems when passed to the linker along with `-shared`.

Part of #55803.