### PR TITLE
Remove most RuntimeAsyncTask<T> instance methods

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -345,54 +345,244 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        // Represents execution of a chain of suspended and resuming runtime
-        // async functions.
-        private sealed class RuntimeAsyncTask<T> : Task<T>, ITaskCompletionAction
+        private static class RuntimeAsyncTaskCore
         {
-            public RuntimeAsyncTask()
+            internal static Action GetContinuationAction(Task runtimeAsyncTask)
             {
-                // We use the base Task's state object field to store the Continuation while posting the task around.
-                // Ensure that state object isn't published out for others to see.
-                Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
-                Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
-                m_action = DispatchContinuations;
-                m_stateFlags |= (int)InternalTaskOptions.HiddenState;
-            }
-
-            internal override void ExecuteFromThreadPool(Thread threadPoolThread)
-            {
-                DispatchContinuations();
-            }
-
-            void ITaskCompletionAction.Invoke(Task completingTask)
-            {
-                DispatchContinuations();
-            }
-
-            bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
-
-            private Action GetContinuationAction()
-            {
-                object? action = m_action;
+                object? action = runtimeAsyncTask.m_action;
                 Debug.Assert(action is Action);
                 return Unsafe.As<Action>(action);
             }
 
-            private Continuation MoveContinuationState()
+            internal static Continuation MoveContinuationState(Task runtimeAsyncTask)
             {
-                object? stateObject = m_stateObject;
+                object? stateObject = runtimeAsyncTask.m_stateObject;
                 Debug.Assert(stateObject is Continuation);
-                m_stateObject = null;
+                runtimeAsyncTask.m_stateObject = null;
                 return Unsafe.As<Continuation>(stateObject);
             }
 
-            private void SetContinuationState(Continuation value)
+            internal static void SetContinuationState(Task runtimeAsyncTask, Continuation value)
             {
-                Debug.Assert(m_stateObject == null);
-                m_stateObject = value;
+                Debug.Assert(runtimeAsyncTask.m_stateObject == null);
+                runtimeAsyncTask.m_stateObject = value;
             }
 
-            internal unsafe bool HandleSuspended(ref RuntimeAsyncAwaitState state)
+            [StackTraceHidden]
+            // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
+            internal static unsafe void DispatchContinuations(Task runtimeAsyncTask, ref byte resultStorage)
+            {
+                if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
+                {
+                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                    if (flags != AsyncInstrumentation.Flags.Disabled)
+                    {
+                        InstrumentedDispatchContinuations(runtimeAsyncTask, ref resultStorage, flags);
+                        return;
+                    }
+                }
+
+                RuntimeAsyncStackState stackState = default;
+
+                ref RuntimeAsyncAwaitState awaitState = ref t_runtimeAsyncAwaitState;
+                awaitState.Push(&stackState);
+
+                ref AsyncDispatcherInfo* refDispatcherInfo = ref AsyncDispatcherInfo.t_current;
+
+                AsyncDispatcherInfo asyncDispatcherInfo;
+                asyncDispatcherInfo.Next = refDispatcherInfo;
+                asyncDispatcherInfo.NextContinuation = MoveContinuationState(runtimeAsyncTask);
+                refDispatcherInfo = &asyncDispatcherInfo;
+
+                while (true)
+                {
+                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
+                    try
+                    {
+                        Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                        Continuation? nextContinuation = curContinuation.Next;
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
+                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref resultStorage;
+
+                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+
+                        if (newContinuation != null)
+                        {
+                            newContinuation.Next = nextContinuation;
+                            HandleSuspended(runtimeAsyncTask, ref awaitState);
+
+                            awaitState.Pop();
+                            refDispatcherInfo = asyncDispatcherInfo.Next;
+                            return;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        uint unwindedFrames = 1; // Count current frame.
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        if (handlerContinuation == null)
+                        {
+                            // Tail of AsyncTaskMethodBuilderT.SetException
+                            bool successfullySet = ex is OperationCanceledException oce ?
+                                runtimeAsyncTask.TrySetCanceled(oce.CancellationToken, oce) :
+                                runtimeAsyncTask.TrySetException(ex);
+
+                            awaitState.Pop();
+                            refDispatcherInfo = asyncDispatcherInfo.Next;
+
+                            if (!successfullySet)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                            }
+
+                            return;
+                        }
+
+                        handlerContinuation.SetException(ex);
+                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
+                    }
+
+                    if (asyncDispatcherInfo.NextContinuation == null)
+                    {
+                        bool successfullySet = runtimeAsyncTask.TrySetResult();
+
+                        awaitState.Pop();
+                        refDispatcherInfo = asyncDispatcherInfo.Next;
+
+                        if (!successfullySet)
+                        {
+                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                        }
+
+                        return;
+                    }
+
+                    if (QueueContinuationFollowUpActionIfNecessary(runtimeAsyncTask, asyncDispatcherInfo.NextContinuation))
+                    {
+                        awaitState.Pop();
+                        refDispatcherInfo = asyncDispatcherInfo.Next;
+                        return;
+                    }
+
+                    if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
+                    {
+                        SetContinuationState(runtimeAsyncTask, asyncDispatcherInfo.NextContinuation);
+
+                        awaitState.Pop();
+                        refDispatcherInfo = asyncDispatcherInfo.Next;
+
+                        InstrumentedDispatchContinuations(runtimeAsyncTask, ref resultStorage, AsyncInstrumentation.ActiveFlags);
+                        return;
+                    }
+                }
+            }
+
+            [StackTraceHidden]
+            internal static unsafe void InstrumentedDispatchContinuations(Task runtimeAsyncTask, ref byte resultStorage, AsyncInstrumentation.Flags flags)
+            {
+                RuntimeAsyncStackState stackState = default;
+
+                ref RuntimeAsyncAwaitState awaitState = ref t_runtimeAsyncAwaitState;
+                awaitState.Push(&stackState);
+
+                ref AsyncDispatcherInfo* refDispatcherInfo = ref AsyncDispatcherInfo.t_current;
+
+                AsyncDispatcherInfo asyncDispatcherInfo;
+                asyncDispatcherInfo.Next = refDispatcherInfo;
+                asyncDispatcherInfo.NextContinuation = MoveContinuationState(runtimeAsyncTask);
+                refDispatcherInfo = &asyncDispatcherInfo;
+
+                RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncContext(runtimeAsyncTask, ref asyncDispatcherInfo, flags);
+
+                while (true)
+                {
+                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
+                    Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                    try
+                    {
+                        Continuation? nextContinuation = curContinuation.Next;
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
+                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref resultStorage;
+
+                        RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+
+                        if (newContinuation != null)
+                        {
+                            newContinuation.Next = nextContinuation;
+                            RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
+                            InstrumentedHandleSuspended(runtimeAsyncTask, flags, ref awaitState, newContinuation);
+
+                            awaitState.Pop();
+                            refDispatcherInfo = asyncDispatcherInfo.Next;
+                            return;
+                        }
+
+                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(flags, curContinuation);
+                    }
+                    catch (Exception ex)
+                    {
+                        uint unwindedFrames = 1; // Count current frame.
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        if (handlerContinuation == null)
+                        {
+                            RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+
+                            // Tail of AsyncTaskMethodBuilderT.SetException
+                            bool successfullySet = ex is OperationCanceledException oce ?
+                                runtimeAsyncTask.TrySetCanceled(oce.CancellationToken, oce) :
+                                runtimeAsyncTask.TrySetException(ex);
+
+                            awaitState.Pop();
+                            refDispatcherInfo = asyncDispatcherInfo.Next;
+
+                            if (!successfullySet)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                            }
+
+                            return;
+                        }
+
+                        RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
+
+                        handlerContinuation.SetException(ex);
+                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
+                    }
+
+                    if (asyncDispatcherInfo.NextContinuation == null)
+                    {
+                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+
+                        bool successfullySet = runtimeAsyncTask.TrySetResult();
+
+                        awaitState.Pop();
+                        refDispatcherInfo = asyncDispatcherInfo.Next;
+
+                        if (!successfullySet)
+                        {
+                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                        }
+
+                        return;
+                    }
+
+                    if (QueueContinuationFollowUpActionIfNecessary(runtimeAsyncTask, asyncDispatcherInfo.NextContinuation))
+                    {
+                        RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+
+                        awaitState.Pop();
+                        refDispatcherInfo = asyncDispatcherInfo.Next;
+                        return;
+                    }
+
+                    flags = AsyncInstrumentation.ActiveFlags;
+                }
+            }
+
+            internal static unsafe bool HandleSuspended(Task runtimeAsyncTask, ref RuntimeAsyncAwaitState state)
             {
                 Thread currentThread = state.CurrentThread;
                 Debug.Assert(currentThread != null);
@@ -423,22 +613,23 @@ namespace System.Runtime.CompilerServices
 
                 Debug.Assert((headContinuation.Flags & continueFlags) == 0);
 
-                SetContinuationState(headContinuation);
+                SetContinuationState(runtimeAsyncTask, headContinuation);
 
                 try
                 {
                     if (stackState->CriticalNotifier is { } critNotifier)
                     {
-                        critNotifier.UnsafeOnCompleted(GetContinuationAction());
+                        critNotifier.UnsafeOnCompleted(GetContinuationAction(runtimeAsyncTask));
                     }
                     else if (stackState->TaskNotifier is { } taskNotifier)
                     {
                         // Runtime async callable wrapper for task returning
                         // method. This implements the context transparent
                         // forwarding and makes these wrappers minimal cost.
-                        if (!taskNotifier.TryAddCompletionAction(this))
+                        Debug.Assert(runtimeAsyncTask is ITaskCompletionAction);
+                        if (!taskNotifier.TryAddCompletionAction(Unsafe.As<ITaskCompletionAction>(runtimeAsyncTask)))
                         {
-                            ThreadPool.UnsafeQueueUserWorkItemInternal(this, preferLocal: true);
+                            ThreadPool.UnsafeQueueUserWorkItemInternal(runtimeAsyncTask, preferLocal: true);
                         }
                     }
                     else if (stackState->ValueTaskSourceNotifier is { } valueTaskSourceNotifier)
@@ -476,12 +667,12 @@ namespace System.Runtime.CompilerServices
 
                         // Clear continuation flags, so that continuation runs transparently
                         nextUserContinuation.Flags &= ~continueFlags;
-                        valueTaskSourceNotifier.OnCompleted(s_runContinuationAction, this, configFlags);
+                        valueTaskSourceNotifier.OnCompleted(s_runContinuationAction, runtimeAsyncTask, configFlags);
                     }
                     else
                     {
                         Debug.Assert(stackState->Notifier != null);
-                        stackState->Notifier!.OnCompleted(GetContinuationAction());
+                        stackState->Notifier!.OnCompleted(GetContinuationAction(runtimeAsyncTask));
                     }
 
                     return true;
@@ -494,7 +685,7 @@ namespace System.Runtime.CompilerServices
                 return false;
             }
 
-            internal void InstrumentedHandleSuspended(AsyncInstrumentation.Flags flags, ref RuntimeAsyncAwaitState state, Continuation? newContinuation = null)
+            internal static void InstrumentedHandleSuspended(Task runtimeAsyncTask, AsyncInstrumentation.Flags flags, ref RuntimeAsyncAwaitState state, Continuation? newContinuation = null)
             {
                 if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
@@ -502,241 +693,18 @@ namespace System.Runtime.CompilerServices
 
                     AsyncDebugger.HandleSuspended(nextContinuation, newContinuation);
 
-                    if (!HandleSuspended(ref state))
+                    if (!HandleSuspended(runtimeAsyncTask, ref state))
                     {
-                        AsyncDebugger.HandleSuspendedFailed(this, nextContinuation);
+                        AsyncDebugger.HandleSuspendedFailed(runtimeAsyncTask, nextContinuation);
                     }
 
                     return;
                 }
 
-                HandleSuspended(ref state);
+                HandleSuspended(runtimeAsyncTask, ref state);
             }
 
-#pragma warning disable CA1822 // Mark members as static
-            [MethodImpl(MethodImplOptions.NoOptimization)]
-            public void NotifyDebuggerOfRuntimeAsyncState()
-            {
-            }
-#pragma warning restore CA1822
-
-            [StackTraceHidden]
-            // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
-            private unsafe void DispatchContinuations()
-            {
-                if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
-                {
-                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
-                    if (flags != AsyncInstrumentation.Flags.Disabled)
-                    {
-                        InstrumentedDispatchContinuations(flags);
-                        return;
-                    }
-                }
-
-                RuntimeAsyncStackState stackState = default;
-
-                ref RuntimeAsyncAwaitState awaitState = ref t_runtimeAsyncAwaitState;
-                awaitState.Push(&stackState);
-
-                ref AsyncDispatcherInfo* refDispatcherInfo = ref AsyncDispatcherInfo.t_current;
-
-                AsyncDispatcherInfo asyncDispatcherInfo;
-                asyncDispatcherInfo.Next = refDispatcherInfo;
-                asyncDispatcherInfo.NextContinuation = MoveContinuationState();
-                refDispatcherInfo = &asyncDispatcherInfo;
-
-                while (true)
-                {
-                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
-                    try
-                    {
-                        Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
-                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
-
-                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
-
-                        if (newContinuation != null)
-                        {
-                            newContinuation.Next = nextContinuation;
-                            HandleSuspended(ref awaitState);
-
-                            awaitState.Pop();
-                            refDispatcherInfo = asyncDispatcherInfo.Next;
-                            return;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        uint unwindedFrames = 1; // Count current frame.
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
-                        if (handlerContinuation == null)
-                        {
-                            // Tail of AsyncTaskMethodBuilderT.SetException
-                            bool successfullySet = ex is OperationCanceledException oce ?
-                                TrySetCanceled(oce.CancellationToken, oce) :
-                                TrySetException(ex);
-
-                            awaitState.Pop();
-                            refDispatcherInfo = asyncDispatcherInfo.Next;
-
-                            if (!successfullySet)
-                            {
-                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                            }
-
-                            return;
-                        }
-
-                        handlerContinuation.SetException(ex);
-                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
-                    }
-
-                    if (asyncDispatcherInfo.NextContinuation == null)
-                    {
-                        bool successfullySet = TrySetResult(m_result);
-
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
-
-                        if (!successfullySet)
-                        {
-                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                        }
-
-                        return;
-                    }
-
-                    if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
-                    {
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
-                        return;
-                    }
-
-                    if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
-                    {
-                        SetContinuationState(asyncDispatcherInfo.NextContinuation);
-
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
-
-                        InstrumentedDispatchContinuations(AsyncInstrumentation.ActiveFlags);
-                        return;
-                    }
-                }
-            }
-
-            [StackTraceHidden]
-            private unsafe void InstrumentedDispatchContinuations(AsyncInstrumentation.Flags flags)
-            {
-                RuntimeAsyncStackState stackState = default;
-
-                ref RuntimeAsyncAwaitState awaitState = ref t_runtimeAsyncAwaitState;
-                awaitState.Push(&stackState);
-
-                ref AsyncDispatcherInfo* refDispatcherInfo = ref AsyncDispatcherInfo.t_current;
-
-                AsyncDispatcherInfo asyncDispatcherInfo;
-                asyncDispatcherInfo.Next = refDispatcherInfo;
-                asyncDispatcherInfo.NextContinuation = MoveContinuationState();
-                refDispatcherInfo = &asyncDispatcherInfo;
-
-                RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
-
-                while (true)
-                {
-                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
-                    Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
-                    try
-                    {
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
-                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
-
-                        RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
-                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
-
-                        if (newContinuation != null)
-                        {
-                            newContinuation.Next = nextContinuation;
-                            RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
-                            InstrumentedHandleSuspended(flags, ref awaitState, newContinuation);
-
-                            awaitState.Pop();
-                            refDispatcherInfo = asyncDispatcherInfo.Next;
-                            return;
-                        }
-
-                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(flags, curContinuation);
-                    }
-                    catch (Exception ex)
-                    {
-                        uint unwindedFrames = 1; // Count current frame.
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
-                        if (handlerContinuation == null)
-                        {
-                            RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
-
-                            // Tail of AsyncTaskMethodBuilderT.SetException
-                            bool successfullySet = ex is OperationCanceledException oce ?
-                                TrySetCanceled(oce.CancellationToken, oce) :
-                                TrySetException(ex);
-
-                            awaitState.Pop();
-                            refDispatcherInfo = asyncDispatcherInfo.Next;
-
-                            if (!successfullySet)
-                            {
-                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                            }
-
-                            return;
-                        }
-
-                        RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
-
-                        handlerContinuation.SetException(ex);
-                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
-                    }
-
-                    if (asyncDispatcherInfo.NextContinuation == null)
-                    {
-                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
-
-                        bool successfullySet = TrySetResult(m_result);
-
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
-
-                        if (!successfullySet)
-                        {
-                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                        }
-
-                        return;
-                    }
-
-                    if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
-                    {
-                        RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
-
-                        awaitState.Pop();
-                        refDispatcherInfo = asyncDispatcherInfo.Next;
-                        return;
-                    }
-
-                    flags = AsyncInstrumentation.ActiveFlags;
-                }
-            }
-
-            private ref byte GetResultStorage() => ref Unsafe.As<T?, byte>(ref m_result);
-
-            private static unsafe Continuation? UnwindToPossibleHandler(Continuation? continuation, Exception ex, ref uint unwindedFrames)
+            internal static unsafe Continuation? UnwindToPossibleHandler(Continuation? continuation, Exception ex, ref uint unwindedFrames)
             {
                 while (true)
                 {
@@ -757,7 +725,7 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private bool QueueContinuationFollowUpActionIfNecessary(Continuation continuation)
+            internal static bool QueueContinuationFollowUpActionIfNecessary(Task runtimeAsyncTask, Continuation continuation)
             {
                 if ((continuation.Flags & ContinuationFlags.ContinueOnThreadPool) != 0)
                 {
@@ -772,8 +740,8 @@ namespace System.Runtime.CompilerServices
                         }
                     }
 
-                    SetContinuationState(continuation);
-                    ThreadPool.UnsafeQueueUserWorkItemInternal(this, preferLocal: true);
+                    SetContinuationState(runtimeAsyncTask, continuation);
+                    ThreadPool.UnsafeQueueUserWorkItemInternal(runtimeAsyncTask, preferLocal: true);
                     return true;
                 }
 
@@ -789,11 +757,11 @@ namespace System.Runtime.CompilerServices
                         return false;
                     }
 
-                    SetContinuationState(continuation);
+                    SetContinuationState(runtimeAsyncTask, continuation);
 
                     try
                     {
-                        continuationSyncCtx.Post(s_postCallback, this);
+                        continuationSyncCtx.Post(s_postCallback, runtimeAsyncTask);
                     }
                     catch (Exception ex)
                     {
@@ -809,9 +777,9 @@ namespace System.Runtime.CompilerServices
                     Debug.Assert(continuationContext is TaskScheduler { });
                     TaskScheduler sched = (TaskScheduler)continuationContext;
 
-                    SetContinuationState(continuation);
+                    SetContinuationState(runtimeAsyncTask, continuation);
                     // TODO: We do not need TaskSchedulerAwaitTaskContinuation here, just need to refactor its Run method...
-                    var taskSchedCont = new TaskSchedulerAwaitTaskContinuation(sched, GetContinuationAction(), flowExecutionContext: false);
+                    var taskSchedCont = new TaskSchedulerAwaitTaskContinuation(sched, GetContinuationAction(runtimeAsyncTask), flowExecutionContext: false);
                     taskSchedCont.Run(Task.CompletedTask, canInlineContinuationTask: true);
 
                     return true;
@@ -822,18 +790,66 @@ namespace System.Runtime.CompilerServices
 
             private static readonly SendOrPostCallback s_postCallback = static state =>
             {
-                Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+                Debug.Assert(state is Task && state.GetType().GetGenericTypeDefinition() == typeof(RuntimeAsyncTask<>));
+                Task runtimeAsyncTask = Unsafe.As<Task>(state);
+                // Relies on us knowing that RuntimeAsyncTask.ExecuteFromThreadPool is a simple forward to DispatchContinuations
+                runtimeAsyncTask.ExecuteFromThreadPool(null!);
             };
 
             private static readonly Action<object?> s_runContinuationAction = static state =>
             {
-                Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+                Debug.Assert(state is Task && state.GetType().GetGenericTypeDefinition() == typeof(RuntimeAsyncTask<>));
+                Task runtimeAsyncTask = Unsafe.As<Task>(state);
+                // Relies on us knowing that RuntimeAsyncTask.ExecuteFromThreadPool is a simple forward to DispatchContinuations
+                runtimeAsyncTask.ExecuteFromThreadPool(null!);
             };
         }
 
-        private static void InstrumentedFinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task, ref RuntimeAsyncAwaitState state, AsyncInstrumentation.Flags flags)
+        // Represents execution of a chain of suspended and resuming runtime
+        // async functions.
+        private sealed class RuntimeAsyncTask<T> : Task<T>, ITaskCompletionAction
+        {
+            public RuntimeAsyncTask()
+            {
+                // We use the base Task's state object field to store the Continuation while posting the task around.
+                // Ensure that state object isn't published out for others to see.
+                Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
+                Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
+                m_action = DispatchContinuations;
+                m_stateFlags |= (int)InternalTaskOptions.HiddenState;
+            }
+
+            [StackTraceHidden]
+            private void DispatchContinuations()
+            {
+                RuntimeAsyncTaskCore.DispatchContinuations(this, ref Unsafe.As<T?, byte>(ref m_result));
+            }
+
+            // This implementation not accessing its parameter is depended on
+            // by s_postCallback and s_runContinuationAction, which rely on the
+            // fact that we can call ExecuteFromThreadPool(null) on a
+            // RuntimeAsyncTask<T> typed as Task to dispatch the continuations.
+            internal override void ExecuteFromThreadPool(Thread threadPoolThread)
+            {
+                DispatchContinuations();
+            }
+
+            void ITaskCompletionAction.Invoke(Task completingTask)
+            {
+                DispatchContinuations();
+            }
+
+            bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
+
+#pragma warning disable CA1822 // Mark members as static
+            [MethodImpl(MethodImplOptions.NoOptimization)]
+            public void NotifyDebuggerOfRuntimeAsyncState()
+            {
+            }
+#pragma warning restore CA1822
+        }
+
+        private static void InstrumentedFinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags, ref RuntimeAsyncAwaitState state)
         {
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags))
             {
@@ -844,24 +860,24 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            task.InstrumentedHandleSuspended(flags, ref state);
+            RuntimeAsyncTaskCore.InstrumentedHandleSuspended(task, flags, ref state);
             return;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void FinalizeRuntimeAsyncTask<T>(ref RuntimeAsyncAwaitState state, RuntimeAsyncTask<T> task)
+        private static void FinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task, ref RuntimeAsyncAwaitState state)
         {
             if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
             {
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                 if (flags != AsyncInstrumentation.Flags.Disabled)
                 {
-                    InstrumentedFinalizeRuntimeAsyncTask(task, ref state, flags);
+                    InstrumentedFinalizeRuntimeAsyncTask(task, flags, ref state);
                     return;
                 }
             }
 
-            task.HandleSuspended(ref state);
+            RuntimeAsyncTaskCore.HandleSuspended(task, ref state);
         }
 
         // Change return type to RuntimeAsyncTask<T?> -- no benefit since this is used for Task returning thunks only
@@ -871,14 +887,14 @@ namespace System.Runtime.CompilerServices
         private static Task<T?> FinalizeTaskReturningThunk<T>(ref RuntimeAsyncAwaitState state)
         {
             RuntimeAsyncTask<T?> result = new();
-            FinalizeRuntimeAsyncTask(ref state, result!);
+            FinalizeRuntimeAsyncTask(result, ref state);
             return result;
         }
 
         private static Task FinalizeTaskReturningThunk(ref RuntimeAsyncAwaitState state)
         {
             RuntimeAsyncTask<VoidTaskResult> result = new();
-            FinalizeRuntimeAsyncTask(ref state, result!);
+            FinalizeRuntimeAsyncTask(result, ref state);
             return result;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -123,7 +123,7 @@ namespace System.Threading.Tasks
         // The delegate to invoke for a delegate-backed Task.
         // This field also may be used by async state machines to cache an Action.
         internal Delegate? m_action;
-        private protected object? m_stateObject; // A state object that can be optionally supplied, passed to action.
+        internal object? m_stateObject; // A state object that can be optionally supplied, passed to action.
         internal TaskScheduler? m_taskScheduler; // The task scheduler this task runs under.
 
         internal volatile int m_stateFlags; // SOS DumpAsync command depends on this name
@@ -3497,7 +3497,7 @@ namespace System.Threading.Tasks
         }
 
         /// <summary>Completes a promise task as RanToCompletion.</summary>
-        /// <remarks>If this is a Task{T}, default(T) is the implied result.</remarks>
+        /// <remarks>If this is a Task{T}, the current value of m_result is the implied result.</remarks>
         /// <returns>true if the task was transitioned to ran to completion; false if it was already completed.</returns>
         internal bool TrySetResult()
         {

--- a/src/tests/async/reflection/reflection.cs
+++ b/src/tests/async/reflection/reflection.cs
@@ -310,8 +310,8 @@ public class Async2Reflection
         {
             // Note: we go through suspend/resume, that is why we see dispatcher as the caller.
             //       we do not see the resume stub though.
-            Assert.Equal("Void DispatchContinuations()", FromStackAsync(1).Result);
-            Assert.Equal("Void DispatchContinuations()", FromStackAwait(1).Result);
+            Assert.Equal("Void DispatchContinuations(System.Threading.Tasks.Task, Byte ByRef)", FromStackAsync(1).Result);
+            Assert.Equal("Void DispatchContinuations(System.Threading.Tasks.Task, Byte ByRef)", FromStackAwait(1).Result);
 
             Assert.Equal("Void FromStack(Int32)", FromStackTask(1).Result);
             // Note: we do not go through suspend/resume, that is why we see the actual caller.


### PR DESCRIPTION
Introduce `RuntimeAsyncTaskCore` that contains most of the runtime async machinery, to avoid this machinery being instantiated for every `T` in a `RuntimeAsyncTask<T>`. To do so we need a few changes:
- The delegates in `RuntimeAsyncTask<T>` called `DispatchContinuations` directly. Now there are delegates in `RuntimeAsyncTaskCore` that call `ExecuteFromThreadPool`, which is known to delegate to `DispatchContinuations` for `RuntimeAsyncTask<T>`.
- `DispatchContinuations` needs to access `Task<T>.m_result`. This now gets passed as a byref to `RuntimeAsyncTaskCore.DispatchContinuations`.

There is a 3-4% perf regression for micro benchmarks suspending/resuming that I am working on.

<details>

<summary> NativeAOT test sizes </summary>

| BaseSize | DiffSize | Delta | Percent | Name |
| ---: | ---: | ---: | ---: | --- |
| 20,030,464 | 19,988,480 | -41,984 | -0.210% | System.Net.WebSockets.Client.Tests.exe |
| 14,931,968 | 14,901,248 | -30,720 | -0.206% | System.Xml.Linq.Streaming.Tests.exe |
| 16,546,304 | 16,515,584 | -30,720 | -0.186% | System.Xml.Linq.Events.Tests.exe |
| 16,701,952 | 16,671,232 | -30,720 | -0.184% | System.Xml.Linq.Properties.Tests.exe |
| 10,068,992 | 10,050,560 | -18,432 | -0.183% | System.IO.Compression.ZipFile.Tests.exe |
| 16,813,568 | 16,782,848 | -30,720 | -0.183% | System.Xml.Linq.Misc.Tests.exe |
| 17,095,168 | 17,064,448 | -30,720 | -0.180% | System.Xml.Linq.xNodeBuilder.Tests.exe |
| 17,155,072 | 17,124,352 | -30,720 | -0.179% | System.Xml.Linq.TreeManipulation.Tests.exe |
| 22,769,664 | 22,729,216 | -40,448 | -0.178% | System.Net.Sockets.Tests.exe |
| 17,038,336 | 17,008,128 | -30,208 | -0.177% | System.Xml.Linq.xNodeReader.Tests.exe |
| 16,594,432 | 16,565,248 | -29,184 | -0.176% | System.Linq.AsyncEnumerable.Tests.exe |
| 9,656,832 | 9,639,936 | -16,896 | -0.175% | Microsoft.Extensions.Hosting.Functional.Tests.exe |
| 16,982,016 | 16,953,344 | -28,672 | -0.169% | System.Private.CoreLib.dll |
| 19,555,328 | 19,523,584 | -31,744 | -0.162% | System.Diagnostics.Process.Tests.exe |
| 31,201,792 | 31,152,640 | -49,152 | -0.158% | System.Net.Http.Functional.Tests.exe |
| 12,174,848 | 12,155,904 | -18,944 | -0.156% | System.Net.NetworkInformation.Functional.Tests.exe |
| 11,330,560 | 11,313,152 | -17,408 | -0.154% | System.Net.WebSockets.Tests.exe |
| 11,273,216 | 11,256,320 | -16,896 | -0.150% | System.IO.Compression.Brotli.Tests.exe |
| 18,390,528 | 18,363,392 | -27,136 | -0.148% | Microsoft.Extensions.Primitives.Tests.exe |
| 18,501,120 | 18,474,496 | -26,624 | -0.144% | Microsoft.Extensions.Configuration.Tests.exe |
| 10,665,984 | 10,650,624 | -15,360 | -0.144% | System.IO.Pipelines.Tests.exe |
| 18,365,440 | 18,339,328 | -26,112 | -0.142% | Microsoft.Extensions.FileProviders.Composite.Tests.exe |
| 18,784,256 | 18,758,144 | -26,112 | -0.139% | Microsoft.Extensions.FileProviders.Physical.Tests.exe |
| 18,462,720 | 18,437,120 | -25,600 | -0.139% | Microsoft.Extensions.Configuration.FileExtensions.Tests.exe |
| 19,980,800 | 19,953,152 | -27,648 | -0.138% | Microsoft.Extensions.Logging.Tests.exe |
| 10,054,144 | 10,040,320 | -13,824 | -0.137% | System.Net.ServerSentEvents.Tests.exe |
| 9,775,104 | 9,761,792 | -13,312 | -0.136% | System.Net.WebProxy.Tests.exe |
| 20,997,120 | 20,968,960 | -28,160 | -0.134% | System.Net.Quic.Functional.Tests.exe |
| 9,189,888 | 9,177,600 | -12,288 | -0.134% | System.ServiceProcess.ServiceController.Tests.exe |
| 9,561,088 | 9,548,288 | -12,800 | -0.134% | System.Memory.Data.Tests.exe |
| 14,579,200 | 14,559,744 | -19,456 | -0.133% | System.Net.WebClient.Tests.exe |
| 10,103,808 | 10,090,496 | -13,312 | -0.132% | Microsoft.Extensions.Caching.Memory.Tests.exe |
| 19,878,912 | 19,852,800 | -26,112 | -0.131% | System.Text.Encoding.Tests.exe |
| 12,421,632 | 12,406,272 | -15,360 | -0.124% | System.Xml.Linq.SDMSample.Tests.exe |
| 10,485,248 | 10,472,448 | -12,800 | -0.122% | System.Net.Http.WinHttpHandler.Unit.Tests.exe |
| 19,072,512 | 19,049,472 | -23,040 | -0.121% | System.Net.HttpListener.Tests.exe |
| 13,251,584 | 13,235,712 | -15,872 | -0.120% | System.IO.Packaging.Tests.exe |
| 12,855,296 | 12,839,936 | -15,360 | -0.119% | System.Xml.Schema.Extensions.Tests.exe |
| 19,614,208 | 19,591,168 | -23,040 | -0.117% | System.IO.Compression.Tests.exe |
| 28,832,768 | 28,798,976 | -33,792 | -0.117% | System.Net.Http.WinHttpHandler.Functional.Tests.exe |
| 10,280,448 | 10,268,672 | -11,776 | -0.115% | System.Threading.Channels.Tests.exe |
| 21,728,256 | 21,703,168 | -25,088 | -0.115% | System.IO.FileSystem.Tests.exe |
| 13,876,224 | 13,860,352 | -15,872 | -0.114% | Microsoft.Extensions.Configuration.Functional.Tests.exe |
| 24,296,448 | 24,268,800 | -27,648 | -0.114% | Microsoft.Extensions.Http.Tests.exe |
| 13,948,928 | 13,933,056 | -15,872 | -0.114% | Microsoft.Extensions.Configuration.Xml.Tests.exe |
| 19,299,328 | 19,277,312 | -22,016 | -0.114% | System.IO.Pipes.Tests.exe |
| 14,134,784 | 14,118,912 | -15,872 | -0.112% | System.DirectoryServices.Protocols.Tests.exe |
| 115,773,440 | 115,646,464 | -126,976 | -0.110% | System.Text.Json.SourceGeneration.Roslyn4.4.Tests.exe |
| 8,810,496 | 8,800,768 | -9,728 | -0.110% | System.Console.Manual.Tests.exe |
| 8,964,608 | 8,954,880 | -9,728 | -0.109% | System.Net.Primitives.Pal.Tests.exe |
| 18,841,600 | 18,821,120 | -20,480 | -0.109% | System.Runtime.Caching.Tests.exe |
| 33,202,176 | 33,166,336 | -35,840 | -0.108% | System.Private.Xml.Tests.exe |
| 8,580,608 | 8,571,392 | -9,216 | -0.107% | System.Resources.Writer.Tests.exe |
| 8,732,160 | 8,722,944 | -9,216 | -0.106% | Invariant.Tests.exe |
| 8,691,712 | 8,682,496 | -9,216 | -0.106% | System.Diagnostics.FileVersionInfo.Tests.exe |
| 26,451,456 | 26,423,808 | -27,648 | -0.105% | System.ComponentModel.TypeConverter.Tests.exe |
| 27,176,448 | 27,148,288 | -28,160 | -0.104% | Microsoft.Extensions.Hosting.Unit.Tests.exe |
| 17,439,744 | 17,421,824 | -17,920 | -0.103% | System.Net.Ping.Functional.Tests.exe |
| 8,977,920 | 8,968,704 | -9,216 | -0.103% | System.Runtime.Serialization.Primitives.Tests.exe |
| 9,462,784 | 9,453,056 | -9,728 | -0.103% | Microsoft.Extensions.Configuration.Ini.Tests.exe |
| 8,532,992 | 8,524,288 | -8,704 | -0.102% | System.Composition.AttributeModel.Tests.exe |
| 9,058,816 | 9,049,600 | -9,216 | -0.102% | System.ValueTuple.Tests.exe |
| 15,044,096 | 15,028,736 | -15,360 | -0.102% | System.Data.DataSetExtensions.Tests.exe |
| 8,537,088 | 8,528,384 | -8,704 | -0.102% | System.Diagnostics.Contracts.Tests.exe |
| 8,521,216 | 8,512,512 | -8,704 | -0.102% | System.Runtime.CompilerServices.VisualC.Tests.exe |
| 8,566,784 | 8,558,080 | -8,704 | -0.102% | Microsoft.Bcl.Numerics.Tests.exe |
| 8,522,240 | 8,513,536 | -8,704 | -0.102% | System.ComponentModel.Tests.exe |
| 8,532,480 | 8,523,776 | -8,704 | -0.102% | System.Text.Encoding.Extensions.Tests.exe |
| 17,161,728 | 17,144,320 | -17,408 | -0.101% | IcuAppLocal.Tests.exe |
| 9,136,128 | 9,126,912 | -9,216 | -0.101% | System.ComponentModel.Primitives.Tests.exe |
| 8,598,528 | 8,589,824 | -8,704 | -0.101% | System.Composition.Runtime.Tests.exe |
| 8,627,712 | 8,619,008 | -8,704 | -0.101% | System.Globalization.CalendarsWithConfigSwitch.Tests.exe |
| 15,771,648 | 15,755,776 | -15,872 | -0.101% | System.Windows.Extensions.Tests.exe |
| 8,598,016 | 8,589,312 | -8,704 | -0.101% | System.Xml.Linq.Axes.Tests.exe |
| 17,289,216 | 17,271,808 | -17,408 | -0.101% | System.Threading.Overlapped.Tests.exe |
| 8,576,000 | 8,567,296 | -8,704 | -0.101% | Microsoft.Extensions.Hosting.Abstractions.Tests.exe |
| 17,800,704 | 17,782,784 | -17,920 | -0.101% | System.Formats.Tar.Manual.Tests.exe |
| 17,668,608 | 17,650,688 | -17,920 | -0.101% | System.IO.FileSystem.Watcher.Tests.exe |
| 8,674,816 | 8,666,112 | -8,704 | -0.100% | System.Security.Cryptography.ProtectedData.Tests.exe |
| 8,674,816 | 8,666,112 | -8,704 | -0.100% | System.IO.FileSystem.Manual.Tests.exe |
| 8,743,936 | 8,735,232 | -8,704 | -0.100% | System.IO.FileSystem.DriveInfo.Tests.exe |
| 8,752,640 | 8,743,936 | -8,704 | -0.099% | Microsoft.Bcl.TimeProvider.Tests.exe |
| 17,582,592 | 17,565,184 | -17,408 | -0.099% | MetricOuterLoop1.Tests.exe |
| 27,917,312 | 27,889,664 | -27,648 | -0.099% | System.Net.Security.Tests.exe |
| 17,319,424 | 17,302,528 | -16,896 | -0.098% | System.Security.Principal.Windows.Tests.exe |
| 15,086,080 | 15,071,232 | -14,848 | -0.098% | System.Security.Cryptography.Cng.Tests.exe |
| 15,108,608 | 15,093,760 | -14,848 | -0.098% | System.Drawing.Primitives.Tests.exe |
| 17,238,016 | 17,221,120 | -16,896 | -0.098% | System.ComponentModel.EventBasedAsync.Tests.exe |
| 8,838,144 | 8,829,440 | -8,704 | -0.098% | System.Reflection.Extensions.Tests.exe |
| 17,305,600 | 17,288,704 | -16,896 | -0.098% | System.Security.Claims.Tests.exe |
| 17,222,144 | 17,205,248 | -16,896 | -0.098% | System.Net.ServicePoint.Tests.exe |
| 11,994,624 | 11,982,848 | -11,776 | -0.098% | System.IO.Tests.exe |
| 8,999,936 | 8,991,232 | -8,704 | -0.097% | System.Reflection.TypeExtensions.Tests.exe |
| 9,013,760 | 9,005,056 | -8,704 | -0.097% | Microsoft.Extensions.FileSystemGlobbing.Tests.exe |
| 17,438,208 | 17,421,312 | -16,896 | -0.097% | System.Diagnostics.TraceSource.Tests.exe |
| 17,337,344 | 17,320,448 | -16,896 | -0.097% | System.Threading.Timer.Tests.exe |
| 17,974,784 | 17,957,376 | -17,408 | -0.097% | System.Threading.ThreadPool.WindowsThreadPool.Tests.exe |
| 17,974,784 | 17,957,376 | -17,408 | -0.097% | System.Threading.ThreadPool.Tests.exe |
| 17,362,944 | 17,346,048 | -16,896 | -0.097% | Microsoft.Win32.SystemEvents.Tests.exe |
| 8,927,232 | 8,918,528 | -8,704 | -0.097% | Microsoft.Bcl.Memory.Tests.exe |
| 8,965,632 | 8,956,928 | -8,704 | -0.097% | Microsoft.Win32.Registry.Tests.exe |
| 18,459,648 | 18,441,728 | -17,920 | -0.097% | System.Threading.Tasks.Parallel.Tests.exe |
| 17,664,512 | 17,647,616 | -16,896 | -0.096% | System.Buffers.Tests.exe |
| 9,083,392 | 9,074,688 | -8,704 | -0.096% | System.IO.FileSystem.AccessControl.Tests.exe |
| 19,688,448 | 19,669,504 | -18,944 | -0.096% | System.Net.Http.Unit.Tests.exe |
| 17,623,552 | 17,606,656 | -16,896 | -0.096% | System.Threading.Thread.Tests.exe |
| 18,136,064 | 18,118,656 | -17,408 | -0.096% | System.Diagnostics.TextWriterTraceListener.Tests.exe |
| 8,522,752 | 8,514,560 | -8,192 | -0.096% | System.Diagnostics.Tools.Tests.exe |
| 18,184,704 | 18,167,296 | -17,408 | -0.096% | System.Text.Encoding.CodePages.Tests.exe |
| 18,071,040 | 18,053,632 | -17,408 | -0.096% | System.Console.Tests.exe |
| 17,167,360 | 17,150,976 | -16,384 | -0.095% | System.Runtime.Serialization.Formatters.Disabled.Tests.exe |
| 8,644,096 | 8,635,904 | -8,192 | -0.095% | System.Runtime.Handles.Tests.exe |
| 21,104,640 | 21,084,672 | -19,968 | -0.095% | System.Net.Requests.Tests.exe |
| 17,295,872 | 17,279,488 | -16,384 | -0.095% | System.Runtime.InteropServices.RuntimeInformation.Tests.exe |
| 17,243,136 | 17,226,752 | -16,384 | -0.095% | System.Runtime.InvariantTimezone.Tests.exe |
| 8,615,424 | 8,607,232 | -8,192 | -0.095% | System.Net.WebHeaderCollection.Tests.exe |
| 8,654,848 | 8,646,656 | -8,192 | -0.095% | System.Runtime.CompilerServices.Unsafe.Tests.exe |
| 8,662,016 | 8,653,824 | -8,192 | -0.095% | System.Runtime.InteropServices.ComDisabled.Tests.exe |
| 9,732,096 | 9,722,880 | -9,216 | -0.095% | System.Threading.RateLimiting.Tests.exe |
| 17,744,896 | 17,728,000 | -16,896 | -0.095% | System.Threading.Tasks.Extensions.Tests.exe |
| 9,139,712 | 9,131,008 | -8,704 | -0.095% | System.Globalization.Calendars.Tests.exe |
| 9,181,184 | 9,172,480 | -8,704 | -0.095% | Microsoft.Extensions.Configuration.EnvironmentVariables.Tests.exe |
| 16,113,152 | 16,097,792 | -15,360 | -0.095% | System.Data.Odbc.Tests.exe |
| 18,039,296 | 18,022,400 | -16,896 | -0.094% | Microsoft.Extensions.Diagnostics.Tests.exe |
| 8,693,760 | 8,685,568 | -8,192 | -0.094% | System.Private.Uri.Unit.Tests.exe |
| 17,368,576 | 17,352,192 | -16,384 | -0.094% | System.Diagnostics.StackTrace.Tests.exe |
| 17,577,472 | 17,561,088 | -16,384 | -0.093% | MetricOuterLoop.Tests.exe |
| 8,785,408 | 8,777,216 | -8,192 | -0.093% | System.Resources.Reader.Tests.exe |
| 9,331,712 | 9,323,008 | -8,704 | -0.093% | Microsoft.Extensions.Diagnostics.Abstractions.Tests.exe |
| 9,923,072 | 9,913,856 | -9,216 | -0.093% | System.Collections.NonGeneric.Tests.exe |
| 9,351,168 | 9,342,464 | -8,704 | -0.093% | System.Net.Mail.Unit.Tests.exe |
| 9,335,296 | 9,326,592 | -8,704 | -0.093% | System.Security.Permissions.Tests.exe |
| 8,791,552 | 8,783,360 | -8,192 | -0.093% | System.Web.HttpUtility.Tests.exe |
| 9,339,904 | 9,331,200 | -8,704 | -0.093% | System.Reflection.Context.Tests.exe |
| 10,037,760 | 10,028,544 | -9,216 | -0.092% | System.Diagnostics.Debug.Tests.exe |
| 8,903,680 | 8,895,488 | -8,192 | -0.092% | System.IO.Pipes.AccessControl.Tests.exe |
| 29,413,888 | 29,386,752 | -27,136 | -0.092% | Microsoft.Extensions.DependencyModel.Tests.exe |
| 18,525,184 | 18,508,288 | -16,896 | -0.091% | System.IO.MemoryMappedFiles.Tests.exe |
| 19,087,360 | 19,069,952 | -17,408 | -0.091% | Microsoft.Extensions.Hosting.WindowsServices.Tests.exe |
| 9,605,120 | 9,596,416 | -8,704 | -0.091% | System.Composition.Convention.Tests.exe |
| 9,030,656 | 9,022,464 | -8,192 | -0.091% | Microsoft.Extensions.Configuration.CommandLine.Tests.exe |
| 18,496,000 | 18,479,104 | -16,896 | -0.091% | Microsoft.Extensions.Hosting.Systemd.Tests.exe |
| 19,302,912 | 19,285,504 | -17,408 | -0.090% | System.Net.Primitives.Functional.Tests.exe |
| 18,700,800 | 18,683,904 | -16,896 | -0.090% | Microsoft.Extensions.Logging.Console.Tests.exe |
| 8,517,632 | 8,509,952 | -7,680 | -0.090% | System.IO.FileSystem.Primitives.Tests.exe |
| 9,621,504 | 9,612,800 | -8,704 | -0.090% | System.Private.Uri.Functional.Tests.exe |
| 9,117,184 | 9,108,992 | -8,192 | -0.090% | System.Security.AccessControl.Tests.exe |
| 9,678,848 | 9,670,144 | -8,704 | -0.090% | System.Text.RegularExpressions.Unit.Tests.exe |
| 9,723,392 | 9,714,688 | -8,704 | -0.090% | System.Collections.Specialized.Tests.exe |
| 8,621,056 | 8,613,376 | -7,680 | -0.089% | Microsoft.Win32.Registry.AccessControl.Tests.exe |
| 8,637,952 | 8,630,272 | -7,680 | -0.089% | Microsoft.Win32.Primitives.Tests.exe |
| 20,810,240 | 20,791,808 | -18,432 | -0.089% | System.Security.Cryptography.Csp.Tests.exe |
| 9,737,728 | 9,729,024 | -8,704 | -0.089% | System.Formats.Asn1.Tests.exe |
| 18,378,752 | 18,362,368 | -16,384 | -0.089% | System.Threading.Tests.exe |
| 9,826,304 | 9,817,600 | -8,704 | -0.089% | System.Formats.Nrbf.Tests.exe |
| 8,677,888 | 8,670,208 | -7,680 | -0.089% | System.Security.SecureString.Tests.exe |
| 19,756,032 | 19,738,624 | -17,408 | -0.088% | System.Resources.ResourceManager.Tests.exe |
| 9,936,896 | 9,928,192 | -8,704 | -0.088% | LibraryImportGenerator.Tests.exe |
| 20,292,608 | 20,274,688 | -17,920 | -0.088% | System.Threading.Tasks.Dataflow.Tests.exe |
| 18,593,280 | 18,576,896 | -16,384 | -0.088% | ComInterfaceGenerator.Tests.exe |
| 9,289,216 | 9,281,024 | -8,192 | -0.088% | System.Net.Primitives.UnitTests.Tests.exe |
| 19,491,328 | 19,474,432 | -16,896 | -0.087% | Microsoft.Extensions.Configuration.UserSecrets.Tests.exe |
| 9,439,232 | 9,431,040 | -8,192 | -0.087% | Microsoft.Extensions.Logging.Testing.Tests.exe |
| 20,082,688 | 20,065,280 | -17,408 | -0.087% | System.Formats.Tar.Tests.exe |
| 20,241,408 | 20,224,000 | -17,408 | -0.086% | System.Runtime.InteropServices.Tests.exe |
| 8,933,376 | 8,925,696 | -7,680 | -0.086% | System.Threading.AccessControl.Tests.exe |
| 19,561,984 | 19,545,088 | -16,896 | -0.086% | Microsoft.Extensions.Configuration.Json.Tests.exe |
| 9,512,960 | 9,504,768 | -8,192 | -0.086% | System.IO.Hashing.Tests.exe |
| 20,539,392 | 20,521,984 | -17,408 | -0.085% | System.Runtime.Extensions.Tests.exe |
| 20,461,056 | 20,443,648 | -17,408 | -0.085% | System.Reflection.Tests.exe |
| 9,015,296 | 9,007,616 | -7,680 | -0.085% | System.Net.NameResolution.Pal.Tests.exe |
| 20,484,096 | 20,466,688 | -17,408 | -0.085% | System.Diagnostics.DiagnosticSource.Tests.exe |
| 20,551,680 | 20,534,272 | -17,408 | -0.085% | System.Threading.Tasks.Tests.exe |
| 21,079,552 | 21,061,632 | -17,920 | -0.085% | Microsoft.Extensions.Logging.EventSource.Tests.exe |
| 11,023,872 | 11,014,656 | -9,216 | -0.084% | System.Runtime.Numerics.Tests.exe |
| 21,629,440 | 21,611,520 | -17,920 | -0.083% | System.Data.OleDb.Tests.exe |
| 10,507,776 | 10,499,072 | -8,704 | -0.083% | Microsoft.Extensions.Options.Tests.exe |
| 9,249,280 | 9,241,600 | -7,680 | -0.083% | Microsoft.Bcl.AsyncInterfaces.Tests.exe |
| 9,325,056 | 9,317,376 | -7,680 | -0.082% | System.IO.IsolatedStorage.Tests.exe |
| 11,585,024 | 11,575,808 | -9,216 | -0.080% | System.Net.Http.Json.Unit.Tests.exe |
| 9,600,512 | 9,592,832 | -7,680 | -0.080% | System.Diagnostics.EventLog.Tests.exe |
| 12,254,208 | 12,244,480 | -9,728 | -0.079% | System.Reflection.Metadata.Tests.exe |
| 20,747,776 | 20,731,392 | -16,384 | -0.079% | System.Collections.Concurrent.Tests.exe |
| 10,574,336 | 10,566,144 | -8,192 | -0.077% | Common.Tests.exe |
| 11,457,536 | 11,448,832 | -8,704 | -0.076% | System.IO.Ports.Tests.exe |
| 10,934,272 | 10,926,080 | -8,192 | -0.075% | System.Runtime.Intrinsics.Tests.exe |
| 9,649,664 | 9,642,496 | -7,168 | -0.074% | System.IO.UnmanagedMemoryStream.Tests.exe |
| 11,767,808 | 11,759,104 | -8,704 | -0.074% | System.Security.Cryptography.Cose.Tests.exe |
| 23,411,712 | 23,394,816 | -16,896 | -0.072% | System.Memory.Tests.exe |
| 11,351,040 | 11,342,848 | -8,192 | -0.072% | System.Net.Security.Unit.Tests.exe |
| 25,900,544 | 25,882,112 | -18,432 | -0.071% | System.Text.Json.SourceGeneration.Roslyn3.11.Tests.exe |
| 11,167,232 | 11,159,552 | -7,680 | -0.069% | System.Text.Encodings.Web.Tests.exe |
| 26,013,184 | 25,995,776 | -17,408 | -0.067% | System.Globalization.Nls.Tests.exe |
| 11,582,976 | 11,575,296 | -7,680 | -0.066% | System.Resources.Extensions.Tests.exe |
| 26,102,272 | 26,085,376 | -16,896 | -0.065% | System.Globalization.Tests.exe |
| 44,718,080 | 44,688,896 | -29,184 | -0.065% | System.Runtime.Tests.exe |
| 15,199,744 | 15,190,528 | -9,216 | -0.061% | System.Linq.Tests.exe |
| 15,374,336 | 15,365,632 | -8,704 | -0.057% | System.Globalization.Extensions.Tests.exe |
| 15,374,336 | 15,365,632 | -8,704 | -0.057% | System.Globalization.Extensions.Nls.Tests.exe |
| 32,745,472 | 32,728,064 | -17,408 | -0.053% | System.Linq.Expressions.Tests.exe |
| 33,392,640 | 33,375,232 | -17,408 | -0.052% | Microsoft.Bcl.Cryptography.Tests.exe |
| 17,812,480 | 17,803,776 | -8,704 | -0.049% | System.Collections.Tests.exe |
| 18,752,000 | 18,742,784 | -9,216 | -0.049% | System.Numerics.Vectors.Tests.exe |
| 22,308,864 | 22,299,648 | -9,216 | -0.041% | System.Security.Cryptography.Pkcs.Tests.exe |
| 45,498,368 | 45,479,936 | -18,432 | -0.041% | System.Security.Cryptography.Tests.exe |

</details>