### PR TITLE
Fix trimming test exclusions for iOS/tvOS simulator CoreCLR builds

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -378,7 +378,7 @@
   <ItemGroup Condition="('$(TargetOS)' != 'browser' and '$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true') or ('$(TargetOS)' == 'browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true')">
   </ItemGroup>
 
-  <ItemGroup Condition="('$(TargetOS)' != 'browser' and '$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true') or ('$(TargetOS)' == 'browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true') or (('$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos' or '$(TargetOS)' == 'maccatalyst') and '$(BuildTestsOnHelix)' == 'true')">
+  <ItemGroup Condition="('$(TargetOS)' != 'browser' and '$(RunAOTCompilation)' == 'true' and '$(MonoForceInterpreter)' != 'true') or ('$(TargetOS)' == 'browser' and '$(BuildAOTTestsOnHelix)' == 'true' and '$(RunDisabledWasmTests)' != 'true') or ('$(TargetsAppleMobile)' == 'true' and '$(BuildTestsOnHelix)' == 'true')">
     <!-- Issue: https://github.com/dotnet/runtime/issues/50724 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.DependencyInjection\tests\DI.Tests\Microsoft.Extensions.DependencyInjection.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)Microsoft.Extensions.Logging.EventSource\tests\Microsoft.Extensions.Logging.EventSource.Tests.csproj" />


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary

The aggressive trimming test exclusion condition in \src/libraries/tests.proj\ only checked for \ios\, \	vos\, and \maccatalyst\ TargetOS values, missing \iossimulator\ and \	vossimulator\. This caused trimming-sensitive tests to run — and fail — on iOS CoreCLR simulator Release builds where \EnableAggressiveTrimming=true\ was recently enabled by #127054.

## Root Cause

PR #127054 (April 20) enabled \EnableAggressiveTrimming=true\ for iOS CoreCLR simulator Release builds. Aggressive trimming strips EventSource reflection metadata (\ParameterInfo[]\), causing \PayloadNames\ to throw \NullReferenceException\ when accessed.

The test exclusion at line 381 of \	ests.proj\ had three clauses:
1. Non-browser AOT builds → catches Mono AOT ✅
2. Browser/WASM AOT builds → catches WASM ✅  
3. Apple mobile with \BuildTestsOnHelix=true\ → **only checked \ios\, \	vos\, \maccatalyst\** ❌

For simulator builds, \TargetOS\ is \iossimulator\ or \	vossimulator\ (not \ios\/\	vos\), confirmed by \ng/RuntimeIdentifier.props:61-63\. So the exclusion didn't match, and 8+ trimming-sensitive tests ran and failed with NRE.

## Fix

Replace the explicit TargetOS list with the \TargetsAppleMobile\ property (defined in \ng/OSArch.props\), which covers all five Apple mobile targets (\ios\, \iossimulator\, \	vos\, \	vossimulator\, \maccatalyst\) and is already used elsewhere in the same file (lines 303, 337, 654, 765).

Fixes #127449
Related: #127448 (DI/Hosting failures on same build — same root cause)