### PR TITLE
Adjust interpreter debugger IL mapping

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1054,7 +1054,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
         if (ilOffset < (uint32_t)m_ILCodeSizeFromILHeader)
         {
             uint32_t nativeOffset = ConvertOffset(ins->nativeOffset);
-            // Only emit mapping entries at IL offsets where the evaluation stack is empty or on NOP instructions
+            // Only emit mapping entries at IL offsets where the evaluation stack is empty
             if ((ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) &&
                 ((m_ILToNativeMapSize == 0) || (m_pILToNativeMap[m_ILToNativeMapSize - 1].ilOffset != ilOffset)))
             {
@@ -1125,9 +1125,10 @@ int32_t *InterpCompiler::EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Re
             ins->nativeOffset = (int32_t)(ip - m_pMethodCode);
             if (prevWasCall && m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
             {
-                // Emit a real NOP so the return address after a call lands within
-                // the call's native offset range, not on the next statement boundary.
-                *ip++ = INTOP_NOP;
+                // Emit a debug sequence point so the return address after a call
+                // lands within the call's native offset range, not on the next
+                // statement boundary.
+                *ip++ = INTOP_DEBUG_SEQ_POINT;
                 prevWasCall = false;
             }
             continue;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1054,7 +1054,9 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
         if (ilOffset < (uint32_t)m_ILCodeSizeFromILHeader)
         {
             uint32_t nativeOffset = ConvertOffset(ins->nativeOffset);
-            if ((m_ILToNativeMapSize == 0) || (m_pILToNativeMap[m_ILToNativeMapSize - 1].ilOffset != ilOffset))
+            // Only emit mapping entries at IL offsets where the evaluation stack is empty or on NOP instructions
+            if ((ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) &&
+                ((m_ILToNativeMapSize == 0) || (m_pILToNativeMap[m_ILToNativeMapSize - 1].ilOffset != ilOffset)))
             {
                 // This code assumes that instructions for the same IL offset are emitted in a single run without
                 // any other IL offsets in between and that they don't repeat again after the run ends.
@@ -1076,7 +1078,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
 
                 m_pILToNativeMap[m_ILToNativeMapSize].ilOffset = ilOffset;
                 m_pILToNativeMap[m_ILToNativeMapSize].nativeOffset = nativeOffset;
-                m_pILToNativeMap[m_ILToNativeMapSize].source = (ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
+                m_pILToNativeMap[m_ILToNativeMapSize].source = ICorDebugInfo::STACK_EMPTY;
                 m_ILToNativeMapSize++;
             }
         }
@@ -1115,14 +1117,23 @@ int32_t *InterpCompiler::EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Re
     m_pCBB = bb;
     m_pCBB->nativeOffset = (int32_t)(ip - m_pMethodCode);
 
+    bool prevWasCall = false;
     for (InterpInst *ins = bb->pFirstIns; ins != NULL; ins = ins->pNext)
     {
         if (InterpOpIsEmitNop(ins->opcode))
         {
             ins->nativeOffset = (int32_t)(ip - m_pMethodCode);
+            if (prevWasCall)
+            {
+                // Emit a real NOP so the return address after a call lands within
+                // the call's native offset range, not on the next statement boundary.
+                *ip++ = INTOP_NOP;
+                prevWasCall = false;
+            }
             continue;
         }
 
+        prevWasCall = InterpOpIsDirectCall(ins->opcode) || InterpOpIsIndirectCall(ins->opcode);
         ip = EmitCodeIns(ip, ins, relocs);
     }
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1123,7 +1123,7 @@ int32_t *InterpCompiler::EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Re
         if (InterpOpIsEmitNop(ins->opcode))
         {
             ins->nativeOffset = (int32_t)(ip - m_pMethodCode);
-            if (prevWasCall)
+            if (prevWasCall && m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
             {
                 // Emit a real NOP so the return address after a call lands within
                 // the call's native offset range, not on the next statement boundary.

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1117,24 +1117,22 @@ int32_t *InterpCompiler::EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Re
     m_pCBB = bb;
     m_pCBB->nativeOffset = (int32_t)(ip - m_pMethodCode);
 
-    bool prevWasCall = false;
     for (InterpInst *ins = bb->pFirstIns; ins != NULL; ins = ins->pNext)
     {
         if (InterpOpIsEmitNop(ins->opcode))
         {
             ins->nativeOffset = (int32_t)(ip - m_pMethodCode);
-            if (prevWasCall && m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
+            if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
             {
-                // Emit a debug sequence point so the return address after a call
-                // lands within the call's native offset range, not on the next
-                // statement boundary.
+                // Emit a debug sequence point so that eliminated IL instructions
+                // still occupy a bytecode slot. This ensures return addresses after
+                // calls land within the call's native offset range rather than on
+                // the next statement boundary.
                 *ip++ = INTOP_DEBUG_SEQ_POINT;
-                prevWasCall = false;
             }
             continue;
         }
 
-        prevWasCall = InterpOpIsDirectCall(ins->opcode) || InterpOpIsIndirectCall(ins->opcode);
         ip = EmitCodeIns(ip, ins, relocs);
     }
 

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2104,6 +2104,7 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
     pFrame = pFrame->pParent;
     if (pFrame != NULL)
     {
+        // The parent frame's IP points past the CALL/CALLVIRT instruction (the resumption point).
         SetIP(pContext, (TADDR)pFrame->ip);
         SetSP(pContext, dac_cast<TADDR>(pFrame));
         SetFP(pContext, (TADDR)pFrame->pStack);

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -2104,7 +2104,7 @@ static void VirtualUnwindInterpreterCallFrame(TADDR sp, T_CONTEXT *pContext)
     pFrame = pFrame->pParent;
     if (pFrame != NULL)
     {
-        // The parent frame's IP points past the CALL/CALLVIRT instruction (the resumption point).
+        // The parent frame's IP points past the call instruction (the resumption point).
         SetIP(pContext, (TADDR)pFrame->ip);
         SetSP(pContext, dac_cast<TADDR>(pFrame));
         SetFP(pContext, (TADDR)pFrame->pStack);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1421,6 +1421,9 @@ SWITCH_OPCODE:
                     MemoryBarrier();
                     ip++;
                     break;
+                case INTOP_NOP:
+                    ip++;
+                    break;
 #ifndef FEATURE_PORTABLE_ENTRYPOINTS
                 case INTOP_STORESTUBCONTEXT:
                 {

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1421,9 +1421,6 @@ SWITCH_OPCODE:
                     MemoryBarrier();
                     ip++;
                     break;
-                case INTOP_NOP:
-                    ip++;
-                    break;
 #ifndef FEATURE_PORTABLE_ENTRYPOINTS
                 case INTOP_STORESTUBCONTEXT:
                 {


### PR DESCRIPTION
When the debugger walks the stack, interpreter frames sometimes report incorrect source line due to IL -> native mapping differences compared to how the JIT generates mappings.  To better align interpreter debug output with how the debugger maps line numbers:
1. The current model generates more mapping IL->native data than we need. Only emit sequence points on IL stack empty points and `nop` instructions.  
2. When stackwalking, the return address points to the instruction after the 'call' instruction. The interpreter eliminates certain IL instructions from the input stream, sometimes causing the next IL instruction to be mapped to the next line number. To address this, 1) when the IL code is built in debug mode, and 2) if an IL instruction is eliminated immediately after a call instruction, we will insert a `nop` IL instruction in its place.