### PR TITLE
Simplify ManagedWebSocket.EnsureBufferContainsAsync

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1590,22 +1590,18 @@ namespace System.Net.WebSockets
                 }
                 _receiveBufferOffset = 0;
 
-                // While we don't have enough data, read more.
-                if (_receiveBufferCount < minimumRequiredBytes)
+                int bytesToRead = minimumRequiredBytes - _receiveBufferCount;
+                int numRead = await _stream.ReadAtLeastAsync(
+                    _receiveBuffer.Slice(_receiveBufferCount), bytesToRead, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
+                _receiveBufferCount += numRead;
+
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this, $"bytesRead={numRead}");
+
+                if (numRead < bytesToRead)
                 {
-                    int bytesToRead = minimumRequiredBytes - _receiveBufferCount;
-                    int numRead = await _stream.ReadAtLeastAsync(
-                        _receiveBuffer.Slice(_receiveBufferCount), bytesToRead, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
-                    _receiveBufferCount += numRead;
-
-                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this, $"bytesRead={numRead}");
-
-                    if (numRead < bytesToRead)
-                    {
-                        ThrowEOFUnexpected();
-                    }
-                    _keepAlivePingState?.OnDataReceived();
+                    ThrowEOFUnexpected();
                 }
+                _keepAlivePingState?.OnDataReceived();
             }
         }
 


### PR DESCRIPTION
## Summary

Cleans up `ManagedWebSocket.EnsureBufferContainsAsync` by removing a dead branch and a stale comment that have been left behind since [#69272](https://github.com/dotnet/runtime/pull/69272) replaced the manual read loop with a single `Stream.ReadAtLeastAsync` call. No behavior change.

## Background

Before [#69272](https://github.com/dotnet/runtime/pull/69272) (May 2022), the method ended with a real loop:

```csharp
// While we don't have enough data, read more.
while (_receiveBufferCount < minimumRequiredBytes)
{
    int numRead = await _stream.ReadAsync(_receiveBuffer.Slice(_receiveBufferCount), cancellationToken).ConfigureAwait(false);
    Debug.Assert(numRead >= 0, $"Expected non-negative bytes read, got {numRead}");
    if (numRead <= 0)
    {
        ThrowEOFUnexpected();
        break;
    }
    _receiveBufferCount += numRead;
}
```

That PR converted it to a single `ReadAtLeastAsync` call (which loops internally until enough bytes are read or EOF) and downgraded `while` to `if`, but kept both the inner predicate and the original comment.

## What was wrong

```csharp
if (_receiveBufferCount < minimumRequiredBytes)              // outer check
{
    if (_receiveBufferCount > 0)
    {
        _receiveBuffer.Span.Slice(_receiveBufferOffset, _receiveBufferCount).CopyTo(_receiveBuffer.Span);
    }
    _receiveBufferOffset = 0;

    // While we don't have enough data, read more.
    if (_receiveBufferCount < minimumRequiredBytes)          // dead: same condition, count unchanged
    {
        ...
    }
}
```

* **Dead branch.** Between the outer check and the inner check, only `CopyTo` (which shifts data within the buffer) and `_receiveBufferOffset = 0` execute. Neither mutates `_receiveBufferCount`, so the inner predicate is provably the same as the outer one. The body always runs.
* **Stale comment.** `// While we don't have enough data, read more.` describes the original `while` loop. The current code performs a single `ReadAtLeastAsync` call (the loop is inside `ReadAtLeastAsync` itself), so "while" no longer matches.

## Change

Remove the inner `if`, drop the misleading comment, and dedent the body. Behavior is unchanged.
