### PR TITLE
JIT: eliminate redundant bounds checks for span.Slice(span.Length - cns)

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -858,8 +858,7 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
                         if (comp->vnStore->IsVNBinFuncWithConst(op1VN, VNF_ADD, &addOpVN, &addCns) &&
                             (addOpVN == op2VN) && (addCns < 0) && (addCns > INT32_MIN))
                         {
-                            Range aRange = GetRangeFromAssertionsWorker(comp, addOpVN, assertions, --budget, visited);
-                            if (aRange.LowerLimit().IsConstant() && (aRange.LowerLimit().GetConstant() >= -addCns))
+                            if (r2.LowerLimit().IsConstant() && (r2.LowerLimit().GetConstant() >= -addCns))
                             {
                                 // ADD(A, K) < A is proven (both signed and unsigned).
                                 switch (cmpOper)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -845,6 +845,43 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
                     }
 
                     result = RangeOps::EvalRelop(cmpOper, isUnsigned, r1, r2);
+
+                    // Example: "(uint)(length - 4) > (uint)length" folds to false when
+                    // length >= 4 (the typical Slice(length - cns) bounds check).
+                    if (!result.IsSingleValueConstant())
+                    {
+                        ValueNum op1VN = funcApp.m_args[0];
+                        ValueNum op2VN = funcApp.m_args[1];
+                        ValueNum addOpVN;
+                        int      addCns;
+
+                        if (comp->vnStore->IsVNBinFuncWithConst(op1VN, VNF_ADD, &addOpVN, &addCns) &&
+                            (addOpVN == op2VN) && (addCns < 0) && (addCns > INT32_MIN))
+                        {
+                            Range aRange = GetRangeFromAssertionsWorker(comp, addOpVN, assertions, --budget, visited);
+                            if (aRange.LowerLimit().IsConstant() && (aRange.LowerLimit().GetConstant() >= -addCns))
+                            {
+                                // ADD(A, K) < A is proven (both signed and unsigned).
+                                switch (cmpOper)
+                                {
+                                    case GT_LT:
+                                    case GT_LE:
+                                    case GT_NE:
+                                        result = Range(Limit(Limit::keConstant, 1));
+                                        break;
+
+                                    case GT_GT:
+                                    case GT_GE:
+                                    case GT_EQ:
+                                        result = Range(Limit(Limit::keConstant, 0));
+                                        break;
+
+                                    default:
+                                        break;
+                                }
+                            }
+                        }
+                    }
                 }
                 break;
             }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -5372,10 +5372,26 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
 
             if (!ovf)
             {
+                // x - (x + a) == -a
+                // x - (a + x) == -a
+                ValueNum arg1Op1;
+                ValueNum arg1Op2;
+                if (IsVNBinFunc(arg1VN, VNF_ADD, &arg1Op1, &arg1Op2))
+                {
+                    if (arg1Op1 == arg0VN)
+                    {
+                        return VNForFunc(typ, VNF_NEG, arg1Op2);
+                    }
+                    if (arg1Op2 == arg0VN)
+                    {
+                        return VNForFunc(typ, VNF_NEG, arg1Op1);
+                    }
+                }
+
                 // (x + a) - x == a
                 // (a + x) - x == a
                 VNFuncApp add;
-                if (GetVNFunc(arg0VN, &add) && (add.m_func == (VNFunc)GT_ADD))
+                if (GetVNFunc(arg0VN, &add) && (add.m_func == VNF_ADD))
                 {
                     if (add.m_args[0] == arg1VN)
                         return add.m_args[1];
@@ -5387,7 +5403,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
                     // (x + a) - (b + x) == a - b
                     // (a + x) - (b + x) == a - b
                     VNFuncApp add2;
-                    if (GetVNFunc(arg1VN, &add2) && (add2.m_func == (VNFunc)GT_ADD))
+                    if (GetVNFunc(arg1VN, &add2) && (add2.m_func == VNF_ADD))
                     {
                         for (int a = 0; a < 2; a++)
                         {
@@ -5395,7 +5411,7 @@ ValueNum ValueNumStore::EvalUsingMathIdentity(var_types typ, VNFunc func, ValueN
                             {
                                 if (add.m_args[a] == add2.m_args[b])
                                 {
-                                    return VNForFunc(typ, (VNFunc)GT_SUB, add.m_args[1 - a], add2.m_args[1 - b]);
+                                    return VNForFunc(typ, VNF_SUB, add.m_args[1 - a], add2.m_args[1 - b]);
                                 }
                             }
                         }


### PR DESCRIPTION
Closes #127486

For the snippet from the issue:

```cs
int Test(ReadOnlySpan<byte> span)
{
    if (span.Length >= sizeof(int))
    {
        return BinaryPrimitives.ReadInt32BigEndian(span.Slice(span.Length - sizeof(int)));
    }
    return -1;
}
```

```diff
-       sub      rsp, 40
-       mov      rcx, bword ptr [rdx]
-       mov      edx, dword ptr [rdx+0x08]
-       cmp      edx, 4
-       jge      SHORT G_M27777_IG05
+       mov      rax, bword ptr [rcx]
+       mov      ecx, dword ptr [rcx+0x08]
+       cmp      ecx, 4
+       jl       SHORT G_M6173_IG05
+       add      ecx, -4
+       add      rax, rcx
+       movbe    eax, dword ptr [rax]
+       ret
        mov      eax, -1
-       add      rsp, 40
        ret
-       lea      eax, [rdx-0x04]
-       cmp      eax, edx
-       ja       SHORT G_M27777_IG07
-       mov      r8d, eax
-       add      rcx, r8
-       sub      edx, eax
-       cmp      edx, 4
-       jl       SHORT G_M27777_IG08
-       movbe    eax, dword ptr [rcx]
-       add      rsp, 40
-       ret
-       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
-       int3
-       mov      ecx, 40
-       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException(int)]
-       int3
```

Two changes:

* **VN**: add identity `x - (x + a) == -a` so that `length - (length - cns)` value-numbers to `cns`. This eliminates the `BinaryPrimitives.ReadInt32BigEndian` length check after `Slice`.
* **RangeCheck**: in `GetRangeFromAssertionsWorker`, recognize the correlated relop `ADD(A, K) op A` (constant `K < 0`) and fold it when `A`'s lower bound is `>= -K` (so the add cannot wrap, signed or unsigned). This eliminates the `Slice(start)` `(uint)start > (uint)_length` check.
