### PR TITLE
Haiku: Clean up redundant flags

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -382,9 +382,6 @@ static void* VirtualReserveInner(size_t size, size_t alignment, uint32_t flags, 
 
     size_t alignedSize = size + (alignment - OS_PAGE_SIZE);
     int mmapFlags = MAP_ANON | MAP_PRIVATE | hugePagesFlag;
-#ifdef __HAIKU__
-    mmapFlags |= MAP_NORESERVE;
-#endif
     void * pRetVal = mmap(nullptr, alignedSize, PROT_NONE, mmapFlags, -1, 0);
 
     if (pRetVal != MAP_FAILED)
@@ -539,9 +536,6 @@ bool GCToOSInterface::VirtualDecommit(void* address, size_t size)
     // longer need these pages. Also, GC depends on re-committed pages to
     // be zeroed-out.
     int mmapFlags = MAP_FIXED | MAP_ANON | MAP_PRIVATE;
-#ifdef TARGET_HAIKU
-    mmapFlags |= MAP_NORESERVE;
-#endif
     bool bRetVal = mmap(address, size, PROT_NONE, mmapFlags, -1, 0) != MAP_FAILED;
 
 #if defined(MADV_DONTDUMP) && !defined(TARGET_WASM)

--- a/src/coreclr/pal/src/map/virtual.cpp
+++ b/src/coreclr/pal/src/map/virtual.cpp
@@ -589,10 +589,6 @@ static LPVOID ReserveVirtualMemory(
     }
 #endif
 
-#ifdef __HAIKU__
-        mmapFlags |= MAP_NORESERVE;
-#endif
-
     LPVOID pRetVal = mmap((LPVOID) StartBoundary,
                           MemSize,
                           PROT_NONE,


### PR DESCRIPTION
Clean up redundant `MAP_NORESERVE` flags for private `PROT_NONE` mappings.

Newer versions of Haiku avoids "committing memory inside mmap for private mappings (i.e. those without MAP_SHARED) which are non-writable (i.e. without PROT_WRITE specified)".

See: https://www.haiku-os.org/blog/waddlesplash/2024-02-13_haiku_activity_contract_report_january_2024/

Part of #55803.