### PR TITLE
Add configurable VariableNameTransformation to EnvironmentVariables config

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Extensions.Configuration
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddEnvironmentVariables(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddEnvironmentVariables(this Microsoft.Extensions.Configuration.IConfigurationBuilder builder, System.Action<Microsoft.Extensions.Configuration.EnvironmentVariables.EnvironmentVariablesConfigurationSource>? configureSource) { throw null; }
         public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddEnvironmentVariables(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string? prefix) { throw null; }
+        public static Microsoft.Extensions.Configuration.IConfigurationBuilder AddEnvironmentVariables(this Microsoft.Extensions.Configuration.IConfigurationBuilder configurationBuilder, string? prefix, System.Func<string, string>? variableNameTransformation) { throw null; }
     }
 }
 namespace Microsoft.Extensions.Configuration.EnvironmentVariables
@@ -25,7 +26,10 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
     public partial class EnvironmentVariablesConfigurationSource : Microsoft.Extensions.Configuration.IConfigurationSource
     {
         public EnvironmentVariablesConfigurationSource() { }
+        public static System.Func<string, string> ColonAndDotTransformation { get { throw null; } }
+        public static System.Func<string, string> DefaultTransformation { get { throw null; } }
         public string? Prefix { get { throw null; } set { } }
+        public System.Func<string, string>? VariableNameTransformation { get { throw null; } set { } }
         public Microsoft.Extensions.Configuration.IConfigurationProvider Build(Microsoft.Extensions.Configuration.IConfigurationBuilder builder) { throw null; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/ref/Microsoft.Extensions.Configuration.EnvironmentVariables.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
     {
         public EnvironmentVariablesConfigurationProvider() { }
         public EnvironmentVariablesConfigurationProvider(string? prefix) { }
+        public EnvironmentVariablesConfigurationProvider(string? prefix, System.Func<string, string>? variableNameTransformation) { }
         public override void Load() { }
         public override string ToString() { throw null; }
     }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 
         private readonly string _prefix;
         private readonly string _normalizedPrefix;
+        private readonly Func<string, string> _transformation;
 
         /// <summary>
         /// Initializes a new instance.
         /// </summary>
         public EnvironmentVariablesConfigurationProvider()
+            : this(null, null)
         {
-            _prefix = string.Empty;
-            _normalizedPrefix = string.Empty;
         }
 
         /// <summary>
@@ -44,8 +44,20 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// </summary>
         /// <param name="prefix">A prefix used to filter the environment variables.</param>
         public EnvironmentVariablesConfigurationProvider(string? prefix)
+            : this(prefix, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance with the specified prefix and variable name transformation.
+        /// </summary>
+        /// <param name="prefix">A prefix used to filter the environment variables.</param>
+        /// <param name="variableNameTransformation">A function that transforms environment variable names.
+        /// When <see langword="null"/>, <see cref="EnvironmentVariablesConfigurationSource.DefaultTransformation"/> is used.</param>
+        internal EnvironmentVariablesConfigurationProvider(string? prefix, Func<string, string>? variableNameTransformation)
         {
             _prefix = prefix ?? string.Empty;
+            _transformation = variableNameTransformation ?? EnvironmentVariablesConfigurationSource.DefaultTransformation;
             _normalizedPrefix = Normalize(_prefix);
         }
 
@@ -159,6 +171,6 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             }
         }
 
-        private static string Normalize(string key) => key.Replace("__", ConfigurationPath.KeyDelimiter);
+        private string Normalize(string key) => _transformation(key);
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -171,6 +171,16 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             }
         }
 
-        private string Normalize(string key) => _transformation(key);
+        private string Normalize(string key)
+        {
+            string? transformed = _transformation(key);
+
+            if (transformed is null)
+            {
+                throw new InvalidOperationException($"The variable name transformation returned null for environment variable name '{key}'.");
+            }
+
+            return transformed;
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationProvider.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// <param name="prefix">A prefix used to filter the environment variables.</param>
         /// <param name="variableNameTransformation">A function that transforms environment variable names.
         /// When <see langword="null"/>, <see cref="EnvironmentVariablesConfigurationSource.DefaultTransformation"/> is used.</param>
-        internal EnvironmentVariablesConfigurationProvider(string? prefix, Func<string, string>? variableNameTransformation)
+        public EnvironmentVariablesConfigurationProvider(string? prefix, Func<string, string>? variableNameTransformation)
         {
             _prefix = prefix ?? string.Empty;
             _transformation = variableNameTransformation ?? EnvironmentVariablesConfigurationSource.DefaultTransformation;

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
@@ -1,6 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Text;
+
 namespace Microsoft.Extensions.Configuration.EnvironmentVariables
 {
     /// <summary>
@@ -9,9 +12,84 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
     public class EnvironmentVariablesConfigurationSource : IConfigurationSource
     {
         /// <summary>
+        /// The default transformation that replaces double underscores (<c>__</c>) with the
+        /// configuration key delimiter (<c>:</c>).
+        /// </summary>
+        public static Func<string, string> DefaultTransformation { get; } =
+            static name => name.Replace("__", ConfigurationPath.KeyDelimiter);
+
+        /// <summary>
+        /// A transformation that replaces triple underscores (<c>___</c>) with a dot (<c>.</c>)
+        /// and double underscores (<c>__</c>) with the configuration key delimiter (<c>:</c>).
+        /// </summary>
+        public static Func<string, string> ColonAndDotTransformation { get; } = TransformUnderscoresToColonAndDot;
+
+        private static string TransformUnderscoresToColonAndDot(string name)
+        {
+            int first = name.IndexOf("__", StringComparison.Ordinal);
+
+            if (first < 0)
+            {
+                return name;
+            }
+
+            return Core(name, first);
+
+            // Local function to avoid the overhead of stackalloc when there are no double underscores in the string.
+            static string Core(string name, int first)
+            {
+#if NET
+                var builder = new ValueStringBuilder(stackalloc char[256]);
+#else
+                var builder = new StringBuilder(name.Length);
+#endif
+
+                // For short strings, this seems to be faster than Append(name.Slice(0, first)).
+                for (int j = 0; j < first; j++)
+                {
+                    builder.Append(name[j]);
+                }
+
+                int i = first;
+
+                while (i < name.Length)
+                {
+                    if (name[i] == '_' && i + 1 < name.Length && name[i + 1] == '_')
+                    {
+                        if (i + 2 < name.Length && name[i + 2] == '_')
+                        {
+                            builder.Append('.');
+                            i += 3;
+                        }
+                        else
+                        {
+                            builder.Append(':');
+                            i += 2;
+                        }
+                    }
+                    else
+                    {
+                        builder.Append(name[i++]);
+                    }
+                }
+
+                return builder.ToString();
+            }
+        }
+
+        /// <summary>
         /// A prefix used to filter environment variables.
         /// </summary>
         public string? Prefix { get; set; }
+
+        /// <summary>
+        /// Gets or sets a function that transforms environment variable names. When set, this
+        /// transformation replaces the default behavior of converting double
+        /// underscores to the configuration key delimiter. When <see langword="null"/>,
+        /// <see cref="DefaultTransformation"/> is used.
+        /// </summary>
+        /// <seealso cref="ColonAndDotTransformation"/>
+        public Func<string, string>? VariableNameTransformation { get; set; }
 
         /// <summary>
         /// Builds the <see cref="EnvironmentVariablesConfigurationProvider"/> for this source.
@@ -20,7 +98,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// <returns>A <see cref="EnvironmentVariablesConfigurationProvider"/>.</returns>
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new EnvironmentVariablesConfigurationProvider(Prefix);
+            return new EnvironmentVariablesConfigurationProvider(Prefix, VariableNameTransformation);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
@@ -36,40 +36,30 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
             return Core(name, first);
 
             // Local function to avoid the overhead of stackalloc when there are no double underscores in the string.
-            static string Core(string name, int first)
+            static string Core(string name, int index)
             {
-#if NET
                 var builder = new ValueStringBuilder(stackalloc char[256]);
-#else
-                var builder = new StringBuilder(name.Length);
-#endif
 
-                // For short strings, this seems to be faster than Append(name.Slice(0, first)).
-                for (int j = 0; j < first; j++)
+                builder.Append(name.AsSpan(0, index));
+
+                while (index < name.Length)
                 {
-                    builder.Append(name[j]);
-                }
-
-                int i = first;
-
-                while (i < name.Length)
-                {
-                    if (name[i] == '_' && i + 1 < name.Length && name[i + 1] == '_')
+                    if (name[index] == '_' && index + 1 < name.Length && name[index + 1] == '_')
                     {
-                        if (i + 2 < name.Length && name[i + 2] == '_')
+                        if (index + 2 < name.Length && name[index + 2] == '_')
                         {
                             builder.Append('.');
-                            i += 3;
+                            index += 3;
                         }
                         else
                         {
                             builder.Append(':');
-                            i += 2;
+                            index += 2;
                         }
                     }
                     else
                     {
-                        builder.Append(name[i++]);
+                        builder.Append(name[index++]);
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesConfigurationSource.cs
@@ -16,16 +16,28 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// configuration key delimiter (<c>:</c>).
         /// </summary>
         public static Func<string, string> DefaultTransformation { get; } =
-            static name => name.Replace("__", ConfigurationPath.KeyDelimiter);
+            static name =>
+            {
+                ArgumentNullException.ThrowIfNull(name);
+                return name.Replace("__", ConfigurationPath.KeyDelimiter);
+            };
 
         /// <summary>
         /// A transformation that replaces triple underscores (<c>___</c>) with a dot (<c>.</c>)
         /// and double underscores (<c>__</c>) with the configuration key delimiter (<c>:</c>).
         /// </summary>
+        /// <remarks>
+        /// Runs of underscores are processed greedily from left to right: each <c>___</c> match
+        /// is consumed before any remaining <c>__</c>. As a result, a run of four underscores
+        /// (<c>____</c>) is interpreted as one triple followed by a single literal underscore
+        /// and produces <c>._</c>, not <c>::</c>.
+        /// </remarks>
         public static Func<string, string> ColonAndDotTransformation { get; } = TransformUnderscoresToColonAndDot;
 
         private static string TransformUnderscoresToColonAndDot(string name)
         {
+            ArgumentNullException.ThrowIfNull(name);
+
             int first = name.IndexOf("__", StringComparison.Ordinal);
 
             if (first < 0)
@@ -70,6 +82,11 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables
         /// <summary>
         /// A prefix used to filter environment variables.
         /// </summary>
+        /// <remarks>
+        /// The prefix is itself passed through <see cref="VariableNameTransformation"/> before
+        /// matching, and the matching (and stripping) is performed against the transformed
+        /// environment variable name.
+        /// </remarks>
         public string? Prefix { get; set; }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
@@ -38,6 +38,29 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
+        /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from environment variables
+        /// with a specified prefix and variable name transformation.
+        /// </summary>
+        /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
+        /// <param name="prefix">The prefix that environment variable names must start with. The prefix will be removed from the environment variable names.</param>
+        /// <param name="variableNameTransformation">A function that transforms environment variable names. When set, this
+        /// completely replaces the default behavior. When <see langword="null"/>,
+        /// <see cref="EnvironmentVariablesConfigurationSource.DefaultTransformation"/> is used.</param>
+        /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddEnvironmentVariables(
+            this IConfigurationBuilder configurationBuilder,
+            string? prefix,
+            Func<string, string>? variableNameTransformation)
+        {
+            configurationBuilder.Add(new EnvironmentVariablesConfigurationSource
+            {
+                Prefix = prefix,
+                VariableNameTransformation = variableNameTransformation
+            });
+            return configurationBuilder;
+        }
+
+        /// <summary>
         /// Adds an <see cref="IConfigurationProvider"/> that reads configuration values from environment variables.
         /// </summary>
         /// <param name="builder">The <see cref="IConfigurationBuilder"/> to add to.</param>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/EnvironmentVariablesExtensions.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Extensions.Configuration
         /// with a specified prefix.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="prefix">The prefix that environment variable names must start with. The prefix will be removed from the environment variable names.</param>
+        /// <param name="prefix">The prefix that environment variable names must start with. The prefix will be removed from the environment variable names.
+        /// The prefix is transformed by <see cref="EnvironmentVariablesConfigurationSource.DefaultTransformation"/> and then matched against transformed environment variable name, so it should be specified in the pre-transformation
+        /// form (for example <c>Logging__</c> for <c>Logging:</c>).</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddEnvironmentVariables(
             this IConfigurationBuilder configurationBuilder,
@@ -42,7 +44,9 @@ namespace Microsoft.Extensions.Configuration
         /// with a specified prefix and variable name transformation.
         /// </summary>
         /// <param name="configurationBuilder">The <see cref="IConfigurationBuilder"/> to add to.</param>
-        /// <param name="prefix">The prefix that environment variable names must start with. The prefix will be removed from the environment variable names.</param>
+        /// <param name="prefix">The prefix that environment variable names must start with. The prefix will be removed from the environment variable names.
+        /// The prefix is transformed by <paramref name="variableNameTransformation"/> and then matched against transformed environment variable name, so it should be specified in the pre-transformation
+        /// form.</param>
         /// <param name="variableNameTransformation">A function that transforms environment variable names. When set, this
         /// completely replaces the default behavior. When <see langword="null"/>,
         /// <see cref="EnvironmentVariablesConfigurationSource.DefaultTransformation"/> is used.</param>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -14,5 +14,10 @@
   <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Abstractions\src\Microsoft.Extensions.Configuration.Abstractions.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+    <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
+             Link="Common\System\Text\ValueStringBuilder.cs" />
+  </ItemGroup>
   
 </Project>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/src/Microsoft.Extensions.Configuration.EnvironmentVariables.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration.Abstractions\src\Microsoft.Extensions.Configuration.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup>
     <Compile Include="$(CommonPath)System\Text\ValueStringBuilder.cs"
              Link="Common\System\Text\ValueStringBuilder.cs" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -466,7 +466,7 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
 
             envConfigSrc.Load(dict);
 
-            Assert.Equal("connection", envConfigSrc.Get("data:Connection___String"));
+            Assert.Equal("connection", envConfigSrc.Get("data:Connection:_String"));
         }
 
         [Fact]

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -382,5 +382,124 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             Assert.Equal("Endpoint=sb://servicebus1.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=key1;", envConfigSrc.Get("ConnectionStrings:servicebus1"));
             Assert.Throws<InvalidOperationException>(() => envConfigSrc.Get("ConnectionStrings:servicebus1_ProviderName"));
         }
+
+        [Theory]
+        [InlineData("data__ConnectionString", "data:ConnectionString")]
+        [InlineData("App___Config", "App:_Config")]
+        [InlineData("A____B", "A::B")]
+        [InlineData("NoUnderscores", "NoUnderscores")]
+        public void DefaultTransformationReplacesDoubleUnderscore(string input, string expected)
+        {
+            var result = EnvironmentVariablesConfigurationSource.DefaultTransformation(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Logging__LogLevel__Microsoft___Hosting", "Logging:LogLevel:Microsoft.Hosting")]
+        [InlineData("App___Config", "App.Config")]
+        [InlineData("App__Config", "App:Config")]
+        [InlineData("App____Config", "App._Config")]
+        [InlineData("App_____Config", "App.:Config")]
+        [InlineData("App______Config", "App..Config")]
+        [InlineData("NoUnderscores", "NoUnderscores")]
+        [InlineData("_X_Y", "_X_Y")]
+        [InlineData("___", ".")]
+        [InlineData("__", ":")]
+        public void ColonAndDotTransformationReplacesTripleUnderscoreWithDotAndDoubleUnderscoreWithColon(string input, string expected)
+        {
+            var result = EnvironmentVariablesConfigurationSource.ColonAndDotTransformation(input);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void ColonAndDotTransformationIsNotTheDefault()
+        {
+            // Sanity check: the two built-in transformations produce different results for triple underscores.
+            // If they ever agree, this test no longer demonstrates that the default isn't ColonAndDot.
+            var dict = new Hashtable()
+            {
+                { "App___Config", "value" }
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider();
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("value", envConfigSrc.Get("App:_Config"));
+            Assert.False(envConfigSrc.TryGet("App.Config", out _));
+        }
+
+        [Fact]
+        public void VariableNameTransformationReplacesDefaultBehavior()
+        {
+            var dict = new Hashtable()
+            {
+                {"Logging__LogLevel__Microsoft___Hosting", "Debug"}
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider(null,
+                EnvironmentVariablesConfigurationSource.ColonAndDotTransformation);
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("Debug", envConfigSrc.Get("Logging:LogLevel:Microsoft.Hosting"));
+        }
+
+        [Fact]
+        public void CustomTransformationIsUsedInsteadOfDefault()
+        {
+            var dict = new Hashtable()
+            {
+                {"test__section-key", "value"}
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider(null,
+                name => name.Replace("-", ":"));
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("value", envConfigSrc.Get("test__section:key"));
+        }
+
+        [Fact]
+        public void NullTransformationUsesDefault()
+        {
+            var dict = new Hashtable()
+            {
+                {"data__Connection___String", "connection"}
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider(null, null);
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("connection", envConfigSrc.Get("data:Connection___String"));
+        }
+
+        [Fact]
+        public void TransformationIsAppliedToPrefix()
+        {
+            var dict = new Hashtable()
+            {
+                {"App___Config__Key", "value"}
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider(
+                prefix: "App___Config__",
+                EnvironmentVariablesConfigurationSource.ColonAndDotTransformation);
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("value", envConfigSrc.Get("Key"));
+        }
+
+        [Fact]
+        public void IdentityTransformationDisablesDoubleUnderscoreReplacement()
+        {
+            var dict = new Hashtable()
+            {
+                {"data__key", "value"}
+            };
+            var envConfigSrc = new EnvironmentVariablesConfigurationProvider(null,
+                static name => name);
+
+            envConfigSrc.Load(dict);
+
+            Assert.Equal("value", envConfigSrc.Get("data__key"));
+        }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -414,8 +414,6 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         [Fact]
         public void ColonAndDotTransformationIsNotTheDefault()
         {
-            // Sanity check: the two built-in transformations produce different results for triple underscores.
-            // If they ever agree, this test no longer demonstrates that the default isn't ColonAndDot.
             var dict = new Hashtable()
             {
                 { "App___Config", "value" }

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/tests/EnvironmentVariablesTest.cs
@@ -388,6 +388,11 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         [InlineData("App___Config", "App:_Config")]
         [InlineData("A____B", "A::B")]
         [InlineData("NoUnderscores", "NoUnderscores")]
+        [InlineData("_X_Y", "_X_Y")]
+        [InlineData("___", ":_")]
+        [InlineData("__", ":")]
+        [InlineData("_", "_")]
+        [InlineData("", "")]
         public void DefaultTransformationReplacesDoubleUnderscore(string input, string expected)
         {
             var result = EnvironmentVariablesConfigurationSource.DefaultTransformation(input);
@@ -405,6 +410,8 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
         [InlineData("_X_Y", "_X_Y")]
         [InlineData("___", ".")]
         [InlineData("__", ":")]
+        [InlineData("_", "_")]
+        [InlineData("", "")]
         public void ColonAndDotTransformationReplacesTripleUnderscoreWithDotAndDoubleUnderscoreWithColon(string input, string expected)
         {
             var result = EnvironmentVariablesConfigurationSource.ColonAndDotTransformation(input);
@@ -498,6 +505,32 @@ namespace Microsoft.Extensions.Configuration.EnvironmentVariables.Test
             envConfigSrc.Load(dict);
 
             Assert.Equal("value", envConfigSrc.Get("data__key"));
+        }
+
+        [Fact]
+        public void AddEnvironmentVariablesWithColonAndDotTransformation()
+        {
+            try
+            {
+                Environment.SetEnvironmentVariable("Logging__LogLevel__Microsoft___Hosting", "Debug");
+
+                var config = new ConfigurationBuilder()
+                    .AddEnvironmentVariables(prefix: null, EnvironmentVariablesConfigurationSource.ColonAndDotTransformation)
+                    .Build();
+
+                Assert.Equal("Debug", config["Logging:LogLevel:Microsoft.Hosting"]);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable("Logging__LogLevel__Microsoft___Hosting", null);
+            }
+        }
+
+        [Fact]
+        public void TransformationReturningNullThrows()
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                new EnvironmentVariablesConfigurationProvider(null, static _ => null!));
         }
     }
 }


### PR DESCRIPTION
Implements [#125137](https://github.com/dotnet/runtime/issues/125137).

## API additions

- `IConfigurationBuilder.AddEnvironmentVariables(string? prefix, Func<string, string>? variableNameTransformation)` overload.
- `EnvironmentVariablesConfigurationSource.VariableNameTransformation` -- a settable `Func<string, string>?` that, when non-null, completely replaces the default transformation.
- `EnvironmentVariablesConfigurationSource.DefaultTransformation` -- the existing default that replaces `__` with the configuration key delimiter (`:`).
- `EnvironmentVariablesConfigurationSource.ColonAndDotTransformation` -- replaces `___` with `.` and `__` with `:`, so configuration keys containing dots can be set from environment variables.

API shape matches [@bartonjs's approval comment](https://github.com/dotnet/runtime/issues/125137#issuecomment-2935488083) on the issue.

## Implementation notes

- `ColonAndDotTransformation` uses `ValueStringBuilder` + `stackalloc char[256]` on .NET, `StringBuilder` on .NET Framework, kept under a single small `#if NET` region. No new package references.
- `Prefix` is itself passed through the active transformation before comparison, so it should be specified in pre-transformation form (e.g. `"Logging__"` rather than `"Logging:"`). Documented in `<remarks>` on the `Prefix` property and the matching overloads.

## Tests

13 new tests in `EnvironmentVariablesTest` cover:
- The two built-in transformations behaviorally (`[Theory]` tables for double/triple/4/5/6 underscores, single-underscore preservation, no-underscore early return).
- `VariableNameTransformation` replacing the default, identity transformation disabling replacement, transformation applied to prefix, source/builder wiring, and a behavioral check that `ColonAndDotTransformation` is not the default.

> [!NOTE]
> This PR description and the implementation were drafted with assistance from GitHub Copilot.
