### PR TITLE
perf: mark RuntimeHelpers.GetSubArray with AggressiveInlining

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -24,6 +24,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Slices the specified array using the specified range.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T[] GetSubArray<T>(T[] array, Range range)
         {
             if (array == null)


### PR DESCRIPTION
## Summary

`RuntimeHelpers.GetSubArray<T>` is emitted by the C# compiler for every `array[x..y]` range expression — it is never called directly by user code. Despite being a compiler-generated call, it currently exceeds the JIT's default inline budget (~119 IL bytes) and is never inlined, which prevents the JIT from using constant information available at the call site.

## Problem

When `GetSubArray` is not inlined, the JIT compiles it as a standalone method where `length` is an opaque runtime value. Even when the range size is a compile-time constant — which is common for slicing patterns like `arr[offset..(offset + chunkSize)]` — the JIT cannot fold any of the internal branches.

Without inlining, the call site looks like this:

```asm
mov  rdx, 0x3200000000          ; Range(0..50) — compiler already folded it to a constant
call RuntimeHelpers:GetSubArray[int]   ; but that constant stops here
```

Inside the standalone `GetSubArray[int]`, `length` is just a register — branches cannot be eliminated.

## Fix

Adding `[AggressiveInlining]` allows the JIT to inline `GetSubArray` into the caller. Once inlined, the JIT can propagate constants from the call site through `GetOffsetAndLength` and fold the internal branches.

**What gets eliminated when the range size is a constant** (`arr[offset..(offset+50)]`):

```asm
; typeof(T[]) == array.GetType() → eliminated when array type is known
; length == 0 → eliminated (50 != 0)
; Memmove byte count → constant-folded (50 * sizeof(int) = 200)
mov  edx, 50
call CORINFO_HELP_NEWARR_1_VC
mov  r8d, 200
call Memmove
```

The range size being constant is enough — the array itself can be dynamic. `arr[i..(i+50)]` where `i` is a variable still produces `length = 50` after `GetOffsetAndLength` is inlined, so all the same folds apply.

The only case that does not benefit from constant folding is a fully dynamic range: `arr[i..j]` where both bounds are variables. Those call sites still gain from eliminating the function call overhead.

## Future work

Since the array returned by `GetSubArray` is immediately and completely overwritten by `Buffer.Memmove`, zero-initializing it first is redundant for unmanaged types. Replacing `new T[length]` with `GC.AllocateUninitializedArray<T>(length)` would skip that work for large arrays. With `[AggressiveInlining]` already in place, the threshold branch inside `AllocateUninitializedArray` (`length < 2048 / sizeof(T)`) would also constant-fold away at call sites with known range sizes — producing a single direct allocation path with no branches at all. That change is worth pursuing separately once this lands.