### PR TITLE
Expand discovery of generic methods on r2r

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -862,6 +862,7 @@ namespace ILCompiler
             this TypeDesc potentialOverrideType, MethodDesc canonMethod, out bool foundMatchingInterface)
         {
             Debug.Assert(canonMethod.IsVirtual);
+            Debug.Assert(canonMethod.HasInstantiation);
             Debug.Assert(canonMethod.OwningType.IsInterface);
             Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
 
@@ -902,19 +903,8 @@ namespace ILCompiler
 
                 if (slotDecl is not null)
                 {
-                    MethodDesc implementingMethod;
-                    if (canonMethod.HasInstantiation)
-                    {
-                        implementingMethod = slotDecl.MakeInstantiatedMethod(canonMethod.Instantiation)
-                            .InstantiateSignature(potentialOverrideType.Instantiation, canonMethod.Instantiation);
-                    }
-                    else
-                    {
-                        implementingMethod = slotDecl.InstantiateSignature(
-                            potentialOverrideType.Instantiation, Instantiation.Empty);
-                    }
-
-                    results.Add(implementingMethod);
+                    results.Add(slotDecl.MakeInstantiatedMethod(canonMethod.Instantiation)
+                            .InstantiateSignature(potentialOverrideType.Instantiation, canonMethod.Instantiation));
                 }
             }
 
@@ -929,6 +919,7 @@ namespace ILCompiler
             this TypeDesc potentialOverrideType, MethodDesc canonMethod)
         {
             Debug.Assert(canonMethod.IsVirtual);
+            Debug.Assert(canonMethod.HasInstantiation);
             Debug.Assert(!canonMethod.OwningType.IsInterface);
             Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
 
@@ -957,12 +948,9 @@ namespace ILCompiler
             }
             else
             {
-                MethodDesc typicalOnConcreteType = context
-                    .GetMethodForInstantiatedType(canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur);
-
-                methodToResolve = canonMethod.HasInstantiation
-                    ? typicalOnConcreteType.MakeInstantiatedMethod(canonMethod.Instantiation)
-                    : typicalOnConcreteType;
+                methodToResolve = context
+                    .GetMethodForInstantiatedType(canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur)
+                    .MakeInstantiatedMethod(canonMethod.Instantiation);
             }
 
             MethodDesc canonTarget = potentialOverrideType.FindVirtualFunctionTargetMethodOnObjectType(methodToResolve)

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -848,5 +848,119 @@ namespace ILCompiler
                     && firstField.Offset.AsInt == 0
                     && ((mdType.GetElementSize().AsInt % firstFieldElementType.GetElementSize().AsInt) == 0);
         }
+
+        /// <summary>
+        /// Given a canonical interface method, resolves its implementation(s) on a concrete type.
+        /// Yields non-canonical implementing methods. A single canonical interface method may map
+        /// to multiple implementations when the type implements the same interface with different
+        /// type arguments (e.g., class Foo&lt;T, U&gt; : IFoo&lt;T&gt;, IFoo&lt;U&gt;).
+        /// Callers should canonicalize the results as needed.
+        /// <paramref name="foundMatchingInterface"/> is set to true if the type implements an interface
+        /// with the same canonical form, even if no concrete implementation was resolved (e.g., diamond ambiguity).
+        /// </summary>
+        public static IEnumerable<MethodDesc> ResolveCanonicalInterfaceMethodImplementations(
+            this TypeDesc potentialOverrideType, MethodDesc canonMethod, out bool foundMatchingInterface)
+        {
+            Debug.Assert(canonMethod.IsVirtual);
+            Debug.Assert(canonMethod.HasInstantiation);
+            Debug.Assert(canonMethod.OwningType.IsInterface);
+            Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
+
+            TypeSystemContext context = canonMethod.Context;
+            TypeDesc methodOwningType = canonMethod.OwningType;
+
+            TypeDesc potentialOverrideDefinition = potentialOverrideType.GetTypeDefinition();
+            DefType[] potentialInterfaces = potentialOverrideType.RuntimeInterfaces;
+            DefType[] potentialDefinitionInterfaces = potentialOverrideDefinition.RuntimeInterfaces;
+
+            foundMatchingInterface = false;
+            List<MethodDesc> results = new List<MethodDesc>();
+
+            for (int interfaceIndex = 0; interfaceIndex < potentialInterfaces.Length; interfaceIndex++)
+            {
+                if (potentialInterfaces[interfaceIndex].ConvertToCanonForm(CanonicalFormKind.Specific) != methodOwningType)
+                    continue;
+
+                foundMatchingInterface = true;
+
+                MethodDesc interfaceMethod = canonMethod.GetMethodDefinition();
+                if (methodOwningType.HasInstantiation)
+                    interfaceMethod = context.GetMethodForInstantiatedType(
+                        canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)potentialDefinitionInterfaces[interfaceIndex]);
+
+                MethodDesc slotDecl = interfaceMethod.Signature.IsStatic
+                    ? potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodToStaticVirtualMethodOnType(interfaceMethod)
+                    : potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethod);
+
+                if (slotDecl is null)
+                {
+                    // The method might be implemented through a default interface method
+                    var result = potentialOverrideDefinition.InstantiateAsOpen()
+                        .ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethod, out slotDecl);
+                    if (result != DefaultInterfaceMethodResolution.DefaultImplementation)
+                        slotDecl = null;
+                }
+
+                if (slotDecl is not null)
+                {
+                    results.Add(slotDecl.MakeInstantiatedMethod(canonMethod.Instantiation)
+                        .InstantiateSignature(potentialOverrideType.Instantiation, canonMethod.Instantiation));
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Given a canonical class virtual method, resolves its override on a concrete type.
+        /// Returns the canonical override target, or null if the type does not override the method.
+        /// </summary>
+        public static MethodDesc ResolveCanonicalClassVirtualMethodOverride(
+            this TypeDesc potentialOverrideType, MethodDesc canonMethod)
+        {
+            Debug.Assert(canonMethod.IsVirtual);
+            Debug.Assert(canonMethod.HasInstantiation);
+            Debug.Assert(!canonMethod.OwningType.IsInterface);
+            Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
+
+            TypeSystemContext context = canonMethod.Context;
+            TypeDesc methodOwningType = canonMethod.OwningType;
+
+            // Walk up the type hierarchy to find where the canonical form matches.
+            // For example, resolving Base<__Canon>.Method on Derived : Base<string> requires
+            // re-instantiating to Base<string>.Method before calling FindVirtualFunctionTargetMethodOnObjectType.
+            TypeDesc overrideTypeCur = potentialOverrideType;
+            do
+            {
+                if (overrideTypeCur.ConvertToCanonForm(CanonicalFormKind.Specific) == methodOwningType)
+                    break;
+                overrideTypeCur = overrideTypeCur.BaseType;
+            }
+            while (overrideTypeCur != null);
+
+            if (overrideTypeCur is null)
+                return null;
+
+            MethodDesc methodToResolve;
+            if (methodOwningType == overrideTypeCur)
+            {
+                methodToResolve = canonMethod;
+            }
+            else
+            {
+                methodToResolve = context
+                    .GetMethodForInstantiatedType(canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur)
+                    .MakeInstantiatedMethod(canonMethod.Instantiation);
+            }
+
+            MethodDesc canonTarget = potentialOverrideType.FindVirtualFunctionTargetMethodOnObjectType(methodToResolve)
+                .GetCanonMethodTarget(CanonicalFormKind.Specific);
+
+            // We didn't find a different target method, so no override for the virtual method we are looking for.
+            if (canonTarget == canonMethod)
+                return null;
+
+            return canonTarget;
+        }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -862,7 +862,6 @@ namespace ILCompiler
             this TypeDesc potentialOverrideType, MethodDesc canonMethod, out bool foundMatchingInterface)
         {
             Debug.Assert(canonMethod.IsVirtual);
-            Debug.Assert(canonMethod.HasInstantiation);
             Debug.Assert(canonMethod.OwningType.IsInterface);
             Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
 
@@ -903,8 +902,19 @@ namespace ILCompiler
 
                 if (slotDecl is not null)
                 {
-                    results.Add(slotDecl.MakeInstantiatedMethod(canonMethod.Instantiation)
-                        .InstantiateSignature(potentialOverrideType.Instantiation, canonMethod.Instantiation));
+                    MethodDesc implementingMethod;
+                    if (canonMethod.HasInstantiation)
+                    {
+                        implementingMethod = slotDecl.MakeInstantiatedMethod(canonMethod.Instantiation)
+                            .InstantiateSignature(potentialOverrideType.Instantiation, canonMethod.Instantiation);
+                    }
+                    else
+                    {
+                        implementingMethod = slotDecl.InstantiateSignature(
+                            potentialOverrideType.Instantiation, Instantiation.Empty);
+                    }
+
+                    results.Add(implementingMethod);
                 }
             }
 
@@ -919,7 +929,6 @@ namespace ILCompiler
             this TypeDesc potentialOverrideType, MethodDesc canonMethod)
         {
             Debug.Assert(canonMethod.IsVirtual);
-            Debug.Assert(canonMethod.HasInstantiation);
             Debug.Assert(!canonMethod.OwningType.IsInterface);
             Debug.Assert(canonMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == canonMethod);
 
@@ -948,9 +957,12 @@ namespace ILCompiler
             }
             else
             {
-                methodToResolve = context
-                    .GetMethodForInstantiatedType(canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur)
-                    .MakeInstantiatedMethod(canonMethod.Instantiation);
+                MethodDesc typicalOnConcreteType = context
+                    .GetMethodForInstantiatedType(canonMethod.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur);
+
+                methodToResolve = canonMethod.HasInstantiation
+                    ? typicalOnConcreteType.MakeInstantiatedMethod(canonMethod.Instantiation)
+                    : typicalOnConcreteType;
             }
 
             MethodDesc canonTarget = potentialOverrideType.FindVirtualFunctionTargetMethodOnObjectType(methodToResolve)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -145,10 +145,9 @@ namespace ILCompiler.DependencyAnalysis
 
                             if (slotDecl != null)
                             {
-                                TypeDesc[] openInstantiation = new TypeDesc[_method.Instantiation.Length];
-                                for (int instArg = 0; instArg < openInstantiation.Length; instArg++)
-                                    openInstantiation[instArg] = context.GetSignatureVariable(instArg, method: true);
-                                MethodDesc implementingMethodInstantiation = slotDecl.MakeInstantiatedMethod(openInstantiation).InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
+                                MethodDesc implementingMethodInstantiation = slotDecl
+                                    .MakeInstantiatedMethod(_method.Instantiation)
+                                    .InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
 
                                 // Static virtuals cannot be further overridden so this is an impl use. Otherwise it's a virtual slot use.
                                 if (implementingMethodInstantiation.Signature.IsStatic)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -75,24 +75,19 @@ namespace ILCompiler.DependencyAnalysis
             TypeDesc methodOwningType = _method.OwningType;
             bool methodIsShared = _method.IsSharedByGenericInstantiations;
 
-            TypeSystemContext context = _method.Context;
-
             for (int i = firstNode; i < markedNodes.Count; i++)
             {
                 DependencyNodeCore<NodeFactory> entry = markedNodes[i];
-                EETypeNode entryAsEETypeNode;
 
                 // This method is often called with a long list of ScannedMethodNode
                 // or MethodCodeNode nodes. We are not interested in those. In order
                 // to make the type check as cheap as possible we check for specific
                 // *sealed* types instead of doing `entry is EETypeNode` which has
                 // to walk the whole class hierarchy for the non matching nodes.
-                if (entry is ConstructedEETypeNode constructedEETypeNode)
-                    entryAsEETypeNode = constructedEETypeNode;
-                else
+                if (entry is not ConstructedEETypeNode constructedEETypeNode)
                     continue;
 
-                TypeDesc potentialOverrideType = entryAsEETypeNode.Type;
+                TypeDesc potentialOverrideType = constructedEETypeNode.Type;
                 if (!potentialOverrideType.IsDefType || potentialOverrideType.IsInterface)
                     continue;
 
@@ -104,113 +99,31 @@ namespace ILCompiler.DependencyAnalysis
 
                 bool foundImpl = false;
 
-                // If this is an interface gvm, look for types that implement the interface
-                // and other instantantiations that have the same canonical form.
-                // This ensure the various slot numbers remain equivalent across all types where there is an equivalence
-                // relationship in the vtable.
                 if (methodOwningType.IsInterface)
                 {
-                    // We go over definitions because a single canonical interface method could actually be implemented
-                    // by multiple methods - consider:
-                    //
-                    // class Foo<T, U> : IFoo<T>, IFoo<U>, IFoo<string> { }
-                    //
-                    // If we ask what implements IFoo<__Canon>.Method, the answer could be "three methods"
-                    // and that's expected. We therefore resolve IFoo<__Canon>.Method for each IFoo<!0>.Method,
-                    // IFoo<!1>.Method, and IFoo<string>.Method, adding GVMDependencies for each.
-                    TypeDesc potentialOverrideDefinition = potentialOverrideType.GetTypeDefinition();
-                    DefType[] potentialInterfaces = potentialOverrideType.RuntimeInterfaces;
-                    DefType[] potentialDefinitionInterfaces = potentialOverrideDefinition.RuntimeInterfaces;
-                    for (int interfaceIndex = 0; interfaceIndex < potentialInterfaces.Length; interfaceIndex++)
+                    foreach (MethodDesc implementingMethod in potentialOverrideType.ResolveCanonicalInterfaceMethodImplementations(_method, out foundImpl))
                     {
-                        if (potentialInterfaces[interfaceIndex].ConvertToCanonForm(CanonicalFormKind.Specific) == methodOwningType)
-                        {
-                            MethodDesc interfaceMethod = _method.GetMethodDefinition();
-                            if (methodOwningType.HasInstantiation)
-                                interfaceMethod = context.GetMethodForInstantiatedType(
-                                    _method.GetTypicalMethodDefinition(), (InstantiatedType)potentialDefinitionInterfaces[interfaceIndex]);
+                        MethodDesc canonImpl = implementingMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
-                            MethodDesc slotDecl = interfaceMethod.Signature.IsStatic ?
-                                potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodToStaticVirtualMethodOnType(interfaceMethod)
-                                : potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodTarget(interfaceMethod);
-                            if (slotDecl == null)
-                            {
-                                // The method might be implemented through a default interface method
-                                var result = potentialOverrideDefinition.InstantiateAsOpen().ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethod, out slotDecl);
-                                if (result != DefaultInterfaceMethodResolution.DefaultImplementation)
-                                {
-                                    slotDecl = null;
-                                }
-                            }
+                        // Static virtuals cannot be further overridden so this is an impl use. Otherwise it's a virtual slot use.
+                        if (implementingMethod.Signature.IsStatic)
+                            dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GenericVirtualMethodImpl(canonImpl), null, "ImplementingMethodInstantiation"));
+                        else
+                            dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(canonImpl), null, "ImplementingMethodInstantiation"));
 
-                            if (slotDecl != null)
-                            {
-                                MethodDesc implementingMethodInstantiation = slotDecl
-                                    .MakeInstantiatedMethod(_method.Instantiation)
-                                    .InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
-
-                                // Static virtuals cannot be further overridden so this is an impl use. Otherwise it's a virtual slot use.
-                                if (implementingMethodInstantiation.Signature.IsStatic)
-                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GenericVirtualMethodImpl(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
-                                else
-                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
-
-                                TypeSystemEntity origin = (implementingMethodInstantiation.OwningType != potentialOverrideType) ? potentialOverrideType : null;
-                                factory.MetadataManager.NoteOverridingMethod(_method, implementingMethodInstantiation, origin);
-                            }
-
-                            foundImpl = true;
-                        }
+                        TypeSystemEntity origin = (implementingMethod.OwningType != potentialOverrideType) ? potentialOverrideType : null;
+                        factory.MetadataManager.NoteOverridingMethod(_method, implementingMethod, origin);
                     }
                 }
                 else
                 {
-                    // This is not an interface GVM. Check whether the current type overrides the virtual method.
-                    // We might need to change what virtual method we ask about - consider:
-                    //
-                    // class Base<T> { virtual Method(); }
-                    // class Derived : Base<string> { override Method(); }
-                    //
-                    // We need to resolve Base<__Canon>.Method on Derived, but if we were to ask the virtual
-                    // method resolution algorithm, the answer would be "does not override" because Base<__Canon>
-                    // is not even in the inheritance hierarchy.
-                    //
-                    // So we need to modify the question to resolve Base<string>.Method instead and then
-                    // canonicalize the result.
-
-                    TypeDesc overrideTypeCur = potentialOverrideType;
-                    do
-                    {
-                        if (overrideTypeCur.ConvertToCanonForm(CanonicalFormKind.Specific) == methodOwningType)
-                            break;
-
-                        overrideTypeCur = overrideTypeCur.BaseType;
-                    }
-                    while (overrideTypeCur != null);
-
-                    if (overrideTypeCur == null)
-                        continue;
-
-                    MethodDesc methodToResolve;
-                    if (methodOwningType == overrideTypeCur)
-                    {
-                        methodToResolve = _method;
-                    }
-                    else
-                    {
-                        methodToResolve = context
-                            .GetMethodForInstantiatedType(_method.GetTypicalMethodDefinition(), (InstantiatedType)overrideTypeCur)
-                            .MakeInstantiatedMethod(_method.Instantiation);
-                    }
-
-                    MethodDesc instantiatedTargetMethod = potentialOverrideType.FindVirtualFunctionTargetMethodOnObjectType(methodToResolve)
-                        .GetCanonMethodTarget(CanonicalFormKind.Specific);
-                    if (instantiatedTargetMethod != _method)
+                    MethodDesc canonTarget = potentialOverrideType.ResolveCanonicalClassVirtualMethodOverride(_method);
+                    if (canonTarget is not null)
                     {
                         dynamicDependencies.Add(new CombinedDependencyListEntry(
-                            factory.GenericVirtualMethodImpl(instantiatedTargetMethod), null, "DerivedMethodInstantiation"));
+                            factory.GenericVirtualMethodImpl(canonTarget), null, "DerivedMethodInstantiation"));
 
-                        factory.MetadataManager.NoteOverridingMethod(_method, instantiatedTargetMethod);
+                        factory.MetadataManager.NoteOverridingMethod(_method, canonTarget);
 
                         foundImpl = true;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// Type discovery marker node for virtual dispatch dependency analysis.
+    ///
+    /// Marked InterestingForDynamicDependencyAnalysis so that ReadyToRunVirtualMethodDependenciesNode
+    /// can iterate on these type nodes to discover new virtual method targets to include in compilation.
+    /// </summary>
+    public class InheritedVirtualMethodsNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly TypeDesc _type;
+
+        public InheritedVirtualMethodsNode(TypeDesc type)
+        {
+            Debug.Assert(type is DefType && !type.IsInterface);
+            _type = type;
+        }
+
+        public TypeDesc Type => _type;
+
+        public override bool InterestingForDynamicDependencyAnalysis => true;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context) => null;
+
+        protected override string GetName(NodeFactory factory) => $"Inherited virtual methods on {_type}";
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -11,7 +11,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
     /// <summary>
     /// Type discovery marker node for virtual dispatch dependency analysis.
     ///
-    /// Marked InterestingForDynamicDependencyAnalysis so that ReadyToRunVirtualMethodDependenciesNode
+    /// Marked InterestingForDynamicDependencyAnalysis so that ReadyToRunGVMDependenciesNode
     /// can iterate on these type nodes to discover new virtual method targets to include in compilation.
     /// </summary>
     public class InheritedVirtualMethodsNode : DependencyNodeCore<NodeFactory>
@@ -20,7 +20,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         public InheritedVirtualMethodsNode(TypeDesc type)
         {
-            Debug.Assert(type is DefType && !type.IsInterface);
+            Debug.Assert(type.IsDefType && !type.IsInterface);
             _type = type;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -54,10 +54,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList list = base.ComputeNonRelocationBasedDependencies(factory);
+            MethodDesc canonMethod = Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             if (_fixupKind == ReadyToRunFixupKind.VirtualEntry &&
                 !Method.IsAbstract &&
                 !Method.HasInstantiation &&
-                Method.GetCanonMethodTarget(CanonicalFormKind.Specific) is var canonMethod &&
                 !factory.CompilationModuleGroup.VersionsWithMethodBody(canonMethod) &&
                 factory.CompilationModuleGroup.CrossModuleCompileable(canonMethod) &&
                 factory.CompilationModuleGroup.ContainsMethodBody(canonMethod, false))
@@ -73,7 +73,46 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
+            // FIXME Including async methods can lead to crash when compiling Async variant: [S.P.CoreLib] System.IO.TextWriter + SyncTextWriter.DisposeAsync()
+            // Crash is assertion in constructStringLiteral that gets called when compiling an IL stub.
+            //
+            // For generic virtual method calls, create a virtual dependency node that will
+            // dynamically discover implementations on types as they are added to the graph.
+            if (_fixupKind == ReadyToRunFixupKind.VirtualEntry &&
+                Method.IsVirtual &&
+                !Method.IsFinal &&
+                !Method.IsAsyncVariant() &&
+                !Method.IsGenericMethodDefinition &&
+                !Method.OwningType.IsGenericDefinition &&
+                (Method.OwningType.IsInterface || !Method.OwningType.IsSealed()))
+            {
+                // Because methods with generic parameters are already compiled in their canonical form, we are only interested in finding
+                // instantiations of virtual methods that have at least one non-canonical argument (aka a valuetype).
+                if (HasNonCanonicalInstantiationArguments(canonMethod))
+                {
+                    list = list ?? new DependencyAnalysisFramework.DependencyNodeCore<NodeFactory>.DependencyList();
+                    list.Add(factory.VirtualMethodUseDependencies(Method), "Virtual dispatch dependency");
+                }
+            }
+
             return list;
+        }
+
+        private static bool HasNonCanonicalInstantiationArguments(MethodDesc canonMethod)
+        {
+            TypeDesc canonType = canonMethod.Context.CanonType;
+            foreach (TypeDesc arg in canonMethod.Instantiation)
+            {
+                if (arg != canonType)
+                    return true;
+            }
+            foreach (TypeDesc arg in canonMethod.OwningType.Instantiation)
+            {
+                if (arg != canonType)
+                    return true;
+            }
+
+            return false;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -62,7 +62,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 factory.CompilationModuleGroup.CrossModuleCompileable(canonMethod) &&
                 factory.CompilationModuleGroup.ContainsMethodBody(canonMethod, false))
             {
-                list = list ?? new DependencyAnalysisFramework.DependencyNodeCore<NodeFactory>.DependencyList();
+                list = list ?? new DependencyList();
                 try
                 {
                     factory.DetectGenericCycles(_method.Method, canonMethod);
@@ -73,15 +73,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
-            // FIXME Including async methods can lead to crash when compiling Async variant: [S.P.CoreLib] System.IO.TextWriter + SyncTextWriter.DisposeAsync()
-            // Crash is assertion in constructStringLiteral that gets called when compiling an IL stub.
-            //
             // For generic virtual method calls, create a virtual dependency node that will
             // dynamically discover implementations on types as they are added to the graph.
             if (_fixupKind == ReadyToRunFixupKind.VirtualEntry &&
                 Method.IsVirtual &&
+                Method.HasInstantiation &&
                 !Method.IsFinal &&
-                !Method.IsAsyncVariant() &&
                 !Method.IsGenericMethodDefinition &&
                 !Method.OwningType.IsGenericDefinition &&
                 (Method.OwningType.IsInterface || !Method.OwningType.IsSealed()))
@@ -90,7 +87,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // instantiations of virtual methods that have at least one non-canonical argument (aka a valuetype).
                 if (HasNonCanonicalInstantiationArguments(canonMethod))
                 {
-                    list = list ?? new DependencyAnalysisFramework.DependencyNodeCore<NodeFactory>.DependencyList();
+                    list = list ?? new DependencyList();
                     list.Add(factory.VirtualMethodUseDependencies(Method), "Virtual dispatch dependency");
                 }
             }
@@ -106,12 +103,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 if (arg != canonType)
                     return true;
             }
-            foreach (TypeDesc arg in canonMethod.OwningType.Instantiation)
-            {
-                if (arg != canonType)
-                    return true;
-            }
-
             return false;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -213,17 +213,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dependencies.Add(factory.AllMethodsOnType(_typeDesc), "Methods on generic type instantiation");
             }
 
-            // Ensure virtual and interface method implementations inherited from generic
-            // base types are compiled for this instantiation. AllMethodsOnType only discovers
-            // methods defined directly on the type, missing inherited implementations needed
-            // for virtual and interface dispatch on value-type instantiations.
-            // This applies to non-generic types too — e.g., a non-generic Derived extending
-            // Base<int> still needs Base<int>'s interface implementations compiled.
+            // We record the usage of this type, so that GVM dependency analysis can resolve all implementations.
             if (!_typeDesc.IsGenericDefinition &&
                 !_typeDesc.IsInterface &&
-                _typeDesc is DefType &&
+                _typeDesc.IsDefType &&
                 (factory.CompilationCurrentPhase == 0) &&
-                factory.CompilationModuleGroup.VersionsWithType(_typeDesc))
+                factory.CompilationModuleGroup.VersionsWithType(_typeDesc) &&
+                TypeHasGVMSlots(_typeDesc))
             {
                 dependencies.Add(factory.InheritedVirtualMethods(_typeDesc), "Inherited virtual/interface methods on type");
             }
@@ -233,6 +229,17 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 AddDependenciesForAsyncStateMachineBox(ref dependencies, factory, _typeDesc);
             }
             return dependencies;
+        }
+
+        private static bool TypeHasGVMSlots(TypeDesc type)
+        {
+            foreach (MethodDesc method in type.EnumAllVirtualSlots())
+            {
+                if (method.HasInstantiation)
+                    return true;
+            }
+
+            return false;
         }
 
         public static void AddDependenciesForAsyncStateMachineBox(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -213,6 +213,21 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dependencies.Add(factory.AllMethodsOnType(_typeDesc), "Methods on generic type instantiation");
             }
 
+            // Ensure virtual and interface method implementations inherited from generic
+            // base types are compiled for this instantiation. AllMethodsOnType only discovers
+            // methods defined directly on the type, missing inherited implementations needed
+            // for virtual and interface dispatch on value-type instantiations.
+            // This applies to non-generic types too — e.g., a non-generic Derived extending
+            // Base<int> still needs Base<int>'s interface implementations compiled.
+            if (!_typeDesc.IsGenericDefinition &&
+                !_typeDesc.IsInterface &&
+                _typeDesc is DefType &&
+                (factory.CompilationCurrentPhase == 0) &&
+                factory.CompilationModuleGroup.VersionsWithType(_typeDesc))
+            {
+                dependencies.Add(factory.InheritedVirtualMethods(_typeDesc), "Inherited virtual/interface methods on type");
+            }
+
             if (_fixupKind == ReadyToRunFixupKind.TypeHandle)
             {
                 AddDependenciesForAsyncStateMachineBox(ref dependencies, factory, _typeDesc);

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -141,6 +141,21 @@ namespace ILCompiler.DependencyAnalysis
             return _allMethodsOnType.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
         }
 
+        private NodeCache<TypeDesc, InheritedVirtualMethodsNode> _inheritedVirtualMethods;
+
+        public InheritedVirtualMethodsNode InheritedVirtualMethods(TypeDesc type)
+        {
+            return _inheritedVirtualMethods.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
+        }
+
+        private NodeCache<MethodDesc, ReadyToRunVirtualMethodDependenciesNode> _virtualMethodUseDependencies;
+
+        public ReadyToRunVirtualMethodDependenciesNode VirtualMethodUseDependencies(MethodDesc method)
+        {
+            Debug.Assert(method.IsVirtual);
+            return _virtualMethodUseDependencies.GetOrAdd(method.GetCanonMethodTarget(CanonicalFormKind.Specific));
+        }
+
         private NodeCache<ReadyToRunGenericHelperKey, ISymbolNode> _genericReadyToRunHelpersFromDict;
 
         public ISymbolNode ReadyToRunHelperFromDictionaryLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
@@ -261,6 +276,16 @@ namespace ILCompiler.DependencyAnalysis
             _allMethodsOnType = new NodeCache<TypeDesc, AllMethodsOnTypeNode>(type =>
             {
                 return new AllMethodsOnTypeNode(type);
+            });
+
+            _inheritedVirtualMethods = new NodeCache<TypeDesc, InheritedVirtualMethodsNode>(type =>
+            {
+                return new InheritedVirtualMethodsNode(type);
+            });
+
+            _virtualMethodUseDependencies = new NodeCache<MethodDesc, ReadyToRunVirtualMethodDependenciesNode>(method =>
+            {
+                return new ReadyToRunVirtualMethodDependenciesNode(method);
             });
 
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(helperKey =>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -148,9 +148,9 @@ namespace ILCompiler.DependencyAnalysis
             return _inheritedVirtualMethods.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
         }
 
-        private NodeCache<MethodDesc, ReadyToRunVirtualMethodDependenciesNode> _virtualMethodUseDependencies;
+        private NodeCache<MethodDesc, ReadyToRunGVMDependenciesNode> _virtualMethodUseDependencies;
 
-        public ReadyToRunVirtualMethodDependenciesNode VirtualMethodUseDependencies(MethodDesc method)
+        public ReadyToRunGVMDependenciesNode VirtualMethodUseDependencies(MethodDesc method)
         {
             Debug.Assert(method.IsVirtual);
             return _virtualMethodUseDependencies.GetOrAdd(method.GetCanonMethodTarget(CanonicalFormKind.Specific));
@@ -283,9 +283,9 @@ namespace ILCompiler.DependencyAnalysis
                 return new InheritedVirtualMethodsNode(type);
             });
 
-            _virtualMethodUseDependencies = new NodeCache<MethodDesc, ReadyToRunVirtualMethodDependenciesNode>(method =>
+            _virtualMethodUseDependencies = new NodeCache<MethodDesc, ReadyToRunGVMDependenciesNode>(method =>
             {
-                return new ReadyToRunVirtualMethodDependenciesNode(method);
+                return new ReadyToRunGVMDependenciesNode(method);
             });
 
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(helperKey =>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunGVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunGVMDependenciesNode.cs
@@ -11,20 +11,21 @@ using Internal.TypeSystem;
 namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     /// <summary>
-    /// Tracks usage of a virtual or interface method call and dynamically discovers
+    /// Tracks usage of a generic virtual/interface method call and dynamically discovers
     /// implementations on types as they are added to the dependency graph.
     ///
     /// For each discovered concrete type (InheritedVirtualMethodsNode as an "interesting" type marker),
     /// this node resolves the method implementation and adds it as a compilation dependency. Used to
     /// find implementations that have non canonical generic type arguments.
     /// </summary>
-    public class ReadyToRunVirtualMethodDependenciesNode : DependencyNodeCore<NodeFactory>
+    public class ReadyToRunGVMDependenciesNode : DependencyNodeCore<NodeFactory>
     {
         private readonly MethodDesc _method;
 
-        public ReadyToRunVirtualMethodDependenciesNode(MethodDesc method)
+        public ReadyToRunGVMDependenciesNode(MethodDesc method)
         {
             Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
+            Debug.Assert(method.HasInstantiation);
             Debug.Assert(method.IsVirtual);
 
             _method = method;
@@ -103,6 +104,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         }
 
         protected override string GetName(NodeFactory factory) =>
-            "__ReadyToRunVirtualMethodDependencies_" + factory.NameMangler.GetMangledMethodName(_method);
+            "__ReadyToRunGVMDependencies_" + factory.NameMangler.GetMangledMethodName(_method);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunVirtualMethodDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunVirtualMethodDependenciesNode.cs
@@ -1,0 +1,108 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// Tracks usage of a virtual or interface method call and dynamically discovers
+    /// implementations on types as they are added to the dependency graph.
+    ///
+    /// For each discovered concrete type (InheritedVirtualMethodsNode as an "interesting" type marker),
+    /// this node resolves the method implementation and adds it as a compilation dependency. Used to
+    /// find implementations that have non canonical generic type arguments.
+    /// </summary>
+    public class ReadyToRunVirtualMethodDependenciesNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly MethodDesc _method;
+
+        public ReadyToRunVirtualMethodDependenciesNode(MethodDesc method)
+        {
+            Debug.Assert(method.GetCanonMethodTarget(CanonicalFormKind.Specific) == method);
+            Debug.Assert(method.IsVirtual);
+
+            _method = method;
+        }
+
+        public override bool InterestingForDynamicDependencyAnalysis => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override bool HasDynamicDependencies => true;
+
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory factory) => null;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(
+            List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory factory)
+        {
+            // InheritedVirtualMethodsNode is only added during phase 0 (in TypeFixupSignature),
+            // so no new interesting nodes will appear in later phases.
+            if (factory.CompilationCurrentPhase > 0)
+                return Array.Empty<CombinedDependencyListEntry>();
+
+            List<CombinedDependencyListEntry> dynamicDependencies = new List<CombinedDependencyListEntry>();
+
+            bool methodIsShared = _method.IsSharedByGenericInstantiations;
+
+            for (int i = firstNode; i < markedNodes.Count; i++)
+            {
+                DependencyNodeCore<NodeFactory> entry = markedNodes[i];
+
+                if (entry is not InheritedVirtualMethodsNode typeNode)
+                    continue;
+
+                TypeDesc potentialOverrideType = typeNode.Type;
+
+                if (methodIsShared &&
+                    potentialOverrideType.ConvertToCanonForm(CanonicalFormKind.Specific) != potentialOverrideType)
+                    continue;
+
+                if (_method.OwningType.IsInterface)
+                {
+                    foreach (MethodDesc impl in potentialOverrideType.ResolveCanonicalInterfaceMethodImplementations(_method, out _))
+                    {
+                        AddMethodDependency(dynamicDependencies, factory, impl.GetCanonMethodTarget(CanonicalFormKind.Specific));
+                    }
+                }
+                else
+                {
+                    MethodDesc canonTarget = potentialOverrideType.ResolveCanonicalClassVirtualMethodOverride(_method);
+                    if (canonTarget is not null)
+                    {
+                        AddMethodDependency(dynamicDependencies, factory, canonTarget);
+                    }
+                }
+            }
+
+            return dynamicDependencies;
+        }
+
+        private void AddMethodDependency(
+            List<CombinedDependencyListEntry> dynamicDependencies,
+            NodeFactory factory,
+            MethodDesc canonMethod)
+        {
+            if (!factory.CompilationModuleGroup.ContainsMethodBody(canonMethod, false))
+                return;
+
+            try
+            {
+                factory.DetectGenericCycles(_method, canonMethod);
+                dynamicDependencies.Add(new CombinedDependencyListEntry(
+                    factory.CompiledMethodNode(canonMethod), null, "Virtual dispatch implementation on discovered type"));
+            }
+            catch (TypeSystemException) { }
+        }
+
+        protected override string GetName(NodeFactory factory) =>
+            "__ReadyToRunVirtualMethodDependencies_" + factory.NameMangler.GetMangledMethodName(_method);
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -226,6 +226,8 @@
     <Compile Include="Compiler\CompositeImageSettings.cs" />
     <Compile Include="Compiler\CryptographicHashProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\AllMethodsOnTypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InheritedVirtualMethodsNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRunVirtualMethodDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -227,7 +227,7 @@
     <Compile Include="Compiler\CryptographicHashProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\AllMethodsOnTypeNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InheritedVirtualMethodsNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\ReadyToRunVirtualMethodDependenciesNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\ReadyToRunGVMDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />


### PR DESCRIPTION
Called methods are obtained from `MethodFixupSignature` and are stored into `ReadyToRunVirtualMethodDependenciesNode`. These will be nodes that `HasDynamicDependencies` so the dependency analysis will do additional iterations for these nodes on the newly added nodes that are `InterestingForDynamicDependencyAnalysis`. These will be `InheritedVirtualMethodsNode` added as part of `TypeFixupSignature`. They will represent types used by the application. We resolve the target method for calling the virtual/interface method on the existing types. This attempts to reuse code that NativeAOT also used for this purpose. If we are able to obtain a new method, we include it in the compilation.