### PR TITLE
Update a few OperIs checks to explicitly do range based checks

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1021,7 +1021,7 @@ public:
 
     bool isLclField() const
     {
-        return OperGet() == GT_LCL_FLD || OperGet() == GT_STORE_LCL_FLD;
+        return OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD);
     }
 
     bool isUsedFromSpillTemp() const;
@@ -1342,12 +1342,20 @@ public:
 
     static bool OperIsNonPhiLocal(genTreeOps gtOper)
     {
-        return OperIsLocal(gtOper) && (gtOper != GT_PHI_ARG);
+        static_assert(AreContiguous(GT_LCL_VAR, GT_LCL_FLD, GT_STORE_LCL_VAR, GT_STORE_LCL_FLD));
+        bool result = (GT_LCL_VAR <= gtOper) && (gtOper <= GT_STORE_LCL_FLD);
+
+        assert(result == (OperIsLocal(gtOper) && !StaticOperIs(gtOper, GT_PHI_ARG)));
+        return result;
     }
 
     static bool OperIsLocalRead(genTreeOps gtOper)
     {
-        return (OperIsLocal(gtOper) && !OperIsLocalStore(gtOper));
+        static_assert(AreContiguous(GT_PHI_ARG, GT_LCL_VAR, GT_LCL_FLD));
+        bool result = (GT_PHI_ARG <= gtOper) && (gtOper <= GT_LCL_FLD);
+
+        assert(result == (OperIsLocal(gtOper) && !OperIsLocalStore(gtOper)));
+        return result;
     }
 
     static bool OperIsLocalStore(genTreeOps gtOper)
@@ -1357,12 +1365,12 @@ public:
 
     static bool OperIsAddrMode(genTreeOps gtOper)
     {
-        return gtOper == GT_LEA;
+        return StaticOperIs(gtOper, GT_LEA);
     }
 
     static bool OperIsInitVal(genTreeOps gtOper)
     {
-        return gtOper == GT_INIT_VAL;
+        return StaticOperIs(gtOper, GT_INIT_VAL);
     }
 
     bool OperIsInitVal() const
@@ -1386,7 +1394,7 @@ public:
 
     static bool OperIsBlk(genTreeOps gtOper)
     {
-        return (gtOper == GT_BLK) || OperIsStoreBlk(gtOper);
+        return StaticOperIs(gtOper, GT_BLK) || OperIsStoreBlk(gtOper);
     }
 
     bool OperIsBlk() const
@@ -1523,7 +1531,8 @@ public:
 
     static bool OperIsShift(genTreeOps gtOper)
     {
-        return StaticOperIs(gtOper, GT_LSH, GT_RSH, GT_RSZ);
+        static_assert(AreContiguous(GT_LSH, GT_RSH, GT_RSZ));
+        return (GT_LSH <= gtOper) && (gtOper <= GT_RSZ);
     }
 
     bool OperIsShift() const
@@ -1557,7 +1566,11 @@ public:
 
     static bool OperIsShiftOrRotate(genTreeOps gtOper)
     {
-        return OperIsShift(gtOper) || OperIsRotate(gtOper) || OperIsShiftLong(gtOper);
+        static_assert(AreContiguous(GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR));
+        bool result = (GT_LSH <= gtOper) && (gtOper <= GT_ROR);
+
+        assert(result == (OperIsShift(gtOper) || OperIsRotate(gtOper)));
+        return result || OperIsShiftLong(gtOper);
     }
 
     bool OperIsShiftOrRotate() const
@@ -1567,11 +1580,19 @@ public:
 
     static bool OperIsMul(genTreeOps gtOper)
     {
-        return StaticOperIs(gtOper, GT_MUL, GT_MULHI)
+        if (StaticOperIs(gtOper, GT_MUL, GT_MULHI))
+        {
+            return true;
+        }
+
 #if !defined(TARGET_64BIT) || defined(TARGET_ARM64)
-               || (gtOper == GT_MUL_LONG)
+        if (StaticOperIs(gtOper, GT_MUL_LONG))
+        {
+            return true;
+        }
 #endif
-            ;
+
+        return false;
     }
 
     bool OperIsMul() const
@@ -1583,8 +1604,9 @@ public:
     static bool OperIsRMWMemOp(genTreeOps gtOper)
     {
         // Return if binary op is one of the supported operations for RMW of memory.
-        return StaticOperIs(gtOper, GT_ADD, GT_SUB, GT_AND, GT_OR, GT_XOR, GT_NOT, GT_NEG) ||
-               OperIsShiftOrRotate(gtOper);
+        static_assert(AreContiguous(GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR));
+        return StaticOperIs(gtOper, GT_ADD, GT_SUB) || ((GT_OR <= gtOper) && (gtOper <= GT_ROR)) ||
+               StaticOperIs(gtOper, GT_NOT, GT_NEG) || OperIsShiftLong(gtOper);
     }
     bool OperIsRMWMemOp() const
     {
@@ -1687,11 +1709,26 @@ public:
 
     static bool OperMayOverflow(genTreeOps gtOper)
     {
-        return StaticOperIs(gtOper, GT_ADD, GT_SUB, GT_MUL, GT_CAST)
+        static_assert(AreContiguous(GT_ADD, GT_SUB, GT_MUL));
+
+        if ((GT_ADD <= gtOper) && (gtOper <= GT_MUL))
+        {
+            return true;
+        }
+
+        if (StaticOperIs(gtOper, GT_CAST))
+        {
+            return true;
+        }
+
 #if !defined(TARGET_64BIT)
-               || StaticOperIs(gtOper, GT_ADD_HI, GT_SUB_HI)
+        if (StaticOperIs(gtOper, GT_ADD_HI, GT_SUB_HI))
+        {
+            return true;
+        }
 #endif
-            ;
+
+        return false;
     }
 
     bool OperMayOverflow() const
@@ -1722,7 +1759,8 @@ public:
     // Is this an access of an SZ array length, MD array length, or MD array lower bounds?
     static bool OperIsArrMetaData(genTreeOps gtOper)
     {
-        return StaticOperIs(gtOper, GT_ARR_LENGTH, GT_MDARR_LENGTH, GT_MDARR_LOWER_BOUND);
+        static_assert(AreContiguous(GT_ARR_LENGTH, GT_MDARR_LENGTH, GT_MDARR_LOWER_BOUND));
+        return (GT_ARR_LENGTH <= gtOper) && (gtOper <= GT_MDARR_LOWER_BOUND);
     }
 
     static bool OperIsIndirOrArrMetaData(genTreeOps gtOper)
@@ -1762,18 +1800,8 @@ public:
 
     static bool OperIsAtomicOp(genTreeOps gtOper)
     {
-        switch (gtOper)
-        {
-            case GT_XADD:
-            case GT_XORR:
-            case GT_XAND:
-            case GT_XCHG:
-            case GT_LOCKADD:
-            case GT_CMPXCHG:
-                return true;
-            default:
-                return false;
-        }
+        static_assert(AreContiguous(GT_LOCKADD, GT_XAND, GT_XORR, GT_XADD, GT_XCHG, GT_CMPXCHG));
+        return (GT_LOCKADD <= gtOper) && (gtOper <= GT_CMPXCHG);
     }
 
     bool OperIsAtomicOp() const
@@ -1819,7 +1847,7 @@ public:
     static bool OperIsHWIntrinsic(genTreeOps gtOper)
     {
 #ifdef FEATURE_HW_INTRINSICS
-        return gtOper == GT_HWINTRINSIC;
+        return StaticOperIs(gtOper, GT_HWINTRINSIC);
 #else
         return false;
 #endif // FEATURE_HW_INTRINSICS
@@ -1841,7 +1869,7 @@ public:
 #if defined(TARGET_64BIT)
         return false;
 #else
-        return gtOper == GT_LONG;
+        return StaticOperIs(gtOper, GT_LONG);
 #endif
     }
 
@@ -1852,29 +1880,54 @@ public:
 
     bool OperIsConditionalJump() const
     {
-        return OperIs(GT_JTRUE, GT_JCMP, GT_JTEST, GT_JCC, GT_WASM_JEXCEPT);
+        static_assert(AreContiguous(GT_JCMP, GT_JTEST, GT_JCC));
+
+        if (OperIs(GT_JTRUE) || ((GT_JCMP <= gtOper) && (gtOper <= GT_JCC)))
+        {
+            return true;
+        }
+
+#if defined(TARGET_WASM)
+        if (OperIs(GT_WASM_JEXCEPT))
+        {
+            return true;
+        }
+#endif
+
+        return false;
     }
 
     bool OperConsumesFlags() const
     {
-#if !defined(TARGET_64BIT)
+#if defined(TARGET_ARM64) || defined(TARGET_AMD64)
+        static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP));
+
+        if ((GT_JCC <= gtOper) && (gtOper <= GT_CCMP))
+        {
+            return true;
+        }
+#else
+        static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC));
+
+        if ((GT_JCC <= gtOper) && (gtOper <= GT_SELECTCC))
+        {
+            return true;
+        }
+#endif
+
+#if defined(TARGET_ARM64)
+        if (OperIs(GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC))
+        {
+            return true;
+        }
+#elif !defined(TARGET_64BIT)
         if (OperIs(GT_ADD_HI, GT_SUB_HI))
         {
             return true;
         }
 #endif
-#if defined(TARGET_ARM64)
-        if (OperIs(GT_CCMP, GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC))
-        {
-            return true;
-        }
-        return OperIs(GT_JCC, GT_SETCC, GT_SELECTCC);
-#elif defined(TARGET_AMD64)
-        static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP));
-        return (GT_JCC <= gtOper) && (gtOper <= GT_CCMP);
-#else
-        return OperIs(GT_JCC, GT_SETCC, GT_SELECTCC);
-#endif
+
+        return false;
     }
 
 #ifdef DEBUG
@@ -2462,7 +2515,7 @@ public:
 
     bool IsCall() const
     {
-        return OperGet() == GT_CALL;
+        return OperIs(GT_CALL);
     }
     inline bool IsHelperCall();
     inline bool IsHelperCall(unsigned helper);
@@ -3245,7 +3298,7 @@ struct GenTreeOp : public GenTreeUnOp
         , gtOp2(nullptr)
     {
         // Unary operators with optional arguments:
-        assert(oper == GT_RETURN || oper == GT_RETFILT || OperIsBlk(oper));
+        assert(StaticOperIs(oper, GT_RETURN, GT_RETFILT) || OperIsBlk(oper));
     }
 
     // returns true if we will use the division by constant optimization for this node.
@@ -8976,7 +9029,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
     // TODO-X86: Implement this routine for x86
     void CopyOtherRegs(GenTreeCopyOrReload* from)
     {
-        assert(OperGet() == from->OperGet());
+        assert(OperIs(from->OperGet()));
 
 #ifdef UNIX_AMD64_ABI
         for (unsigned i = 0; i < MAX_MULTIREG_COUNT - 1; ++i)
@@ -10396,7 +10449,7 @@ inline void GenTree::ClearLastUse(int fieldIndex)
 //
 inline bool GenTree::IsCopyOrReload() const
 {
-    return (OperIs(GT_COPY) || OperIs(GT_RELOAD));
+    return OperIs(GT_COPY, GT_RELOAD);
 }
 
 //-----------------------------------------------------------------------------------
@@ -10421,16 +10474,24 @@ inline bool GenTree::IsCopyOrReloadOfMultiRegCall() const
 
 inline bool GenTree::IsCnsIntOrI() const
 {
-    return (OperIs(GT_CNS_INT));
+    return OperIs(GT_CNS_INT);
 }
 
 inline bool GenTree::IsIntegralConst() const
 {
-#ifdef TARGET_64BIT
-    return IsCnsIntOrI();
-#else  // !TARGET_64BIT
-    return ((OperIs(GT_CNS_INT)) || (OperIs(GT_CNS_LNG)));
-#endif // !TARGET_64BIT
+    if (IsCnsIntOrI())
+    {
+        return true;
+    }
+
+#if !defined(TARGET_64BIT)
+    if (OperIs(GT_CNS_LNG))
+    {
+        return true;
+    }
+#endif
+
+    return false;
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1580,19 +1580,12 @@ public:
 
     static bool OperIsMul(genTreeOps gtOper)
     {
-        if (StaticOperIs(gtOper, GT_MUL, GT_MULHI))
-        {
-            return true;
-        }
-
 #if !defined(TARGET_64BIT) || defined(TARGET_ARM64)
-        if (StaticOperIs(gtOper, GT_MUL_LONG))
-        {
-            return true;
-        }
+        static_assert(AreContiguous(GT_MUL, GT_MULHI, GT_MUL_LONG));
+        return (GT_MUL <= gtOper) && (gtOper <= GT_MUL_LONG);
+#else
+        return StaticOperIs(gtOper, GT_MUL, GT_MULHI);
 #endif
-
-        return false;
     }
 
     bool OperIsMul() const
@@ -1604,9 +1597,8 @@ public:
     static bool OperIsRMWMemOp(genTreeOps gtOper)
     {
         // Return if binary op is one of the supported operations for RMW of memory.
-        static_assert(AreContiguous(GT_OR, GT_XOR, GT_AND, GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR));
-        return StaticOperIs(gtOper, GT_ADD, GT_SUB) || ((GT_OR <= gtOper) && (gtOper <= GT_ROR)) ||
-               StaticOperIs(gtOper, GT_NOT, GT_NEG) || OperIsShiftLong(gtOper);
+        static_assert(AreContiguous(GT_NOT, GT_NEG, GT_OR, GT_XOR, GT_AND, GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR, GT_ADD, GT_SUB));
+        return ((GT_NOT <= gtOper) && (gtOper <= GT_SUB)) || OperIsShiftLong(gtOper);
     }
     bool OperIsRMWMemOp() const
     {
@@ -1880,9 +1872,9 @@ public:
 
     bool OperIsConditionalJump() const
     {
-        static_assert(AreContiguous(GT_JCMP, GT_JTEST, GT_JCC));
+        static_assert(AreContiguous(GT_JTRUE, GT_JCMP, GT_JTEST, GT_JCC));
 
-        if (OperIs(GT_JTRUE) || ((GT_JCMP <= gtOper) && (gtOper <= GT_JCC)))
+        if ((GT_JTRUE <= gtOper) && (gtOper <= GT_JCC))
         {
             return true;
         }
@@ -1901,18 +1893,10 @@ public:
     {
 #if defined(TARGET_ARM64)
         static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP, GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC));
-
-        if ((GT_JCC <= gtOper) && (gtOper <= GT_SELECT_NEGCC))
-        {
-            return true;
-        }
+        return (GT_JCC <= gtOper) && (gtOper <= GT_SELECT_NEGCC);
 #elif defined(TARGET_AMD64)
         static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP));
-
-        if ((GT_JCC <= gtOper) && (gtOper <= GT_CCMP))
-        {
-            return true;
-        }
+        return (GT_JCC <= gtOper) && (gtOper <= GT_CCMP);
 #else
         static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC));
 
@@ -1920,7 +1904,6 @@ public:
         {
             return true;
         }
-#endif
 
 #if !defined(TARGET_64BIT)
         if (OperIs(GT_ADD_HI, GT_SUB_HI))
@@ -1930,6 +1913,7 @@ public:
 #endif
 
         return false;
+#endif
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1899,7 +1899,14 @@ public:
 
     bool OperConsumesFlags() const
     {
-#if defined(TARGET_ARM64) || defined(TARGET_AMD64)
+#if defined(TARGET_ARM64)
+        static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP, GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC));
+
+        if ((GT_JCC <= gtOper) && (gtOper <= GT_SELECT_NEGCC))
+        {
+            return true;
+        }
+#elif defined(TARGET_AMD64)
         static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP));
 
         if ((GT_JCC <= gtOper) && (gtOper <= GT_CCMP))
@@ -1915,12 +1922,7 @@ public:
         }
 #endif
 
-#if defined(TARGET_ARM64)
-        if (OperIs(GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC))
-        {
-            return true;
-        }
-#elif !defined(TARGET_64BIT)
+#if !defined(TARGET_64BIT)
         if (OperIs(GT_ADD_HI, GT_SUB_HI))
         {
             return true;

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1597,7 +1597,8 @@ public:
     static bool OperIsRMWMemOp(genTreeOps gtOper)
     {
         // Return if binary op is one of the supported operations for RMW of memory.
-        static_assert(AreContiguous(GT_NOT, GT_NEG, GT_OR, GT_XOR, GT_AND, GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR, GT_ADD, GT_SUB));
+        static_assert(AreContiguous(GT_NOT, GT_NEG, GT_OR, GT_XOR, GT_AND, GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR,
+                                    GT_ADD, GT_SUB));
         return ((GT_NOT <= gtOper) && (gtOper <= GT_SUB)) || OperIsShiftLong(gtOper);
     }
     bool OperIsRMWMemOp() const
@@ -1892,7 +1893,8 @@ public:
     bool OperConsumesFlags() const
     {
 #if defined(TARGET_ARM64)
-        static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP, GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC));
+        static_assert(
+            AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP, GT_SELECT_INCCC, GT_SELECT_INVCC, GT_SELECT_NEGCC));
         return (GT_JCC <= gtOper) && (gtOper <= GT_SELECT_NEGCC);
 #elif defined(TARGET_AMD64)
         static_assert(AreContiguous(GT_JCC, GT_SETCC, GT_SELECTCC, GT_CCMP));

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1604,7 +1604,7 @@ public:
     static bool OperIsRMWMemOp(genTreeOps gtOper)
     {
         // Return if binary op is one of the supported operations for RMW of memory.
-        static_assert(AreContiguous(GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR));
+        static_assert(AreContiguous(GT_OR, GT_XOR, GT_AND, GT_LSH, GT_RSH, GT_RSZ, GT_ROL, GT_ROR));
         return StaticOperIs(gtOper, GT_ADD, GT_SUB) || ((GT_OR <= gtOper) && (gtOper <= GT_ROR)) ||
                StaticOperIs(gtOper, GT_NOT, GT_NEG) || OperIsShiftLong(gtOper);
     }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1580,12 +1580,19 @@ public:
 
     static bool OperIsMul(genTreeOps gtOper)
     {
+        if (StaticOperIs(gtOper, GT_MUL, GT_MULHI))
+        {
+            return true;
+        }
+
 #if !defined(TARGET_64BIT) || defined(TARGET_ARM64)
-        static_assert(AreContiguous(GT_MUL, GT_MULHI, GT_MUL_LONG));
-        return (GT_MUL <= gtOper) && (gtOper <= GT_MUL_LONG);
-#else
-        return StaticOperIs(gtOper, GT_MUL, GT_MULHI);
+        if (StaticOperIs(gtOper, GT_MUL_LONG))
+        {
+            return true;
+        }
 #endif
+
+        return false;
     }
 
     bool OperIsMul() const
@@ -1873,9 +1880,14 @@ public:
 
     bool OperIsConditionalJump() const
     {
-        static_assert(AreContiguous(GT_JTRUE, GT_JCMP, GT_JTEST, GT_JCC));
+        if (OperIs(GT_JTRUE))
+        {
+            return true;
+        }
 
-        if ((GT_JTRUE <= gtOper) && (gtOper <= GT_JCC))
+        static_assert(AreContiguous(GT_JCMP, GT_JTEST, GT_JCC));
+
+        if ((GT_JCMP <= gtOper) && (gtOper <= GT_JCC))
         {
             return true;
         }

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -6,6 +6,15 @@
 #ifndef GTNODE
 #error  Define GTNODE before including this file.
 #endif
+
+/*****************************************************************************/
+/*                             IMPORTANT                                     */
+/* Several of the nodes below are explicitly ordered to allow for efficient  */
+/* range checks in the various OperIs queries on GenTree. All such usages    */
+/* should be guarded by a corresponding static_assert(AreContiguous(...))    */
+/* check, so be mindful if updating the list and ensure these aren't broken. */
+/*****************************************************************************/
+
 /*****************************************************************************/
 //
 //     Node enum
@@ -60,9 +69,7 @@ GTNODE(CNS_MSK          , GenTreeMskCon      ,0,0,GTK_LEAF)
 //  Unary  operators (1 operand):
 //-----------------------------------------------------------------------------
 
-GTNODE(NOT              , GenTreeOp          ,0,0,GTK_UNOP)
 GTNODE(NOP              , GenTree            ,0,1,GTK_LEAF|DBK_NOCONTAIN)
-GTNODE(NEG              , GenTreeOp          ,0,0,GTK_UNOP)
 
 GTNODE(INTRINSIC        , GenTreeIntrinsic   ,0,0,GTK_BINOP|GTK_EXOP)
 GTNODE(KEEPALIVE        , GenTree            ,0,0,GTK_UNOP|GTK_NOVALUE)   // keep operand alive, generate no code, produce no result
@@ -107,18 +114,12 @@ GTNODE(LZCNT            , GenTreeOp          ,0,0,GTK_UNOP)               // Lea
 
 GTNODE(NONLOCAL_JMP     , GenTreeOp          ,0,0,GTK_UNOP|GTK_NOVALUE)   // Non-local jump to specified address
 
+GTNODE(NOT              , GenTreeOp          ,0,0,GTK_UNOP)
+GTNODE(NEG              , GenTreeOp          ,0,0,GTK_UNOP)
+
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):
 //-----------------------------------------------------------------------------
-
-GTNODE(ADD              , GenTreeOp          ,1,0,GTK_BINOP)
-GTNODE(SUB              , GenTreeOp          ,0,0,GTK_BINOP)
-GTNODE(MUL              , GenTreeOp          ,1,0,GTK_BINOP)
-GTNODE(DIV              , GenTreeOp          ,0,0,GTK_BINOP)
-GTNODE(MOD              , GenTreeOp          ,0,0,GTK_BINOP)
-
-GTNODE(UDIV             , GenTreeOp          ,0,0,GTK_BINOP)
-GTNODE(UMOD             , GenTreeOp          ,0,0,GTK_BINOP)
 
 GTNODE(OR               , GenTreeOp          ,1,0,GTK_BINOP)
 GTNODE(XOR              , GenTreeOp          ,1,0,GTK_BINOP)
@@ -129,6 +130,34 @@ GTNODE(RSH              , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(RSZ              , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(ROL              , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(ROR              , GenTreeOp          ,0,0,GTK_BINOP)
+
+GTNODE(ADD              , GenTreeOp          ,1,0,GTK_BINOP)
+GTNODE(SUB              , GenTreeOp          ,0,0,GTK_BINOP)
+GTNODE(MUL              , GenTreeOp          ,1,0,GTK_BINOP)
+
+// Returns high bits (top N bits of the 2N bit result of an NxN multiply)
+// GT_MULHI is used in division by a constant (LowerUnsignedDivOrMod). We turn
+// the div into a MULHI + some adjustments. In codegen, we only use the
+// results of the high register, and we drop the low results.
+GTNODE(MULHI            , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
+
+// A mul that returns the 2N bit result of an NxN multiply. This op is used for
+// multiplies that take two ints and return a long result. For 32 bit targets,
+// all other multiplies with long results are morphed into helper calls.
+// It is similar to GT_MULHI, the difference being that GT_MULHI drops the lo
+// part of the result, whereas GT_MUL_LONG keeps both parts of the result.
+// MUL_LONG is also used on ARM64, where 64 bit multiplication is more expensive.
+#if !defined(TARGET_64BIT)
+GTNODE(MUL_LONG         , GenTreeMultiRegOp  ,1,0,GTK_BINOP|DBK_NOTHIR)
+#elif defined(TARGET_ARM64)
+GTNODE(MUL_LONG         , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
+#endif
+
+GTNODE(DIV              , GenTreeOp          ,0,0,GTK_BINOP)
+GTNODE(MOD              , GenTreeOp          ,0,0,GTK_BINOP)
+
+GTNODE(UDIV             , GenTreeOp          ,0,0,GTK_BINOP)
+GTNODE(UMOD             , GenTreeOp          ,0,0,GTK_BINOP)
 
 GTNODE(EQ               , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(NE               , GenTreeOp          ,0,0,GTK_BINOP)
@@ -197,23 +226,6 @@ GTNODE(HWINTRINSIC      , GenTreeHWIntrinsic ,0,0,GTK_SPECIAL)               // 
 // Saturating increment, used in division by a constant (LowerUnsignedDivOrMod).
 GTNODE(INC_SATURATE     , GenTreeOp          ,0,0,GTK_UNOP|DBK_NOTHIR)
 
-// Returns high bits (top N bits of the 2N bit result of an NxN multiply)
-// GT_MULHI is used in division by a constant (LowerUnsignedDivOrMod). We turn
-// the div into a MULHI + some adjustments. In codegen, we only use the
-// results of the high register, and we drop the low results.
-GTNODE(MULHI            , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
-
-// A mul that returns the 2N bit result of an NxN multiply. This op is used for
-// multiplies that take two ints and return a long result. For 32 bit targets,
-// all other multiplies with long results are morphed into helper calls.
-// It is similar to GT_MULHI, the difference being that GT_MULHI drops the lo
-// part of the result, whereas GT_MUL_LONG keeps both parts of the result.
-// MUL_LONG is also used on ARM64, where 64 bit multiplication is more expensive.
-#if !defined(TARGET_64BIT)
-GTNODE(MUL_LONG         , GenTreeMultiRegOp  ,1,0,GTK_BINOP|DBK_NOTHIR)
-#elif defined(TARGET_ARM64)
-GTNODE(MUL_LONG         , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
-#endif
 // AndNot - emitted on ARM/ARM64 as the BIC instruction. Also used for creating AndNot HWINTRINSIC vector nodes in a cross-ISA manner.
 GTNODE(AND_NOT          , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 
@@ -228,17 +240,15 @@ GTNODE(BFIZ             , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR) // Bitfi
 #endif
 
 //-----------------------------------------------------------------------------
+//  Other nodes that look like unary/binary operators:
+//-----------------------------------------------------------------------------
+
+GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
+
+//-----------------------------------------------------------------------------
 //  LIR specific compare and conditional branch/set nodes:
 //-----------------------------------------------------------------------------
 
-// Sets the condition flags according to the compare result. N.B. Not a relop, it does not produce a value and it cannot be reversed.
-GTNODE(CMP              , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
-// Generate a test instruction; sets the CPU flags according to (a & b) and does not produce a value.
-GTNODE(TEST             , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
-#ifdef TARGET_XARCH
-// The XARCH BT instruction. Like CMP, this sets the condition flags (CF to be precise) and does not produce a value.
-GTNODE(BT               , GenTreeOp          ,0,0,(GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR))
-#endif
 // Makes a comparison and jumps if the condition specified by gtCondition is true. Does not set flags.
 GTNODE(JCMP             , GenTreeOpCC        ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
 // Do a bit test and jump if set/not set.
@@ -257,7 +267,6 @@ GTNODE(SELECTCC         , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
 GTNODE(CCMP             , GenTreeCCMP        ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
 #endif
 
-
 #ifdef TARGET_ARM64
 // Variant of SELECT_INC that reuses flags computed by a previous node with the specified condition.
 GTNODE(SELECT_INCCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
@@ -275,6 +284,15 @@ GTNODE(SELECT_INV       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 // Maps to arm64 csneg/cneg instruction.. Computes result = condition ? op1 : -op2.
 // If op2 is null, computes result = condition ? -op1 : op1.
 GTNODE(SELECT_NEG       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
+#endif
+
+// Sets the condition flags according to the compare result. N.B. Not a relop, it does not produce a value and it cannot be reversed.
+GTNODE(CMP              , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
+// Generate a test instruction; sets the CPU flags according to (a & b) and does not produce a value.
+GTNODE(TEST             , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
+#ifdef TARGET_XARCH
+// The XARCH BT instruction. Like CMP, this sets the condition flags (CF to be precise) and does not produce a value.
+GTNODE(BT               , GenTreeOp          ,0,0,(GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR))
 #endif
 
 //-----------------------------------------------------------------------------
@@ -306,12 +324,6 @@ GTNODE(BIT_CLEAR        , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 // Maps to binv/binvi instruction. Computes result = op1 ^ (1 << op2)
 GTNODE(BIT_INVERT       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 #endif
-
-//-----------------------------------------------------------------------------
-//  Other nodes that look like unary/binary operators:
-//-----------------------------------------------------------------------------
-
-GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
 
 //-----------------------------------------------------------------------------
 //  Other nodes that have special structure:

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -259,21 +259,22 @@ GTNODE(CCMP             , GenTreeCCMP        ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTH
 
 
 #ifdef TARGET_ARM64
+// Variant of SELECT_INC that reuses flags computed by a previous node with the specified condition.
+GTNODE(SELECT_INCCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
+// Variant of SELECT_INV that reuses flags computed by a previous node with the specified condition.
+GTNODE(SELECT_INVCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
+// Variant of SELECT_NEG that reuses flags computed by a previous node with the specified condition.
+GTNODE(SELECT_NEGCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
+
 // Maps to arm64 csinc/cinc instruction. Computes result = condition ? op1 : op2 + 1.
 // If op2 is null, computes result = condition ? op1 + 1 : op1.
 GTNODE(SELECT_INC       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
-// Variant of SELECT_INC that reuses flags computed by a previous node with the specified condition.
-GTNODE(SELECT_INCCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
 // Maps to arm64 csinv/cinv instruction. Computes result = condition ? op1 : ~op2.
 // If op2 is null, computes result = condition ? ~op1 : op1.
 GTNODE(SELECT_INV       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
-// Variant of SELECT_INV that reuses flags computed by a previous node with the specified condition.
-GTNODE(SELECT_INVCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
 // Maps to arm64 csneg/cneg instruction.. Computes result = condition ? op1 : -op2.
 // If op2 is null, computes result = condition ? -op1 : op1.
 GTNODE(SELECT_NEG       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
-// Variant of SELECT_NEG that reuses flags computed by a previous node with the specified condition.
-GTNODE(SELECT_NEGCC     , GenTreeOpCC        ,0,0,GTK_BINOP|DBK_NOTHIR)
 #endif
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -135,24 +135,6 @@ GTNODE(ADD              , GenTreeOp          ,1,0,GTK_BINOP)
 GTNODE(SUB              , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(MUL              , GenTreeOp          ,1,0,GTK_BINOP)
 
-// Returns high bits (top N bits of the 2N bit result of an NxN multiply)
-// GT_MULHI is used in division by a constant (LowerUnsignedDivOrMod). We turn
-// the div into a MULHI + some adjustments. In codegen, we only use the
-// results of the high register, and we drop the low results.
-GTNODE(MULHI            , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
-
-// A mul that returns the 2N bit result of an NxN multiply. This op is used for
-// multiplies that take two ints and return a long result. For 32 bit targets,
-// all other multiplies with long results are morphed into helper calls.
-// It is similar to GT_MULHI, the difference being that GT_MULHI drops the lo
-// part of the result, whereas GT_MUL_LONG keeps both parts of the result.
-// MUL_LONG is also used on ARM64, where 64 bit multiplication is more expensive.
-#if !defined(TARGET_64BIT)
-GTNODE(MUL_LONG         , GenTreeMultiRegOp  ,1,0,GTK_BINOP|DBK_NOTHIR)
-#elif defined(TARGET_ARM64)
-GTNODE(MUL_LONG         , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
-#endif
-
 GTNODE(DIV              , GenTreeOp          ,0,0,GTK_BINOP)
 GTNODE(MOD              , GenTreeOp          ,0,0,GTK_BINOP)
 
@@ -226,6 +208,24 @@ GTNODE(HWINTRINSIC      , GenTreeHWIntrinsic ,0,0,GTK_SPECIAL)               // 
 // Saturating increment, used in division by a constant (LowerUnsignedDivOrMod).
 GTNODE(INC_SATURATE     , GenTreeOp          ,0,0,GTK_UNOP|DBK_NOTHIR)
 
+// Returns high bits (top N bits of the 2N bit result of an NxN multiply)
+// GT_MULHI is used in division by a constant (LowerUnsignedDivOrMod). We turn
+// the div into a MULHI + some adjustments. In codegen, we only use the
+// results of the high register, and we drop the low results.
+GTNODE(MULHI            , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
+
+// A mul that returns the 2N bit result of an NxN multiply. This op is used for
+// multiplies that take two ints and return a long result. For 32 bit targets,
+// all other multiplies with long results are morphed into helper calls.
+// It is similar to GT_MULHI, the difference being that GT_MULHI drops the lo
+// part of the result, whereas GT_MUL_LONG keeps both parts of the result.
+// MUL_LONG is also used on ARM64, where 64 bit multiplication is more expensive.
+#if !defined(TARGET_64BIT)
+GTNODE(MUL_LONG         , GenTreeMultiRegOp  ,1,0,GTK_BINOP|DBK_NOTHIR)
+#elif defined(TARGET_ARM64)
+GTNODE(MUL_LONG         , GenTreeOp          ,1,0,GTK_BINOP|DBK_NOTHIR)
+#endif
+
 // AndNot - emitted on ARM/ARM64 as the BIC instruction. Also used for creating AndNot HWINTRINSIC vector nodes in a cross-ISA manner.
 GTNODE(AND_NOT          , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 
@@ -240,15 +240,17 @@ GTNODE(BFIZ             , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR) // Bitfi
 #endif
 
 //-----------------------------------------------------------------------------
-//  Other nodes that look like unary/binary operators:
-//-----------------------------------------------------------------------------
-
-GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
-
-//-----------------------------------------------------------------------------
 //  LIR specific compare and conditional branch/set nodes:
 //-----------------------------------------------------------------------------
 
+// Sets the condition flags according to the compare result. N.B. Not a relop, it does not produce a value and it cannot be reversed.
+GTNODE(CMP              , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
+// Generate a test instruction; sets the CPU flags according to (a & b) and does not produce a value.
+GTNODE(TEST             , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
+#ifdef TARGET_XARCH
+// The XARCH BT instruction. Like CMP, this sets the condition flags (CF to be precise) and does not produce a value.
+GTNODE(BT               , GenTreeOp          ,0,0,(GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR))
+#endif
 // Makes a comparison and jumps if the condition specified by gtCondition is true. Does not set flags.
 GTNODE(JCMP             , GenTreeOpCC        ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
 // Do a bit test and jump if set/not set.
@@ -286,15 +288,6 @@ GTNODE(SELECT_INV       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 GTNODE(SELECT_NEG       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 #endif
 
-// Sets the condition flags according to the compare result. N.B. Not a relop, it does not produce a value and it cannot be reversed.
-GTNODE(CMP              , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
-// Generate a test instruction; sets the CPU flags according to (a & b) and does not produce a value.
-GTNODE(TEST             , GenTreeOp          ,0,0,GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR)
-#ifdef TARGET_XARCH
-// The XARCH BT instruction. Like CMP, this sets the condition flags (CF to be precise) and does not produce a value.
-GTNODE(BT               , GenTreeOp          ,0,0,(GTK_BINOP|GTK_NOVALUE|DBK_NOTHIR))
-#endif
-
 //-----------------------------------------------------------------------------
 //  LIR specific arithmetic nodes:
 //-----------------------------------------------------------------------------
@@ -324,6 +317,12 @@ GTNODE(BIT_CLEAR        , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 // Maps to binv/binvi instruction. Computes result = op1 ^ (1 << op2)
 GTNODE(BIT_INVERT       , GenTreeOp          ,0,0,GTK_BINOP|DBK_NOTHIR)
 #endif
+
+//-----------------------------------------------------------------------------
+//  Other nodes that look like unary/binary operators:
+//-----------------------------------------------------------------------------
+
+GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
 
 //-----------------------------------------------------------------------------
 //  Other nodes that have special structure:


### PR DESCRIPTION
Ideally this improves throughput minimally by doing less checks. Not all the compilers consistently catch and fold this themselves.