### PR TITLE
JIT: fix Vector{128,256}.ConvertToInt32 use-before-def in gtNewSimdCvtNode

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -23197,8 +23197,8 @@ GenTree* Compiler::gtNewSimdCvtNode(
         // mask1 contains the output either 0xFFFFFFFF or 0.
         // FixupVal zeros out any NaN values in the input by ANDing input with mask1.
         GenTree* op1Clone1 = fgMakeMultiUse(&op1);
-        GenTree* mask1     = gtNewSimdIsNaNNode(type, op1, simdSourceBaseType, simdSize);
-        fixupVal           = gtNewSimdBinOpNode(GT_AND_NOT, type, op1Clone1, mask1, simdSourceBaseType, simdSize);
+        GenTree* mask1     = gtNewSimdIsNaNNode(type, op1Clone1, simdSourceBaseType, simdSize);
+        fixupVal           = gtNewSimdBinOpNode(GT_AND_NOT, type, op1, mask1, simdSourceBaseType, simdSize);
     }
 
     if (varTypeIsSigned(simdTargetBaseType))


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/127440

Fixes a use-before-def in the non-AVX-512 saturation path of `Compiler::gtNewSimdCvtNode` that produces wrong results for `Vector{128,256,512}.ConvertToInt32(Vector*<float>)` when the input is not invariant or a local.

## Repro (DOTNET_EnableAVX512=0)

```cs
[MethodImpl(MethodImplOptions.NoInlining)]
static Vector512<int> Test() => Vector512.ConvertToInt32(Vector512.Create(float.MinValue));
```

Before this PR:
```
<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2147483647, 0, 0, 0>
```
After this PR:
```
<-2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648,
 -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648, -2147483648>
```

## Root cause

```cpp
GenTree* op1Clone1 = fgMakeMultiUse(&op1);   // op1 := COMMA(STORE temp = orig, LCL_VAR temp); op1Clone1 := fresh LCL_VAR temp
GenTree* mask1     = gtNewSimdIsNaNNode(type, op1, ...);                  // uses op1 (the COMMA)
fixupVal           = gtNewSimdBinOpNode(GT_AND_NOT, op1Clone1, mask1, …); // AND_NOT(LCL_VAR temp, IsNaN(COMMA(STORE temp, ...)))
```

`AND_NOT(a, b)` decomposes into `AND(a, NOT(b))`, so the left operand `a` evaluates first. The `LCL_VAR temp` read happens **before** the `STORE temp` that lives inside the COMMA on the right, so the AND consumes whatever was on the stack.

Disasm on main with AVX-512 disabled (only the relevant block, V05 / V08 are the temps in question):

```asm
vpcmpeqd ymm0, ymm0, ymm0
vandps   ymm0, ymm0, ymmword ptr [rsp+0x20]   ; reads V05 - never written
vbroadcastss ymm1, dword ptr [reloc @RWD00]
vcmpgeps ymm2, ymm0, ymm1
vbroadcastss ymm3, dword ptr [reloc @RWD04]
vcvttps2dq ymm0, ymm0
vpblendvb ymm0, ymm0, ymm3, ymm2
vmovups  ymm2, ymmword ptr [rsp]              ; reads V08 - never written
...
```

The bug has existed since `gtNewSimdCvtNode` was first introduced; it stayed latent because pre-#127124 / #127402 the inner `IsNaN(op1)` expanded into per-element compares that kept enough materialization around to mask the bad ordering. With SIMD32/64 constant propagation, `CompareNotEqual(temp, temp)` value-numbers as AllBitsSet and the whole right subtree collapses to constants, leaving only the broken left-side read - which is exactly what `Vector512Tests.ConvertToInt32Test` started catching on non-AVX-512 hosts.

## Fix

Two-line swap: pass `op1` (the COMMA, evaluated first) as `AND_NOT`'s left arg; use the clone for the IsNaN check.

```cpp
GenTree* op1Clone1 = fgMakeMultiUse(&op1);
GenTree* mask1     = gtNewSimdIsNaNNode(type, op1Clone1, simdSourceBaseType, simdSize);
fixupVal           = gtNewSimdBinOpNode(GT_AND_NOT, type, op1, mask1, simdSourceBaseType, simdSize);
```

Now the COMMA evaluates first, the STORE happens, both subsequent reads of the temp get the correct value.

## Validation

- Repro produces correct output on AVX-512 disabled and AVX-512 enabled.
- `Vector512Tests.ConvertToInt32Test` / `ConvertToInt32NativeTest` pass with `DOTNET_EnableAVX512=0`.
- SuperPMI replay against `benchmarks.run` clean (38409 contexts, 0 failures, 0 asserts).

## Note on #127499

That PR adds an AVX-512 gate in `impSpecialIntrinsic`'s `NI_Vector512_ConvertToInt32` case. As @tannergooding pointed out in https://github.com/dotnet/runtime/pull/127499#discussion_r3154379943 / https://github.com/dotnet/runtime/pull/127499#discussion_r3154400992, that case is already unreachable on non-AVX-512 hosts because `Compiler::lookupId` returns `NI_Illegal` for `Vector512` ISA when AVX-512 is not opportunistically supported. I verified that applying #127499 alone leaves the test failing - the gate it adds is dead code. This PR addresses the actual bug; #127499 can be closed.

Fixes #127440.