### PR TITLE
[QUIC] Do not allocate exception if it might not be used

### DIFF
--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -672,7 +672,10 @@ public sealed partial class QuicStream
             _receiveTcs.TrySetException(exception);
             _sendTcs.TrySetException(exception);
         }
-        _startedTcs.TrySetException(ThrowHelper.GetOperationAbortedException());
+        if (!_startedTcs.IsCompleted)
+        {
+            _startedTcs.TrySetException(ThrowHelper.GetOperationAbortedException());
+        }
         _shutdownTcs.TrySetResult();
         return QUIC_STATUS_SUCCESS;
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/127455
Validation manual on the repro code, before:
<img width="1904" height="664" alt="before" src="https://github.com/user-attachments/assets/08dd64f7-c4f6-421b-add2-5a2182fc84a0" />
after (no more `QuicException`):
<img width="1901" height="662" alt="after" src="https://github.com/user-attachments/assets/739e6423-2820-40e3-9cf6-6b1ca849ccbc" />
