### PR TITLE
Add catalog signing for .js files during MSI installer phase

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -49,9 +49,13 @@
     <MacOSPkg Include="$(ArtifactsPackagesDir)**/dotnet-runtime*.pkg" Exclude="$(ArtifactsPackagesDir)**/dotnet-runtime-internal*.pkg" />
     <FileSignInfo Include="@(MacOSPkg->'%(Filename)%(Extension)')" CertificateName="MacDeveloperWithNotarization" />
 
-    <!-- We don't need to code sign .js files because they are not used in Windows Script Host. -->
-    <!-- WARNING: Needs to happed outside of any target -->
+    <!-- JS files are customer-modifiable runtime/toolchain files. They cannot be
+         Authenticode-signed because modifying a signed file breaks the signature.
+         Instead, a catalog file (.cat) is generated and signed to provide integrity
+         verification. See the GenerateCatalogForJsFiles target in
+         src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Mono.sfxproj. -->
     <FileExtensionSignInfo Update=".js" CertificateName="None" />
+    <FileExtensionSignInfo Include=".cat" CertificateName="Microsoft400" />
 
     <!-- Third-party components which should be signed.  -->
     <FileSignInfo Include="Antlr4.Runtime.Standard.dll" CertificateName="3PartySHA2" />

--- a/eng/generate-catalog.ps1
+++ b/eng/generate-catalog.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Generates a catalog definition file (.cdf) and catalog file (.cat) for all .js files
+    in the specified root directory. Used for VS signing compliance - the .js files are
+    customer-modifiable and cannot be directly Authenticode-signed.
+
+.PARAMETER RootPath
+    Root directory to search for .js files recursively.
+
+.PARAMETER CatOutputPath
+    Full path for the output .cat file.
+#>
+param(
+    [Parameter(Mandatory)][string]$RootPath,
+    [Parameter(Mandatory)][string]$CatOutputPath,
+    [string]$WindowsSdkDir = '',
+    [switch]$ErrorIfMakecatNotFound
+)
+
+$ErrorActionPreference = 'Stop'
+
+$cdfPath = [System.IO.Path]::ChangeExtension($CatOutputPath, '.cdf')
+
+$files = Get-ChildItem -Path $RootPath -Recurse -Filter '*.js' -File
+if ($files.Count -eq 0) {
+    Write-Warning "No .js files found under $RootPath - skipping catalog generation."
+    exit 0
+}
+
+# Ensure output directory exists before writing files
+$catDir = [System.IO.Path]::GetDirectoryName($CatOutputPath)
+if (-not (Test-Path $catDir)) {
+    New-Item -ItemType Directory -Path $catDir -Force | Out-Null
+}
+
+$cdf = @()
+$cdf += '[CatalogHeader]'
+$cdf += "Name=$CatOutputPath"
+$cdf += 'CatalogVersion=2'
+$cdf += 'HashAlgorithms=SHA256'
+$cdf += ''
+$cdf += '[CatalogFiles]'
+
+$i = 0
+foreach ($f in $files) {
+    $label = "js_${i}_" + ($f.Name -replace '[^\w\.-]', '_')
+    $cdf += "<hash>$label=$($f.FullName)"
+    $i++
+}
+
+$cdf | Set-Content -Path $cdfPath -Encoding ASCII
+Write-Host "Generated CDF with $($files.Count) .js files at $cdfPath"
+
+# Find makecat.exe - it ships with the Windows SDK and may not be on PATH.
+$makecat = $null
+if ($WindowsSdkDir -and (Test-Path $WindowsSdkDir)) {
+    $makecat = Get-ChildItem -Path (Join-Path $WindowsSdkDir 'bin') -Recurse -Filter 'makecat.exe' -File |
+        Where-Object { $_.DirectoryName -match 'x64' } |
+        Sort-Object DirectoryName -Descending |
+        Select-Object -First 1
+}
+
+if (-not $makecat) {
+    $makecat = Get-Command makecat.exe -ErrorAction SilentlyContinue
+}
+
+if (-not $makecat) {
+    # Fallback: search common Windows SDK locations
+    $sdkRoot = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+    if (Test-Path $sdkRoot) {
+        $makecat = Get-ChildItem -Path $sdkRoot -Recurse -Filter 'makecat.exe' -File |
+            Where-Object { $_.DirectoryName -match 'x64' } |
+            Sort-Object DirectoryName -Descending |
+            Select-Object -First 1
+    }
+}
+
+if (-not $makecat) {
+    if ($ErrorIfMakecatNotFound) {
+        throw "makecat.exe not found. Catalog signing requires the Windows SDK which must be available in CI builds."
+    }
+    Write-Warning "makecat.exe not found - skipping catalog generation. Catalog signing requires the Windows SDK."
+    exit 0
+}
+
+$makecatPath = if ($makecat -is [System.Management.Automation.CommandInfo]) { $makecat.Source } else { $makecat.FullName }
+Write-Host "Using makecat.exe at: $makecatPath"
+
+& $makecatPath $cdfPath
+if ($LASTEXITCODE -ne 0) {
+    throw "makecat.exe failed with exit code $LASTEXITCODE"
+}
+
+Write-Host "Generated catalog file: $CatOutputPath"

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Mono.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.Mono.sfxproj
@@ -70,4 +70,35 @@
       <ReferenceCopyLocalPaths Include="@(MonoRuntimeFiles)" />
     </ItemGroup>
   </Target>
+
+  <!--
+    Generate a catalog (.cat) file covering all .js files in the runtime pack
+    during the MSI installer build phase. This target runs AFTER PublishToDisk
+    extracts the NuPkg contents into the installer layout directory, and BEFORE
+    WiX Heat harvests files for the MSI. This ensures the .cat is included in
+    the MSI alongside the .js files it covers.
+
+    Key design: The NuPkg is built on Linux (in the VMR), but the MSI installer
+    is built on Windows. This target hooks into the installer phase (Windows)
+    rather than the pack phase (Linux), so makecat.exe is available.
+
+    The .js files are customer-modifiable runtime/toolchain files that cannot be
+    directly Authenticode-signed. The .cat provides integrity verification
+    without preventing modification. Same pattern as dotnet/emsdk#1671.
+  -->
+  <Target Name="GenerateCatalogForJsFiles"
+          AfterTargets="PublishToDisk"
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) and
+                     '$(RuntimeIdentifier)' == 'browser-wasm' and
+                     '$(GenerateMSI)' == 'true'">
+    <PropertyGroup>
+      <_CatalogRootPath>$(OutputPath)</_CatalogRootPath>
+      <_CatOutputPath>$(OutputPath)mono-runtime-js.cat</_CatOutputPath>
+      <_ErrorIfMakecatNotFound Condition="'$(ContinuousIntegrationBuild)' == 'true' or '$(OfficialBuild)' == 'true'">-ErrorIfMakecatNotFound</_ErrorIfMakecatNotFound>
+    </PropertyGroup>
+
+    <Exec Command="powershell.exe -NoProfile -ExecutionPolicy Bypass -Command &quot;&amp; '$(RepoRoot)eng\generate-catalog.ps1' -RootPath '$(_CatalogRootPath)' -CatOutputPath '$(_CatOutputPath)' -WindowsSdkDir '$(WindowsSdkDir)' $(_ErrorIfMakecatNotFound)&quot;" StandardOutputImportance="High" />
+
+    <Message Condition="Exists('$(_CatOutputPath)')" Importance="High" Text="Generated catalog file: $(_CatOutputPath)" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Problem

The Visual Studio signing scan flags 198 unsigned `.js` files across Mono browser-wasm runtime pack MSI payloads (.NET 6-10). These are customer-modifiable runtime/toolchain files that cannot be directly Authenticode-signed.

Additionally, 282 `.cab` files are unsigned, but that fix is handled separately in dotnet/arcade#16742 (adds `.cab` to default `FileExtensionSignInfo`).

## Root Cause

`eng/Signing.props` explicitly sets `.js` to `CertificateName="None"`, skipping Authenticode signing. This is correct behavior (the files are customer-modifiable), but VS signing compliance requires every signable file to have integrity verification.

## Approach

Catalog signing, following the pattern from dotnet/emsdk#1671. Instead of Authenticode-signing each `.js` file (which would break on modification), generate a `.cat` catalog file that provides integrity verification.

### Key design: Installer phase, not pack phase

The Mono browser-wasm runtime pack NuPkg is built on **Linux** in the VMR (dotnet/dotnet). However, the MSI installer is generated on **Windows** (the installer stage). This PR hooks the catalog generation into the **installer phase** (`AfterTargets="PublishToDisk"`), which runs on Windows where `makecat.exe` is available.

This addresses the feedback from dotnet/runtime#127242 where @jkoritzinsky noted that the original approach (hooking into the pack phase) would never trigger because the pack is built on Linux in the VMR.

```
Linux Leg (VMR)                    Windows Leg (Installer Stage)
┌──────────────────────┐           ┌──────────────────────────────┐
│ Build Mono Runtime   │           │ PublishToDisk (extract NuPkg)│
│ Package sfxproj      │──artifact─▶ GenerateCatalogForJsFiles ◄──── NEW
│ NuPkg (.js unsigned) │           │ WiX Heat (includes .cat)     │
└──────────────────────┘           │ WiX Light → MSI              │
                                   │ Arcade SignTool:              │
                                   │  .cat → Microsoft400 ✅       │
                                   │  .js  → None (covered) ✅     │
                                   └──────────────────────────────┘
```

### Target conditions

The `GenerateCatalogForJsFiles` target only runs when all three conditions are met:
1. `IsOSPlatform('Windows')` — `makecat.exe` requires Windows
2. `RuntimeIdentifier == 'browser-wasm'` — only browser-wasm packs contain .js files
3. `GenerateMSI == 'true'` — only runs during the MSI installer build phase

## Changes

| File | Change |
|------|--------|
| `eng/Signing.props` | Keep `.js` as `None`; add `.cat` with `Microsoft400` (auto-replaced by `MicrosoftDotNet500` via `UseDotNetCertificate`) |
| `eng/generate-catalog.ps1` | New script — generates CDF listing all .js files, runs `makecat.exe` to produce .cat |
| `src/installer/pkg/sfx/.../Microsoft.NETCore.App.Runtime.Mono.sfxproj` | `GenerateCatalogForJsFiles` target hooked to installer phase |

## Related PRs

- dotnet/arcade#16742 — Add `.cab` to default `FileExtensionSignInfo` (covers all repos)
- dotnet/emsdk#1671 — Same catalog signing pattern for Emscripten SDK (merged, same VMR limitation)
- dotnet/runtime#127242 — Previous attempt (hooks into pack phase; doesn't work in VMR)

## Tracking

VS signing compliance: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2911494
