### PR TITLE
Fix Wasm ArgIterator SizeOfArgStack for methods with only hidden args

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ArgIterator.cs
@@ -1721,10 +1721,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     }
                 }
 
-                if (maxOffset == 0 && _transitionBlock.IsWasm32)
+                if (maxOffset == _transitionBlock.OffsetOfArgs && _transitionBlock.IsWasm32)
                 {
                     // Wasm puts all arguments on the stack, even the unnamed ones like the param registers, this pointer and async continuation. If we didn't see any named arguments, then we need to account for the unnamed ones here.
-                    maxOffset = _wasmOfsStack;
+                    maxOffset = _transitionBlock.OffsetOfArgs + _wasmOfsStack;
                 }
 
                 // Clear the iterator started flag


### PR DESCRIPTION
The ForceSigWalk method had two bugs in its Wasm-specific path for accounting for hidden arguments (this, retbuf, generic context, etc.) when no named arguments are present:

1. The check 'maxOffset == 0' could never be true because maxOffset is initialized to OffsetOfArgs (8 on Wasm32). Changed to compare against OffsetOfArgs.

2. The fallback 'maxOffset = _wasmOfsStack' was incorrect because _wasmOfsStack is relative to OffsetOfArgs, but maxOffset is an absolute offset. Changed to 'OffsetOfArgs + _wasmOfsStack'.

These bugs caused GCRefMapBuilder to allocate a zero-length fake stack for methods with only unnamed arguments (e.g. parameterless instance methods), leading to IndexOutOfRangeException when writing the 'this' pointer GC ref at ThisOffset.