### PR TITLE
X25519DiffieHellmanOpenSsl

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
@@ -30,6 +30,11 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519GenerateKey")]
         private static partial SafeEvpPKeyHandle CryptoNative_X25519GenerateKey();
 
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519IsValidHandle")]
+        private static partial int CryptoNative_X25519IsValidHandle(
+            SafeEvpPKeyHandle key,
+            [MarshalAs(UnmanagedType.Bool)] out bool hasPrivateKey);
+
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519ImportPrivateKey")]
         private static partial SafeEvpPKeyHandle X25519ImportPrivateKey(ReadOnlySpan<byte> source, int sourceLength);
 
@@ -86,6 +91,26 @@ internal static partial class Interop
             }
 
             return key;
+        }
+
+        internal static bool X25519IsValidHandle(SafeEvpPKeyHandle key, out bool hasPrivateKey)
+        {
+            const int Success = 1;
+            const int Fail = 0;
+
+            int ret = CryptoNative_X25519IsValidHandle(key, out hasPrivateKey);
+
+            switch (ret)
+            {
+                case Success:
+                    return true;
+                case Fail:
+                    hasPrivateKey = false;
+                    return false;
+                default:
+                    Debug.Fail($"{nameof(CryptoNative_X25519IsValidHandle)} returned '{ret}' unexpectedly.");
+                    throw CreateOpenSslCryptographicException();
+            }
         }
 
         internal static SafeEvpPKeyHandle X25519ImportPrivateKey(ReadOnlySpan<byte> source)

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -3493,6 +3493,22 @@ namespace System.Security.Cryptography
         protected abstract bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten);
         public bool TryExportSubjectPublicKeyInfo(System.Span<byte> destination, out int bytesWritten) { throw null; }
     }
+    public sealed partial class X25519DiffieHellmanOpenSsl : System.Security.Cryptography.X25519DiffieHellman
+    {
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("android")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("browser")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("ios")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("osx")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("tvos")]
+        [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
+        public X25519DiffieHellmanOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
+        protected override void DeriveRawSecretAgreementCore(System.Security.Cryptography.X25519DiffieHellman otherParty, System.Span<byte> destination) { }
+        protected override void Dispose(bool disposing) { }
+        public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
+        protected override void ExportPrivateKeyCore(System.Span<byte> destination) { }
+        protected override void ExportPublicKeyCore(System.Span<byte> destination) { }
+        protected override bool TryExportPkcs8PrivateKeyCore(System.Span<byte> destination, out int bytesWritten) { throw null; }
+    }
 }
 namespace System.Security.Cryptography.X509Certificates
 {

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -543,6 +543,9 @@
   <data name="Cryptography_KemInvalidAlgorithmHandle" xml:space="preserve">
     <value>The specified EVP_PKEY handle is not a known ML-KEM algorithm.</value>
   </data>
+  <data name="Cryptography_X25519InvalidAlgorithmHandle" xml:space="preserve">
+    <value>The specified EVP_PKEY handle is not an X25519 Diffie-Hellman key.</value>
+  </data>
   <data name="Cryptography_KemNoDecapsulationKey" xml:space="preserve">
     <value>The current instance does not contain a decapsulation key.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -688,6 +688,7 @@
     <Compile Include="System\Security\Cryptography\UniversalCryptoDecryptor.cs" />
     <Compile Include="System\Security\Cryptography\UniversalCryptoOneShot.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellman.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\XmlKeyHelper.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificateExtensionsCommon.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificatePal.cs" />
@@ -886,6 +887,7 @@
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellmanImplementation.NotSupported.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificatePal.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\ChainPal.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\FindPal.NotSupported.cs" />
@@ -1130,6 +1132,7 @@
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.Wrap.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.OpenSsl.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellmanImplementation.OpenSsl.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.OpenSsl.cs" />
     <AsnXml Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml" />
     <Compile Include="System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml.cs">
       <DependentUpon>System\Security\Cryptography\X509Certificates\Asn1\DistributionPointAsn.xml</DependentUpon>
@@ -1299,6 +1302,7 @@
     <Compile Include="System\Security\Cryptography\Shake128.NonWindows.cs" />
     <Compile Include="System\Security\Cryptography\Shake256.NonWindows.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellmanImplementation.NotSupported.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StorePal.Android.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StorePal.Android.AndroidKeyStore.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\StorePal.Android.ExportPal.cs" />
@@ -1437,6 +1441,7 @@
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.Wrap.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.Apple.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellmanImplementation.Apple.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\AppleCertificatePal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\AppleCertificatePal.TempExportPal.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificateData.ManagedDecode.cs" />
@@ -2031,6 +2036,7 @@
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.Wrap.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.Windows.cs" />
     <Compile Include="System\Security\Cryptography\X25519DiffieHellmanImplementation.Windows.cs" />
+    <Compile Include="System\Security\Cryptography\X25519DiffieHellmanOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificateHelpers.Windows.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificatePal.Windows.cs" />
     <Compile Include="System\Security\Cryptography\X509Certificates\CertificatePal.Windows.Import.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
@@ -11,6 +11,7 @@ namespace System.Security.Cryptography
         private readonly bool _hasPrivate;
 
         internal static new bool IsSupported { get; } = Interop.Crypto.X25519Available();
+        internal SafeEvpPKeyHandle Key => _key;
 
         private X25519DiffieHellmanImplementation(SafeEvpPKeyHandle key, bool hasPrivate)
         {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class X25519DiffieHellmanOpenSsl
+    {
+        public partial X25519DiffieHellmanOpenSsl(SafeEvpPKeyHandle pkeyHandle)
+        {
+            _ = pkeyHandle;
+            throw new PlatformNotSupportedException();
+        }
+
+        public partial SafeEvpPKeyHandle DuplicateKeyHandle()
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void ExportPrivateKeyCore(Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override void ExportPublicKeyCore(Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+
+namespace System.Security.Cryptography
+{
+    public sealed partial class X25519DiffieHellmanOpenSsl
+    {
+        private readonly SafeEvpPKeyHandle _key;
+        private readonly bool _hasPrivate;
+
+        public partial X25519DiffieHellmanOpenSsl(SafeEvpPKeyHandle pkeyHandle)
+        {
+            ArgumentNullException.ThrowIfNull(pkeyHandle);
+
+            if (pkeyHandle.IsInvalid)
+            {
+                throw new ArgumentException(SR.Cryptography_OpenInvalidHandle, nameof(pkeyHandle));
+            }
+
+            _key = pkeyHandle.DuplicateHandle();
+            bool isValid = Interop.Crypto.X25519IsValidHandle(_key, out _hasPrivate);
+
+            if (!isValid)
+            {
+                _key.Dispose();
+                throw new CryptographicException(SR.Cryptography_X25519InvalidAlgorithmHandle);
+            }
+        }
+
+        public partial SafeEvpPKeyHandle DuplicateKeyHandle()
+        {
+            ThrowIfDisposed();
+            return _key.DuplicateHandle();
+        }
+
+        protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            ThrowIfPrivateNeeded();
+
+            int written;
+
+            if (otherParty is X25519DiffieHellmanOpenSsl x25519OpenSsl)
+            {
+                written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, x25519OpenSsl._key, destination);
+            }
+            else
+            {
+                Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
+                otherParty.ExportPublicKey(publicKey);
+
+                using (SafeEvpPKeyHandle peerKeyHandle = Interop.Crypto.X25519ImportPublicKey(publicKey))
+                {
+                    written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, peerKeyHandle, destination);
+                }
+            }
+
+            if (written != SecretAgreementSizeInBytes)
+            {
+                Debug.Fail($"{nameof(Interop.Crypto.EvpPKeyDeriveSecretAgreement)} wrote an unexpected number of bytes: {written}.");
+                throw new CryptographicException();
+            }
+        }
+
+        protected override void ExportPrivateKeyCore(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == PrivateKeySizeInBytes);
+            ThrowIfPrivateNeeded();
+            Interop.Crypto.X25519ExportPrivateKey(_key, destination);
+        }
+
+        protected override void ExportPublicKeyCore(Span<byte> destination)
+        {
+            Debug.Assert(destination.Length == PublicKeySizeInBytes);
+            Interop.Crypto.X25519ExportPublicKey(_key, destination);
+        }
+
+        protected override bool TryExportPkcs8PrivateKeyCore(Span<byte> destination, out int bytesWritten)
+        {
+            ThrowIfPrivateNeeded();
+            return TryExportPkcs8PrivateKeyImpl(destination, out bytesWritten);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _key.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        private void ThrowIfPrivateNeeded()
+        {
+            if (!_hasPrivate)
+                throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -46,6 +46,10 @@ namespace System.Security.Cryptography
             {
                 written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, x25519OpenSsl._key, destination);
             }
+            else if (otherParty is X25519DiffieHellmanImplementation x25519Impl)
+            {
+                written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, x25519Impl.Key, destination);
+            }
             else
             {
                 Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.Versioning;
+
+namespace System.Security.Cryptography
+{
+    /// <summary>
+    ///   Represents an X25519 Diffie-Hellman key backed by OpenSSL.
+    /// </summary>
+    /// <remarks>
+    ///   <para>
+    ///     This algorithm is specified by RFC 7748.
+    ///   </para>
+    ///   <para>
+    ///     Developers are encouraged to program against the <c>X25519DiffieHellman</c> base class,
+    ///     rather than any specific derived class.
+    ///     The derived classes are intended for interop with the underlying system
+    ///     cryptographic libraries.
+    ///   </para>
+    /// </remarks>
+    public sealed partial class X25519DiffieHellmanOpenSsl : X25519DiffieHellman
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="X25519DiffieHellmanOpenSsl" /> class from an existing OpenSSL key
+        ///   represented as an <c>EVP_PKEY*</c>.
+        /// </summary>
+        /// <param name="pkeyHandle">
+        ///   The OpenSSL <c>EVP_PKEY*</c> value to use as the key, represented as a <see cref="SafeEvpPKeyHandle" />.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="pkeyHandle" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   <para>The handle in <paramref name="pkeyHandle" /> is not recognized as an X25519 Diffie-Hellman key.</para>
+        ///   <para>-or-</para>
+        ///   <para>An error occurred while creating the algorithm instance.</para>
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        ///   The handle in <paramref name="pkeyHandle" /> is already disposed.
+        /// </exception>
+        [UnsupportedOSPlatform("android")]
+        [UnsupportedOSPlatform("browser")]
+        [UnsupportedOSPlatform("ios")]
+        [UnsupportedOSPlatform("osx")]
+        [UnsupportedOSPlatform("tvos")]
+        [UnsupportedOSPlatform("windows")]
+        public partial X25519DiffieHellmanOpenSsl(SafeEvpPKeyHandle pkeyHandle);
+
+        /// <summary>
+        ///   Gets a <see cref="SafeEvpPKeyHandle" /> representation of the cryptographic key.
+        /// </summary>
+        /// <returns>A <see cref="SafeEvpPKeyHandle" /> representation of the cryptographic key.</returns>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public partial SafeEvpPKeyHandle DuplicateKeyHandle();
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -785,6 +785,8 @@
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.MLDsa.cs" />
     <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.SlhDsa.cs"
              Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.SlhDsa.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.X25519.cs"
+             Link="Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EvpPkey.X25519.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PersistedFiles.Unix.cs"
              Link="Common\System\IO\PersistedFiles.Unix.cs" />
     <Compile Include="$(CoreLibSharedDir)System\IO\PersistedFiles.Names.Unix.cs"
@@ -794,6 +796,7 @@
     <Compile Include="MLKemOpenSslTests.Unix.cs" />
     <Compile Include="SlhDsaOpenSslConstructionTests.Unix.cs" />
     <Compile Include="SlhDsaOpenSslTests.cs" />
+    <Compile Include="X25519DiffieHellmanOpenSslTests.Unix.cs" />
     <Compile Include="X509Certificates\HostnameMatchTests.Unix.cs" />
     <Compile Include="X509Certificates\X509FilesystemTests.Unix.cs" />
     <Compile Include="X509Certificates\X509StoreTests.Unix.cs" />

--- a/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
+++ b/src/libraries/System.Security.Cryptography/tests/System.Security.Cryptography.Tests.csproj
@@ -715,6 +715,7 @@
   <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true' or '$(UseAppleCrypto)' == 'true'">
     <Compile Include="MLKemOpenSslTests.NotSupported.cs" />
     <Compile Include="SlhDsaOpenSslConstructionTests.NotSupported.cs" />
+    <Compile Include="X25519DiffieHellmanOpenSslTests.NotSupported.cs" />
     <Compile Include="X509Certificates\X509StoreMutableTests.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(UseAndroidCrypto)' == 'true'">
@@ -845,6 +846,7 @@
 
     <Compile Include="MLKemOpenSslTests.NotSupported.cs" />
     <Compile Include="SlhDsaOpenSslConstructionTests.NotSupported.cs" />
+    <Compile Include="X25519DiffieHellmanOpenSslTests.NotSupported.cs" />
     <Compile Include="X509Certificates\InteropTests.Windows.cs" />
     <Compile Include="X509Certificates\X509FilesystemTests.Windows.cs" />
   </ItemGroup>

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.NotSupported.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    public sealed class X25519DiffieHellmanOpenSslTests
+    {
+        [Fact]
+        public static void X25519DiffieHellmanOpenSsl_NotSupportedOnNonUnixPlatforms()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new X25519DiffieHellmanOpenSsl(new SafeEvpPKeyHandle()));
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
@@ -63,5 +63,104 @@ namespace System.Security.Cryptography.Tests
             Assert.False(key.IsInvalid, nameof(key.IsInvalid));
             Assert.NotNull(xdh.ExportPrivateKey());
         }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_OpenSslKeyWithCreateKey_Symmetric()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
+
+            byte[] secret1 = openSslKey.DeriveRawSecretAgreement(createKey);
+            byte[] secret2 = createKey.DeriveRawSecretAgreement(openSslKey);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_OpenSslKeyWithCreateKey_ExactBuffers()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
+
+            byte[] secret1 = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            byte[] secret2 = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            openSslKey.DeriveRawSecretAgreement(createKey, secret1);
+            createKey.DeriveRawSecretAgreement(openSslKey, secret2);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_OpenSslKeyWithImportedCreateKey()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+
+            byte[] openSslPublicKey = openSslKey.ExportPublicKey();
+            using X25519DiffieHellman createKeyFromPublic = X25519DiffieHellman.ImportPublicKey(openSslPublicKey);
+
+            using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
+
+            byte[] secret1 = openSslKey.DeriveRawSecretAgreement(createKey);
+            byte[] secret2 = createKey.DeriveRawSecretAgreement(openSslKey);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_CreateKeyWithOpenSslPublicOnly()
+        {
+            using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
+
+            byte[] createPublicKey = createKey.ExportPublicKey();
+            using X25519DiffieHellmanOpenSsl openSslPublicOnly = (X25519DiffieHellmanOpenSsl)ImportPublicKey(createPublicKey);
+
+            using X25519DiffieHellmanOpenSsl openSslPrivate = (X25519DiffieHellmanOpenSsl)GenerateKey();
+
+            byte[] secret1 = openSslPrivate.DeriveRawSecretAgreement(createKey);
+            byte[] secret2 = createKey.DeriveRawSecretAgreement(openSslPrivate);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_PrivateKeyRoundtripBetweenOpenSslAndCreate()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            byte[] privateKey = openSslKey.ExportPrivateKey();
+
+            using X25519DiffieHellman createFromPrivate = X25519DiffieHellman.ImportPrivateKey(privateKey);
+            using X25519DiffieHellman peer = X25519DiffieHellman.GenerateKey();
+
+            byte[] secret1 = openSslKey.DeriveRawSecretAgreement(peer);
+            byte[] secret2 = createFromPrivate.DeriveRawSecretAgreement(peer);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_Pkcs8RoundtripBetweenOpenSslAndCreate()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            byte[] pkcs8 = openSslKey.ExportPkcs8PrivateKey();
+
+            using X25519DiffieHellman createFromPkcs8 = X25519DiffieHellman.ImportPkcs8PrivateKey(pkcs8);
+            using X25519DiffieHellman peer = X25519DiffieHellman.GenerateKey();
+
+            byte[] secret1 = openSslKey.DeriveRawSecretAgreement(peer);
+            byte[] secret2 = createFromPkcs8.DeriveRawSecretAgreement(peer);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
+        public void ExportPublicKey_ConsistentBetweenOpenSslAndCreate()
+        {
+            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            byte[] privateKey = openSslKey.ExportPrivateKey();
+
+            using X25519DiffieHellman createKey = X25519DiffieHellman.ImportPrivateKey(privateKey);
+
+            AssertExtensions.SequenceEqual(openSslKey.ExportPublicKey(), createKey.ExportPublicKey());
+        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
@@ -8,19 +8,19 @@ namespace System.Security.Cryptography.Tests
     [ConditionalClass(typeof(X25519DiffieHellman), nameof(X25519DiffieHellman.IsSupported))]
     public sealed class X25519DiffieHellmanOpenSslTests : X25519DiffieHellmanBaseTests
     {
-        public override X25519DiffieHellman GenerateKey()
+        public override X25519DiffieHellmanOpenSsl GenerateKey()
         {
             using SafeEvpPKeyHandle key = Interop.Crypto.X25519GenerateKey();
             return new X25519DiffieHellmanOpenSsl(key);
         }
 
-        public override X25519DiffieHellman ImportPrivateKey(ReadOnlySpan<byte> source)
+        public override X25519DiffieHellmanOpenSsl ImportPrivateKey(ReadOnlySpan<byte> source)
         {
             using SafeEvpPKeyHandle key = Interop.Crypto.X25519ImportPrivateKey(source);
             return new X25519DiffieHellmanOpenSsl(key);
         }
 
-        public override X25519DiffieHellman ImportPublicKey(ReadOnlySpan<byte> source)
+        public override X25519DiffieHellmanOpenSsl ImportPublicKey(ReadOnlySpan<byte> source)
         {
             using SafeEvpPKeyHandle key = Interop.Crypto.X25519ImportPublicKey(source);
             return new X25519DiffieHellmanOpenSsl(key);
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void DeriveRawSecretAgreement_OpenSslKeyWithCreateKey_Symmetric()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
             using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
 
             byte[] secret1 = openSslKey.DeriveRawSecretAgreement(createKey);
@@ -79,7 +79,7 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void DeriveRawSecretAgreement_OpenSslKeyWithCreateKey_ExactBuffers()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
             using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
 
             byte[] secret1 = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
@@ -93,15 +93,15 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void DeriveRawSecretAgreement_OpenSslKeyWithImportedCreateKey()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
 
             byte[] openSslPublicKey = openSslKey.ExportPublicKey();
             using X25519DiffieHellman createKeyFromPublic = X25519DiffieHellman.ImportPublicKey(openSslPublicKey);
 
             using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
 
-            byte[] secret1 = openSslKey.DeriveRawSecretAgreement(createKey);
-            byte[] secret2 = createKey.DeriveRawSecretAgreement(openSslKey);
+            byte[] secret1 = createKey.DeriveRawSecretAgreement(openSslKey);
+            byte[] secret2 = createKey.DeriveRawSecretAgreement(createKeyFromPublic);
 
             AssertExtensions.SequenceEqual(secret1, secret2);
         }
@@ -112,12 +112,12 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman createKey = X25519DiffieHellman.GenerateKey();
 
             byte[] createPublicKey = createKey.ExportPublicKey();
-            using X25519DiffieHellmanOpenSsl openSslPublicOnly = (X25519DiffieHellmanOpenSsl)ImportPublicKey(createPublicKey);
+            using X25519DiffieHellmanOpenSsl openSslPublicOnly = ImportPublicKey(createPublicKey);
 
-            using X25519DiffieHellmanOpenSsl openSslPrivate = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslPrivate = GenerateKey();
 
             byte[] secret1 = openSslPrivate.DeriveRawSecretAgreement(createKey);
-            byte[] secret2 = createKey.DeriveRawSecretAgreement(openSslPrivate);
+            byte[] secret2 = openSslPrivate.DeriveRawSecretAgreement(openSslPublicOnly);
 
             AssertExtensions.SequenceEqual(secret1, secret2);
         }
@@ -125,7 +125,7 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void DeriveRawSecretAgreement_PrivateKeyRoundtripBetweenOpenSslAndCreate()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
             byte[] privateKey = openSslKey.ExportPrivateKey();
 
             using X25519DiffieHellman createFromPrivate = X25519DiffieHellman.ImportPrivateKey(privateKey);
@@ -140,7 +140,7 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void DeriveRawSecretAgreement_Pkcs8RoundtripBetweenOpenSslAndCreate()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
             byte[] pkcs8 = openSslKey.ExportPkcs8PrivateKey();
 
             using X25519DiffieHellman createFromPkcs8 = X25519DiffieHellman.ImportPkcs8PrivateKey(pkcs8);
@@ -155,7 +155,7 @@ namespace System.Security.Cryptography.Tests
         [Fact]
         public void ExportPublicKey_ConsistentBetweenOpenSslAndCreate()
         {
-            using X25519DiffieHellmanOpenSsl openSslKey = (X25519DiffieHellmanOpenSsl)GenerateKey();
+            using X25519DiffieHellmanOpenSsl openSslKey = GenerateKey();
             byte[] privateKey = openSslKey.ExportPrivateKey();
 
             using X25519DiffieHellman createKey = X25519DiffieHellman.ImportPrivateKey(privateKey);

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanOpenSslTests.Unix.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Tests
+{
+    [ConditionalClass(typeof(X25519DiffieHellman), nameof(X25519DiffieHellman.IsSupported))]
+    public sealed class X25519DiffieHellmanOpenSslTests : X25519DiffieHellmanBaseTests
+    {
+        public override X25519DiffieHellman GenerateKey()
+        {
+            using SafeEvpPKeyHandle key = Interop.Crypto.X25519GenerateKey();
+            return new X25519DiffieHellmanOpenSsl(key);
+        }
+
+        public override X25519DiffieHellman ImportPrivateKey(ReadOnlySpan<byte> source)
+        {
+            using SafeEvpPKeyHandle key = Interop.Crypto.X25519ImportPrivateKey(source);
+            return new X25519DiffieHellmanOpenSsl(key);
+        }
+
+        public override X25519DiffieHellman ImportPublicKey(ReadOnlySpan<byte> source)
+        {
+            using SafeEvpPKeyHandle key = Interop.Crypto.X25519ImportPublicKey(source);
+            return new X25519DiffieHellmanOpenSsl(key);
+        }
+
+        [Fact]
+        public void X25519DiffieHellmanOpenSsl_Ctor_ArgValidation()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("pkeyHandle", static () => new X25519DiffieHellmanOpenSsl(null));
+        }
+
+        [Fact]
+        public void X25519DiffieHellmanOpenSsl_Ctor_InvalidHandle()
+        {
+            AssertExtensions.Throws<ArgumentException>("pkeyHandle", static () => new X25519DiffieHellmanOpenSsl(new SafeEvpPKeyHandle()));
+        }
+
+        [Fact]
+        public void X25519DiffieHellmanOpenSsl_WrongAlgorithm()
+        {
+            using RSAOpenSsl rsa = new();
+            using SafeEvpPKeyHandle rsaHandle = rsa.DuplicateKeyHandle();
+
+            Assert.Throws<CryptographicException>(() => new X25519DiffieHellmanOpenSsl(rsaHandle));
+        }
+
+        [Fact]
+        public void X25519DiffieHellmanOpenSsl_DuplicateKeyHandle()
+        {
+            using SafeEvpPKeyHandle key = Interop.Crypto.X25519GenerateKey();
+            using X25519DiffieHellmanOpenSsl xdh = new(key);
+            SafeEvpPKeyHandle secondKey;
+
+            using (secondKey = xdh.DuplicateKeyHandle())
+            {
+                Assert.False(secondKey.IsInvalid, nameof(secondKey.IsInvalid));
+            }
+
+            Assert.True(secondKey.IsInvalid, nameof(secondKey.IsInvalid));
+            Assert.False(key.IsInvalid, nameof(key.IsInvalid));
+            Assert.NotNull(xdh.ExportPrivateKey());
+        }
+    }
+}

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -427,6 +427,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_X25519GenerateKey)
     DllImportEntry(CryptoNative_X25519ImportPrivateKey)
     DllImportEntry(CryptoNative_X25519ImportPublicKey)
+    DllImportEntry(CryptoNative_X25519IsValidHandle)
     DllImportEntry(CryptoNative_X509DecodeOcspToExpiration)
     DllImportEntry(CryptoNative_X509Duplicate)
     DllImportEntry(CryptoNative_SslGet0AlpnSelected)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
@@ -119,3 +119,29 @@ EVP_PKEY* CryptoNative_X25519ImportPublicKey(const uint8_t* source, int32_t sour
         source,
         Int32ToSizeT(sourceLength));
 }
+
+int32_t CryptoNative_X25519IsValidHandle(const EVP_PKEY* key, int32_t* hasPrivateKey)
+{
+    assert(key != NULL && hasPrivateKey != NULL);
+    ERR_clear_error();
+
+    *hasPrivateKey = 0;
+
+    if (EVP_PKEY_get_base_id(key) != EVP_PKEY_X25519)
+    {
+        return 0;
+    }
+
+    size_t privateKeyLength = 0;
+
+    if (EVP_PKEY_get_raw_private_key(key, NULL, &privateKeyLength) == 1)
+    {
+        *hasPrivateKey = 1;
+    }
+    else
+    {
+        ERR_clear_error();
+    }
+
+    return 1;
+}

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
@@ -46,3 +46,10 @@ Generates a new X25519 key pair and returns it as an EVP_PKEY.
 Returns the new EVP_PKEY on success, NULL on failure.
 */
 PALEXPORT EVP_PKEY* CryptoNative_X25519GenerateKey(void);
+
+/*
+Determines if an EVP_PKEY is an X25519 key, and whether it contains private key material.
+
+Returns 1 if the key is an X25519 key, 0 otherwise.
+*/
+PALEXPORT int32_t CryptoNative_X25519IsValidHandle(const EVP_PKEY* key, int32_t* hasPrivateKey);


### PR DESCRIPTION
This is the `X25519DiffieHellmanOpenSsl` implementation that works with EVP_PKEY handles.

Contributes to #126206