### PR TITLE
Fix scanner/JIT mismatch when awaiting non-runtime-async generic methods in NativeAOT

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1903,6 +1903,12 @@ namespace Internal.JitInterface
                     // Don't get async variant of Delegate.Invoke method; the pointed to method is not an async variant either.
                     allowAsyncVariant = allowAsyncVariant && !method.OwningType.IsDelegate;
 
+                    // Only use the async variant for runtime-async methods. For non-runtime-async Task-returning
+                    // methods, the JIT will revert to the original method (via the getAsyncOtherVariant check for
+                    // direct calls). Returning null here causes the JIT to treat this as a regular awaited call,
+                    // which is the correct behavior and avoids unnecessary work.
+                    allowAsyncVariant = allowAsyncVariant && method.IsAsync;
+
                     method = allowAsyncVariant
                         ? _compilation.TypeSystemContext.GetAsyncVariantMethod(method)
                         : null;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -486,6 +486,11 @@ namespace Internal.IL
                 // Don't get async variant of Delegate.Invoke method; the pointed to method is not an async variant either.
                 allowAsyncVariant = allowAsyncVariant && !method.OwningType.IsDelegate;
 
+                // Don't use the async variant for non-runtime-async methods. The JIT will revert to the original
+                // method in such cases (via the getAsyncOtherVariant check for direct calls), causing a mismatch
+                // between the precomputed generic dictionary entries and what the JIT looks up at compile time.
+                allowAsyncVariant = allowAsyncVariant && method.IsAsync;
+
                 if (allowAsyncVariant && MatchTaskAwaitPattern())
                 {
                     runtimeDeterminedMethod = _factory.TypeSystemContext.GetAsyncVariantMethod(runtimeDeterminedMethod);


### PR DESCRIPTION
When a runtime-async method awaits a non-runtime-async Task-returning generic method, the NativeAOT scanner was replacing the callee with its async variant in the precomputed generic dictionary. However, the JIT reverts such direct calls to the original method (via the getAsyncOtherVariant isSyncCallThunk check). This caused a mismatch: the precomputed dictionary had MethodDictionary(asyncVariant) but the JIT looked up MethodDictionary(original), throwing InvalidOperationException at compile time.

Fix: add method.IsAsync check to allowAsyncVariant in both ILImporter.Scanner.cs and CorInfoImpl.cs resolveToken so neither the scanner nor the JIT resolveToken produces the async variant for non-runtime-async methods.

Fixes #127179

---
Fix initially proposed by @Copilot in https://github.com/manandre/runtime/pull/14
Test not included in this PR as the one proposed by Copilot does not reproduce the use case of the initial issue.