### PR TITLE
Remove regNumberSmall and just use regNumber everywhere

### DIFF
--- a/src/coreclr/jit/abi.cpp
+++ b/src/coreclr/jit/abi.cpp
@@ -200,7 +200,7 @@ ABIPassingSegment ABIPassingSegment::InRegister(regNumber reg, unsigned offset, 
 {
     assert(reg != REG_NA);
     ABIPassingSegment segment;
-    segment.m_register    = static_cast<regNumberSmall>(reg);
+    segment.m_register    = static_cast<regNumber>(reg);
     segment.m_stackOffset = 0;
     segment.Offset        = offset;
     segment.Size          = size;

--- a/src/coreclr/jit/abi.h
+++ b/src/coreclr/jit/abi.h
@@ -8,9 +8,9 @@ enum class WellKnownArg : unsigned;
 
 class ABIPassingSegment
 {
-    regNumberSmall m_register        = REG_NA;
-    bool           m_isFullStackSlot = true;
-    unsigned       m_stackOffset     = 0;
+    regNumber m_register        = REG_NA;
+    bool      m_isFullStackSlot = true;
+    unsigned  m_stackOffset     = 0;
 
 public:
     bool IsPassedInRegister() const;

--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -205,10 +205,10 @@ Documentation for VS debugger format specifiers: https://learn.microsoft.com/vis
   </Type>
 
   <Type Name="emitter::instrDesc">
-    <DisplayString Condition="(_idInsFmt == IF_RRD) || (_idInsFmt == IF_RWR) || (_idInsFmt == IF_RRW)">{_idIns,en} {_idReg1,en}</DisplayString>
-    <DisplayString Condition="(_idInsFmt == IF_RRD_CNS) || (_idInsFmt == IF_RWR_CNS) || (_idInsFmt == IF_RRW_CNS)">{_idIns,en} {_idReg1,en}, {_idLargeCns,d}</DisplayString>
-    <DisplayString Condition="(_idInsFmt == IF_RRW_SHF) &amp;&amp; (_idLargeCns != 0)">{_idIns,en} {_idReg1,en}, {_idLargeCns,d}</DisplayString>
-    <DisplayString Condition="(_idInsFmt == IF_RRW_SHF) &amp;&amp; (_idLargeCns == 0)">{_idIns,en} {_idReg1,en}, {_idSmallCns,d}</DisplayString>
+    <DisplayString Condition="(_idInsFmt == IF_RRD) || (_idInsFmt == IF_RWR) || (_idInsFmt == IF_RRW)">{_idIns,en} {(regNumber)_idReg1,en}</DisplayString>
+    <DisplayString Condition="(_idInsFmt == IF_RRD_CNS) || (_idInsFmt == IF_RWR_CNS) || (_idInsFmt == IF_RRW_CNS)">{_idIns,en} {(regNumber)_idReg1,en}, {_idLargeCns,d}</DisplayString>
+    <DisplayString Condition="(_idInsFmt == IF_RRW_SHF) &amp;&amp; (_idLargeCns != 0)">{_idIns,en} {(regNumber)_idReg1,en}, {_idLargeCns,d}</DisplayString>
+    <DisplayString Condition="(_idInsFmt == IF_RRW_SHF) &amp;&amp; (_idLargeCns == 0)">{_idIns,en} {(regNumber)_idReg1,en}, {_idSmallCns,d}</DisplayString>
     <DisplayString>{_idIns,en}</DisplayString>
   </Type>
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -771,16 +771,16 @@ public:
 #endif
 
 private:
-    regNumberSmall _lvRegNum; // Used to store the register this variable is in (or, the low register of a
-                              // register pair). It is set during codegen any time the
-                              // variable is enregistered (lvRegister is only set
-                              // to non-zero if the variable gets the same register assignment for its entire
-                              // lifetime).
+    regNumber _lvRegNum; // Used to store the register this variable is in (or, the low register of a
+                         // register pair). It is set during codegen any time the
+                         // variable is enregistered (lvRegister is only set
+                         // to non-zero if the variable gets the same register assignment for its entire
+                         // lifetime).
 #if !defined(TARGET_64BIT)
-    regNumberSmall _lvOtherReg; // Used for "upper half" of long var.
-#endif                          // !defined(TARGET_64BIT)
+    regNumber _lvOtherReg; // Used for "upper half" of long var.
+#endif                     // !defined(TARGET_64BIT)
 
-    regNumberSmall _lvArgInitReg; // the register into which the argument is moved at entry
+    regNumber _lvArgInitReg; // the register into which the argument is moved at entry
 
 public:
     // The register number is stored in a small format (8 bits), but the getters return and the setters take
@@ -795,7 +795,7 @@ public:
 
     void SetRegNum(regNumber reg)
     {
-        _lvRegNum = (regNumberSmall)reg;
+        _lvRegNum = (regNumber)reg;
         assert(_lvRegNum == reg);
     }
 
@@ -824,7 +824,7 @@ public:
 
     void SetOtherReg(regNumber reg)
     {
-        _lvOtherReg = (regNumberSmall)reg;
+        _lvOtherReg = reg;
         assert(_lvOtherReg == reg);
     }
 #endif // !TARGET_64BIT
@@ -877,7 +877,7 @@ public:
 
     void SetArgInitReg(regNumber reg)
     {
-        _lvArgInitReg = (regNumberSmall)reg;
+        _lvArgInitReg = (regNumber)reg;
         assert(_lvArgInitReg == reg);
     }
 

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -3582,9 +3582,7 @@ emitter::instrDesc* emitter::emitNewInstrCallInd(int              argCnt,
         id->idSetIsCall();
 
 #ifdef TARGET_XARCH
-        /* Store the displacement and make sure the value fit */
-        id->idAddr()->iiaAddrMode.amDisp = disp;
-        assert(id->idAddr()->iiaAddrMode.amDisp == disp);
+        id->idAddr()->iiaAddrMode.amDisp(disp);
 #endif // TARGET_XARCH
 
         /* Save the live GC registers in the unused register fields */

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -662,11 +662,6 @@ protected:
         {
             return _amDisp;
         }
-        void amDisp(int disp)
-        {
-            _amDisp = disp;
-            assert(disp == _amDisp);
-        }
         void amDisp(ssize_t disp)
         {
             _amDisp = static_cast<int>(disp);

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -621,10 +621,57 @@ protected:
 
     struct emitAddrMode
     {
-        regNumber       amBaseReg : REGNUM_BITS + 1;
-        regNumber       amIndxReg : REGNUM_BITS + 1;
-        emitter::opSize amScale : 2;
-        int             amDisp : AM_DISP_BITS;
+    private:
+        unsigned        _amBaseReg : REGNUM_BITS + 1;
+        unsigned        _amIndxReg : REGNUM_BITS + 1;
+        emitter::opSize _amScale : 2;
+        int             _amDisp : AM_DISP_BITS;
+
+    public:
+        regNumber amBaseReg() const
+        {
+            return static_cast<regNumber>(_amBaseReg);
+        }
+        void amBaseReg(regNumber reg)
+        {
+            _amBaseReg = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(_amBaseReg));
+        }
+
+        regNumber amIndxReg() const
+        {
+            return static_cast<regNumber>(_amIndxReg);
+        }
+        void amIndxReg(regNumber reg)
+        {
+            _amIndxReg = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(_amIndxReg));
+        }
+
+        emitter::opSize amScale() const
+        {
+            return static_cast<emitter::opSize>(_amScale);
+        }
+        void amScale(emitter::opSize scale)
+        {
+            _amScale = scale;
+            assert(scale == _amScale);
+        }
+
+        int amDisp() const
+        {
+            return _amDisp;
+        }
+        void amDisp(int disp)
+        {
+            _amDisp = disp;
+            assert(disp == _amDisp);
+        }
+        void amDisp(ssize_t disp)
+        {
+            _amDisp = static_cast<int>(disp);
+            assert(disp == _amDisp);
+        }
     };
 
 #endif // TARGET_XARCH
@@ -805,8 +852,8 @@ protected:
         // the live gcrefReg mask for the call instructions on x86/x64
         //
 #if !defined(TARGET_XARCH)
-        regNumber _idReg1 : REGNUM_BITS; // register num
-        regNumber _idReg2 : REGNUM_BITS;
+        unsigned _idReg1 : REGNUM_BITS; // register num
+        unsigned _idReg2 : REGNUM_BITS;
 #endif
 
         ////////////////////////////////////////////////////////////////////////
@@ -832,8 +879,8 @@ protected:
         unsigned _idCustom2 : 1;
         unsigned _idCustom3 : 1;
 #if defined(TARGET_XARCH)
-        regNumber _idReg1 : REGNUM_BITS; // register num
-        regNumber _idReg2 : REGNUM_BITS;
+        unsigned _idReg1 : REGNUM_BITS; // register num
+        unsigned _idReg2 : REGNUM_BITS;
 #endif
 
 #define _idBound          _idCustom1 /* jump target / frame offset bound */
@@ -1075,8 +1122,8 @@ protected:
 #ifdef TARGET_ARM
             struct
             {
-                regNumber _idReg3 : REGNUM_BITS;
-                regNumber _idReg4 : REGNUM_BITS;
+                unsigned _idReg3 : REGNUM_BITS;
+                unsigned _idReg4 : REGNUM_BITS;
             };
 #elif defined(TARGET_ARM64)
             struct
@@ -1085,8 +1132,8 @@ protected:
                 emitLclVarAddr iiaLclVar;
                 unsigned       _idRegBit : 1; // Reg3 is scaled by idOpSize bits
                 GCtype         _idGCref2 : 2;
-                regNumber      _idReg3 : REGNUM_BITS;
-                regNumber      _idReg4 : REGNUM_BITS;
+                unsigned       _idReg3 : REGNUM_BITS;
+                unsigned       _idReg4 : REGNUM_BITS;
             };
 
             insSvePattern _idSvePattern;
@@ -1094,15 +1141,15 @@ protected:
 #elif defined(TARGET_XARCH)
             struct
             {
-                regNumber _idReg3 : REGNUM_BITS;
-                regNumber _idReg4 : REGNUM_BITS;
+                unsigned _idReg3 : REGNUM_BITS;
+                unsigned _idReg4 : REGNUM_BITS;
             };
 #elif defined(TARGET_LOONGARCH64)
             struct
             {
                 unsigned int iiaEncodedInstr; // instruction's binary encoding.
-                regNumber    _idReg3 : REGNUM_BITS;
-                regNumber    _idReg4 : REGNUM_BITS;
+                unsigned int _idReg3 : REGNUM_BITS;
+                unsigned int _idReg4 : REGNUM_BITS;
             };
 
             struct
@@ -1132,8 +1179,8 @@ protected:
 #elif defined(TARGET_RISCV64)
             struct
             {
-                regNumber    _idReg3 : REGNUM_BITS;
-                regNumber    _idReg4 : REGNUM_BITS;
+                unsigned int _idReg3 : REGNUM_BITS;
+                unsigned int _idReg4 : REGNUM_BITS;
                 unsigned int iiaEncodedInstr; // instruction's binary encoding.
             };
 
@@ -1297,12 +1344,12 @@ protected:
 
         regNumber idReg1() const
         {
-            return _idReg1;
+            return static_cast<regNumber>(_idReg1);
         }
         void idReg1(regNumber reg)
         {
-            _idReg1 = reg;
-            assert(reg == _idReg1);
+            _idReg1 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(_idReg1));
         }
 
 #ifdef TARGET_WASM
@@ -1332,37 +1379,37 @@ protected:
 
         regNumber idReg2() const
         {
-            return _idReg2;
+            return static_cast<regNumber>(_idReg2);
         }
         void idReg2(regNumber reg)
         {
-            _idReg2 = reg;
-            assert(reg == _idReg2);
+            _idReg2 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(_idReg2));
         }
 
 #if defined(TARGET_XARCH)
         regNumber idReg3() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg3;
+            return static_cast<regNumber>(idAddr()->_idReg3);
         }
         void idReg3(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg3 = reg;
-            assert(reg == idAddr()->_idReg3);
+            idAddr()->_idReg3 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg3));
         }
 
         regNumber idReg4() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg4;
+            return static_cast<regNumber>(idAddr()->_idReg4);
         }
         void idReg4(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg4 = reg;
-            assert(reg == idAddr()->_idReg4);
+            idAddr()->_idReg4 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg4));
         }
 
         bool idHasReg1() const
@@ -1511,24 +1558,24 @@ protected:
         regNumber idReg3() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg3;
+            return static_cast<regNumber>(idAddr()->_idReg3);
         }
         void idReg3(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg3 = reg;
-            assert(reg == idAddr()->_idReg3);
+            idAddr()->_idReg3 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg3));
         }
         regNumber idReg4() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg4;
+            return static_cast<regNumber>(idAddr()->_idReg4);
         }
         void idReg4(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg4 = reg;
-            assert(reg == idAddr()->_idReg4);
+            idAddr()->_idReg4 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg4));
         }
 #ifdef TARGET_ARM64
         bool idReg3Scaled() const
@@ -1610,24 +1657,24 @@ protected:
         regNumber idReg3() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg3;
+            return static_cast<regNumber>(idAddr()->_idReg3);
         }
         void idReg3(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg3 = reg;
-            assert(reg == idAddr()->_idReg3);
+            idAddr()->_idReg3 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg3));
         }
         regNumber idReg4() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg4;
+            return static_cast<regNumber>(idAddr()->_idReg4);
         }
         void idReg4(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg4 = reg;
-            assert(reg == idAddr()->_idReg4);
+            idAddr()->_idReg4 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg4));
         }
 
 #endif // TARGET_LOONGARCH64
@@ -1646,24 +1693,24 @@ protected:
         regNumber idReg3() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg3;
+            return static_cast<regNumber>(idAddr()->_idReg3);
         }
         void idReg3(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg3 = reg;
-            assert(reg == idAddr()->_idReg3);
+            idAddr()->_idReg3 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg3));
         }
         regNumber idReg4() const
         {
             assert(!idIsSmallDsc());
-            return idAddr()->_idReg4;
+            return static_cast<regNumber>(idAddr()->_idReg4);
         }
         void idReg4(regNumber reg)
         {
             assert(!idIsSmallDsc());
-            idAddr()->_idReg4 = reg;
-            assert(reg == idAddr()->_idReg4);
+            idAddr()->_idReg4 = static_cast<unsigned>(reg);
+            assert(reg == static_cast<regNumber>(idAddr()->_idReg4));
         }
 
 #endif // TARGET_RISCV64

--- a/src/coreclr/jit/emitinl.h
+++ b/src/coreclr/jit/emitinl.h
@@ -121,7 +121,7 @@ inline regNumber emitter::inst3opImulReg(instruction ins)
 
 inline ssize_t emitter::emitGetInsAmd(instrDesc* id) const
 {
-    return id->idIsLargeDsp() ? ((instrDescAmd*)id)->idaAmdVal : id->idAddr()->iiaAddrMode.amDisp;
+    return id->idIsLargeDsp() ? ((instrDescAmd*)id)->idaAmdVal : id->idAddr()->iiaAddrMode.amDisp();
 }
 
 inline int emitter::emitGetInsCDinfo(instrDesc* id)
@@ -183,7 +183,7 @@ inline ssize_t emitter::emitGetInsAmdCns(const instrDesc* id, CnsVal* cv) const
             cv->cnsVal = id->idSmallCns();
         }
 
-        return id->idAddr()->iiaAddrMode.amDisp;
+        return id->idAddr()->iiaAddrMode.amDisp();
     }
 }
 
@@ -218,7 +218,7 @@ inline ssize_t emitter::emitGetInsAmdAny(const instrDesc* id) const
         return ((instrDescAmd*)id)->idaAmdVal;
     }
 
-    return id->idAddr()->iiaAddrMode.amDisp;
+    return id->idAddr()->iiaAddrMode.amDisp();
 }
 
 #endif // TARGET_XARCH

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2537,7 +2537,7 @@ bool emitter::HasExtendedGPReg(const instrDesc* id) const
 #if defined(TARGET_AMD64)
     // First check if addressing mode is used and if any of those uses eGPRs.
     if (id->idHasMemAdr() &&
-        (IsExtendedGPReg(id->idAddr()->iiaAddrMode.amBaseReg) || IsExtendedGPReg(id->idAddr()->iiaAddrMode.amIndxReg)))
+        (IsExtendedGPReg(id->idAddr()->iiaAddrMode.amBaseReg()) || IsExtendedGPReg(id->idAddr()->iiaAddrMode.amIndxReg())))
     {
         return true;
     }
@@ -3878,7 +3878,7 @@ inline ssize_t emitter::emitGetInsCIdisp(instrDesc* id) const
         assert(!id->idIsLargeDsp());
         assert(!id->idIsLargeCns());
 
-        return id->idAddr()->iiaAddrMode.amDisp;
+        return id->idAddr()->iiaAddrMode.amDisp();
     }
 }
 
@@ -4312,7 +4312,7 @@ unsigned emitter::emitGetVexPrefixSize(instrDesc* id) const
 
     if (id->idHasMemAdr())
     {
-        regNumber regForSibBits = id->idAddr()->iiaAddrMode.amIndxReg;
+        regNumber regForSibBits = id->idAddr()->iiaAddrMode.amIndxReg();
 
         if (IsExtendedReg(regForSibBits))
         {
@@ -4321,7 +4321,7 @@ unsigned emitter::emitGetVexPrefixSize(instrDesc* id) const
             return 3;
         }
 
-        regFor012Bits = id->idAddr()->iiaAddrMode.amBaseReg;
+        regFor012Bits = id->idAddr()->iiaAddrMode.amBaseReg();
     }
     else if (id->idHasMemGen() || id->idHasMemStk())
     {
@@ -5340,8 +5340,8 @@ UNATIVE_OFFSET emitter::emitInsSizeAM(instrDesc* id, code_t code)
 
     if (id->idHasMemAdr())
     {
-        reg = id->idAddr()->iiaAddrMode.amBaseReg;
-        rgx = id->idAddr()->iiaAddrMode.amIndxReg;
+        reg = id->idAddr()->iiaAddrMode.amBaseReg();
+        rgx = id->idAddr()->iiaAddrMode.amIndxReg();
     }
     else
     {
@@ -5362,8 +5362,8 @@ UNATIVE_OFFSET emitter::emitInsSizeAM(instrDesc* id, code_t code)
             default:
             {
                 assert(!"Unexpected insFormat in emitInsSizeAMD");
-                reg = id->idAddr()->iiaAddrMode.amBaseReg;
-                rgx = id->idAddr()->iiaAddrMode.amIndxReg;
+                reg = id->idAddr()->iiaAddrMode.amBaseReg();
+                rgx = id->idAddr()->iiaAddrMode.amIndxReg();
                 break;
             }
         }
@@ -5500,7 +5500,7 @@ UNATIVE_OFFSET emitter::emitInsSizeAM(instrDesc* id, code_t code)
 
         /* Is the index value scaled? */
 
-        if (emitDecodeScale(id->idAddr()->iiaAddrMode.amScale) > 1)
+        if (emitDecodeScale(id->idAddr()->iiaAddrMode.amScale()) > 1)
         {
             /* Is there a base register? */
 
@@ -5545,9 +5545,9 @@ UNATIVE_OFFSET emitter::emitInsSizeAM(instrDesc* id, code_t code)
                 !isFloatReg(rgx))
             {
                 // Swap reg and rgx, such that reg is not EBP/R13.
-                regNumber tmp                       = reg;
-                id->idAddr()->iiaAddrMode.amBaseReg = reg = rgx;
-                id->idAddr()->iiaAddrMode.amIndxReg = rgx = tmp;
+                regNumber tmp = reg;
+                id->idAddr()->iiaAddrMode.amBaseReg(reg = rgx);
+                id->idAddr()->iiaAddrMode.amIndxReg(rgx = tmp);
             }
 
             /* The address is "[reg+rgx+dsp]" */
@@ -5688,7 +5688,7 @@ inline emitter::instrDesc* emitter::emitNewInstrAmd(emitAttr size, ssize_t dsp)
 
         id->idSetIsLargeDsp();
 #ifdef DEBUG
-        id->idAddr()->iiaAddrMode.amDisp = AM_DISP_BIG_VAL;
+        id->idAddr()->iiaAddrMode.amDisp(AM_DISP_BIG_VAL);
 #endif
         id->idaAmdVal = dsp;
 
@@ -5697,10 +5697,7 @@ inline emitter::instrDesc* emitter::emitNewInstrAmd(emitAttr size, ssize_t dsp)
     else
     {
         instrDesc* id = emitAllocInstr(size);
-
-        id->idAddr()->iiaAddrMode.amDisp = dsp;
-        assert(id->idAddr()->iiaAddrMode.amDisp == dsp); // make sure the value fit
-
+        id->idAddr()->iiaAddrMode.amDisp(dsp);
         return id;
     }
 }
@@ -5716,15 +5713,14 @@ inline void emitter::emitSetAmdDisp(instrDescAmd* id, ssize_t dsp)
     {
         id->idSetIsLargeDsp();
 #ifdef DEBUG
-        id->idAddr()->iiaAddrMode.amDisp = AM_DISP_BIG_VAL;
+        id->idAddr()->iiaAddrMode.amDisp(AM_DISP_BIG_VAL);
 #endif
         id->idaAmdVal = dsp;
     }
     else
     {
         id->idSetIsSmallDsp();
-        id->idAddr()->iiaAddrMode.amDisp = dsp;
-        assert(id->idAddr()->iiaAddrMode.amDisp == dsp); // make sure the value fit
+        id->idAddr()->iiaAddrMode.amDisp(dsp);
     }
 }
 
@@ -5738,10 +5734,8 @@ emitter::instrDesc* emitter::emitNewInstrAmdCns(emitAttr size, ssize_t dsp, int 
 {
     if (dsp >= AM_DISP_MIN && dsp <= AM_DISP_MAX)
     {
-        instrDesc* id                    = emitNewInstrCns(size, cns);
-        id->idAddr()->iiaAddrMode.amDisp = dsp;
-        assert(id->idAddr()->iiaAddrMode.amDisp == dsp); // make sure the value fit
-
+        instrDesc* id = emitNewInstrCns(size, cns);
+        id->idAddr()->iiaAddrMode.amDisp(dsp);
         return id;
     }
     else
@@ -5752,7 +5746,7 @@ emitter::instrDesc* emitter::emitNewInstrAmdCns(emitAttr size, ssize_t dsp, int 
 
             id->idSetIsLargeDsp();
 #ifdef DEBUG
-            id->idAddr()->iiaAddrMode.amDisp = AM_DISP_BIG_VAL;
+            id->idAddr()->iiaAddrMode.amDisp(AM_DISP_BIG_VAL);
 #endif
             id->idaAmdVal = dsp;
 
@@ -5769,7 +5763,7 @@ emitter::instrDesc* emitter::emitNewInstrAmdCns(emitAttr size, ssize_t dsp, int 
 
             id->idSetIsLargeDsp();
 #ifdef DEBUG
-            id->idAddr()->iiaAddrMode.amDisp = AM_DISP_BIG_VAL;
+            id->idAddr()->iiaAddrMode.amDisp(AM_DISP_BIG_VAL);
 #endif
             id->idacAmdVal = dsp;
 
@@ -6040,9 +6034,9 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
             id->idSetIsDspReloc();
         }
 
-        id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-        id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
-        id->idAddr()->iiaAddrMode.amScale   = emitter::OPSZ1; // for completeness
+        id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+        id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
+        id->idAddr()->iiaAddrMode.amScale(emitter::OPSZ1); // for completeness
 
         id->idInsFmt(emitMapFmtForIns(fmt, ins));
 
@@ -6069,9 +6063,9 @@ void emitter::emitHandleMemOp(GenTreeIndir* indir, instrDesc* id, insFormat fmt,
         }
 
         assert((amBaseReg != REG_NA) || (amIndxReg != REG_NA) || (indir->Offset() != 0)); // At least one should be set.
-        id->idAddr()->iiaAddrMode.amBaseReg = amBaseReg;
-        id->idAddr()->iiaAddrMode.amIndxReg = amIndxReg;
-        id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(indir->Scale());
+        id->idAddr()->iiaAddrMode.amBaseReg(amBaseReg);
+        id->idAddr()->iiaAddrMode.amIndxReg(amIndxReg);
+        id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(indir->Scale()));
 
         id->idInsFmt(emitMapFmtForIns(fmt, ins));
 
@@ -6109,9 +6103,9 @@ void emitter::spillIntArgRegsToShadowSlots()
         id = emitNewInstrAmd(EA_PTRSIZE, offset);
         id->idIns(INS_mov);
         id->idInsFmt(emitInsModeFormat(INS_mov, IF_ARD_RRD));
-        id->idAddr()->iiaAddrMode.amBaseReg = REG_SPBASE;
-        id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
-        id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(1);
+        id->idAddr()->iiaAddrMode.amBaseReg(REG_SPBASE);
+        id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
+        id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(1));
 
         // The offset has already been set in the intrDsc ctor,
         // make sure we got it right.
@@ -7286,9 +7280,9 @@ void emitter::emitIns_IJ(emitAttr attr, regNumber reg, unsigned base)
 
     id->idIns(ins);
     id->idInsFmt(emitInsModeFormat(ins, IF_ARD));
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = reg;
-    id->idAddr()->iiaAddrMode.amScale   = emitter::OPSZP;
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(reg);
+    id->idAddr()->iiaAddrMode.amScale(emitter::OPSZP);
 
     if (m_debugInfoSize > 0)
     {
@@ -8057,8 +8051,8 @@ void emitter::emitIns_AR(instruction ins, emitAttr attr, regNumber base, int off
     id->idIns(ins);
 
     id->idInsFmt(emitInsModeFormat(ins, IF_ARD));
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     if ((instOptions & INS_OPTS_EVEX_NoApxPromotion) != 0)
     {
@@ -8099,8 +8093,8 @@ void emitter::emitIns_AR_R_R(
     id->idReg2(op3Reg);
 
     id->idInsFmt(IF_AWR_RRD_RRD);
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     assert((instOptions & INS_OPTS_EVEX_b_MASK) == 0);
     SetEvexEmbMaskIfNeeded(id, instOptions);
@@ -8287,8 +8281,8 @@ void emitter::emitIns_R_R_AR(instruction ins, emitAttr attr, regNumber reg1, reg
     id->idReg2(reg2);
 
     id->idInsFmt(emitInsModeFormat(ins, IF_RRD_RRD_ARD));
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     UNATIVE_OFFSET sz = emitInsSizeAM(id, insCodeRM(ins));
     id->idCodeSize(sz);
@@ -8354,9 +8348,9 @@ void emitter::emitIns_R_AR_R(instruction ins,
     id->idReg2(reg2);
 
     id->idInsFmt(emitInsModeFormat(ins, IF_RRD_ARD_RRD));
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = index;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeSize((emitAttr)scale);
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(index);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeSize((emitAttr)scale));
 
     UNATIVE_OFFSET sz = emitInsSizeAM(id, insCodeRM(ins));
     id->idCodeSize(sz);
@@ -8509,8 +8503,8 @@ void emitter::emitIns_R_R_AR_I(
     id->idReg2(reg2);
 
     id->idInsFmt(IF_RWR_RRD_ARD_CNS);
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     UNATIVE_OFFSET sz = emitInsSizeAM(id, insCodeRM(ins), ival);
     id->idCodeSize(sz);
@@ -9232,8 +9226,8 @@ void emitter::emitIns_I_AR(instruction ins, emitAttr attr, int val, regNumber re
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = reg;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(reg);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
     if ((instOptions & INS_OPTS_EVEX_NoApxPromotion) != 0)
     {
         id->idSetNoApxEvexPromotion();
@@ -9292,8 +9286,8 @@ void emitter::emitIns_I_AI(instruction ins, emitAttr attr, int val, ssize_t disp
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9325,8 +9319,8 @@ void emitter::emitIns_R_AI(instruction  ins,
     id->idInsFmt(fmt);
     id->idReg1(ireg);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
     if (EA_IS_CNS_TLSGD_RELOC(attr))
     {
         id->idSetTlsGD();
@@ -9473,8 +9467,8 @@ void emitter::emitIns_AI_R(instruction ins, emitAttr attr, regNumber ireg, ssize
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9523,9 +9517,9 @@ void emitter::emitIns_I_ARR(instruction ins, emitAttr attr, int val, regNumber r
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = reg;
-    id->idAddr()->iiaAddrMode.amIndxReg = rg2;
-    id->idAddr()->iiaAddrMode.amScale   = emitter::OPSZ1;
+    id->idAddr()->iiaAddrMode.amBaseReg(reg);
+    id->idAddr()->iiaAddrMode.amIndxReg(rg2);
+    id->idAddr()->iiaAddrMode.amScale(emitter::OPSZ1);
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9584,9 +9578,9 @@ void emitter::emitIns_I_ARX(
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = reg;
-    id->idAddr()->iiaAddrMode.amIndxReg = rg2;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(mul);
+    id->idAddr()->iiaAddrMode.amBaseReg(reg);
+    id->idAddr()->iiaAddrMode.amIndxReg(rg2);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(mul));
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9619,9 +9613,9 @@ void emitter::emitIns_R_ARX(
     id->idInsFmt(fmt);
     id->idReg1(reg);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = index;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(scale);
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(index);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(scale));
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9662,9 +9656,9 @@ void emitter::emitIns_ARX_R(instruction    ins,
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = base;
-    id->idAddr()->iiaAddrMode.amIndxReg = index;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(scale);
+    id->idAddr()->iiaAddrMode.amBaseReg(base);
+    id->idAddr()->iiaAddrMode.amIndxReg(index);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(scale));
     if ((instOptions & INS_OPTS_EVEX_NoApxPromotion) != 0)
     {
         id->idSetNoApxEvexPromotion();
@@ -9717,9 +9711,9 @@ void emitter::emitIns_I_AX(instruction ins, emitAttr attr, int val, regNumber re
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = reg;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(mul);
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(reg);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(mul));
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9743,9 +9737,9 @@ void emitter::emitIns_R_AX(instruction ins, emitAttr attr, regNumber ireg, regNu
     id->idInsFmt(fmt);
     id->idReg1(ireg);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = reg;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(mul);
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(reg);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(mul));
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -9778,9 +9772,9 @@ void emitter::emitIns_AX_R(instruction ins, emitAttr attr, regNumber ireg, regNu
     id->idIns(ins);
     id->idInsFmt(fmt);
 
-    id->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-    id->idAddr()->iiaAddrMode.amIndxReg = reg;
-    id->idAddr()->iiaAddrMode.amScale   = emitEncodeScale(mul);
+    id->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+    id->idAddr()->iiaAddrMode.amIndxReg(reg);
+    id->idAddr()->iiaAddrMode.amScale(emitEncodeScale(mul));
 
     assert(emitGetInsAmdAny(id) == disp); // make sure "disp" is stored properly
 
@@ -11370,9 +11364,9 @@ void emitter::emitIns_Call(const EmitCallParams& params)
 
         id->idInsFmt(emitInsModeFormat(ins, IF_ARD));
 
-        id->idAddr()->iiaAddrMode.amBaseReg = params.ireg;
-        id->idAddr()->iiaAddrMode.amIndxReg = params.xreg;
-        id->idAddr()->iiaAddrMode.amScale   = params.xmul ? emitEncodeScale(params.xmul) : emitter::OPSZ1;
+        id->idAddr()->iiaAddrMode.amBaseReg(params.ireg);
+        id->idAddr()->iiaAddrMode.amIndxReg(params.xreg);
+        id->idAddr()->iiaAddrMode.amScale(params.xmul ? emitEncodeScale(params.xmul) : emitter::OPSZ1);
 
         code_t code = insCodeMR(ins);
         if (ins == INS_tail_i_jmp)
@@ -12306,23 +12300,23 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
 
     printf("[");
 
-    if (id->idAddr()->iiaAddrMode.amBaseReg != REG_NA)
+    if (id->idAddr()->iiaAddrMode.amBaseReg() != REG_NA)
     {
-        printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amBaseReg));
+        printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amBaseReg()));
         nsep = true;
-        if (id->idAddr()->iiaAddrMode.amBaseReg == REG_ESP)
+        if (id->idAddr()->iiaAddrMode.amBaseReg() == REG_ESP)
         {
             frameRef = true;
         }
-        else if (m_compiler->isFramePointerUsed() && id->idAddr()->iiaAddrMode.amBaseReg == REG_EBP)
+        else if (m_compiler->isFramePointerUsed() && id->idAddr()->iiaAddrMode.amBaseReg() == REG_EBP)
         {
             frameRef = true;
         }
     }
 
-    if (id->idAddr()->iiaAddrMode.amIndxReg != REG_NA)
+    if (id->idAddr()->iiaAddrMode.amIndxReg() != REG_NA)
     {
-        size_t scale = emitDecodeScale(id->idAddr()->iiaAddrMode.amScale);
+        size_t scale = emitDecodeScale(id->idAddr()->iiaAddrMode.amScale());
 
         if (nsep)
         {
@@ -12332,7 +12326,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
         {
             printf("%u*", (unsigned)scale);
         }
-        printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amIndxReg));
+        printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amIndxReg()));
         nsep = true;
     }
 
@@ -12870,7 +12864,7 @@ void emitter::emitDispIns(
 
             if (((ins == INS_call) || (ins == INS_tail_i_jmp)) && id->idIsCallRegPtr())
             {
-                printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amBaseReg));
+                printf("%s", emitRegName(id->idAddr()->iiaAddrMode.amBaseReg()));
             }
             else
             {
@@ -14371,8 +14365,8 @@ BYTE* emitter::emitOutputAM(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
     size_t      opsz = EA_SIZE_IN_BYTES(size);
 
     // Get the base/index registers
-    reg = id->idAddr()->iiaAddrMode.amBaseReg;
-    rgx = id->idAddr()->iiaAddrMode.amIndxReg;
+    reg = id->idAddr()->iiaAddrMode.amBaseReg();
+    rgx = id->idAddr()->iiaAddrMode.amIndxReg();
 
     // For INS_call the instruction size is actually the return value size
     if ((ins == INS_call) || (ins == INS_tail_i_jmp))
@@ -15065,7 +15059,7 @@ GOT_DSP:
         unsigned regByte;
 
         // We have a scaled index operand
-        unsigned mul = emitDecodeScale(id->idAddr()->iiaAddrMode.amScale);
+        unsigned mul = emitDecodeScale(id->idAddr()->iiaAddrMode.amScale());
 
         // Is the index operand scaled?
         if (mul > 1)
@@ -17967,8 +17961,8 @@ BYTE* emitter::emitOutputLJ(insGroup* ig, BYTE* dst, instrDesc* i)
             }
 
             idAmd->idInsFmt(emitInsModeFormat(ins, IF_RRD_ARD));
-            idAmd->idAddr()->iiaAddrMode.amBaseReg = REG_NA;
-            idAmd->idAddr()->iiaAddrMode.amIndxReg = REG_NA;
+            idAmd->idAddr()->iiaAddrMode.amBaseReg(REG_NA);
+            idAmd->idAddr()->iiaAddrMode.amIndxReg(REG_NA);
             emitSetAmdDisp(idAmd, distVal); // set the displacement
             idAmd->idSetIsDspReloc(id->idIsDspReloc());
             assert(emitGetInsAmdAny(idAmd) == distVal); // make sure "disp" is stored properly
@@ -20447,9 +20441,9 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
             }
             else if (insFmt != IF_RWR_SRD)
             {
-                if (id->idAddr()->iiaAddrMode.amIndxReg != REG_NA)
+                if (id->idAddr()->iiaAddrMode.amIndxReg() != REG_NA)
                 {
-                    regNumber baseReg = id->idAddr()->iiaAddrMode.amBaseReg;
+                    regNumber baseReg = id->idAddr()->iiaAddrMode.amBaseReg();
                     if (baseReg != REG_NA)
                     {
                         ssize_t dsp = emitGetInsAmdAny(id);

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -2536,8 +2536,8 @@ bool emitter::HasExtendedGPReg(const instrDesc* id) const
 {
 #if defined(TARGET_AMD64)
     // First check if addressing mode is used and if any of those uses eGPRs.
-    if (id->idHasMemAdr() &&
-        (IsExtendedGPReg(id->idAddr()->iiaAddrMode.amBaseReg()) || IsExtendedGPReg(id->idAddr()->iiaAddrMode.amIndxReg())))
+    if (id->idHasMemAdr() && (IsExtendedGPReg(id->idAddr()->iiaAddrMode.amBaseReg()) ||
+                              IsExtendedGPReg(id->idAddr()->iiaAddrMode.amIndxReg())))
     {
         return true;
     }

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4682,7 +4682,6 @@ void GCInfo::gcInfoRecordGCRegStateChange(GcInfoEncoder* gcInfoEncoder,
             regFlags = (GcSlotFlags)(regFlags | GC_SLOT_INTERIOR);
         }
 
-        assert(regNum == (regNumber)regNum);
         RegSlotIdKey rskey((unsigned short)regNum, regFlags);
         GcSlotId     regSlotId;
         if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)

--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -4682,7 +4682,7 @@ void GCInfo::gcInfoRecordGCRegStateChange(GcInfoEncoder* gcInfoEncoder,
             regFlags = (GcSlotFlags)(regFlags | GC_SLOT_INTERIOR);
         }
 
-        assert(regNum == (regNumberSmall)regNum);
+        assert(regNum == (regNumber)regNum);
         RegSlotIdKey rskey((unsigned short)regNum, regFlags);
         GcSlotId     regSlotId;
         if (mode == MAKE_REG_PTR_MODE_ASSIGN_SLOTS)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1085,9 +1085,8 @@ public:
     void SetRegNum(regNumber reg)
     {
         genIsValidReg(reg);
-        _gtRegNum = (regNumber)reg;
+        _gtRegNum = reg;
         INDEBUG(gtRegTag = GT_REGTAG_REG;)
-        assert(_gtRegNum == reg);
     }
 
     void ClearRegNum()

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -978,7 +978,7 @@ private:
 
 private:
     // This stores the register assigned to the node. If a register is not assigned, _gtRegNum is set to REG_NA.
-    regNumberSmall _gtRegNum;
+    regNumber _gtRegNum;
 
     // Count of operands. Used *only* by GenTreeMultiOp, exists solely due to padding constraints.
     friend struct GenTreeMultiOp;
@@ -1085,7 +1085,7 @@ public:
     void SetRegNum(regNumber reg)
     {
         genIsValidReg(reg);
-        _gtRegNum = (regNumberSmall)reg;
+        _gtRegNum = (regNumber)reg;
         INDEBUG(gtRegTag = GT_REGTAG_REG;)
         assert(_gtRegNum == reg);
     }
@@ -3931,7 +3931,7 @@ inline MultiRegSpillFlags SetMultiRegSpillFlagsByIdx(MultiRegSpillFlags oldFlags
 struct GenTreeLclVar : public GenTreeLclVarCommon
 {
 private:
-    regNumberSmall     gtOtherReg[MAX_MULTIREG_COUNT - 1];
+    regNumber          gtOtherReg[MAX_MULTIREG_COUNT - 1];
     MultiRegSpillFlags gtSpillFlags;
 
 public:
@@ -3967,7 +3967,7 @@ public:
         }
         else
         {
-            gtOtherReg[regIndex - 1] = (regNumberSmall)reg;
+            gtOtherReg[regIndex - 1] = (regNumber)reg;
         }
     }
 
@@ -5172,7 +5172,7 @@ struct GenTreeCall final : public GenTree
 
     // GetRegNum() would always be the first return reg.
     // The following array holds the other reg numbers of multi-reg return.
-    regNumberSmall gtOtherRegs[MAX_RET_REG_COUNT - 1];
+    regNumber gtOtherRegs[MAX_RET_REG_COUNT - 1];
 
     MultiRegSpillFlags gtSpillFlags;
 
@@ -5280,7 +5280,7 @@ struct GenTreeCall final : public GenTree
 #if FEATURE_MULTIREG_RET
         else
         {
-            gtOtherRegs[idx - 1] = (regNumberSmall)reg;
+            gtOtherRegs[idx - 1] = reg;
             assert(gtOtherRegs[idx - 1] == reg);
         }
 #else
@@ -6418,7 +6418,7 @@ protected:
 #endif // FEATURE_READYTORUN
         };
     };
-    regNumberSmall     gtOtherReg;   // The second register for multi-reg intrinsics.
+    regNumber          gtOtherReg;   // The second register for multi-reg intrinsics.
     MultiRegSpillFlags gtSpillFlags; // Spill flags for multi-reg intrinsics.
     unsigned char  gtAuxiliaryType;  // For intrinsics than need another type (e.g. Avx2.Gather* or SIMD (by element))
     unsigned char  gtSimdBaseType;   // SIMD vector base JIT type
@@ -6501,7 +6501,7 @@ public:
 #endif
         // should only be used to set otherReg
         assert(idx == 1);
-        gtOtherReg = (regNumberSmall)reg;
+        gtOtherReg = (regNumber)reg;
     }
 
     GenTreeFlags GetRegSpillFlagByIdx(unsigned idx) const
@@ -8897,7 +8897,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
     // State required to support copy/reload of a multi-reg call node.
     // The first register is always given by GetRegNum().
     //
-    regNumberSmall gtOtherRegs[MAX_MULTIREG_COUNT - 1];
+    regNumber gtOtherRegs[MAX_MULTIREG_COUNT - 1];
 
     //----------------------------------------------------------
     // ClearOtherRegs: set gtOtherRegs to REG_NA.
@@ -8957,7 +8957,7 @@ struct GenTreeCopyOrReload : public GenTreeUnOp
         }
         else
         {
-            gtOtherRegs[idx - 1] = (regNumberSmall)reg;
+            gtOtherRegs[idx - 1] = (regNumber)reg;
             assert(gtOtherRegs[idx - 1] == reg);
         }
     }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -2115,9 +2115,7 @@ VarToRegMap LinearScan::getOutVarToRegMap(unsigned int bbNum)
 void LinearScan::setVarReg(VarToRegMap bbVarToRegMap, unsigned int trackedVarIndex, regNumber reg)
 {
     assert(trackedVarIndex < m_compiler->lvaTrackedCount);
-    regNumber regSmall = (regNumber)reg;
-    assert((regNumber)regSmall == reg);
-    bbVarToRegMap[trackedVarIndex] = regSmall;
+    bbVarToRegMap[trackedVarIndex] = reg;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -142,7 +142,7 @@ void lsraAssignRegToTree(GenTree* tree, regNumber reg, unsigned regIdx)
     {
         assert(regIdx == 1);
         GenTreeCopyOrReload* copy = tree->AsCopyOrReload();
-        copy->gtOtherRegs[0]      = (regNumberSmall)reg;
+        copy->gtOtherRegs[0]      = reg;
     }
 #endif // FEATURE_MULTIREG_RET
 #ifdef FEATURE_HW_INTRINSICS
@@ -1988,18 +1988,18 @@ void LinearScan::initVarRegMaps()
     // So, if we want to index by bbNum we have to know the maximum value.
     unsigned int bbCount = m_compiler->fgBBNumMax + 1;
 
-    inVarToRegMaps  = new (m_compiler, CMK_LSRA) regNumberSmall*[bbCount];
-    outVarToRegMaps = new (m_compiler, CMK_LSRA) regNumberSmall*[bbCount];
+    inVarToRegMaps  = new (m_compiler, CMK_LSRA) regNumber*[bbCount];
+    outVarToRegMaps = new (m_compiler, CMK_LSRA) regNumber*[bbCount];
 
     if (varCount > 0)
     {
         // This VarToRegMap is used during the resolution of critical edges.
-        sharedCriticalVarToRegMap = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
+        sharedCriticalVarToRegMap = new (m_compiler, CMK_LSRA) regNumber[regMapCount];
 
         for (unsigned int i = 0; i < bbCount; i++)
         {
-            VarToRegMap inVarToRegMap  = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
-            VarToRegMap outVarToRegMap = new (m_compiler, CMK_LSRA) regNumberSmall[regMapCount];
+            VarToRegMap inVarToRegMap  = new (m_compiler, CMK_LSRA) regNumber[regMapCount];
+            VarToRegMap outVarToRegMap = new (m_compiler, CMK_LSRA) regNumber[regMapCount];
 
             for (unsigned int j = 0; j < regMapCount; j++)
             {
@@ -2025,14 +2025,14 @@ void LinearScan::setInVarRegForBB(unsigned int bbNum, unsigned int varNum, regNu
 {
     assert(enregisterLocalVars);
     assert(reg < UCHAR_MAX && varNum < m_compiler->lvaCount);
-    inVarToRegMaps[bbNum][m_compiler->lvaTable[varNum].lvVarIndex] = (regNumberSmall)reg;
+    inVarToRegMaps[bbNum][m_compiler->lvaTable[varNum].lvVarIndex] = (regNumber)reg;
 }
 
 void LinearScan::setOutVarRegForBB(unsigned int bbNum, unsigned int varNum, regNumber reg)
 {
     assert(enregisterLocalVars);
     assert(reg < UCHAR_MAX && varNum < m_compiler->lvaCount);
-    outVarToRegMaps[bbNum][m_compiler->lvaTable[varNum].lvVarIndex] = (regNumberSmall)reg;
+    outVarToRegMaps[bbNum][m_compiler->lvaTable[varNum].lvVarIndex] = (regNumber)reg;
 }
 
 LinearScan::SplitEdgeInfo LinearScan::getSplitEdgeInfo(unsigned int bbNum)
@@ -2115,7 +2115,7 @@ VarToRegMap LinearScan::getOutVarToRegMap(unsigned int bbNum)
 void LinearScan::setVarReg(VarToRegMap bbVarToRegMap, unsigned int trackedVarIndex, regNumber reg)
 {
     assert(trackedVarIndex < m_compiler->lvaTrackedCount);
-    regNumberSmall regSmall = (regNumberSmall)reg;
+    regNumber regSmall = (regNumber)reg;
     assert((regNumber)regSmall == reg);
     bbVarToRegMap[trackedVarIndex] = regSmall;
 }
@@ -8706,7 +8706,7 @@ regNumber LinearScan::getTempRegForResolution(BasicBlock*      fromBlock,
 void LinearScan::addResolutionForDouble(BasicBlock*             block,
                                         GenTree*                insertionPoint,
                                         Interval**              sourceIntervals,
-                                        regNumberSmall*         location,
+                                        regNumber*              location,
                                         regNumber               toReg,
                                         regNumber               fromReg,
                                         ResolveType resolveType DEBUG_ARG(BasicBlock* fromBlock)
@@ -8733,7 +8733,7 @@ void LinearScan::addResolutionForDouble(BasicBlock*             block,
         }
         addResolution(block, insertionPoint, intervalToBeMoved1, toReg,
                       fromReg DEBUG_ARG(fromBlock) DEBUG_ARG(toBlock) DEBUG_ARG(resolveTypeName[resolveType]));
-        location[fromReg] = (regNumberSmall)toReg;
+        location[fromReg] = toReg;
     }
 
     if (intervalToBeMoved2 != nullptr)
@@ -8745,7 +8745,7 @@ void LinearScan::addResolutionForDouble(BasicBlock*             block,
         addResolution(block, insertionPoint, intervalToBeMoved2, secondHalfTempReg,
                       secondHalfTargetReg DEBUG_ARG(fromBlock) DEBUG_ARG(toBlock)
                           DEBUG_ARG(resolveTypeName[resolveType]));
-        location[secondHalfTargetReg] = (regNumberSmall)secondHalfTempReg;
+        location[secondHalfTargetReg] = secondHalfTempReg;
     }
 
     return;
@@ -9508,10 +9508,10 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
     //   location[rax] == REG_NA
     // This indicates that the var originally in rax is now in its target register.
 
-    regNumberSmall location[REG_COUNT];
-    static_assert(sizeof(char) == sizeof(regNumberSmall)); // for memset to work
+    regNumber location[REG_COUNT];
+    static_assert(sizeof(char) == sizeof(regNumber)); // for memset to work
     memset(location, REG_NA, REG_COUNT);
-    regNumberSmall source[REG_COUNT];
+    regNumber source[REG_COUNT];
     memset(source, REG_NA, REG_COUNT);
 
     // What interval is this register associated with?
@@ -9611,8 +9611,8 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
         }
         else
         {
-            location[fromReg]        = (regNumberSmall)fromReg;
-            source[toReg]            = (regNumberSmall)fromReg;
+            location[fromReg]        = (regNumber)fromReg;
+            source[toReg]            = (regNumber)fromReg;
             sourceIntervals[fromReg] = interval;
             targetRegsToDo |= genRegMask(toReg);
         }
@@ -9834,7 +9834,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                         insertSwap(block, insertionPoint, sourceIntervals[source[otherTargetReg]]->varNum, targetReg,
                                    sourceIntervals[sourceReg]->varNum, fromReg);
                         location[sourceReg]              = REG_NA;
-                        location[source[otherTargetReg]] = (regNumberSmall)fromReg;
+                        location[source[otherTargetReg]] = (regNumber)fromReg;
 
                         INTRACK_STATS(updateLsraStat(STAT_RESOLUTION_MOV, block->bbNum));
                     }
@@ -9924,7 +9924,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                         addResolution(block, insertionPoint, sourceIntervals[targetReg], tempReg,
                                       targetReg DEBUG_ARG(fromBlock) DEBUG_ARG(toBlock)
                                           DEBUG_ARG(resolveTypeName[resolveType]));
-                        location[targetReg] = (regNumberSmall)tempReg;
+                        location[targetReg] = tempReg;
 
                         if (sourceIntervals[targetReg]->registerType == TYP_DOUBLE)
                         {
@@ -9940,7 +9940,7 @@ void LinearScan::resolveEdge(BasicBlock*      fromBlock,
                     addResolution(block, insertionPoint, sourceIntervals[targetReg], tempReg,
                                   targetReg DEBUG_ARG(fromBlock) DEBUG_ARG(toBlock)
                                       DEBUG_ARG(resolveTypeName[resolveType]));
-                    location[targetReg] = (regNumberSmall)tempReg;
+                    location[targetReg] = (regNumber)tempReg;
 #endif // TARGET_ARM
                     targetRegsReady |= targetRegMask;
                 }

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -448,7 +448,7 @@ inline bool RefTypeIsDef(RefType refType)
     return ((refType & RefTypeDef) == RefTypeDef);
 }
 
-typedef regNumberSmall* VarToRegMap;
+typedef regNumber* VarToRegMap;
 
 typedef jitstd::list<Interval>                      IntervalList;
 typedef jitstd::list<RefPosition>                   RefPositionList;
@@ -719,7 +719,7 @@ public:
     void addResolutionForDouble(BasicBlock*             block,
                                 GenTree*                insertionPoint,
                                 Interval**              sourceIntervals,
-                                regNumberSmall*         location,
+                                regNumber*              location,
                                 regNumber               toReg,
                                 regNumber               fromReg,
                                 ResolveType resolveType DEBUG_ARG(BasicBlock* fromBlock)

--- a/src/coreclr/jit/registeropswasm.cpp
+++ b/src/coreclr/jit/registeropswasm.cpp
@@ -6,7 +6,7 @@
 #pragma hdrstop
 #endif
 
-using RegNumUnderlyingType                               = regNumberSmall;
+using RegNumUnderlyingType                               = regNumberBase_t;
 static const RegNumUnderlyingType WASM_REG_TYPE_BITS     = 3;
 static const RegNumUnderlyingType WASM_REG_TYPE_SHIFT    = 8 * sizeof(RegNumUnderlyingType) - WASM_REG_TYPE_BITS;
 static const RegNumUnderlyingType WASM_REG_TYPE_MASK     = ~0u << WASM_REG_TYPE_SHIFT;

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -72,33 +72,37 @@ inline bool compUnixX86Abi()
 #if defined(TARGET_AMD64)
 #define REGMASK_BITS              64
 #define CSE_CONST_SHARED_LOW_BITS 16
-
 #elif defined(TARGET_X86)
 #define REGMASK_BITS              32
 #define CSE_CONST_SHARED_LOW_BITS 16
-
 #elif defined(TARGET_ARM)
 #define REGMASK_BITS              64
 #define CSE_CONST_SHARED_LOW_BITS 12
-
 #elif defined(TARGET_ARM64)
 #define REGMASK_BITS              64
 #define CSE_CONST_SHARED_LOW_BITS 12
-
 #elif defined(TARGET_LOONGARCH64)
 #define REGMASK_BITS              64
 #define CSE_CONST_SHARED_LOW_BITS 12
-
 #elif defined(TARGET_RISCV64)
 #define REGMASK_BITS              64
 #define CSE_CONST_SHARED_LOW_BITS 12
-
 #elif defined(TARGET_WASM)
 #define REGMASK_BITS              32
 #define CSE_CONST_SHARED_LOW_BITS 12
-
 #else
 #error Unsupported or unset target architecture
+#endif
+
+#if defined(TARGET_WASM)
+typedef uint32_t regNumberBase_t;
+typedef uint32_t regMaskBase_t;
+#elif defined(TARGET_X86)
+typedef uint8_t  regNumberBase_t;
+typedef uint32_t regMaskBase_t;
+#else
+typedef uint8_t  regNumberBase_t;
+typedef uint64_t regMaskBase_t;
 #endif
 
 //------------------------------------------------------------------------
@@ -112,10 +116,12 @@ inline bool compUnixX86Abi()
 //                       be assigned during register allocation.
 //    REG_NA           - Used to indicate that a register is either not yet assigned or not required.
 //
-#if defined(TARGET_ARM) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64) || defined(TARGET_WASM)
-enum _regNumber_enum : unsigned
+enum regNumber : regNumberBase_t
 {
-#if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64) || defined(TARGET_WASM)
+#if defined(TARGET_ARM64)
+#define REGDEF(name, rnum, mask, xname, wname) JITREG_##name = rnum,
+#define REGALIAS(alias, realname)              JITREG_##alias = JITREG_##realname,
+#elif defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64) || defined(TARGET_WASM)
 // LA64 and RV64 don't require JITREG_ workaround for Android (see register.h)
 #define REGDEF(name, rnum, mask, sname) REG_##name = rnum,
 #define REGALIAS(alias, realname)       REG_##alias = REG_##realname,
@@ -123,6 +129,7 @@ enum _regNumber_enum : unsigned
 #define REGDEF(name, rnum, mask, sname) JITREG_##name = rnum,
 #define REGALIAS(alias, realname)       JITREG_##alias = JITREG_##realname,
 #endif
+
 #include "register.h"
 
     REG_COUNT,
@@ -130,119 +137,35 @@ enum _regNumber_enum : unsigned
     ACTUAL_REG_COUNT = REG_COUNT - 1 // everything but REG_STK (only real regs)
 };
 
-enum _regMask_enum : uint64_t
+enum _regMask_enum : regMaskBase_t
 {
     RBM_NONE = 0,
-#define REGDEF(name, rnum, mask, sname) SRBM_##name = mask,
-#define REGALIAS(alias, realname)       SRBM_##alias = SRBM_##realname,
-#include "register.h"
-};
 
-#elif defined(TARGET_ARM64)
-
-enum _regNumber_enum : unsigned
-{
-#define REGDEF(name, rnum, mask, xname, wname) JITREG_##name = rnum,
-#define REGALIAS(alias, realname)              JITREG_##alias = JITREG_##realname,
-#include "register.h"
-
-    REG_COUNT,
-    REG_NA           = REG_COUNT,
-    ACTUAL_REG_COUNT = REG_COUNT - 1 // everything but REG_STK (only real regs)
-};
-
-enum _regMask_enum : uint64_t
-{
-    RBM_NONE = 0,
+#if defined(TARGET_ARM64)
 #define REGDEF(name, rnum, mask, xname, wname) SRBM_##name = mask,
 #define REGALIAS(alias, realname)              SRBM_##alias = SRBM_##realname,
-#include "register.h"
-};
-
-#elif defined(TARGET_AMD64)
-
-enum _regNumber_enum : unsigned
-{
-#define REGDEF(name, rnum, mask, sname) JITREG_##name = rnum,
-#define REGALIAS(alias, realname)       JITREG_##alias = JITREG_##realname,
-#include "register.h"
-
-    REG_COUNT,
-    REG_NA           = REG_COUNT,
-    ACTUAL_REG_COUNT = REG_COUNT - 1 // everything but REG_STK (only real regs)
-};
-
-enum _regMask_enum : uint64_t
-{
-    RBM_NONE = 0,
-
-#define REGDEF(name, rnum, mask, sname) SRBM_##name = mask,
-#define REGALIAS(alias, realname)       SRBM_##alias = SRBM_##realname,
-#include "register.h"
-};
-
-#elif defined(TARGET_X86)
-
-enum _regNumber_enum : unsigned
-{
-#define REGDEF(name, rnum, mask, sname) JITREG_##name = rnum,
-#define REGALIAS(alias, realname)       JITREG_##alias = JITREG_##realname,
-#include "register.h"
-
-    REG_COUNT,
-    REG_NA           = REG_COUNT,
-    ACTUAL_REG_COUNT = REG_COUNT - 1 // everything but REG_STK (only real regs)
-};
-
-enum _regMask_enum : unsigned
-{
-    RBM_NONE = 0,
-
-#define REGDEF(name, rnum, mask, sname) SRBM_##name = mask,
-#define REGALIAS(alias, realname)       SRBM_##alias = SRBM_##realname,
-#include "register.h"
-};
-
 #else
-#error Unsupported target architecture
+#define REGDEF(name, rnum, mask, sname) SRBM_##name = mask,
+#define REGALIAS(alias, realname)       SRBM_##alias = SRBM_##realname,
 #endif
+
+#include "register.h"
+};
 
 #define AVAILABLE_REG_COUNT get_AVAILABLE_REG_COUNT()
 
 /*****************************************************************************/
 
-// TODO-Cleanup: The types defined below are mildly confusing: why are there both?
-// regMaskSmall is large enough to represent the entire set of registers.
-// If regMaskSmall is smaller than a "natural" integer type, regMaskTP is wider, based
-// on a belief by the original authors of the JIT that in some situations it is more
-// efficient to have the wider representation.  This belief should be tested, and if it
-// is false, then we should coalesce these two types into one (the Small width, probably).
-// In any case, we believe that is OK to freely cast between these types; no information will
-// be lost.
-
-typedef _regNumber_enum regNumber;
-#ifdef TARGET_WASM
-typedef unsigned regNumberSmall; // An 'unlimited' number of registers.
-#else
-typedef unsigned char regNumberSmall;
-#endif
-
-#if REGMASK_BITS == 8
-typedef unsigned char regMaskSmall;
-#define REG_MASK_INT_FMT "%02X"
-#define REG_MASK_ALL_FMT "%02X"
-#elif REGMASK_BITS == 16
-typedef unsigned short regMaskSmall;
-#define REG_MASK_INT_FMT "%04X"
-#define REG_MASK_ALL_FMT "%04X"
-#elif REGMASK_BITS == 32
+#if REGMASK_BITS == 32
 typedef unsigned regMaskSmall;
 #define REG_MASK_INT_FMT "%08X"
 #define REG_MASK_ALL_FMT "%08X"
-#else
+#elif REGMASK_BITS == 64
 typedef uint64_t regMaskSmall;
 #define REG_MASK_INT_FMT "%04llX"
 #define REG_MASK_ALL_FMT "%016llX"
+#else
+#error Unsupported value for REGMASK_BITS
 #endif
 
 #if defined(TARGET_ARM64) || defined(TARGET_AMD64)


### PR DESCRIPTION
This follows up on a TODO to see if `regNumber` and `regNumberSmall` are actually needed or if we can just type the enum to the right size and use it everywhere.