### PR TITLE
Revert "[android] Enable CoreCLR runtime pack production for android-arm (#127225)"

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -29,7 +29,8 @@
     <!-- Determine if the CoreCLR runtime can build/run for the specified target. -->
     <_CoreCLRSupportedOS Condition="'$(TargetsMobile)' != 'true' and '$(TargetsLinuxBionic)' != 'true'">true</_CoreCLRSupportedOS>
 
-    <_CoreCLRSupportedOS Condition="'$(TargetsAndroid)' == 'true' and '$(TargetArchitecture)' != 'x86'">true</_CoreCLRSupportedOS>
+    <!-- Android 32-bit builds blocked by https://github.com/dotnet/runtime/issues/111665 -->
+    <_CoreCLRSupportedOS Condition="'$(TargetsAndroid)' == 'true' and '$(TargetArchitecture)' != 'arm' and '$(TargetArchitecture)' != 'x86'">true</_CoreCLRSupportedOS>
     <_CoreCLRSupportedOS Condition="'$(TargetsBrowser)' == 'true'">true</_CoreCLRSupportedOS>
     <_CoreCLRSupportedOS Condition="'$(TargetsAppleMobile)' == 'true'">true</_CoreCLRSupportedOS>
 

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -46,13 +46,6 @@ jobs:
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         - OSX.15.Amd64
 
-    # Android arm
-    - ${{ if in(parameters.platform, 'android_arm') }}:
-      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - Windows.11.Amd64.Android.Open
-      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - Windows.11.Amd64.Android
-
     # Android arm64
     - ${{ if in(parameters.platform, 'android_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -95,7 +95,6 @@ jobs:
     buildConfig: Release
     runtimeFlavor: coreclr
     platforms:
-    - android_arm
     - android_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1099,7 +1099,7 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # Android arm/arm64 devices and x64 emulators
+      # Android arm64 devices and x64 emulators
       # Build the whole product using CoreCLR and run functional tests
       #
       - template: /eng/pipelines/common/platform-matrix.yml
@@ -1109,7 +1109,6 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-          - android_arm
           - android_x64
           - android_arm64
           variables:


### PR DESCRIPTION
Reverts #127225
Closes #127500

android-arm is crashing in CI with `SIGSEGV` in `System.DateTime.get_Now()`. See #127500.

Reverting while the underlying crash is investigated.