### PR TITLE
ReadPipesToBuffers: remove unneeded DangerousAddRef/DangerousRelease from ReadPipesToBuffers.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Multiplexing.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/Process.Multiplexing.cs
@@ -392,30 +392,9 @@ namespace System.Diagnostics
             var outputHandle = GetSafeHandleFromStreamReader(_standardOutput!);
             var errorHandle = GetSafeHandleFromStreamReader(_standardError!);
 
-            bool outputRefAdded = false;
-            bool errorRefAdded = false;
-
-            try
-            {
-                outputHandle.DangerousAddRef(ref outputRefAdded);
-                errorHandle.DangerousAddRef(ref errorRefAdded);
-
-                ReadPipes(outputHandle, errorHandle, timeoutMs,
-                    ref outputBuffer, ref outputBytesRead,
-                    ref errorBuffer, ref errorBytesRead);
-            }
-            finally
-            {
-                if (outputRefAdded)
-                {
-                    outputHandle.DangerousRelease();
-                }
-
-                if (errorRefAdded)
-                {
-                    errorHandle.DangerousRelease();
-                }
-            }
+            ReadPipes(outputHandle, errorHandle, timeoutMs,
+                ref outputBuffer, ref outputBytesRead,
+                ref errorBuffer, ref errorBytesRead);
         }
 
         /// <summary>


### PR DESCRIPTION
Per https://github.com/dotnet/runtime/pull/126807/changes#r3085172163.

@adamsitnik @jkotas ptal.