### PR TITLE
[cDAC] Use locally-built crossgen2 for dump test debuggees

### DIFF
--- a/eng/pipelines/cdac/prepare-cdac-helix-steps.yml
+++ b/eng/pipelines/cdac/prepare-cdac-helix-steps.yml
@@ -6,6 +6,7 @@
 parameters:
   buildDebuggees: true
   skipDebuggeeCopy: false
+  runtimeConfiguration: 'Checked'
 
 steps:
 - ${{ if parameters.buildDebuggees }}:
@@ -14,6 +15,7 @@ steps:
       /t:BuildDebuggeesOnly
       /p:Configuration=$(_BuildConfig)
       /p:TargetArchitecture=$(archType)
+      /p:RuntimeConfiguration=${{ parameters.runtimeConfiguration }}
       -bl:$(Build.SourcesDirectory)/artifacts/log/BuildDebuggees.binlog
     displayName: 'Build Debuggees'
 

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.targets
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.targets
@@ -1,6 +1,22 @@
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)..\'))" />
 
+  <!--
+    Force debuggees to use the locally-built runtime/targeting packs and crossgen2
+    (not the SDK's bundled versions from global.json) when publishing with
+    PublishReadyToRun=true.
+
+    targetingpacks.targets handles runtime/targeting pack resolution.
+    tests.readytorun.targets overrides ResolveReadyToRunCompilers to use the
+    locally-built crossgen2 directly (the local build layout is flat, not the
+    NuGet pack "tools/" subdirectory layout the SDK expects).
+  -->
+  <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" />
+
+  <PropertyGroup>
+    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(RepositoryEngineeringDir)testing\tests.readytorun.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
+
   <!-- Target invoked by GenerateAllDumps (from DumpTests.targets) on each debuggee csproj
        to extract the DumpTypes property. Returns the project name with DumpTypes metadata. -->
   <Target Name="GetDumpTypes" Returns="@(_DumpTypeOutput)">

--- a/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
@@ -39,6 +39,24 @@
     <DebuggeesDir>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'Debuggees'))</DebuggeesDir>
     <!-- Platform-aware dotnet host and exe suffix -->
     <_DotNetExe>$([MSBuild]::NormalizePath('$(RepoRoot)', '.dotnet', 'dotnet$(ExeSuffix)'))</_DotNetExe>
+    <!-- The configuration the locally-built CoreCLR (and crossgen2) lives under.
+         The debuggee publish must pass this through so that targetingpacks.targets
+         resolves Crossgen2InBuildDir to the right path (artifacts/bin/coreclr/<os>.<arch>.<CoreCLRConfiguration>/...).
+         CoreCLRConfiguration derives from RuntimeConfiguration, which itself defaults to Configuration. -->
+    <_DebuggeeRuntimeConfig Condition="'$(_DebuggeeRuntimeConfig)' == ''">$(RuntimeConfiguration)</_DebuggeeRuntimeConfig>
+    <_DebuggeeRuntimeConfig Condition="'$(_DebuggeeRuntimeConfig)' == ''">$(Configuration)</_DebuggeeRuntimeConfig>
+    <_DebuggeeRuntimeConfig Condition="'$(_DebuggeeRuntimeConfig)' == ''">Debug</_DebuggeeRuntimeConfig>
+
+    <!-- Properties that must be propagated through to the child `dotnet publish`
+         process so that targetingpacks.targets can resolve the local runtime/ref
+         packs and Crossgen2 pack at the correct paths. In a cross-build (e.g.
+         building on linux-x64 for linux-arm) the child publish would otherwise
+         default TargetArchitecture from the process architecture and resolve
+         MicrosoftNetCoreAppRuntimePackDir to the wrong RID. -->
+    <_DebuggeePublishProps>/p:RuntimeConfiguration=$(_DebuggeeRuntimeConfig)</_DebuggeePublishProps>
+    <_DebuggeePublishProps Condition="'$(TargetArchitecture)' != ''">$(_DebuggeePublishProps) /p:TargetArchitecture=$(TargetArchitecture)</_DebuggeePublishProps>
+    <_DebuggeePublishProps Condition="'$(TargetOS)' != ''">$(_DebuggeePublishProps) /p:TargetOS=$(TargetOS)</_DebuggeePublishProps>
+    <_DebuggeePublishProps Condition="'$(BuildArchitecture)' != ''">$(_DebuggeePublishProps) /p:BuildArchitecture=$(BuildArchitecture)</_DebuggeePublishProps>
   </PropertyGroup>
 
   <!-- Auto-detect testhost from repo artifacts (used for "local" runtime version). -->
@@ -167,7 +185,7 @@
     <PropertyGroup>
       <_PublishOutDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)'))</_PublishOutDir>
     </PropertyGroup>
-    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --no-self-contained /p:PublishReadyToRun=true --nologo -o &quot;$(_PublishOutDir)&quot;" />
+    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --no-self-contained /p:PublishReadyToRun=true $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishOutDir)&quot;" />
   </Target>
 
   <Target Name="_GenerateDumpsForDebuggee">
@@ -254,7 +272,7 @@
       <_DebuggeeCsproj>$([MSBuild]::NormalizePath('$(_DebuggeeDir)', '$(DebuggeeName).csproj'))</_DebuggeeCsproj>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --no-self-contained /p:PublishReadyToRun=true --nologo -o &quot;$(_DebuggeeBinDir)&quot;"
+    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --no-self-contained /p:PublishReadyToRun=true $(_DebuggeePublishProps) --nologo -o &quot;$(_DebuggeeBinDir)&quot;"
           WorkingDirectory="$(_DebuggeeDir)" />
 
     <MakeDir Directories="$(_DumpDir)" />


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of GitHub Copilot (AI-generated content).

## Problem

The `AsyncContinuationDumpTests` (and potentially other R2R dump tests) fail in CI because the debuggee apps are R2R-compiled with the SDK's bundled crossgen2 instead of the locally-built one. When the locally-built runtime removes or changes types between previews (e.g. PR #127336 removing `ExecutionAndSyncBlockStore`), the SDK's crossgen2 emits R2R thunks referencing types that no longer exist, causing `TypeLoadException` or null globals at runtime.

## Root Cause

Two issues prevent the locally-built crossgen2 from being used:

1. **NuGet pack layout mismatch**: The SDK's `ResolveReadyToRunCompilers` task expects crossgen2 at `PackagePath/tools/crossgen2.exe` (NuGet pack layout), but the local build produces a flat layout with `crossgen2.exe` at the root of `Crossgen2InBuildDir`. `targetingpacks.targets` alone cannot fix this because it only updates `PackageDirectory` without restructuring the layout.

2. **Missing property propagation**: The child `dotnet publish` process doesn't inherit `RuntimeConfiguration`, `TargetArchitecture`, `TargetOS`, or `BuildArchitecture` from the outer build, causing crossgen2 and runtime pack paths to resolve incorrectly (especially in cross-build scenarios like building on linux-x64 for linux-arm).

## Fix

### `Debuggees/Directory.Build.targets`
- Import `targetingpacks.targets` for runtime/targeting pack resolution
- Import `tests.readytorun.targets` via `AfterMicrosoftNETSdkTargets` to override `ResolveReadyToRunCompilers` after the SDK defines it, pointing directly at the locally-built crossgen2

### `DumpTests.targets`
- Add `_DebuggeeRuntimeConfig` property (falls back from `RuntimeConfiguration` -> `Configuration` -> `Debug`)
- Add `_DebuggeePublishProps` to propagate `RuntimeConfiguration`, `TargetArchitecture`, `TargetOS`, and `BuildArchitecture` to child `dotnet publish` calls

### `prepare-cdac-helix-steps.yml`
- Add `runtimeConfiguration` parameter (default: `Checked`) and pass it to `BuildDebuggeesOnly` so crossgen2 is found under the correct `Checked` artifacts path