### PR TITLE
[wasm][coreclr] Do not use SetCleanupNeededForFinalizedThread

### DIFF
--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -630,7 +630,9 @@ FCIMPL1(void, ThreadNative::Finalize, ThreadBaseObject* pThisUNSAFE)
         }
 
         thread->SetThreadState(Thread::TS_Finalized);
+#ifndef TARGET_WASM
         Thread::SetCleanupNeededForFinalizedThread();
+#endif // TARGET_WASM
     }
 }
 FCIMPLEND

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -630,9 +630,9 @@ FCIMPL1(void, ThreadNative::Finalize, ThreadBaseObject* pThisUNSAFE)
         }
 
         thread->SetThreadState(Thread::TS_Finalized);
-#ifndef TARGET_WASM
+#ifdef FEATURE_MULTITHREADING
         Thread::SetCleanupNeededForFinalizedThread();
-#endif // TARGET_WASM
+#endif // FEATURE_MULTITHREADING
     }
 }
 FCIMPLEND

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -185,8 +185,6 @@
 
   <!-- https://github.com/dotnet/runtime/issues/125495 - These tests are disabled on browser/CoreCLR because of crashes and test failures. -->
   <ItemGroup Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR' and '$(RunDisabledWasmTests)' != 'true'">
-    <!-- crashes -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Threading.Thread\tests\System.Threading.Thread.Tests.csproj" />
     <!-- test failures -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Nrbf\tests\System.Formats.Nrbf.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />


### PR DESCRIPTION
> [!NOTE]
> PR description generated with Copilot assistance.

On wasm there is no finalizer thread. GC finalizers run inline on the main thread, causing `SetCleanupNeededForFinalizedThread` to hit the `IsFinalizerThread()` assert when a `Thread` object is finalized.

The call to  `CleanupFinalizedThreads` is not reached anyway because `HaveExtraWorkForFinalizer` returns false on wasm.

Also enable System.Threading.Thread tests on browser/CoreCLR.