### PR TITLE
ProcessTests: redirect stdio and kill entire process tree for shell-script-based tests.

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -15,6 +15,7 @@ using System.Security;
 using Xunit;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
+using Microsoft.Win32.SafeHandles;
 
 namespace System.Diagnostics.Tests
 {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -173,7 +173,8 @@ namespace System.Diagnostics.Tests
             File.WriteAllText(filename, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
             File.SetUnixFileMode(filename, ExecutablePermissions);
 
-            using (var process = Process.Start(new ProcessStartInfo { FileName = filename }))
+            var psi = new ProcessStartInfo { FileName = filename, RedirectStandardOutput = true, RedirectStandardError = true };
+            using (var process = Process.Start(psi))
             {
                 try
                 {
@@ -186,7 +187,7 @@ namespace System.Diagnostics.Tests
                 }
                 finally
                 {
-                    process.Kill();
+                    process.Kill(entireProcessTree: true);
                     process.WaitForExit();
                 }
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.Unix.cs
@@ -173,7 +173,12 @@ namespace System.Diagnostics.Tests
             File.WriteAllText(filename, $"#!/bin/sh\nsleep 600\n"); // sleep 10 min.
             File.SetUnixFileMode(filename, ExecutablePermissions);
 
-            var psi = new ProcessStartInfo { FileName = filename, RedirectStandardOutput = true, RedirectStandardError = true };
+            using SafeFileHandle nullHandle = File.OpenNullHandle();
+            ProcessStartInfo psi = new(filename)
+            {
+                StandardOutputHandle = nullHandle,
+                StandardErrorHandle= nullHandle
+            };
             using (var process = Process.Start(psi))
             {
                 try

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2499,10 +2499,11 @@ namespace System.Diagnostics.Tests
             string sleepCommandPathFileName = Path.Combine(TestDirectory, LongProcessName);
             File.Copy(sleepPath, sleepCommandPathFileName);
 
+            using SafeFileHandle nullHandle = File.OpenNullHandle();
             ProcessStartInfo psi = new(sleepCommandPathFileName, "600")
             {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
+                StandardOutputHandle = nullHandle,
+                StandardErrorHandle= nullHandle
             };
             using (Process px = Process.Start(psi))
             {

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2499,7 +2499,12 @@ namespace System.Diagnostics.Tests
             string sleepCommandPathFileName = Path.Combine(TestDirectory, LongProcessName);
             File.Copy(sleepPath, sleepCommandPathFileName);
 
-            using (Process px = Process.Start(sleepCommandPathFileName, "600"))
+            var psi = new ProcessStartInfo(sleepCommandPathFileName, "600")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            using (Process px = Process.Start(psi))
             {
                 // Reading of long process names is flaky during process startup and shutdown.
                 // Wait a bit to skip over the period where the ProcessName is not reliable.
@@ -2512,7 +2517,7 @@ namespace System.Diagnostics.Tests
                 }
                 finally
                 {
-                    px.Kill();
+                    px.Kill(entireProcessTree: true);
                     px.WaitForExit();
                 }
             }

--- a/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -2499,7 +2499,7 @@ namespace System.Diagnostics.Tests
             string sleepCommandPathFileName = Path.Combine(TestDirectory, LongProcessName);
             File.Copy(sleepPath, sleepCommandPathFileName);
 
-            var psi = new ProcessStartInfo(sleepCommandPathFileName, "600")
+            ProcessStartInfo psi = new(sleepCommandPathFileName, "600")
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,


### PR DESCRIPTION
The LongProcessNamesAreSupported and ProcessNameMatchesScriptName tests spawn a shell script that runs sleep as a grandchild. Killing only the shell left the sleep process alive, holding stdout/stderr pipes open for the parent that runs the tests.

@dotnet/area-system-diagnostics-process ptal.