### PR TITLE
Copy createdump alongside NativeAOT test binaries for crash dumps

### DIFF
--- a/eng/testing/tests.singlefile.targets
+++ b/eng/testing/tests.singlefile.targets
@@ -63,6 +63,20 @@
     <PackageReference Include="xunit.runner.utility" Version="$(XUnitVersion)" />
   </ItemGroup>
 
+  <!-- Copy createdump next to the published NativeAOT test binary so crash dumps can be collected on Helix. -->
+  <Target Name="CopyCreatedumpForNativeAot"
+          Condition="'$(TestNativeAot)' == 'true' and '$(TargetOS)' != 'windows'"
+          AfterTargets="Publish">
+    <PropertyGroup>
+      <_CreatedumpSource Condition="'$(TargetOS)' == 'osx'">$(CoreCLRArtifactsPath)sharedFramework/createdump</_CreatedumpSource>
+      <_CreatedumpSource Condition="'$(TargetOS)' != 'osx'">$(CoreCLRArtifactsPath)createdump</_CreatedumpSource>
+    </PropertyGroup>
+    <Copy SourceFiles="$(_CreatedumpSource)"
+          DestinationFolder="$(BundleDir)"
+          Condition="Exists('$(_CreatedumpSource)')"
+          SkipUnchangedFiles="true" />
+  </Target>
+
   <Target Name="__ExcludeAssembliesFromSingleFile"
           Inputs="%(ResolvedFileToPublish.Identity)"
           Outputs="__NewResolvedFiles"


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the help of GitHub Copilot.

NativeAOT tests set `DOTNET_DbgEnableMiniDump=1` via `RunnerTemplate.sh` but `createdump` was not being deployed next to the test binary, so crash dumps could not be collected on Helix. Regular CoreCLR tests get `createdump` via the testhost shared framework, but NativeAOT tests are self-contained and don't have a testhost.

This adds an MSBuild target that copies `createdump` from CoreCLR artifacts into the NativeAOT test publish directory after `Publish`, so it's included in the test archive sent to Helix.