### PR TITLE
JIT: make funclet order correspond to EH clause order

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6678,9 +6678,9 @@ void CodeGen::genIPmappingGen()
                 DebugInfo rootInfo = stmt->GetDebugInfo().GetRoot();
                 if (rootInfo.IsValid())
                 {
-                    for (unsigned vmIndex = 0; vmIndex < m_compiler->eeBoundariesCount; ++vmIndex)
+                    for (unsigned i = 0; i < m_compiler->eeBoundariesCount; ++i)
                     {
-                        if (m_compiler->eeBoundaries[vmIndex].ilOffset == rootInfo.GetLocation().GetOffset())
+                        if (m_compiler->eeBoundaries[i].ilOffset == rootInfo.GetLocation().GetOffset())
                         {
                             found = true;
                             break;
@@ -7926,7 +7926,7 @@ void CodeGen::genMultiRegStoreToLocal(GenTreeLclVar* lclNode)
         {
 #if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             // Should consider the padding, empty struct fields, etc within a struct.
-            offset = returnTypeDesc->GetReturnFieldOffset(vmIndex);
+            offset = returnTypeDesc->GetReturnFieldOffset(i);
 #endif
 #ifdef SWIFT_SUPPORT
             if (offsets != nullptr)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2552,31 +2552,12 @@ void CodeGen::genReportEH()
 
     EHClauseInfo* clauses = new (m_compiler, CMK_Codegen) EHClauseInfo[m_compiler->compHndBBtabCount];
 
-    INDEBUG(unsigned lastFuncletIndex = 0);
-
     // Set up EH clause table, but don't report anything to the VM, yet.
     //
-    for (unsigned int i = 0; i < m_compiler->compHndBBtabCount; i++)
+    for (unsigned int XTnum = 0; XTnum < m_compiler->compHndBBtabCount; XTnum++)
     {
-        unsigned const  XTNum = m_compiler->compEHorderTab[i];
-        EHblkDsc* const HBtab = &m_compiler->compHndBBtab[XTNum];
-
-#ifdef DEBUG
-        // We should be seeing funclet numbers increase predictably
-        // as we go through the EH table in VM order.
-        //
-        if (HBtab->HasFilter())
-        {
-            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 2));
-        }
-        else
-        {
-            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 1));
-        }
-        lastFuncletIndex = HBtab->ebdFuncIndex;
-#endif
-
-        UNATIVE_OFFSET tryBeg, tryEnd, hndBeg, hndEnd, hndTyp;
+        EHblkDsc* const HBtab = &m_compiler->compHndBBtab[XTnum];
+        UNATIVE_OFFSET  tryBeg, tryEnd, hndBeg, hndEnd, hndTyp;
 
         tryBeg = m_compiler->ehCodeOffset(HBtab->ebdTryBeg);
         hndBeg = m_compiler->ehCodeOffset(HBtab->ebdHndBeg);
@@ -2605,7 +2586,10 @@ void CodeGen::genReportEH()
         clause.TryLength     = tryEnd;
         clause.HandlerOffset = hndBeg;
         clause.HandlerLength = hndEnd;
-        clauses[i]           = {clause, HBtab};
+
+        unsigned const vmIndex = m_compiler->compEHTabOrderToVMClauseOrder[XTnum];
+
+        clauses[vmIndex] = {clause, HBtab};
     }
 
     genReportEHClauses(clauses);
@@ -2621,25 +2605,39 @@ void CodeGen::genReportEH()
 //
 void CodeGen::genReportEHClauses(EHClauseInfo* clauses)
 {
-    // Now, report EH clauses to the VM in the proper order.
-    // It may differ from the order in the EH table.
+    // Now, report EH clauses to the VM
     //
-    // We computed this order in fgCreateFunclets.
-    //
-    for (unsigned i = 0; i < m_compiler->compHndBBtabCount; i++)
-    {
-        unsigned           XTnum  = m_compiler->compEHorderTab[i];
-        CORINFO_EH_CLAUSE& clause = clauses[XTnum].clause;
-        EHblkDsc* const    HBtab  = clauses[XTnum].HBtab;
+    INDEBUG(unsigned lastFuncletIndex = 0);
 
-        if (XTnum > 0)
+    for (unsigned vmIndex = 0; vmIndex < m_compiler->compHndBBtabCount; vmIndex++)
+    {
+        CORINFO_EH_CLAUSE& clause = clauses[vmIndex].clause;
+        unsigned const     XTnum  = m_compiler->compVMClauseOrderToEHTabOrder[vmIndex];
+        EHblkDsc* const    HBtab  = &m_compiler->compHndBBtab[XTnum];
+
+#ifdef DEBUG
+        // We should be seeing funclet numbers increase predictably
+        // as we go through the EH table in VM order.
+        //
+        if (HBtab->HasFilter())
+        {
+            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 2));
+        }
+        else
+        {
+            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 1));
+        }
+        lastFuncletIndex = HBtab->ebdFuncIndex;
+#endif
+
+        if (vmIndex > 0)
         {
             // CORINFO_EH_CLAUSE_SAMETRY flag means that the current clause covers same
             // try block as the previous one. The runtime cannot reliably infer this information from
             // native code offsets because of different try blocks can have same offsets. Alternative
             // solution to this problem would be inserting extra nops to ensure that different try
             // blocks have different offsets.
-            if (EHblkDsc::ebdIsSameTry(HBtab, clauses[XTnum - 1].HBtab))
+            if (EHblkDsc::ebdIsSameTry(HBtab, clauses[vmIndex - 1].HBtab))
             {
                 // The SAMETRY bit should only be set on catch clauses. This is ensured in IL, where only 'catch' is
                 // allowed to be mutually-protect. E.g., the C# "try {} catch {} catch {} finally {}" actually exists in
@@ -2649,7 +2647,7 @@ void CodeGen::genReportEHClauses(EHClauseInfo* clauses)
             }
         }
 
-        m_compiler->eeSetEHinfo(XTnum, &clause);
+        m_compiler->eeSetEHinfo(vmIndex, &clause);
     }
 }
 
@@ -6680,9 +6678,9 @@ void CodeGen::genIPmappingGen()
                 DebugInfo rootInfo = stmt->GetDebugInfo().GetRoot();
                 if (rootInfo.IsValid())
                 {
-                    for (unsigned i = 0; i < m_compiler->eeBoundariesCount; ++i)
+                    for (unsigned vmIndex = 0; vmIndex < m_compiler->eeBoundariesCount; ++vmIndex)
                     {
-                        if (m_compiler->eeBoundaries[i].ilOffset == rootInfo.GetLocation().GetOffset())
+                        if (m_compiler->eeBoundaries[vmIndex].ilOffset == rootInfo.GetLocation().GetOffset())
                         {
                             found = true;
                             break;
@@ -7928,7 +7926,7 @@ void CodeGen::genMultiRegStoreToLocal(GenTreeLclVar* lclNode)
         {
 #if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
             // Should consider the padding, empty struct fields, etc within a struct.
-            offset = returnTypeDesc->GetReturnFieldOffset(i);
+            offset = returnTypeDesc->GetReturnFieldOffset(vmIndex);
 #endif
 #ifdef SWIFT_SUPPORT
             if (offsets != nullptr)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2542,14 +2542,6 @@ void CodeGen::genReportEH()
     if (m_compiler->opts.dspEHTable)
     {
         printf("*************** EH table for %s\n", m_compiler->info.compFullName);
-    }
-#endif // DEBUG
-
-    unsigned XTnum;
-
-#ifdef DEBUG
-    if (m_compiler->opts.dspEHTable)
-    {
         printf("%d EH table entries\n", m_compiler->compHndBBtabCount);
     }
 #endif // DEBUG
@@ -2560,10 +2552,30 @@ void CodeGen::genReportEH()
 
     EHClauseInfo* clauses = new (m_compiler, CMK_Codegen) EHClauseInfo[m_compiler->compHndBBtabCount];
 
+    INDEBUG(unsigned lastFuncletIndex = 0);
+
     // Set up EH clause table, but don't report anything to the VM, yet.
-    XTnum = 0;
-    for (EHblkDsc* const HBtab : EHClauses(m_compiler))
+    //
+    for (unsigned int i = 0; i < m_compiler->compHndBBtabCount; i++)
     {
+        unsigned const  XTNum = m_compiler->compEHorderTab[i];
+        EHblkDsc* const HBtab = &m_compiler->compHndBBtab[XTNum];
+
+#ifdef DEBUG
+        // We should be seeing funclet numbers increase predictably
+        // as we go through the EH table in VM order.
+        //
+        if (HBtab->HasFilter())
+        {
+            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 2));
+        }
+        else
+        {
+            assert(HBtab->ebdFuncIndex == (lastFuncletIndex + 1));
+        }
+        lastFuncletIndex = HBtab->ebdFuncIndex;
+#endif
+
         UNATIVE_OFFSET tryBeg, tryEnd, hndBeg, hndEnd, hndTyp;
 
         tryBeg = m_compiler->ehCodeOffset(HBtab->ebdTryBeg);
@@ -2593,7 +2605,7 @@ void CodeGen::genReportEH()
         clause.TryLength     = tryEnd;
         clause.HandlerOffset = hndBeg;
         clause.HandlerLength = hndEnd;
-        clauses[XTnum++]     = {clause, HBtab};
+        clauses[i]           = {clause, HBtab};
     }
 
     genReportEHClauses(clauses);
@@ -2605,34 +2617,18 @@ void CodeGen::genReportEH()
 // genReportEH: create and report EH info to the VM
 //
 // Arguments:
-//    clauses -- eh clause data to report
+//    clauses -- eh clause data to fill in and report
 //
 void CodeGen::genReportEHClauses(EHClauseInfo* clauses)
 {
-    // The JIT's ordering of EH clauses does not guarantee that clauses covering the same try region are contiguous.
-    // We need this property to hold true so the CORINFO_EH_CLAUSE_SAMETRY flag is accurate.
-    jitstd::sort(clauses, clauses + m_compiler->compHndBBtabCount,
-                 [this](const EHClauseInfo& left, const EHClauseInfo& right) {
-        const unsigned short leftTryIndex  = left.HBtab->ebdTryBeg->bbTryIndex;
-        const unsigned short rightTryIndex = right.HBtab->ebdTryBeg->bbTryIndex;
-
-        if (leftTryIndex == rightTryIndex)
-        {
-            // We have two clauses mapped to the same try region.
-            // Make sure we report the clause with the smaller index first.
-            const ptrdiff_t leftIndex  = left.HBtab - this->m_compiler->compHndBBtab;
-            const ptrdiff_t rightIndex = right.HBtab - this->m_compiler->compHndBBtab;
-            return leftIndex < rightIndex;
-        }
-
-        return leftTryIndex < rightTryIndex;
-    });
-
-    unsigned XTnum;
-
-    // Now, report EH clauses to the VM in order of increasing try region index.
-    for (XTnum = 0; XTnum < m_compiler->compHndBBtabCount; XTnum++)
+    // Now, report EH clauses to the VM in the proper order.
+    // It may differ from the order in the EH table.
+    //
+    // We computed this order in fgCreateFunclets.
+    //
+    for (unsigned i = 0; i < m_compiler->compHndBBtabCount; i++)
     {
+        unsigned           XTnum  = m_compiler->compEHorderTab[i];
         CORINFO_EH_CLAUSE& clause = clauses[XTnum].clause;
         EHblkDsc* const    HBtab  = clauses[XTnum].HBtab;
 
@@ -2655,8 +2651,6 @@ void CodeGen::genReportEHClauses(EHClauseInfo* clauses)
 
         m_compiler->eeSetEHinfo(XTnum, &clause);
     }
-
-    assert(XTnum == m_compiler->compHndBBtabCount);
 }
 
 #ifndef TARGET_WASM

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9459,9 +9459,10 @@ public:
     }
 
     // Things that MAY belong either in CodeGen or CodeGenContext
-    FuncInfoDsc*   compFuncInfos;
-    unsigned short compCurrFuncIdx;
-    unsigned short compFuncInfoCount;
+    FuncInfoDsc*    compFuncInfos;
+    unsigned short  compCurrFuncIdx;
+    unsigned short  compFuncInfoCount;
+    unsigned short* compEHorderTab;
 
     unsigned short compFuncCount()
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9462,7 +9462,8 @@ public:
     FuncInfoDsc*    compFuncInfos;
     unsigned short  compCurrFuncIdx;
     unsigned short  compFuncInfoCount;
-    unsigned short* compEHorderTab;
+    unsigned short* compVMClauseOrderToEHTabOrder;
+    unsigned short* compEHTabOrderToVMClauseOrder;
 
     unsigned short compFuncCount()
     {

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -5380,10 +5380,6 @@ void Compiler::fgMoveBlocksAfter(BasicBlock* bStart, BasicBlock* bEnd, BasicBloc
 // Return Value:
 //    The last block that was relocated, or nullptr on failure.
 //
-// Notes:
-//    This function can invalidate all pointers into the EH table, as well as
-//    change the size of the EH table!
-//
 BasicBlock* Compiler::fgRelocateEHRange(unsigned regionIndex, FG_RELOCATE_TYPE relocateType)
 {
     INDEBUG(const char* reason = "None";)

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2490,10 +2490,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
     {
         clauses = new (this, CMK_WasmEH) EHClauseInfo[compHndBBtabCount];
 
-        for (unsigned i = 0; i < compHndBBtabCount; i++)
+        for (unsigned XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
         {
-            unsigned const    index = compEHorderTab[i];
-            EHblkDsc* const   dsc   = ehGetDsc(index);
+            unsigned const    vmIndex = compEHTabOrderToVMClauseOrder[XTnum];
+            EHblkDsc* const   dsc     = ehGetDsc(vmIndex);
             CORINFO_EH_CLAUSE clause;
             clause.ClassToken    = dsc->HasFilter() ? 0 : dsc->ebdTyp;
             clause.Flags         = ToCORINFO_EH_CLAUSE_FLAGS(dsc->ebdHandlerType);
@@ -2501,7 +2501,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             clause.TryLength     = 0;
             clause.HandlerOffset = 0;
             clause.HandlerLength = 0;
-            clauses[index]       = {clause, dsc};
+            clauses[vmIndex]     = {clause, dsc};
         }
     }
 
@@ -2594,7 +2594,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 virtualIP++;
 
                 const unsigned tryIndex               = block->getTryIndex();
-                const unsigned clauseIndex            = compEHorderTab[tryIndex];
+                const unsigned clauseIndex            = compEHTabOrderToVMClauseOrder[tryIndex];
                 clauses[clauseIndex].clause.TryOffset = virtualIP;
 
                 // Multiple try regions can begin at the same block.
@@ -2607,8 +2607,8 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                         // These should be mutual-protect trys.
                         //
                         assert(EHblkDsc::ebdIsSameTry(tryDsc, enclosingDsc));
-                        const unsigned enclosingTryIndex               = ehGetIndex(enclosingDsc);
-                        const unsigned enclosingClauseIndex            = compEHorderTab[enclosingTryIndex];
+                        const unsigned enclosingTryIndex    = ehGetIndex(enclosingDsc);
+                        const unsigned enclosingClauseIndex = compEHTabOrderToVMClauseOrder[enclosingTryIndex];
                         clauses[enclosingClauseIndex].clause.TryOffset = virtualIP;
                     }
                 }
@@ -2618,7 +2618,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             {
                 virtualIP++;
                 const unsigned hndIndex                   = block->getHndIndex();
-                const unsigned clauseIndex                = compEHorderTab[hndIndex];
+                const unsigned clauseIndex                = compEHTabOrderToVMClauseOrder[hndIndex];
                 clauses[clauseIndex].clause.HandlerOffset = virtualIP;
             }
 
@@ -2628,7 +2628,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 // For filters we store the offset in the class token field.
                 //
                 const unsigned filterIndex             = block->getHndIndex();
-                const unsigned clauseIndex             = compEHorderTab[filterIndex];
+                const unsigned clauseIndex             = compEHTabOrderToVMClauseOrder[filterIndex];
                 clauses[clauseIndex].clause.ClassToken = virtualIP;
             }
 
@@ -2648,7 +2648,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             {
                 virtualIP++;
                 const unsigned tryIndex    = block->getTryIndex();
-                const unsigned clauseIndex = compEHorderTab[tryIndex];
+                const unsigned clauseIndex = compEHTabOrderToVMClauseOrder[tryIndex];
                 assert(virtualIP > clauses[clauseIndex].clause.TryOffset);
                 clauses[clauseIndex].clause.TryLength = virtualIP;
 
@@ -2662,7 +2662,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                     if (enclosingDsc->ebdTryLast == block)
                     {
                         const unsigned enclosingTryIndex    = ehGetIndex(enclosingDsc);
-                        const unsigned enclosingClauseIndex = compEHorderTab[enclosingTryIndex];
+                        const unsigned enclosingClauseIndex = compEHTabOrderToVMClauseOrder[enclosingTryIndex];
                         assert(virtualIP > clauses[enclosingClauseIndex].clause.TryOffset);
                         clauses[enclosingClauseIndex].clause.TryLength = virtualIP;
                     }
@@ -2673,7 +2673,7 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             {
                 virtualIP++;
                 const unsigned hndIndex    = block->getHndIndex();
-                const unsigned clauseIndex = compEHorderTab[hndIndex];
+                const unsigned clauseIndex = compEHTabOrderToVMClauseOrder[hndIndex];
                 assert(virtualIP > clauses[clauseIndex].clause.HandlerOffset);
                 clauses[clauseIndex].clause.HandlerLength = virtualIP;
             }

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2697,19 +2697,20 @@ PhaseStatus Compiler::fgWasmVirtualIP()
         JITDUMP("EH virtual IP ranges\n");
         for (EHblkDsc* const dsc : EHClauses(this))
         {
-            const unsigned index = ehGetIndex(dsc);
+            const unsigned index       = ehGetIndex(dsc);
+            const unsigned clauseIndex = compEHTabOrderToVMClauseOrder[index];
 
-            JITDUMP("EH#%02u: Try [%04u..%04u)", index, clauses[index].clause.TryOffset,
-                    clauses[index].clause.TryLength);
+            JITDUMP("EH#%02u: Try [%04u..%04u)", index, clauses[clauseIndex].clause.TryOffset,
+                    clauses[clauseIndex].clause.TryLength);
 
             if (dsc->HasFilter())
             {
-                JITDUMP(" Filter [%04u..%04u)\n", clauses[index].clause.ClassToken,
-                        clauses[index].clause.HandlerOffset);
+                JITDUMP(" Filter [%04u..%04u)\n", clauses[clauseIndex].clause.ClassToken,
+                        clauses[clauseIndex].clause.HandlerOffset);
             }
 
-            JITDUMP(" Handler [%04u..%04u)\n", clauses[index].clause.HandlerOffset,
-                    clauses[index].clause.HandlerLength);
+            JITDUMP(" Handler [%04u..%04u)\n", clauses[clauseIndex].clause.HandlerOffset,
+                    clauses[clauseIndex].clause.HandlerLength);
         }
     }
 #endif // DEBUG

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2478,8 +2478,11 @@ PhaseStatus Compiler::fgWasmVirtualIP()
     unsigned virtualIP    = 0;
     unsigned updatesAdded = 0;
 
-    // Prefill the EH data fields that are not dependent on
-    // the Virtual IP.
+    // Prefill the EH data fields that are not dependent on the Virtual IP.
+    //
+    // Note this and subsequent accesses to the clause info must respect
+    // the order in which clauses will be reported to the VM, not the order
+    // in the compHndBBtab.
     //
     EHClauseInfo* clauses = nullptr;
 
@@ -2487,9 +2490,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
     {
         clauses = new (this, CMK_WasmEH) EHClauseInfo[compHndBBtabCount];
 
-        for (EHblkDsc* const dsc : EHClauses(this))
+        for (unsigned i = 0; i < compHndBBtabCount; i++)
         {
-            const unsigned    index = ehGetIndex(dsc);
+            unsigned const    index = compEHorderTab[i];
+            EHblkDsc* const   dsc   = ehGetDsc(index);
             CORINFO_EH_CLAUSE clause;
             clause.ClassToken    = dsc->HasFilter() ? 0 : dsc->ebdTyp;
             clause.Flags         = ToCORINFO_EH_CLAUSE_FLAGS(dsc->ebdHandlerType);
@@ -2588,7 +2592,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             if ((tryDsc != nullptr) && (block == tryDsc->ebdTryBeg))
             {
                 virtualIP++;
-                clauses[block->getTryIndex()].clause.TryOffset = virtualIP;
+
+                const unsigned tryIndex               = block->getTryIndex();
+                const unsigned clauseIndex            = compEHorderTab[tryIndex];
+                clauses[clauseIndex].clause.TryOffset = virtualIP;
 
                 // Multiple try regions can begin at the same block.
                 // Update all of their offsets here.
@@ -2600,8 +2607,9 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                         // These should be mutual-protect trys.
                         //
                         assert(EHblkDsc::ebdIsSameTry(tryDsc, enclosingDsc));
-                        const unsigned enclosingIndex            = ehGetIndex(enclosingDsc);
-                        clauses[enclosingIndex].clause.TryOffset = virtualIP;
+                        const unsigned enclosingTryIndex               = ehGetIndex(enclosingDsc);
+                        const unsigned enclosingClauseIndex            = compEHorderTab[enclosingTryIndex];
+                        clauses[enclosingClauseIndex].clause.TryOffset = virtualIP;
                     }
                 }
             }
@@ -2609,7 +2617,9 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             if ((hndDsc != nullptr) && (block == hndDsc->ebdHndBeg))
             {
                 virtualIP++;
-                clauses[block->getHndIndex()].clause.HandlerOffset = virtualIP;
+                const unsigned hndIndex                   = block->getHndIndex();
+                const unsigned clauseIndex                = compEHorderTab[hndIndex];
+                clauses[clauseIndex].clause.HandlerOffset = virtualIP;
             }
 
             if ((hndDsc != nullptr) && hndDsc->HasFilter() && (block == hndDsc->ebdFilter))
@@ -2617,7 +2627,9 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 virtualIP++;
                 // For filters we store the offset in the class token field.
                 //
-                clauses[block->getHndIndex()].clause.ClassToken = virtualIP;
+                const unsigned filterIndex             = block->getHndIndex();
+                const unsigned clauseIndex             = compEHorderTab[filterIndex];
+                clauses[clauseIndex].clause.ClassToken = virtualIP;
             }
 
             // For now, just refresh the stack Virtual IP at the start of each non-empty
@@ -2635,8 +2647,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             if ((tryDsc != nullptr) && (block == tryDsc->ebdTryLast))
             {
                 virtualIP++;
-                assert(virtualIP > clauses[block->getTryIndex()].clause.TryOffset);
-                clauses[block->getTryIndex()].clause.TryLength = virtualIP;
+                const unsigned tryIndex    = block->getTryIndex();
+                const unsigned clauseIndex = compEHorderTab[tryIndex];
+                assert(virtualIP > clauses[clauseIndex].clause.TryOffset);
+                clauses[clauseIndex].clause.TryLength = virtualIP;
 
                 // Multiple try regions can end at the same block.
                 // Update all of their extents here.
@@ -2647,9 +2661,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 {
                     if (enclosingDsc->ebdTryLast == block)
                     {
-                        const unsigned enclosingIndex = ehGetIndex(enclosingDsc);
-                        assert(virtualIP > clauses[enclosingIndex].clause.TryOffset);
-                        clauses[enclosingIndex].clause.TryLength = virtualIP;
+                        const unsigned enclosingTryIndex    = ehGetIndex(enclosingDsc);
+                        const unsigned enclosingClauseIndex = compEHorderTab[enclosingTryIndex];
+                        assert(virtualIP > clauses[enclosingClauseIndex].clause.TryOffset);
+                        clauses[enclosingClauseIndex].clause.TryLength = virtualIP;
                     }
                 }
             }
@@ -2657,8 +2672,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             if ((hndDsc != nullptr) && (block == hndDsc->ebdHndLast))
             {
                 virtualIP++;
-                assert(virtualIP > clauses[block->getHndIndex()].clause.HandlerOffset);
-                clauses[block->getHndIndex()].clause.HandlerLength = virtualIP;
+                const unsigned hndIndex    = block->getHndIndex();
+                const unsigned clauseIndex = compEHorderTab[hndIndex];
+                assert(virtualIP > clauses[clauseIndex].clause.HandlerOffset);
+                clauses[clauseIndex].clause.HandlerLength = virtualIP;
             }
 
             if ((hndDsc != nullptr) && hndDsc->HasFilter() && (block->Next() == hndDsc->ebdHndBeg))

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2492,8 +2492,8 @@ PhaseStatus Compiler::fgWasmVirtualIP()
 
         for (unsigned XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
         {
-            unsigned const    vmIndex = compEHTabOrderToVMClauseOrder[XTnum];
-            EHblkDsc* const   dsc     = ehGetDsc(vmIndex);
+            EHblkDsc* const dsc = ehGetDsc(XTnum);
+
             CORINFO_EH_CLAUSE clause;
             clause.ClassToken    = dsc->HasFilter() ? 0 : dsc->ebdTyp;
             clause.Flags         = ToCORINFO_EH_CLAUSE_FLAGS(dsc->ebdHandlerType);
@@ -2501,7 +2501,10 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             clause.TryLength     = 0;
             clause.HandlerOffset = 0;
             clause.HandlerLength = 0;
-            clauses[vmIndex]     = {clause, dsc};
+
+            unsigned const vmIndex = compEHTabOrderToVMClauseOrder[XTnum];
+
+            clauses[vmIndex] = {clause, dsc};
         }
     }
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3172,8 +3172,9 @@ PhaseStatus Compiler::fgCreateFunclets()
         fgCreateFuncletPrologBlocks();
 
         // We want to have the funclet order match the order of emission of EH clauses to the runtime.
-        // This is not the same as the order of entries as the EH table. So build a mapping from
-        // So, build mappings from vm order to table order and vice-versa.
+        //
+        // This is not the same as the order of entries in the EH table, so build a mapping from
+        // So, build mappings from vm order to table order and vice versa.
         //
         vmClauseOrderToEHTabOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
         ehTabOrderToVMClauseOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3173,9 +3173,7 @@ PhaseStatus Compiler::fgCreateFunclets()
 
         // We want to have the funclet order match the order of emission of EH clauses to the runtime.
         // This is not the same as the order of entries as the EH table. So build a mapping from
-        // So, build a mapping from emission order to table order.
-        //
-        // (todo: persist this and reuse in emission)
+        // So, build mappings from vm order to table order and vice-versa.
         //
         vmClauseOrderToEHTabOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
         ehTabOrderToVMClauseOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
@@ -3198,7 +3196,7 @@ PhaseStatus Compiler::fgCreateFunclets()
             if (leftTryIndex == rightTryIndex)
             {
                 // We have two clauses mapped to the same try region.
-                // Make sure we report the clause with the smaller index first.
+                // Make sure we order the clause with the smaller index first.
                 return leftIndex < rightIndex;
             }
 
@@ -3227,6 +3225,7 @@ PhaseStatus Compiler::fgCreateFunclets()
         }
 
         // Fill in the inverse mapping.
+        //
         for (unsigned i = 0; i < compHndBBtabCount; i++)
         {
             ehTabOrderToVMClauseOrder[vmClauseOrderToEHTabOrder[i]] = (unsigned short)i;

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3163,8 +3163,9 @@ PhaseStatus Compiler::fgCreateFunclets()
 #endif
     assert(funcInfo[0].funKind == FUNC_ROOT);
 
-    unsigned short* ehClauseOrderMap = nullptr;
-    unsigned short  funcIdx          = 1;
+    unsigned short* vmClauseOrderToEHTabOrder = nullptr;
+    unsigned short* ehTabOrderToVMClauseOrder = nullptr;
+    unsigned short  funcIdx                   = 1;
 
     if (compHndBBtabCount > 0)
     {
@@ -3176,19 +3177,20 @@ PhaseStatus Compiler::fgCreateFunclets()
         //
         // (todo: persist this and reuse in emission)
         //
-        ehClauseOrderMap = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
+        vmClauseOrderToEHTabOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
+        ehTabOrderToVMClauseOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
 
         unsigned XTnum;
 
         for (XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
         {
-            ehClauseOrderMap[XTnum] = (unsigned short)XTnum;
+            vmClauseOrderToEHTabOrder[XTnum] = (unsigned short)XTnum;
         }
 
         // The JIT's ordering of EH clauses does not guarantee that clauses covering the same try region are contiguous.
         // We need this property to hold true so the CORINFO_EH_CLAUSE_SAMETRY flag is accurate.
         //
-        jitstd::sort(ehClauseOrderMap, ehClauseOrderMap + compHndBBtabCount,
+        jitstd::sort(vmClauseOrderToEHTabOrder, vmClauseOrderToEHTabOrder + compHndBBtabCount,
                      [this](const unsigned short& leftIndex, const unsigned short& rightIndex) {
             const unsigned short leftTryIndex  = ehGetDsc(leftIndex)->ebdTryBeg->bbTryIndex;
             const unsigned short rightTryIndex = ehGetDsc(rightIndex)->ebdTryBeg->bbTryIndex;
@@ -3207,7 +3209,7 @@ PhaseStatus Compiler::fgCreateFunclets()
         //
         for (unsigned orderNum = 0; orderNum < compHndBBtabCount; orderNum++)
         {
-            XTnum                 = ehClauseOrderMap[orderNum];
+            XTnum                 = vmClauseOrderToEHTabOrder[orderNum];
             EHblkDsc* const HBtab = ehGetDsc(XTnum);
             if (HBtab->HasFilter())
             {
@@ -3223,16 +3225,23 @@ PhaseStatus Compiler::fgCreateFunclets()
             funcIdx++;
             fgRelocateEHRange(XTnum, FG_RELOCATE_HANDLER);
         }
+
+        // Fill in the inverse mapping.
+        for (unsigned i = 0; i < compHndBBtabCount; i++)
+        {
+            ehTabOrderToVMClauseOrder[vmClauseOrderToEHTabOrder[i]] = (unsigned short)i;
+        }
     }
 
     // We better have populated all of them by now
     assert(funcIdx == funcCnt);
 
     // Publish
-    compCurrFuncIdx   = 0;
-    compFuncInfos     = funcInfo;
-    compFuncInfoCount = (unsigned short)funcCnt;
-    compEHorderTab    = ehClauseOrderMap;
+    compCurrFuncIdx               = 0;
+    compFuncInfos                 = funcInfo;
+    compFuncInfoCount             = (unsigned short)funcCnt;
+    compVMClauseOrderToEHTabOrder = vmClauseOrderToEHTabOrder;
+    compEHTabOrderToVMClauseOrder = ehTabOrderToVMClauseOrder;
 
     fgFuncletsCreated = true;
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3172,9 +3172,10 @@ PhaseStatus Compiler::fgCreateFunclets()
         fgCreateFuncletPrologBlocks();
 
         // We want to have the funclet order match the order of emission of EH clauses to the runtime.
+        // We cannot change the order of entries in the JIT's EH table, as there are many places
+        // in the JIT that depend on the current ordering.
         //
-        // This is not the same as the order of entries in the EH table, so build a mapping from
-        // So, build mappings from vm order to table order and vice versa.
+        // So, build mappings from vm order to EH table order and vice versa.
         //
         vmClauseOrderToEHTabOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
         ehTabOrderToVMClauseOrder = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -7,7 +7,8 @@
 #pragma hdrstop
 #endif
 
-#include "lower.h" // for LowerRange()
+#include "lower.h"            // for LowerRange()
+#include "jitstd/algorithm.h" // for sort()
 
 // Flowgraph Miscellany
 
@@ -3136,10 +3137,6 @@ PhaseStatus Compiler::fgCreateFunclets()
 {
     assert(!fgFuncletsCreated);
 
-    fgCreateFuncletPrologBlocks();
-
-    unsigned           XTnum;
-    EHblkDsc*          HBtab;
     const unsigned int funcCnt = ehFuncletCount() + 1;
 
     if (!FitsIn<unsigned short>(funcCnt))
@@ -3148,8 +3145,6 @@ PhaseStatus Compiler::fgCreateFunclets()
     }
 
     FuncInfoDsc* funcInfo = new (this, CMK_BasicBlock) FuncInfoDsc[funcCnt];
-
-    unsigned short funcIdx;
 
     // Setup the root FuncInfoDsc and prepare to start associating
     // FuncInfoDsc's with their corresponding EH region
@@ -3167,34 +3162,67 @@ PhaseStatus Compiler::fgCreateFunclets()
     }
 #endif
     assert(funcInfo[0].funKind == FUNC_ROOT);
-    funcIdx = 1;
 
-    // Because we iterate from the top to the bottom of the compHndBBtab array, we are iterating
-    // from most nested (innermost) to least nested (outermost) EH region. It would be reasonable
-    // to iterate in the opposite order, but the order of funclets shouldn't matter.
-    //
-    // We move every handler region to the end of the function: each handler will become a funclet.
-    //
-    // Note that fgRelocateEHRange() can add new entries to the EH table. However, they will always
-    // be added *after* the current index, so our iteration here is not invalidated.
-    // It *can* invalidate the compHndBBtab pointer itself, though, if it gets reallocated!
+    unsigned short* ehClauseOrderMap = nullptr;
+    unsigned short  funcIdx          = 1;
 
-    for (XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
+    if (compHndBBtabCount > 0)
     {
-        HBtab = ehGetDsc(XTnum); // must re-compute this every loop, since fgRelocateEHRange changes the table
-        if (HBtab->HasFilter())
+        fgCreateFuncletPrologBlocks();
+
+        // We want to have the funclet order match the order of emission of EH clauses to the runtime.
+        // This is not the same as the order of entries as the EH table. So build a mapping from
+        // So, build a mapping from emission order to table order.
+        //
+        // (todo: persist this and reuse in emission)
+        //
+        ehClauseOrderMap = new (this, CMK_BasicBlock) unsigned short[compHndBBtabCount];
+
+        unsigned XTnum;
+
+        for (XTnum = 0; XTnum < compHndBBtabCount; XTnum++)
         {
-            assert(funcIdx < funcCnt);
-            funcInfo[funcIdx].funKind    = FUNC_FILTER;
-            funcInfo[funcIdx].funEHIndex = (unsigned short)XTnum;
-            funcIdx++;
+            ehClauseOrderMap[XTnum] = (unsigned short)XTnum;
         }
-        assert(funcIdx < funcCnt);
-        funcInfo[funcIdx].funKind    = FUNC_HANDLER;
-        funcInfo[funcIdx].funEHIndex = (unsigned short)XTnum;
-        HBtab->ebdFuncIndex          = funcIdx;
-        funcIdx++;
-        fgRelocateEHRange(XTnum, FG_RELOCATE_HANDLER);
+
+        // The JIT's ordering of EH clauses does not guarantee that clauses covering the same try region are contiguous.
+        // We need this property to hold true so the CORINFO_EH_CLAUSE_SAMETRY flag is accurate.
+        //
+        jitstd::sort(ehClauseOrderMap, ehClauseOrderMap + compHndBBtabCount,
+                     [this](const unsigned short& leftIndex, const unsigned short& rightIndex) {
+            const unsigned short leftTryIndex  = ehGetDsc(leftIndex)->ebdTryBeg->bbTryIndex;
+            const unsigned short rightTryIndex = ehGetDsc(rightIndex)->ebdTryBeg->bbTryIndex;
+
+            if (leftTryIndex == rightTryIndex)
+            {
+                // We have two clauses mapped to the same try region.
+                // Make sure we report the clause with the smaller index first.
+                return leftIndex < rightIndex;
+            }
+
+            return leftTryIndex < rightTryIndex;
+        });
+
+        // We move every handler region to the end of the function: each handler will become a funclet.
+        //
+        for (unsigned orderNum = 0; orderNum < compHndBBtabCount; orderNum++)
+        {
+            XTnum                 = ehClauseOrderMap[orderNum];
+            EHblkDsc* const HBtab = ehGetDsc(XTnum);
+            if (HBtab->HasFilter())
+            {
+                assert(funcIdx < funcCnt);
+                funcInfo[funcIdx].funKind    = FUNC_FILTER;
+                funcInfo[funcIdx].funEHIndex = (unsigned short)XTnum;
+                funcIdx++;
+            }
+            assert(funcIdx < funcCnt);
+            funcInfo[funcIdx].funKind    = FUNC_HANDLER;
+            funcInfo[funcIdx].funEHIndex = (unsigned short)XTnum;
+            HBtab->ebdFuncIndex          = funcIdx;
+            funcIdx++;
+            fgRelocateEHRange(XTnum, FG_RELOCATE_HANDLER);
+        }
     }
 
     // We better have populated all of them by now
@@ -3204,6 +3232,7 @@ PhaseStatus Compiler::fgCreateFunclets()
     compCurrFuncIdx   = 0;
     compFuncInfos     = funcInfo;
     compFuncInfoCount = (unsigned short)funcCnt;
+    compEHorderTab    = ehClauseOrderMap;
 
     fgFuncletsCreated = true;
 


### PR DESCRIPTION
For Wasm the JIT host will need to match up funclets with EH clauses without relying on the offset data in the EH clause.

To allow this, set things up so that the host can infer which funclets are associated with an EH clause by making the ordering of EH clauses and the order of funclets (reported via unwind info) correspond.

Note this is not 1-1 as EH clauses with filters will inspire two funclets. In those cases the JIT will always put the filter funclet before the catch funclet.