### PR TITLE
Fix interpreter breakpoint to pass fIsVEH=FALSE to FirstChanceNativeException

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -782,11 +782,14 @@ static void InterpBreakpoint(const int32_t *ip, const InterpMethodContextFrame *
             (void*)GetSP(&ctx),
             (void*)GetFP(&ctx)));
 
+        // Pass fIsVEH=FALSE: interpreter breakpoints are synthetic software callbacks,
+        // not vectored exception handler callbacks.
         if (g_pDebugInterface->FirstChanceNativeException(
             &exceptionRecord,
             &ctx,
             STATUS_BREAKPOINT,
-            pThread))
+            pThread,
+            FALSE /* fIsVEH */))
         {
             InterpThreadContext *pThreadContext = pThread->GetInterpThreadContext();
 


### PR DESCRIPTION
Fix a Windows crash with x64 debugging with Interpreter breakpoints on CET-enabled hardware.  Interpreter breakpoints are synthetic software callbacks, not vectored exception handler callbacks. We were passing in Passing `fIsVEH=TRUE` (the default) but this caused `SendSetThreadContextNeeded` to fire unconditionally for every interpreter breakpoint, resulting in a crash.  