### PR TITLE
Improve GCHeap::Promote debug validation

### DIFF
--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -2745,12 +2745,6 @@ void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
 
     uint8_t* o = (uint8_t*)*ppObject;
 
-#ifdef DEBUG_DestroyedHandleValue
-    // we can race with destroy handle during concurrent scan
-    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
-        return;
-#endif //DEBUG_DestroyedHandleValue
-
     if (!is_in_find_object_range (o))
     {
 #ifdef _DEBUG

--- a/src/coreclr/gc/background.cpp
+++ b/src/coreclr/gc/background.cpp
@@ -544,16 +544,22 @@ void gc_heap::background_promote (Object** ppObject, ScanContext* sc, uint32_t f
 
     uint8_t* o = (uint8_t*)*ppObject;
 
-    if (!is_in_find_object_range (o))
-    {
-        return;
-    }
-
 #ifdef DEBUG_DestroyedHandleValue
     // we can race with destroy handle during concurrent scan
     if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
         return;
 #endif //DEBUG_DestroyedHandleValue
+
+    if (!is_in_find_object_range (o))
+    {
+#ifdef _DEBUG
+        if ((o != NULL) && !(flags & GC_CALL_INTERIOR))
+        {
+            ((CObjectHeader*)o)->Validate();
+        }
+#endif //_DEBUG
+        return;
+    }
 
     HEAP_FROM_THREAD;
 
@@ -2739,8 +2745,20 @@ void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
 
     uint8_t* o = (uint8_t*)*ppObject;
 
+#ifdef DEBUG_DestroyedHandleValue
+    // we can race with destroy handle during concurrent scan
+    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
+        return;
+#endif //DEBUG_DestroyedHandleValue
+
     if (!is_in_find_object_range (o))
     {
+#ifdef _DEBUG
+        if ((o != NULL) && !(flags & GC_CALL_INTERIOR))
+        {
+            ((CObjectHeader*)o)->Validate();
+        }
+#endif //_DEBUG
         return;
     }
 

--- a/src/coreclr/gc/interface.cpp
+++ b/src/coreclr/gc/interface.cpp
@@ -1056,6 +1056,12 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 
     if (!gc_heap::is_in_find_object_range (o))
     {
+#ifdef _DEBUG
+        if ((o != NULL) && !(flags & GC_CALL_INTERIOR))
+        {
+            ((CObjectHeader*)o)->Validate();
+        }
+#endif
         return;
     }
 

--- a/src/coreclr/gc/interface.cpp
+++ b/src/coreclr/gc/interface.cpp
@@ -1054,6 +1054,12 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 
     uint8_t* o = (uint8_t*)*ppObject;
 
+#ifdef DEBUG_DestroyedHandleValue
+    // we can race with destroy handle during concurrent scan
+    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
+        return;
+#endif //DEBUG_DestroyedHandleValue
+
     if (!gc_heap::is_in_find_object_range (o))
     {
 #ifdef _DEBUG
@@ -1064,12 +1070,6 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 #endif
         return;
     }
-
-#ifdef DEBUG_DestroyedHandleValue
-    // we can race with destroy handle during concurrent scan
-    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
-        return;
-#endif //DEBUG_DestroyedHandleValue
 
     HEAP_FROM_THREAD;
 

--- a/src/coreclr/gc/interface.cpp
+++ b/src/coreclr/gc/interface.cpp
@@ -1067,7 +1067,7 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
         {
             ((CObjectHeader*)o)->Validate();
         }
-#endif
+#endif //_DEBUG
         return;
     }
 

--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -3085,8 +3085,7 @@ bool EnumGcRefsX86(PREGDISPLAY     pContext,
     /* Are we in the prolog or epilog of the method, or is this a
      * non-interruptible method that will not resume execution at this offset?
      * In either case, GC slots may not be initialized at the current offset
-     * and we can simply skip all reporting.
-     * (mirrors the fix in gcinfodecoder.cpp for non-interruptible aborted frames) */
+     * and we can simply skip all reporting. */
 
     if (info.prologOffs != hdrInfo::NOT_IN_PROLOG ||
         info.epilogOffs != hdrInfo::NOT_IN_EPILOG ||

--- a/src/coreclr/vm/gc_unwind_x86.inl
+++ b/src/coreclr/vm/gc_unwind_x86.inl
@@ -3082,10 +3082,15 @@ bool EnumGcRefsX86(PREGDISPLAY     pContext,
     }
 #endif
 
-    /* Are we in the prolog or epilog of the method? */
+    /* Are we in the prolog or epilog of the method, or is this a
+     * non-interruptible method that will not resume execution at this offset?
+     * In either case, GC slots may not be initialized at the current offset
+     * and we can simply skip all reporting.
+     * (mirrors the fix in gcinfodecoder.cpp for non-interruptible aborted frames) */
 
     if (info.prologOffs != hdrInfo::NOT_IN_PROLOG ||
-        info.epilogOffs != hdrInfo::NOT_IN_EPILOG)
+        info.epilogOffs != hdrInfo::NOT_IN_EPILOG ||
+        ((flags & ExecutionAborted) && !info.interruptible))
     {
 
 #if !DUMP_PTR_REFS

--- a/src/tests/Regressions/coreclr/GitHub_119403/test119403.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_119403/test119403.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test119403.cs" />

--- a/src/tests/Regressions/coreclr/GitHub_119403/test119403.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_119403/test119403.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>0</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test119403.cs" />


### PR DESCRIPTION
- Mirrors the fix from #119403 in x86 GCInfo decoder
- Improve GCHeap::Promote debug validation to repro this class of issues deterministically

Fixes #127581