### PR TITLE
Disable Android arm32 test runs

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -63,7 +63,8 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms:
-    - android_arm
+    # Disabled until https://github.com/dotnet/runtime/issues/125440 is resolved.
+    # - android_arm
     - android_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1067,7 +1067,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-          - android_arm
+          # Disabled until https://github.com/dotnet/runtime/issues/125440 is resolved.
+          # - android_arm
           - android_arm64
           variables:
             # map dependencies variables to local variables


### PR DESCRIPTION
> [!NOTE]
> This pull request description was generated by GitHub Copilot.

## Summary
- Disable the `android_arm` Mono library test matrix entry in the default runtime pipeline.
- Disable the same `android_arm` entry in the Android-only extra-platforms pipeline.
- Leave Android arm64 coverage enabled.

References dotnet/runtime#125440.

## Testing
- `git diff --check -- eng\pipelines\runtime.yml eng\pipelines\extra-platforms\runtime-extra-platforms-android.yml`