### PR TITLE
Limit metadata block size when reading TAR archives

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -719,7 +719,7 @@ namespace System.Formats.Tar
 
         private void ValidateSize()
         {
-            if ((uint)_size > (uint)Array.MaxLength)
+            if ((uint)_size > (uint)MaxMetadataBlockSize)
             {
                 ThrowSizeFieldTooLarge();
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -719,7 +719,7 @@ namespace System.Formats.Tar
 
         private void ValidateSize()
         {
-            if ((uint)_size > (uint)MaxMetadataBlockSize)
+            if ((ulong)_size > (ulong)MaxMetadataBlockSize)
             {
                 ThrowSizeFieldTooLarge();
             }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -24,6 +24,9 @@ namespace System.Formats.Tar
         private const string GnuMagic = "ustar ";
         private const string GnuVersion = " \0";
 
+        // // Maximum allowed size for metadata data sections (PAX extended attributes, GNU LongPath/LongLink).
+        private const int MaxMetadataBlockSize = 1024 * 1024;
+
         // Names of PAX extended attributes commonly found fields
         internal const string PaxEaName = "path";
         internal const string PaxEaLinkName = "linkpath";

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.cs
@@ -24,7 +24,7 @@ namespace System.Formats.Tar
         private const string GnuMagic = "ustar ";
         private const string GnuVersion = " \0";
 
-        // // Maximum allowed size for metadata data sections (PAX extended attributes, GNU LongPath/LongLink).
+        // Maximum allowed size for metadata sections (PAX extended attributes, GNU LongPath/LongLink).
         private const int MaxMetadataBlockSize = 1024 * 1024;
 
         // Names of PAX extended attributes commonly found fields

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -624,5 +624,57 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
             Assert.Null(reader2.GetNextEntry());
         }
+
+        [Fact]
+        public void PaxExtendedAttributes_ExceedsMaxMetadataBlockSize_Throws()
+        {
+            using MemoryStream archive = new MemoryStream();
+            var extendedAttributes = new Dictionary<string, string>
+            {
+                ["bigkey"] = new string('x', 1024 * 1024 + 1)
+            };
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes);
+                writer.WriteEntry(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            using TarReader reader = new TarReader(archive);
+            Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
+        }
+
+        [Fact]
+        public void GnuLongPath_ExceedsMaxMetadataBlockSize_Throws()
+        {
+            using MemoryStream archive = new MemoryStream();
+            string longName = new string('a', 1024 * 1024 + 1);
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
+                writer.WriteEntry(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            using TarReader reader = new TarReader(archive);
+            Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
+        }
+
+        [Fact]
+        public void GnuLongLink_ExceedsMaxMetadataBlockSize_Throws()
+        {
+            using MemoryStream archive = new MemoryStream();
+            string longLink = new string('a', 1024 * 1024 + 1);
+            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
+                entry.LinkName = longLink;
+                writer.WriteEntry(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            using TarReader reader = new TarReader(archive);
+            Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
+        }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -628,13 +628,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("PaxExtendedAttributes")]
-        [InlineData("GnuLongPath")]
-        [InlineData("GnuLongLink")]
-        public void MetadataBlock_AtMaxSize_Succeeds(string metadataType)
+        [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize - 100)]
+        [InlineData("GnuLongPath", MaxMetadataBlockSize)]
+        [InlineData("GnuLongLink", MaxMetadataBlockSize)]
+        public void MetadataBlock_AtMaxSize_Succeeds(string metadataType, int size)
         {
             using MemoryStream archive = new MemoryStream();
-            WriteMetadataEntry(archive, metadataType, MaxMetadataBlockSize);
+            WriteMetadataEntry(archive, metadataType, size);
 
             archive.Seek(0, SeekOrigin.Begin);
             using TarReader reader = new TarReader(archive);
@@ -642,28 +642,31 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("PaxExtendedAttributes")]
-        [InlineData("GnuLongPath")]
-        [InlineData("GnuLongLink")]
-        public void MetadataBlock_ExceedsMaxSize_Throws(string metadataType)
+        [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize)]
+        [InlineData("GnuLongPath", MaxMetadataBlockSize + 1)]
+        [InlineData("GnuLongLink", MaxMetadataBlockSize + 1)]
+        public void MetadataBlock_ExceedsMaxSize_Throws(string metadataType, int size)
         {
             using MemoryStream archive = new MemoryStream();
-            WriteMetadataEntry(archive, metadataType, MaxMetadataBlockSize + 1);
+            WriteMetadataEntry(archive, metadataType, size);
 
             archive.Seek(0, SeekOrigin.Begin);
             using TarReader reader = new TarReader(archive);
             Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
         }
 
+        // Writes a TAR entry with metadata of the specified size.
+        // For GNU types, size is the on-disk block size (string length = size - 1 for null terminator).
+        // For PAX, size is the extended attribute value length; the total block will be
+        // slightly larger due to framing overhead (length prefixes, key names, default attributes).
         private static void WriteMetadataEntry(MemoryStream archive, string metadataType, int size)
         {
             switch (metadataType)
             {
                 case "PaxExtendedAttributes":
-                    // PAX metadata block includes framing overhead, so we adjust the value size accordingly.
                     var extendedAttributes = new Dictionary<string, string>
                     {
-                        ["bigkey"] = new string('x', size - 1024)
+                        ["bigkey"] = new string('x', size)
                     };
                     using (TarWriter paxWriter = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
                     {
@@ -674,7 +677,7 @@ namespace System.Formats.Tar.Tests
                 case "GnuLongPath":
                     using (TarWriter gnuPathWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
                     {
-                        gnuPathWriter.WriteEntry(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size)));
+                        gnuPathWriter.WriteEntry(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size - 1)));
                     }
                     break;
 
@@ -682,7 +685,7 @@ namespace System.Formats.Tar.Tests
                     using (TarWriter gnuLinkWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
                     {
                         GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
-                        entry.LinkName = new string('a', size);
+                        entry.LinkName = new string('a', size - 1);
                         gnuLinkWriter.WriteEntry(entry);
                     }
                     break;

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -10,6 +10,8 @@ namespace System.Formats.Tar.Tests
 {
     public class TarReader_GetNextEntry_Tests : TarTestsBase
     {
+        private const int MaxMetadataBlockSize = 1024 * 1024;
+
         [Fact]
         public void MalformedArchive_TooSmall()
         {
@@ -631,7 +633,7 @@ namespace System.Formats.Tar.Tests
             using MemoryStream archive = new MemoryStream();
             var extendedAttributes = new Dictionary<string, string>
             {
-                ["bigkey"] = new string('x', 1024 * 1024 + 1)
+                ["bigkey"] = new string('x', MaxMetadataBlockSize + 1)
             };
             using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
             {
@@ -648,7 +650,7 @@ namespace System.Formats.Tar.Tests
         public void GnuLongPath_ExceedsMaxMetadataBlockSize_Throws()
         {
             using MemoryStream archive = new MemoryStream();
-            string longName = new string('a', 1024 * 1024 + 1);
+            string longName = new string('a', MaxMetadataBlockSize + 1);
             using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
@@ -664,7 +666,7 @@ namespace System.Formats.Tar.Tests
         public void GnuLongLink_ExceedsMaxMetadataBlockSize_Throws()
         {
             using MemoryStream archive = new MemoryStream();
-            string longLink = new string('a', 1024 * 1024 + 1);
+            string longLink = new string('a', MaxMetadataBlockSize + 1);
             using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -627,56 +627,66 @@ namespace System.Formats.Tar.Tests
             Assert.Null(reader2.GetNextEntry());
         }
 
-        [Fact]
-        public void PaxExtendedAttributes_ExceedsMaxMetadataBlockSize_Throws()
+        [Theory]
+        [InlineData("PaxExtendedAttributes")]
+        [InlineData("GnuLongPath")]
+        [InlineData("GnuLongLink")]
+        public void MetadataBlock_AtMaxSize_Succeeds(string metadataType)
         {
             using MemoryStream archive = new MemoryStream();
-            var extendedAttributes = new Dictionary<string, string>
-            {
-                ["bigkey"] = new string('x', MaxMetadataBlockSize + 1)
-            };
-            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
-            {
-                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes);
-                writer.WriteEntry(entry);
-            }
+            WriteMetadataEntry(archive, metadataType, MaxMetadataBlockSize);
+
+            archive.Seek(0, SeekOrigin.Begin);
+            using TarReader reader = new TarReader(archive);
+            Assert.NotNull(reader.GetNextEntry());
+        }
+
+        [Theory]
+        [InlineData("PaxExtendedAttributes")]
+        [InlineData("GnuLongPath")]
+        [InlineData("GnuLongLink")]
+        public void MetadataBlock_ExceedsMaxSize_Throws(string metadataType)
+        {
+            using MemoryStream archive = new MemoryStream();
+            WriteMetadataEntry(archive, metadataType, MaxMetadataBlockSize + 1);
 
             archive.Seek(0, SeekOrigin.Begin);
             using TarReader reader = new TarReader(archive);
             Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
         }
 
-        [Fact]
-        public void GnuLongPath_ExceedsMaxMetadataBlockSize_Throws()
+        private static void WriteMetadataEntry(MemoryStream archive, string metadataType, int size)
         {
-            using MemoryStream archive = new MemoryStream();
-            string longName = new string('a', MaxMetadataBlockSize + 1);
-            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            switch (metadataType)
             {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
-                writer.WriteEntry(entry);
+                case "PaxExtendedAttributes":
+                    // PAX metadata block includes framing overhead, so we adjust the value size accordingly.
+                    var extendedAttributes = new Dictionary<string, string>
+                    {
+                        ["bigkey"] = new string('x', size - 1024)
+                    };
+                    using (TarWriter paxWriter = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+                    {
+                        paxWriter.WriteEntry(new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes));
+                    }
+                    break;
+
+                case "GnuLongPath":
+                    using (TarWriter gnuPathWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+                    {
+                        gnuPathWriter.WriteEntry(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size)));
+                    }
+                    break;
+
+                case "GnuLongLink":
+                    using (TarWriter gnuLinkWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+                    {
+                        GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
+                        entry.LinkName = new string('a', size);
+                        gnuLinkWriter.WriteEntry(entry);
+                    }
+                    break;
             }
-
-            archive.Seek(0, SeekOrigin.Begin);
-            using TarReader reader = new TarReader(archive);
-            Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
-        }
-
-        [Fact]
-        public void GnuLongLink_ExceedsMaxMetadataBlockSize_Throws()
-        {
-            using MemoryStream archive = new MemoryStream();
-            string longLink = new string('a', MaxMetadataBlockSize + 1);
-            using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
-                entry.LinkName = longLink;
-                writer.WriteEntry(entry);
-            }
-
-            archive.Seek(0, SeekOrigin.Begin);
-            using TarReader reader = new TarReader(archive);
-            Assert.Throws<InvalidOperationException>(() => reader.GetNextEntry());
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -631,7 +631,7 @@ namespace System.Formats.Tar.Tests
         [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize - 100)]
         [InlineData("GnuLongPath", MaxMetadataBlockSize)]
         [InlineData("GnuLongLink", MaxMetadataBlockSize)]
-        public void MetadataBlock_AtMaxSize_Succeeds(string metadataType, int size)
+        public void MetadataBlock_UnderMaxSize_Succeeds(string metadataType, int size)
         {
             using MemoryStream archive = new MemoryStream();
             WriteMetadataEntry(archive, metadataType, size);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -517,6 +518,58 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(longLinkTarget, entry.LinkName);
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
             Assert.Null(await reader2.GetNextEntryAsync());
+        }
+
+        [Fact]
+        public async Task PaxExtendedAttributes_ExceedsMaxMetadataBlockSize_Throws_Async()
+        {
+            await using MemoryStream archive = new MemoryStream();
+            var extendedAttributes = new Dictionary<string, string>
+            {
+                ["bigkey"] = new string('x', 1024 * 1024 + 1)
+            };
+            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+            {
+                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes);
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            await using TarReader reader = new TarReader(archive);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
+        }
+
+        [Fact]
+        public async Task GnuLongPath_ExceedsMaxMetadataBlockSize_Throws_Async()
+        {
+            await using MemoryStream archive = new MemoryStream();
+            string longName = new string('a', 1024 * 1024 + 1);
+            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            await using TarReader reader = new TarReader(archive);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
+        }
+
+        [Fact]
+        public async Task GnuLongLink_ExceedsMaxMetadataBlockSize_Throws_Async()
+        {
+            await using MemoryStream archive = new MemoryStream();
+            string longLink = new string('a', 1024 * 1024 + 1);
+            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            {
+                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
+                entry.LinkName = longLink;
+                await writer.WriteEntryAsync(entry);
+            }
+
+            archive.Seek(0, SeekOrigin.Begin);
+            await using TarReader reader = new TarReader(archive);
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -523,13 +523,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("PaxExtendedAttributes")]
-        [InlineData("GnuLongPath")]
-        [InlineData("GnuLongLink")]
-        public async Task MetadataBlock_AtMaxSize_Succeeds_Async(string metadataType)
+        [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize - 100)]
+        [InlineData("GnuLongPath", MaxMetadataBlockSize)]
+        [InlineData("GnuLongLink", MaxMetadataBlockSize)]
+        public async Task MetadataBlock_AtMaxSize_Succeeds_Async(string metadataType, int size)
         {
             await using MemoryStream archive = new MemoryStream();
-            await WriteMetadataEntryAsync(archive, metadataType, MaxMetadataBlockSize);
+            await WriteMetadataEntryAsync(archive, metadataType, size);
 
             archive.Seek(0, SeekOrigin.Begin);
             await using TarReader reader = new TarReader(archive);
@@ -537,13 +537,13 @@ namespace System.Formats.Tar.Tests
         }
 
         [Theory]
-        [InlineData("PaxExtendedAttributes")]
-        [InlineData("GnuLongPath")]
-        [InlineData("GnuLongLink")]
-        public async Task MetadataBlock_ExceedsMaxSize_Throws_Async(string metadataType)
+        [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize)]
+        [InlineData("GnuLongPath", MaxMetadataBlockSize + 1)]
+        [InlineData("GnuLongLink", MaxMetadataBlockSize + 1)]
+        public async Task MetadataBlock_ExceedsMaxSize_Throws_Async(string metadataType, int size)
         {
             await using MemoryStream archive = new MemoryStream();
-            await WriteMetadataEntryAsync(archive, metadataType, MaxMetadataBlockSize + 1);
+            await WriteMetadataEntryAsync(archive, metadataType, size);
 
             archive.Seek(0, SeekOrigin.Begin);
             await using TarReader reader = new TarReader(archive);
@@ -555,10 +555,9 @@ namespace System.Formats.Tar.Tests
             switch (metadataType)
             {
                 case "PaxExtendedAttributes":
-                    // PAX metadata block includes framing overhead, so we adjust the value size accordingly.
                     var extendedAttributes = new Dictionary<string, string>
                     {
-                        ["bigkey"] = new string('x', size - 1024)
+                        ["bigkey"] = new string('x', size)
                     };
                     await using (TarWriter paxWriter = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
                     {
@@ -569,7 +568,7 @@ namespace System.Formats.Tar.Tests
                 case "GnuLongPath":
                     await using (TarWriter gnuPathWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
                     {
-                        await gnuPathWriter.WriteEntryAsync(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size)));
+                        await gnuPathWriter.WriteEntryAsync(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size - 1)));
                     }
                     break;
 
@@ -577,7 +576,7 @@ namespace System.Formats.Tar.Tests
                     await using (TarWriter gnuLinkWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
                     {
                         GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
-                        entry.LinkName = new string('a', size);
+                        entry.LinkName = new string('a', size - 1);
                         await gnuLinkWriter.WriteEntryAsync(entry);
                     }
                     break;

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -12,6 +12,8 @@ namespace System.Formats.Tar.Tests
 {
     public class TarReader_GetNextEntryAsync_Tests : TarTestsBase
     {
+        private const int MaxMetadataBlockSize = 1024 * 1024;
+
         [Fact]
         public async Task GetNextEntryAsync_Cancel()
         {
@@ -526,7 +528,7 @@ namespace System.Formats.Tar.Tests
             await using MemoryStream archive = new MemoryStream();
             var extendedAttributes = new Dictionary<string, string>
             {
-                ["bigkey"] = new string('x', 1024 * 1024 + 1)
+                ["bigkey"] = new string('x', MaxMetadataBlockSize + 1)
             };
             await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
             {
@@ -543,7 +545,7 @@ namespace System.Formats.Tar.Tests
         public async Task GnuLongPath_ExceedsMaxMetadataBlockSize_Throws_Async()
         {
             await using MemoryStream archive = new MemoryStream();
-            string longName = new string('a', 1024 * 1024 + 1);
+            string longName = new string('a', MaxMetadataBlockSize + 1);
             await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
@@ -559,7 +561,7 @@ namespace System.Formats.Tar.Tests
         public async Task GnuLongLink_ExceedsMaxMetadataBlockSize_Throws_Async()
         {
             await using MemoryStream archive = new MemoryStream();
-            string longLink = new string('a', 1024 * 1024 + 1);
+            string longLink = new string('a', MaxMetadataBlockSize + 1);
             await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
             {
                 GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -526,7 +526,7 @@ namespace System.Formats.Tar.Tests
         [InlineData("PaxExtendedAttributes", MaxMetadataBlockSize - 100)]
         [InlineData("GnuLongPath", MaxMetadataBlockSize)]
         [InlineData("GnuLongLink", MaxMetadataBlockSize)]
-        public async Task MetadataBlock_AtMaxSize_Succeeds_Async(string metadataType, int size)
+        public async Task MetadataBlock_UnderMaxSize_Succeeds_Async(string metadataType, int size)
         {
             await using MemoryStream archive = new MemoryStream();
             await WriteMetadataEntryAsync(archive, metadataType, size);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -522,56 +522,66 @@ namespace System.Formats.Tar.Tests
             Assert.Null(await reader2.GetNextEntryAsync());
         }
 
-        [Fact]
-        public async Task PaxExtendedAttributes_ExceedsMaxMetadataBlockSize_Throws_Async()
+        [Theory]
+        [InlineData("PaxExtendedAttributes")]
+        [InlineData("GnuLongPath")]
+        [InlineData("GnuLongLink")]
+        public async Task MetadataBlock_AtMaxSize_Succeeds_Async(string metadataType)
         {
             await using MemoryStream archive = new MemoryStream();
-            var extendedAttributes = new Dictionary<string, string>
-            {
-                ["bigkey"] = new string('x', MaxMetadataBlockSize + 1)
-            };
-            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
-            {
-                PaxTarEntry entry = new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes);
-                await writer.WriteEntryAsync(entry);
-            }
+            await WriteMetadataEntryAsync(archive, metadataType, MaxMetadataBlockSize);
+
+            archive.Seek(0, SeekOrigin.Begin);
+            await using TarReader reader = new TarReader(archive);
+            Assert.NotNull(await reader.GetNextEntryAsync());
+        }
+
+        [Theory]
+        [InlineData("PaxExtendedAttributes")]
+        [InlineData("GnuLongPath")]
+        [InlineData("GnuLongLink")]
+        public async Task MetadataBlock_ExceedsMaxSize_Throws_Async(string metadataType)
+        {
+            await using MemoryStream archive = new MemoryStream();
+            await WriteMetadataEntryAsync(archive, metadataType, MaxMetadataBlockSize + 1);
 
             archive.Seek(0, SeekOrigin.Begin);
             await using TarReader reader = new TarReader(archive);
             await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
         }
 
-        [Fact]
-        public async Task GnuLongPath_ExceedsMaxMetadataBlockSize_Throws_Async()
+        private static async Task WriteMetadataEntryAsync(MemoryStream archive, string metadataType, int size)
         {
-            await using MemoryStream archive = new MemoryStream();
-            string longName = new string('a', MaxMetadataBlockSize + 1);
-            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+            switch (metadataType)
             {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.RegularFile, longName);
-                await writer.WriteEntryAsync(entry);
+                case "PaxExtendedAttributes":
+                    // PAX metadata block includes framing overhead, so we adjust the value size accordingly.
+                    var extendedAttributes = new Dictionary<string, string>
+                    {
+                        ["bigkey"] = new string('x', size - 1024)
+                    };
+                    await using (TarWriter paxWriter = new TarWriter(archive, TarEntryFormat.Pax, leaveOpen: true))
+                    {
+                        await paxWriter.WriteEntryAsync(new PaxTarEntry(TarEntryType.RegularFile, "test.txt", extendedAttributes));
+                    }
+                    break;
+
+                case "GnuLongPath":
+                    await using (TarWriter gnuPathWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+                    {
+                        await gnuPathWriter.WriteEntryAsync(new GnuTarEntry(TarEntryType.RegularFile, new string('a', size)));
+                    }
+                    break;
+
+                case "GnuLongLink":
+                    await using (TarWriter gnuLinkWriter = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
+                    {
+                        GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
+                        entry.LinkName = new string('a', size);
+                        await gnuLinkWriter.WriteEntryAsync(entry);
+                    }
+                    break;
             }
-
-            archive.Seek(0, SeekOrigin.Begin);
-            await using TarReader reader = new TarReader(archive);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
-        }
-
-        [Fact]
-        public async Task GnuLongLink_ExceedsMaxMetadataBlockSize_Throws_Async()
-        {
-            await using MemoryStream archive = new MemoryStream();
-            string longLink = new string('a', MaxMetadataBlockSize + 1);
-            await using (TarWriter writer = new TarWriter(archive, TarEntryFormat.Gnu, leaveOpen: true))
-            {
-                GnuTarEntry entry = new GnuTarEntry(TarEntryType.SymbolicLink, "test.txt");
-                entry.LinkName = longLink;
-                await writer.WriteEntryAsync(entry);
-            }
-
-            archive.Seek(0, SeekOrigin.Begin);
-            await using TarReader reader = new TarReader(archive);
-            await Assert.ThrowsAsync<InvalidOperationException>(async () => await reader.GetNextEntryAsync());
         }
     }
 }


### PR DESCRIPTION
Limits the maximum allowed size of PAX extended attribute blocks and GNU LongPath/LongLink data sections to 1 MB when reading TAR archives by introducing a MaxMetadataBlockSize constant (1 MB).