### PR TITLE
Change unique stack trace GC flag from 0xF to 0x10

### DIFF
--- a/docs/design/coreclr/jit/investigate-stress.md
+++ b/docs/design/coreclr/jit/investigate-stress.md
@@ -22,7 +22,7 @@ Enabling GC Hole Stress causes GCs to always occur in specific locations and tha
 - **0x2** &ndash; GC on transitions to Preemptive GC.
 - **0x4** &ndash; GC on every allowable JITed instr.
 - **0x8** &ndash; GC on every allowable R2R instr.
-- **0xF** &ndash; GC only on a unique stack trace.
+- **0x10** &ndash; GC only on a unique stack trace.
 
 ### Common combinations
 


### PR DESCRIPTION
Updated the unique stack trace GC flag from 0xF to 0x10. Looks like this was a typo, gcenv.h uses 16 / 0x10 for GCSTRESS_UNIQUE.