### PR TITLE
Change commit message topic to 'container image digests'

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -37,7 +37,7 @@
         "eng/pipelines/libraries/helix-queues-setup.yml"
       ],
       "pinDigests": true,
-      "commitMessageTopic": "container image dependencies"
+      "commitMessageTopic": "container image digests"
     }
   ]
 }


### PR DESCRIPTION
"dependencies" is confusing or misleading. That's the default renovate terminology. "digests" is much clearer to anyone that is in a position to merge the generated PRs.

PR examples: https://github.com/dotnet/runtime/pulls?q=is%3Apr+author%3Adotnet-renovate-bot+