### PR TITLE
JIT: Move all `OperIsConst()` to right-side for comparisons (including missing EQ, NE)

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7772,14 +7772,14 @@ DONE_MORPHING_CHILDREN:
         case GT_EQ:
         case GT_NE:
             // Change "CNS relop op2" to "op2 relop* CNS"
-            if (op1->IsIntegralConst() && tree->OperIsCompare() && gtCanSwapOrder(op1, op2))
+            if (op1->OperIsConst() && gtCanSwapOrder(op1, op2))
             {
+                assert(tree->OperIsCompare());
+                assert(oper == GenTree::SwapRelop(oper));
                 std::swap(tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
-                tree->gtOper = GenTree::SwapRelop(tree->OperGet());
 
-                oper = tree->OperGet();
-                op1  = tree->gtGetOp1();
-                op2  = tree->gtGetOp2();
+                op1 = tree->gtGetOp1();
+                op2 = tree->gtGetOp2();
             }
 
             if (op2->IsIntegralConst())
@@ -7798,8 +7798,9 @@ DONE_MORPHING_CHILDREN:
         case GT_GE:
         case GT_GT:
             // Change "CNS relop op2" to "op2 relop* CNS"
-            if (op1->IsIntegralConst() && tree->OperIsCompare() && gtCanSwapOrder(op1, op2))
+            if (op1->OperIsConst() && gtCanSwapOrder(op1, op2))
             {
+                assert(tree->OperIsCompare());
                 std::swap(tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
                 tree->gtOper = GenTree::SwapRelop(tree->OperGet());
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -7771,6 +7771,17 @@ DONE_MORPHING_CHILDREN:
 
         case GT_EQ:
         case GT_NE:
+            // Change "CNS relop op2" to "op2 relop* CNS"
+            if (op1->IsIntegralConst() && tree->OperIsCompare() && gtCanSwapOrder(op1, op2))
+            {
+                std::swap(tree->AsOp()->gtOp1, tree->AsOp()->gtOp2);
+                tree->gtOper = GenTree::SwapRelop(tree->OperGet());
+
+                oper = tree->OperGet();
+                op1  = tree->gtGetOp1();
+                op2  = tree->gtGetOp2();
+            }
+
             if (op2->IsIntegralConst())
             {
                 tree = fgOptimizeEqualityComparisonWithConst(tree->AsOp());


### PR DESCRIPTION
When turning 'CNS relop op2' into  'CNS relop* op2' we previously only allowed `IsIntegralConst`.
Also EQ, NE where not canonicalized at all.