### PR TITLE
Fix ChaCha20Poly1305 IsSupported test on Azure Linux 4

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Unix.cs
@@ -31,6 +31,7 @@ namespace System
         public static bool IsLinuxBionic => IsBionic();
         public static bool IsRedHatFamily => IsRedHatFamilyAndVersion();
         public static bool IsAzureLinux => IsDistroAndVersionOrHigher("azurelinux", 3);
+        public static bool IsAzureLinux4OrHigher => IsDistroAndVersionOrHigher("azurelinux", 4);
 
         public static bool IsMonoLinuxArm64 => IsMonoRuntime && IsLinux && IsArm64Process;
         public static bool IsNotMonoLinuxArm64 => !IsMonoLinuxArm64;

--- a/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/ChaCha20Poly1305Tests.cs
@@ -480,8 +480,9 @@ namespace System.Security.Cryptography.Tests
             }
             else if (PlatformDetection.IsAzureLinux)
             {
-                // Though Azure Linux uses OpenSSL, they build OpenSSL without ChaCha20-Poly1305.
-                expectedIsSupported = false;
+                // Though Azure Linux uses OpenSSL, Azure Linux 3 built OpenSSL with ChaCha20Poly1305 disabled.
+                // It was re-enabled in Azure Linux 4.
+                expectedIsSupported = PlatformDetection.IsAzureLinux4OrHigher;
             }
             else if (PlatformDetection.OpenSslPresentOnSystem && PlatformDetection.IsOpenSslSupported)
             {


### PR DESCRIPTION
Azure Linux 4 re-enabled ChaCha20Poly1305.

The output from `openssl list -cipher-algorithms` includes `ChaCha20-Poly1305 @ default`.

Found in https://github.com/dotnet/runtime/pull/127613.