### PR TITLE
Fix GetUserString DEBUG validation to use length-bounded string construction

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/MetaDataImportImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/MetaDataImportImpl.cs
@@ -1456,8 +1456,11 @@ internal sealed unsafe partial class MetaDataImportImpl : ICustomQueryInterface,
                     Debug.Assert(*pchString == pchLocal, $"String length mismatch: cDAC={*pchString}, DAC={pchLocal}");
                 if (szString is not null && cchString > 0)
                 {
-                    string cdacStr = new string(szString);
-                    string dacStr = new string(szLocal);
+                    // GetUserString does not null-terminate its output buffer (matching native behavior),
+                    // so we must use length-bounded string construction instead of new string(char*).
+                    int compareLen = Math.Min((int)pchLocal, (int)cchString);
+                    string cdacStr = new string(szString, 0, compareLen);
+                    string dacStr = new string(szLocal, 0, compareLen);
                     Debug.Assert(cdacStr == dacStr, $"UserString content mismatch: cDAC='{cdacStr}', DAC='{dacStr}'");
                 }
             }


### PR DESCRIPTION
## Summary

Fixes a DEBUG assertion failure in the cDAC `GetUserString` validation introduced in #127471.

This failure wasn't in the method implementation but the validation logic. With this fix the runtime-diagnostics SOS test runs are clean.

## Problem

The `GetUserString` implementation correctly matches native behavior by **not** null-terminating its output buffer when the string fits without truncation. However, the DEBUG validation block used `new string(char*)` which reads until a null terminator, potentially reading garbage bytes past the actual string data.

This caused assertion failures in SOS integration tests:

```
UserString content mismatch: cDAC='ThrowExceptionA', DAC='ThrowException'
```

The extra `A` character came from whatever followed the string in the caller's buffer.

## Fix

Use length-bounded string construction `new string(char*, 0, length)` with the known character count instead of relying on null termination. This is safe regardless of the buffer's contents past the written characters.