### PR TITLE
[release/8.0-staging] Add an in-memory cache for CRLs on Linux

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Formats.Asn1;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography.Asn1;
 using System.Security.Cryptography.X509Certificates.Asn1;
+using System.Threading;
 using Microsoft.Win32.SafeHandles;
 
 namespace System.Security.Cryptography.X509Certificates
@@ -22,6 +24,8 @@ namespace System.Security.Cryptography.X509Certificates
             PersistedFiles.GetUserFeatureDirectory(
                 X509Persistence.CryptographyFeatureName,
                 X509Persistence.OcspSubFeatureName);
+
+        private static readonly MruCrlCache s_crlCache = new();
 
         private const ulong X509_R_CERT_ALREADY_IN_HASH_TABLE = 0x0B07D065;
 
@@ -74,6 +78,95 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static bool AddCachedCrl(string crlFileName, SafeX509StoreHandle store, DateTime verificationTime)
         {
+            // OpenSSL is going to convert our input time to universal, so we should be in Local or
+            // Unspecified (local-assumed).
+            Debug.Assert(
+                verificationTime.Kind != DateTimeKind.Utc,
+                "UTC verificationTime should have been normalized to Local");
+
+            if (s_crlCache.TryGetValueAndUpRef(crlFileName, out CachedCrlEntry? cacheEntry))
+            {
+                try
+                {
+                    Debug.Assert(cacheEntry is not null);
+
+                    if (verificationTime < cacheEntry.Expiration)
+                    {
+                        if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                        {
+                            OpenSslX509ChainEventSource.Log.CrlCacheInMemoryHit(cacheEntry.Expiration);
+                        }
+
+                        AttachCrl(store, cacheEntry.CrlHandle);
+                        return true;
+                    }
+
+                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                    {
+                        OpenSslX509ChainEventSource.Log.CrlCacheInMemoryExpired(verificationTime, cacheEntry.Expiration);
+                    }
+                }
+                finally
+                {
+                    cacheEntry.CrlHandle.DangerousRelease();
+                }
+            }
+            else if (OpenSslX509ChainEventSource.Log.IsEnabled())
+            {
+                OpenSslX509ChainEventSource.Log.CrlCacheInMemoryMiss();
+            }
+
+            // Check the disk cache.
+            // For uncached this is the first load, for collected it's a reload,
+            // for expired it's checking to see if another process has updated the disk cache.
+            CachedCrlEntry? diskCacheEntry = CheckDiskCache(crlFileName, verificationTime);
+
+            if (diskCacheEntry is null)
+            {
+                return false;
+            }
+
+            UpdateCacheAndAttachCrl(crlFileName, store, diskCacheEntry);
+            return true;
+        }
+
+        private static void UpdateCacheAndAttachCrl(string crlFileName, SafeX509StoreHandle store, CachedCrlEntry newEntry)
+        {
+            Debug.Assert(!newEntry.CrlHandle.IsInvalid);
+            CachedCrlEntry toAttach = s_crlCache.AddOrUpdateAndUpRef(crlFileName, newEntry);
+
+            try
+            {
+                AttachCrl(store, toAttach.CrlHandle);
+            }
+            finally
+            {
+                toAttach.CrlHandle.DangerousRelease();
+            }
+        }
+
+        private static void AttachCrl(SafeX509StoreHandle store, SafeX509CrlHandle crl)
+        {
+            Debug.Assert(!crl.IsInvalid);
+
+            // X509_STORE_add_crl will increase the refcount on the CRL object,
+            // so we don't need to worry about our copy getting cleaned up as a weak reference.
+            if (!Interop.Crypto.X509StoreAddCrl(store, crl))
+            {
+                // Ignore error "cert already in store", throw on anything else. In any case the error queue will be cleared.
+                if (X509_R_CERT_ALREADY_IN_HASH_TABLE == Interop.Crypto.ErrPeekLastError())
+                {
+                    Interop.Crypto.ErrClearError();
+                }
+                else
+                {
+                    throw Interop.Crypto.CreateOpenSslCryptographicException();
+                }
+            }
+        }
+
+        private static CachedCrlEntry? CheckDiskCache(string crlFileName, DateTime verificationTime)
+        {
             string crlFile = GetCachedCrlPath(crlFileName);
 
             if (OpenSslX509ChainEventSource.Log.IsEnabled())
@@ -83,7 +176,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                return AddCachedCrlCore(crlFile, store, verificationTime);
+                return CheckDiskCacheCore(crlFile, verificationTime);
             }
             finally
             {
@@ -94,7 +187,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        private static bool AddCachedCrlCore(string crlFile, SafeX509StoreHandle store, DateTime verificationTime)
+        private static CachedCrlEntry? CheckDiskCacheCore(string crlFile, DateTime verificationTime)
         {
             using (SafeBioHandle bio = Interop.Crypto.BioNewFile(crlFile, "rb"))
             {
@@ -106,12 +199,11 @@ namespace System.Security.Cryptography.X509Certificates
                     }
 
                     Interop.Crypto.ErrClearError();
-                    return false;
+                    return null;
                 }
 
-                // X509_STORE_add_crl will increase the refcount on the CRL object, so we should still
-                // dispose our copy.
-                using (SafeX509CrlHandle crl = Interop.Crypto.PemReadBioX509Crl(bio))
+                SafeX509CrlHandle crl = Interop.Crypto.PemReadBioX509Crl(bio);
+
                 {
                     if (crl.IsInvalid)
                     {
@@ -120,8 +212,9 @@ namespace System.Security.Cryptography.X509Certificates
                             OpenSslX509ChainEventSource.Log.CrlCacheDecodeError();
                         }
 
+                        crl.Dispose();
                         Interop.Crypto.ErrClearError();
-                        return false;
+                        return null;
                     }
 
                     // If crl.LastUpdate is in the past, downloading a new version isn't really going
@@ -144,26 +237,21 @@ namespace System.Security.Cryptography.X509Certificates
 
                         try
                         {
-                            nextUpdate = File.GetLastWriteTime(crlFile).AddDays(3);
+                            nextUpdate = ExpirationTimeFromCacheFileTime(File.GetLastWriteTime(crlFile));
                         }
                         catch
                         {
                             // We couldn't determine when the CRL was last written to,
                             // so consider it expired.
                             Debug.Fail("Failed to get the last write time of the CRL file");
-                            return false;
+                            crl.Dispose();
+                            return null;
                         }
                     }
                     else
                     {
                         nextUpdate = OpenSslX509CertificateReader.ExtractValidityDateTime(nextUpdatePtr);
                     }
-
-                    // OpenSSL is going to convert our input time to universal, so we should be in Local or
-                    // Unspecified (local-assumed).
-                    Debug.Assert(
-                        verificationTime.Kind != DateTimeKind.Utc,
-                        "UTC verificationTime should have been normalized to Local");
 
                     // In the event that we're to-the-second accurate on the match, OpenSSL will consider this
                     // to be already expired.
@@ -174,20 +262,8 @@ namespace System.Security.Cryptography.X509Certificates
                             OpenSslX509ChainEventSource.Log.CrlCacheExpired(nextUpdate, verificationTime);
                         }
 
-                        return false;
-                    }
-
-                    if (!Interop.Crypto.X509StoreAddCrl(store, crl))
-                    {
-                        // Ignore error "cert already in store", throw on anything else. In any case the error queue will be cleared.
-                        if (X509_R_CERT_ALREADY_IN_HASH_TABLE == Interop.Crypto.ErrPeekLastError())
-                        {
-                            Interop.Crypto.ErrClearError();
-                        }
-                        else
-                        {
-                            throw Interop.Crypto.CreateOpenSslCryptographicException();
-                        }
+                        crl.Dispose();
+                        return null;
                     }
 
                     if (OpenSslX509ChainEventSource.Log.IsEnabled())
@@ -195,7 +271,7 @@ namespace System.Security.Cryptography.X509Certificates
                         OpenSslX509ChainEventSource.Log.CrlCacheAcceptedFile(nextUpdate);
                     }
 
-                    return true;
+                    return new CachedCrlEntry(crl, nextUpdate);
                 }
             }
         }
@@ -206,57 +282,81 @@ namespace System.Security.Cryptography.X509Certificates
             SafeX509StoreHandle store,
             TimeSpan downloadTimeout)
         {
-            // X509_STORE_add_crl will increase the refcount on the CRL object, so we should still
-            // dispose our copy.
-            using (SafeX509CrlHandle? crl = OpenSslCertificateAssetDownloader.DownloadCrl(url, downloadTimeout))
+            CachedCrlEntry? newEntry = DownloadAndCacheCrl(url, crlFileName, downloadTimeout);
+
+            if (newEntry is not null)
             {
-                // null is a valid return (e.g. no remainingDownloadTime)
-                if (crl != null && !crl.IsInvalid)
+                UpdateCacheAndAttachCrl(crlFileName, store, newEntry);
+            }
+        }
+
+        private static CachedCrlEntry? DownloadAndCacheCrl(
+            string url,
+            string crlFileName,
+            TimeSpan downloadTimeout)
+        {
+            SafeX509CrlHandle? crl = OpenSslCertificateAssetDownloader.DownloadCrl(url, downloadTimeout);
+
+            // null is a valid return (e.g. no remainingDownloadTime)
+            if (crl == null || crl.IsInvalid)
+            {
+                crl?.Dispose();
+                return null;
+            }
+
+            IntPtr nextUpdatePtr = Interop.Crypto.GetX509CrlNextUpdate(crl);
+            DateTime expiryTime;
+
+            // If there is no crl.NextUpdate, this indicates that the CA is not providing
+            // any more updates to the CRL, or they made a mistake not providing a NextUpdate.
+            // We'll cache it for a few days to cover the case it was a mistake.
+            if (nextUpdatePtr == IntPtr.Zero)
+            {
+                expiryTime = ExpirationTimeFromCacheFileTime(DateTime.Now);
+            }
+            else
+            {
+                expiryTime = OpenSslX509CertificateReader.ExtractValidityDateTime(nextUpdatePtr);
+            }
+
+            // Saving the CRL to the disk is just a performance optimization for later requests to not
+            // need to use the network again, so failure to save shouldn't throw an exception or mark
+            // the chain as invalid.
+            try
+            {
+                string crlFile = GetCachedCrlPath(crlFileName, mkDir: true);
+
+                using (SafeBioHandle bio = Interop.Crypto.BioNewFile(crlFile, "wb"))
                 {
-                    if (!Interop.Crypto.X509StoreAddCrl(store, crl))
+                    if (bio.IsInvalid || Interop.Crypto.PemWriteBioX509Crl(bio, crl) == 0)
                     {
-                        // Ignore error "cert already in store", throw on anything else. In any case the error queue will be cleared.
-                        if (X509_R_CERT_ALREADY_IN_HASH_TABLE == Interop.Crypto.ErrPeekLastError())
+                        // No bio, or write failed
+
+                        if (OpenSslX509ChainEventSource.Log.IsEnabled())
                         {
-                            Interop.Crypto.ErrClearError();
+                            OpenSslX509ChainEventSource.Log.CrlCacheWriteFailed(crlFile);
                         }
-                        else
-                        {
-                            throw Interop.Crypto.CreateOpenSslCryptographicException();
-                        }
-                    }
 
-                    // Saving the CRL to the disk is just a performance optimization for later requests to not
-                    // need to use the network again, so failure to save shouldn't throw an exception or mark
-                    // the chain as invalid.
-                    try
-                    {
-                        string crlFile = GetCachedCrlPath(crlFileName, mkDir: true);
-
-                        using (SafeBioHandle bio = Interop.Crypto.BioNewFile(crlFile, "wb"))
-                        {
-                            if (bio.IsInvalid || Interop.Crypto.PemWriteBioX509Crl(bio, crl) == 0)
-                            {
-                                // No bio, or write failed
-
-                                if (OpenSslX509ChainEventSource.Log.IsEnabled())
-                                {
-                                    OpenSslX509ChainEventSource.Log.CrlCacheWriteFailed(crlFile);
-                                }
-
-                                Interop.Crypto.ErrClearError();
-                            }
-                        }
-                    }
-                    catch (UnauthorizedAccessException) { }
-                    catch (IOException) { }
-
-                    if (OpenSslX509ChainEventSource.Log.IsEnabled())
-                    {
-                        OpenSslX509ChainEventSource.Log.CrlCacheWriteSucceeded();
+                        Interop.Crypto.ErrClearError();
                     }
                 }
             }
+            catch (UnauthorizedAccessException) { }
+            catch (IOException) { }
+
+            if (OpenSslX509ChainEventSource.Log.IsEnabled())
+            {
+                OpenSslX509ChainEventSource.Log.CrlCacheWriteSucceeded();
+            }
+
+            return new CachedCrlEntry(crl, expiryTime);
+        }
+
+        private static DateTime ExpirationTimeFromCacheFileTime(DateTime cacheFileTime)
+        {
+            // CA/Browser Forum says that CRLs should be updated every 4 to 7 days,
+            // so recheck any cached CRL, that doesn't have a NextUpdate, every 3 days.
+            return cacheFileTime.AddDays(3);
         }
 
         internal static string GetCachedOcspResponseDirectory()
@@ -378,6 +478,301 @@ namespace System.Security.Cryptography.X509Certificates
             }
 
             return null;
+        }
+
+        // The MRU CRL cache always does a DangerousAddReference before returning the value,
+        // so that neither cooperative GC pruning nor a cache-value refresh trigger ReleaseHandle
+        // on a CRL entry in use.
+        private sealed class MruCrlCache
+        {
+            // Each CRL is only a SafeHandle to the GC, but represents a non-trivial amount of
+            // native memory, so keep the cache small.
+            private const int MaxItems = 30;
+
+            private readonly Lock _lock = new();
+
+            private int _count = -1;
+            private Node? _head;
+            private Node? _expire;
+
+            internal CachedCrlEntry AddOrUpdateAndUpRef(string key, CachedCrlEntry value)
+            {
+                Debug.Assert(key is not null);
+                Debug.Assert(value is not null);
+                Debug.Assert(value.CrlHandle is not null && !value.CrlHandle.IsInvalid);
+                // Don't assert/enforce anything about expiration, because a) clock-skew, or b)
+                // the caller might have a verification time that's in the past.
+
+                int hashCode = key.GetHashCode();
+                CachedCrlEntry ret = value;
+                string? fullMemberKey = null;
+                SafeX509CrlHandle? toDispose = null;
+
+                lock (_lock)
+                {
+                    // The first time we add something, create the object to monitor for GC events.
+                    if (_count < 0)
+                    {
+                        new GCWatcher(this);
+                        _count = 0;
+                    }
+
+                    bool ignore = false;
+
+                    if (TryGetNode(hashCode, key, out Node? current))
+                    {
+                        Debug.Assert(current is not null);
+
+                        if (current.Value.Expiration >= value.Expiration)
+                        {
+                            toDispose = value.CrlHandle;
+                            ret = current.Value;
+                        }
+                        else
+                        {
+                            toDispose = current.Value.CrlHandle;
+                            current.Value = value;
+                        }
+                    }
+                    else
+                    {
+                        Node node = new Node(hashCode, key, value);
+                        node.Next = _head;
+
+                        if (_count < MaxItems)
+                        {
+                            _count++;
+                        }
+                        else
+                        {
+                            // Because MaxItems is small, it's better to just iterate from head
+                            // instead of using a doubly-linked list.
+
+                            Node? previous = null;
+                            Node? cur = _head;
+                            Node? next = cur?.Next;
+
+                            while (next is not null)
+                            {
+                                previous = cur;
+                                cur = next;
+                                next = cur.Next;
+                            }
+
+                            Debug.Assert(previous is not null);
+                            Debug.Assert(cur is not null);
+
+                            previous.Next = null;
+                            toDispose = cur.Value.CrlHandle;
+                            fullMemberKey = cur.Key;
+                            if (cur == _expire)
+                            {
+                                _expire = null;
+                            }
+                        }
+
+                        _head = node;
+                    }
+
+                    ret.CrlHandle.DangerousAddRef(ref ignore);
+                }
+
+                toDispose?.Dispose();
+
+                if (fullMemberKey is not null && OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    OpenSslX509ChainEventSource.Log.CrlCacheInMemoryFull(fullMemberKey);
+                }
+
+                return ret;
+            }
+
+            internal bool TryGetValueAndUpRef(string key, [NotNullWhen(true)] out CachedCrlEntry? value)
+            {
+                int hashCode = key.GetHashCode();
+
+                lock (_lock)
+                {
+                    if (TryGetNode(hashCode, key, out Node? node))
+                    {
+                        bool ignore = false;
+                        node.Value.CrlHandle.DangerousAddRef(ref ignore);
+                        value = node.Value;
+                        return true;
+                    }
+                }
+
+                value = null;
+                return false;
+            }
+
+            private bool TryGetNode(int hashCode, string key, [NotNullWhen(true)] out Node? value)
+            {
+                Debug.Assert(_lock.IsHeldByCurrentThread);
+
+                Node? previous = null;
+                Node? current = _head;
+
+                while (current is not null)
+                {
+                    if (current.MatchesKey(hashCode, key))
+                    {
+                        // If we find the expire node, move expiration to after it, so that promoting it to
+                        // most recent doesn't prune the whole list.
+                        //
+                        // This might, of course, make _expire null.
+                        if (current == _expire)
+                        {
+                            _expire = current.Next;
+                        }
+
+                        // Move the found node to the head of the list, maintaining MRU ordering.
+                        if (previous != null)
+                        {
+                            previous.Next = current.Next;
+                            current.Next = _head;
+                            _head = current;
+                        }
+
+                        value = current;
+                        return true;
+                    }
+
+                    previous = current;
+                    current = current.Next;
+                }
+
+                value = null;
+                return false;
+            }
+
+            private void PruneForGC()
+            {
+                // The general flow:
+                // * The current head is where we expire next time.
+                // * Under the lock: If there is an expire node, determine the new count by walking to it,
+                //   and unlink it from the previous node.
+                // * After the lock: Dispose all the values from the prune node onward.
+
+                Node? prune;
+                int countStart;
+                int countEnd;
+
+                lock (_lock)
+                {
+                    prune = _expire;
+                    _expire = _head;
+                    countStart = _count;
+
+                    if (prune is null)
+                    {
+                        return;
+                    }
+
+                    if (prune == _head)
+                    {
+                        _count = 0;
+                        _head = null;
+                        _expire = null;
+                    }
+                    else
+                    {
+                        Debug.Assert(_head is not null);
+                        int count = 1;
+                        Node current = _head;
+
+                        while (current.Next != prune && current.Next is not null)
+                        {
+                            count++;
+                            current = current.Next;
+                        }
+
+                        Debug.Assert(current.Next == prune, "The prune node should be in the list");
+                        current.Next = null;
+                        _count = count;
+                    }
+
+                    countEnd = _count;
+                }
+
+                // `prune` and beyond are now unlinked from the list, so we can dispose its values without holding the lock.
+                while (prune is not null)
+                {
+                    prune.Value.CrlHandle.Dispose();
+                    prune = prune.Next;
+                }
+
+                if (OpenSslX509ChainEventSource.Log.IsEnabled())
+                {
+                    OpenSslX509ChainEventSource.Log.CrlCacheInMemoryPruned(countStart - countEnd, countEnd);
+                }
+            }
+
+            private sealed class Node
+            {
+                private readonly int _keyHashCode;
+
+                internal string Key { get; }
+                internal CachedCrlEntry Value { get; set; }
+                internal Node? Next { get; set; }
+
+                internal Node(int hashCode, string key, CachedCrlEntry value)
+                {
+                    Debug.Assert(key.GetHashCode() == hashCode);
+
+                    Key = key;
+                    _keyHashCode = hashCode;
+                    Value = value;
+                }
+
+                internal bool MatchesKey(int hashCode, string key)
+                {
+                    return _keyHashCode == hashCode && Key.Equals(key, StringComparison.Ordinal);
+                }
+            }
+
+            private sealed class GCWatcher
+            {
+                private readonly MruCrlCache _owner;
+
+                internal GCWatcher(MruCrlCache owner)
+                {
+                    _owner = owner;
+                }
+
+                ~GCWatcher()
+                {
+                    GC.ReRegisterForFinalize(this);
+
+                    if (GC.GetGeneration(this) == GC.MaxGeneration)
+                    {
+                        try
+                        {
+                            _owner.PruneForGC();
+                        }
+                        catch
+                        {
+                            // Eat any exception so we don't terminate the finalizer thread.
+#if DEBUG
+                            // Except in DEBUG, as we really shouldn't be hitting any exceptions here.
+                            throw;
+#endif
+                        }
+                    }
+                }
+            }
+        }
+
+        private sealed class CachedCrlEntry
+        {
+            internal SafeX509CrlHandle CrlHandle { get; }
+            internal DateTime Expiration { get; }
+
+            internal CachedCrlEntry(SafeX509CrlHandle crlHandle, DateTime expiration)
+            {
+                CrlHandle = crlHandle;
+                Expiration = expiration;
+            }
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -608,7 +608,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             private bool TryGetNode(int hashCode, string key, [NotNullWhen(true)] out Node? value)
             {
-                Debug.Assert(_lock.IsHeldByCurrentThread);
+                Debug.Assert(Monitor.IsEntered(_lock));
 
                 Node? previous = null;
                 Node? current = _head;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -489,7 +489,7 @@ namespace System.Security.Cryptography.X509Certificates
             // native memory, so keep the cache small.
             private const int MaxItems = 30;
 
-            private readonly Lock _lock = new();
+            private readonly object _lock = new();
 
             private int _count = -1;
             private Node? _head;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainEventSource.cs
@@ -60,6 +60,11 @@ namespace System.Security.Cryptography.X509Certificates
         private const int EventId_RevocationCheckStop = 46;
         private const int EventId_CrlIdentifiersDetermined = 47;
         private const int EventId_StapledOcspPresent = 48;
+        private const int EventId_CrlCacheInMemoryHit = 49;
+        private const int EventId_CrlCacheInMemoryExpired = 50;
+        private const int EventId_CrlCacheInMemoryMiss = 51;
+        private const int EventId_CrlCacheInMemoryPruned = 52;
+        private const int EventId_CrlCacheInMemoryFull = 53;
 
         private static string GetCertificateSubject(SafeX509Handle certHandle)
         {
@@ -429,7 +434,7 @@ namespace System.Security.Cryptography.X509Certificates
             EventId_CrlCacheCheckStart,
             Level = EventLevel.Verbose,
             Opcode = EventOpcode.Start,
-            Message = "Checking for a cached CRL.")]
+            Message = "Checking for a CRL cached on disk.")]
         internal void CrlCacheCheckStart()
         {
             if (IsEnabled())
@@ -477,7 +482,7 @@ namespace System.Security.Cryptography.X509Certificates
         [Event(
             EventId_CrlCacheExpired,
             Level = EventLevel.Verbose,
-            Message = "The cached CRL's nextUpdate value ({1:O}) is not after the verification time ({0:O}).")]
+            Message = "The CRL cached on disk has a nextUpdate value ({1:O}) that is before the verification time ({0:O}).")]
         internal void CrlCacheExpired(DateTime verificationTime, DateTime nextUpdate)
         {
             if (IsEnabled())
@@ -489,7 +494,7 @@ namespace System.Security.Cryptography.X509Certificates
         [Event(
             EventId_CrlCacheFileBasedExpiry,
             Level = EventLevel.Verbose,
-            Message = "The cached crl has no nextUpdate value, basing nextUpdate on the file write time.")]
+            Message = "The CRL cached on disk has no nextUpdate value, basing nextUpdate on the file write time.")]
         internal void CrlCacheFileBasedExpiry()
         {
             if (IsEnabled())
@@ -501,7 +506,7 @@ namespace System.Security.Cryptography.X509Certificates
         [Event(
             EventId_CrlCacheAcceptedFile,
             Level = EventLevel.Verbose,
-            Message = "The cached crl nextUpdate value ({0:O}) is acceptable, using the cached file.")]
+            Message = "The CRL cached on disk has a nextUpdate value ({0:O}) that is acceptable, using the cached file.")]
         internal void CrlCacheAcceptedFile(DateTime nextUpdate)
         {
             if (IsEnabled())
@@ -525,7 +530,7 @@ namespace System.Security.Cryptography.X509Certificates
         [Event(
             EventId_CrlCacheWriteSucceeded,
             Level = EventLevel.Verbose,
-            Message = "The downloaded CRL was successfully written to the cache.")]
+            Message = "The downloaded CRL was successfully written to the disk cache.")]
         internal void CrlCacheWriteSucceeded()
         {
             if (IsEnabled())
@@ -750,6 +755,66 @@ namespace System.Security.Cryptography.X509Certificates
             if (IsEnabled())
             {
                 WriteEvent(EventId_StapledOcspPresent);
+            }
+        }
+
+        [Event(
+            EventId_CrlCacheInMemoryHit,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory CRL cache has a valid entry for the requested CRL, expiration at {0:O}.")]
+        internal void CrlCacheInMemoryHit(DateTime expiration)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_CrlCacheInMemoryHit, expiration);
+            }
+        }
+
+        [Event(
+            EventId_CrlCacheInMemoryExpired,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory cached CRL's expiration time ({1:O}) is before the verification time ({0:O}).")]
+        internal void CrlCacheInMemoryExpired(DateTime verificationTime, DateTime expirationTime)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_CrlCacheInMemoryExpired, verificationTime, expirationTime);
+            }
+        }
+
+        [Event(
+            EventId_CrlCacheInMemoryPruned,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory CRL cache was pruned. {0} entries removed, {1} entries remain.")]
+        internal void CrlCacheInMemoryPruned(int prunedCount, int remainingCount)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_CrlCacheInMemoryPruned, prunedCount, remainingCount);
+            }
+        }
+
+        [Event(
+            EventId_CrlCacheInMemoryMiss,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory CRL cache has no entry for the requested CRL.")]
+        internal void CrlCacheInMemoryMiss()
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_CrlCacheInMemoryMiss);
+            }
+        }
+
+        [Event(
+            EventId_CrlCacheInMemoryFull,
+            Level = EventLevel.Verbose,
+            Message = "The in-memory CRL cache is full, dismissing {0}.")]
+        internal void CrlCacheInMemoryFull(string cacheFileName)
+        {
+            if (IsEnabled())
+            {
+                WriteEvent(EventId_CrlCacheInMemoryFull, cacheFileName);
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
@@ -106,12 +106,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string crlFile = Path.Combine(crlDirectory, crlFileName);
             string crlPem = await File.ReadAllTextAsync(crlFile).ConfigureAwait(false);
 
-            await File.WriteAllTextAsync(crlFile, crlPem.AsMemory(0, crlPem.Length / 2)).ConfigureAwait(false);
+            await File.WriteAllTextAsync(crlFile, crlPem.AsMemory(0, crlPem.Length / 2).ToString()).ConfigureAwait(false);
 
             RemoteExecutor.Invoke(
                 static base64Cert =>
                 {
-                    using (X509Certificate2 cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(base64Cert)))
+                    using (X509Certificate2 cert = new X509Certificate2(Convert.FromBase64String(base64Cert)))
                     using (ChainHolder chainHolder = new ChainHolder())
                     {
                         bool valid = chainHolder.Chain.Build(cert);
@@ -137,7 +137,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     {
                         RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
                         {
-                            getDotNetCert = (X509Certificate2)certificate;
+                            getDotNetCert = new X509Certificate2(((X509Certificate2)certificate).RawData);
                             return errors == SslPolicyErrors.None;
                         }
                     }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
@@ -1,9 +1,14 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.Tracing;
 using System.IO;
-using System.Linq;
+using System.Net.Http;
+using System.Net.Security;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -77,6 +82,75 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 valid = chain.Build(microsoftDotComIssuer);
                 Assert.True(valid, "Chain should build validly now");
                 Assert.Equal(initialErrorCount, chain.ChainStatus.Length);
+            }
+        }
+
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public static async Task CrlDiskCacheRecovers()
+        {
+            using X509Certificate2 getDotNetCert = await GetGetDotNetCert();
+            string crlFileName;
+
+            using (CrlCacheNameFinderEventListener listener = new(getDotNetCert.Subject))
+            using (CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+            using (ChainHolder chainHolder = new ChainHolder())
+            {
+                Task<string> nameTask = listener.GetCacheFileNameAsync(tokenSource.Token);
+
+                _ = chainHolder.Chain.Build(getDotNetCert);
+                crlFileName = await nameTask.ConfigureAwait(false);
+            }
+
+            string crlDirectory = PersistedFiles.GetUserFeatureDirectory("cryptography", "crls");
+            string crlFile = Path.Combine(crlDirectory, crlFileName);
+            string crlPem = await File.ReadAllTextAsync(crlFile).ConfigureAwait(false);
+
+            await File.WriteAllTextAsync(crlFile, crlPem.AsMemory(0, crlPem.Length / 2)).ConfigureAwait(false);
+
+            RemoteExecutor.Invoke(
+                static base64Cert =>
+                {
+                    using (X509Certificate2 cert = X509CertificateLoader.LoadCertificate(Convert.FromBase64String(base64Cert)))
+                    using (ChainHolder chainHolder = new ChainHolder())
+                    {
+                        bool valid = chainHolder.Chain.Build(cert);
+
+                        return valid ? RemoteExecutor.SuccessExitCode : 0;
+                    }
+                },
+                Convert.ToBase64String(getDotNetCert.RawDataMemory.Span))
+                .Dispose();
+
+            string pem2 = await File.ReadAllTextAsync(crlFile).ConfigureAwait(false);
+
+            // Rather than assert the CRL didn't change, just check that it's a valid CRL:
+            CertificateRevocationListBuilder.LoadPem(pem2, out _);
+
+            static async Task<X509Certificate2> GetGetDotNetCert()
+            {
+                X509Certificate2 getDotNetCert = null;
+
+                SocketsHttpHandler handler = new SocketsHttpHandler
+                {
+                    SslOptions =
+                    {
+                        RemoteCertificateValidationCallback = (sender, certificate, chain, errors) =>
+                        {
+                            getDotNetCert = (X509Certificate2)certificate;
+                            return errors == SslPolicyErrors.None;
+                        }
+                    }
+                };
+
+                using (HttpClient client = new HttpClient(handler))
+                using (CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(10)))
+                {
+                    using HttpRequestMessage req = new HttpRequestMessage(HttpMethod.Head, "https://get.dot.net/");
+                    using HttpResponseMessage response = await client.SendAsync(req, cts.Token).ConfigureAwait(false);
+                }
+
+                Assert.NotNull(getDotNetCert);
+                return getDotNetCert;
             }
         }
 
@@ -669,6 +743,53 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 {
                     // Don't allow any (additional?) I/O errors to propagate.
                 }
+            }
+        }
+
+        private class CrlCacheNameFinderEventListener : EventListener
+        {
+            private readonly string _certificateName;
+            private string _cacheName;
+
+            internal CrlCacheNameFinderEventListener(string certificateName)
+            {
+                _certificateName = certificateName;
+            }
+
+            protected override void OnEventSourceCreated(EventSource eventSource)
+            {
+                if (eventSource.Name.Equals("System.Security.Cryptography.X509Certificates.X509Chain.OpenSsl"))
+                {
+                    EnableEvents(eventSource, EventLevel.Verbose);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData)
+            {
+                if (eventData.EventName == "CrlIdentifiersDetermined")
+                {
+                    if (eventData.Payload?.Count == 3)
+                    {
+                        if (eventData.Payload[0] is string certName &&
+                            certName == _certificateName &&
+                            eventData.Payload[1] is string cdp &&
+                            eventData.Payload[2] is string cacheName)
+                        {
+                            _cacheName = cacheName;
+                        }
+                    }
+                }
+            }
+
+            internal async Task<string> GetCacheFileNameAsync(CancellationToken cancellationToken)
+            {
+                while (_cacheName == null)
+                {
+                    await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+                }
+
+                Dispose();
+                return _cacheName;
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509FilesystemTests.Unix.cs
@@ -85,6 +85,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
+        [OuterLoop]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public static async Task CrlDiskCacheRecovers()
         {


### PR DESCRIPTION
Manual backport/cherry-pick of #123562 to release/8.0-staging

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Customers have been reporting "memory leaks" on Linux related to CRL processing for quite a while.  These "leaks" aren't actual leaks, but an interaction with how OpenSSL processes CRLs (using many small calls to malloc), and glibc memory arenas and small-allocation caching -- glibc holds onto the small allocs from free so it can hand them out again later.

Because we handle CRLs by loading them, checking them, and discarding them, a process that does a lot of revocation checks will end up checking the CRL on every thread, and thus can end up with large "reserved" memory for their process.  As the size of the CRL goes up, the number of threads goes up, and memory limits come down (e.g. Kubernetes) the reserved memory becomes more of a potential problem.

This change (originally introduced for 11 preview 3) changes the CRL processing to use an in-memory bounded MRU cache with GC cooperation.  So, a process that repeatedly hits the same endpoints over and over (or even multiple endpoints from the same CA+CRL) ideally only ever has to load the CRL once (unless it expires).  Since it isn't freed while still in use, it doesn't contribute to small-allocation accumulation.

## Regression

- [ ] Yes
- [X] No

## Testing

As with the PR into main, most of the tests are existing tests.  A new test is included to show cross-process disk cache recovery.

## Risk

Medium-Low.  The MRU cache isn't just a drop-in layering piece, so the volume of code carries inherent risk.  The risk is largely mitigated by a large amount of coverage from unit tests, and manual stress tests against the feature when it was written in main (cycling through a few hundred HTTPS hosts randomly across several threads while doing a large amount of background memory allocation/deallocation).

Users experiencing the high RES memory problem on Linux have reported that .NET 11 Preview 3 ameliorated the problem.  Otherwise, no feedback has been received regarding the change (implying that it has not _caused_ a problem for anyone).
