### PR TITLE
Fix ImmutableHashSet.SetEquals correctness for mismatched comparers

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet_1.cs
@@ -743,39 +743,40 @@ namespace System.Collections.Immutable
             switch (other)
             {
                 case ImmutableHashSet<T> otherAsImmutableHashSet:
-                    if (otherAsImmutableHashSet.Count != origin.Count)
-                    {
-                        return false;
-                    }
-
                     if (EqualityComparer<IEqualityComparer<T>>.Default.Equals(origin.EqualityComparer, otherAsImmutableHashSet.KeyComparer))
                     {
+                        if (otherAsImmutableHashSet.Count != origin.Count)
+                        {
+                            return false;
+                        }
                         return SetEqualsWithImmutableHashset(otherAsImmutableHashSet, origin);
+                    }
+
+                    if (otherAsImmutableHashSet.Count < origin.Count)
+                    {
+                        return false;
                     }
                     break;
 
                 case HashSet<T> otherAsHashset:
-                    if (otherAsHashset.Count != origin.Count)
-                    {
-                        return false;
-                    }
-
                     if (EqualityComparer<IEqualityComparer<T>>.Default.Equals(origin.EqualityComparer, otherAsHashset.Comparer))
                     {
+                        if (otherAsHashset.Count != origin.Count)
+                        {
+                            return false;
+                        }
                         return SetEqualsWithHashset(otherAsHashset, origin);
+                    }
+
+                    if (otherAsHashset.Count < origin.Count)
+                    {
+                        return false;
                     }
                     break;
 
                 case ICollection<T> otherAsICollectionGeneric:
                     // We check for < instead of != because other is not guaranteed to be a set, it could be a collection with duplicates.
                     if (otherAsICollectionGeneric.Count < origin.Count)
-                    {
-                        return false;
-                    }
-                    break;
-
-                case ICollection otherAsICollection:
-                    if (otherAsICollection.Count < origin.Count)
                     {
                         return false;
                     }

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableHashSetTest.cs
@@ -32,6 +32,96 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
+        public void SetEqualsMismatchedComparersOriginInsensitiveOtherSensitive()
+        {
+            var ignoreCaseSet = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a");
+            var sensitiveSet = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "A");
+
+            Assert.True(ignoreCaseSet.SetEquals(sensitiveSet));
+        }
+
+        [Fact]
+        public void SetEqualsMismatchedComparersOriginSensitiveOtherInsensitive()
+        {
+            var sensitiveSetMain = ImmutableHashSet.Create(StringComparer.Ordinal, "a");
+            var insensitiveMutable = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a", "A" };
+
+            Assert.True(sensitiveSetMain.SetEquals(insensitiveMutable));
+        }
+
+        [Fact]
+        public void SetEqualsICollectionWithDuplicatesValidatesCorrectness()
+        {
+            var ignoreCaseSet = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a");
+            var listWithDupes = new List<string> { "a", "a", "a", "a" };
+
+            Assert.True(ignoreCaseSet.SetEquals(listWithDupes));
+        }
+
+        [Fact]
+        public void SetEqualsDifferentContent()
+        {
+            var ignoreCaseSet = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a");
+            var setB = ImmutableHashSet.Create(StringComparer.Ordinal, "b");
+
+            Assert.False(ignoreCaseSet.SetEquals(setB));
+        }
+
+        [Fact]
+        public void SetEqualsMismatchedComparersOtherCountSmaller()
+        {
+            var originTwoElements = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a", "b");
+            var otherOneElement = ImmutableHashSet.Create(StringComparer.Ordinal, "a");
+
+            Assert.False(originTwoElements.SetEquals(otherOneElement));
+        }
+
+        [Fact]
+        public void SetEqualsMatchedComparersDifferentCounts()
+        {
+            var matchedSet1 = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "b");
+            var matchedSet2 = ImmutableHashSet.Create(StringComparer.Ordinal, "a");
+
+            Assert.False(matchedSet1.SetEquals(matchedSet2));
+        }
+
+        [Fact]
+        public void SetEqualsMatchedComparersSameContent()
+        {
+            var matchedSet1 = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "b");
+            var matchedSet2 = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "b");
+
+            Assert.True(matchedSet1.SetEquals(matchedSet2));
+        }
+
+        [Fact]
+        public void SetEqualsEmptySetsDifferentComparers()
+        {
+            var empty1 = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+            var empty2 = ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase);
+
+            Assert.True(empty1.SetEquals(empty2));
+        }
+
+        [Fact]
+        public void SetEqualsMismatchedComparersOriginSensitiveOtherInsensitiveSameCount()
+        {
+            var sensitiveSet = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "A");
+            var insensitiveSet = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a", "b");
+
+            Assert.False(sensitiveSet.SetEquals(insensitiveSet));
+        }
+
+        [Fact]
+        public void SetEqualsMismatchedComparersOtherIsLarger()
+        {
+            var origin = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a");
+            var other = ImmutableHashSet.Create(StringComparer.Ordinal, "a", "b");
+
+            Assert.False(origin.SetEquals(other));
+        }
+
+        [Fact]
         public void ChangeUnorderedEqualityComparer()
         {
             ImmutableHashSet<string> ordinalSet = ImmutableHashSet<string>.Empty


### PR DESCRIPTION
## Summary
This PR fixes a correctness issue in `SetEquals` introduced in my previous PR #126309.

The `Count` check was moved inside the `Comparer` equality block. This ensures that when comparers differ, we don't return a false negative and instead fall back to the safe path.

### Example of the issue fixed:
```csharp
// This should return true, but was returning false
var main = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "a");
var other = ImmutableHashSet.Create("a", "A");
Console.WriteLine(main.SetEquals(other));
```

## Changes
- Moved `if (count != origin.Count)` inside the `EqualityComparer<IEqualityComparer<T>>.Default.Equals` check.
- This ensures mismatched comparers safely bypass the fast-path and proceed to a proper set comparison.

## Testing
In addition to the fix, I have added comprehensive unit tests covering various scenarios to ensure correctness:

- **Mismatched Comparers (Ordinal vs. OrdinalIgnoreCase):** Verified that `SetEquals` returns `true` when logically equal but with different comparers, and `false` when logically different.
- **ICollection with Duplicates:** Verified the fallback path correctly handles collections like `List<T>` with duplicate elements.
- **Count Optimizations:** 
  - Verified that mismatched comparers correctly bypass the fast-path count check.
  - Verified that `SetEquals` still performs early-exit when `other.Count < origin.Count`.
- **Fast-Path Validation:** Ensured that when comparers match, the optimized count-based comparison still works as expected.
- **Edge Cases:** Included tests for empty sets with different comparers and content-specific mismatches.

**Related to:** #126309