### PR TITLE
Always add ManagedDataDescriptorProvider to compilationRoots

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -257,8 +257,7 @@ namespace ILCompiler
                     }
                 }
 
-                if (Get(_command.EnableDebugInfo))
-                    compilationRoots.Add(new ManagedDataDescriptorProvider());
+                compilationRoots.Add(new ManagedDataDescriptorProvider());
 
                 string win32resourcesModule = Get(_command.Win32ResourceModuleName);
                 if (typeSystemContext.Target.IsWindows && !string.IsNullOrEmpty(win32resourcesModule))


### PR DESCRIPTION
This just causes `error LNK2001: unresolved external symbol DotNetManagedContractDescriptor`