### PR TITLE
JIT: Eliminate redundant bounds checks via transitive index relationships

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -904,6 +904,10 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                    curAssertion.GetOp2().GetCheckedBoundConstant());
             break;
 
+        case O2K_VN:
+            printf(FMT_VN, curAssertion.GetOp2().GetVN());
+            break;
+
         default:
             unreached();
             break;
@@ -1421,6 +1425,11 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
                 mayHaveDuplicates |= optAssertionHasAssertionsForVN(addOpVN, /* addIfNotFound */ canAddNewAssertions);
             }
         }
+        else if (newAssertion.GetOp2().KindIs(O2K_VN))
+        {
+            mayHaveDuplicates |= optAssertionHasAssertionsForVN(newAssertion.GetOp2().GetVN(),
+                                                                /* addIfNotFound */ canAddNewAssertions);
+        }
 
         if (mayHaveDuplicates)
         {
@@ -1802,6 +1811,30 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     if (vnStore->IsVNIntegralConstant(op2VN, &cns) && (!isUnsignedRelop || (cns > 0)))
     {
         AssertionDsc   dsc = AssertionDsc::CreateConstantBound(this, relopFunc, op1VN, op2VN);
+        AssertionIndex idx = optAddAssertion(dsc);
+        optCreateComplementaryAssertion(idx);
+        return idx;
+    }
+
+    // "X <relop> Y" - both arbitrary int VNs, neither a checked bound nor a constant.
+    // We use this to express assertions like "j <= i" between two indices to enable
+    // transitive bounds-check elimination such as:
+    //
+    //     if (j <= i && j >= 0) { arr[i] = 0; arr[j] = 0; }
+    //
+    // where "j <= i" combined with a known "i < arr.Length" (from the bounds check on
+    // arr[i]) and "j >= 0" lets us eliminate the bounds check on arr[j].
+    //
+    // Restricted to signed relops; unsigned would need extra reasoning to be sound.
+    // Gate tightly: BOTH operands must be "checked indices" (VNs seen as the index
+    // argument of some GT_BOUNDS_CHECK). This captures the index-vs-index pattern
+    // without polluting the assertion table for unrelated comparisons that are not
+    // useful for transitive BCE (e.g. comparator return values, loop bound compares
+    // already handled by the existing checked-bound paths).
+    if (!isUnsignedRelop && (op1VN != op2VN) && vnStore->IsVNCheckedIndex(op1VN) &&
+        vnStore->IsVNCheckedIndex(op2VN))
+    {
+        AssertionDsc   dsc = AssertionDsc::CreateCompareVN(this, relopFunc, op1VN, op2VN);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7981,7 +7981,9 @@ public:
                                    // nor it implies that it's never negative.
         O2K_ZEROOBJ,
         O2K_SUBRANGE,
-        O2K_CONST_VEC
+        O2K_CONST_VEC,
+        O2K_VN, // arbitrary VN (used to express "X <relop> Y" for non-checked-bound Y).
+                // Only valid for O1K_VN op1 with relop kinds (OAK_LT/LE/GT/GE etc.)
     };
 
     struct AssertionDsc
@@ -8127,7 +8129,7 @@ public:
             ValueNum GetVN() const
             {
                 assert(!m_compiler->optLocalAssertionProp);
-                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CONST_VEC));
+                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CONST_VEC, O2K_VN));
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -8472,6 +8474,9 @@ public:
                            GetOp2().GetCheckedBoundConstant() == that.GetOp2().GetCheckedBoundConstant() &&
                            GetOp2().IsCheckedBoundNeverNegative() == that.GetOp2().IsCheckedBoundNeverNegative();
 
+                case O2K_VN:
+                    return GetOp2().GetVN() == that.GetOp2().GetVN();
+
                 case O2K_LCLVAR_COPY:
                     return GetOp2().GetLclNum() == that.GetOp2().GetLclNum();
 
@@ -8735,6 +8740,22 @@ public:
             dsc.m_op2.m_kind           = O2K_CONST_INT;
             dsc.m_op2.m_vn             = cnsVN;
             dsc.m_op2.m_icon.m_iconVal = cns;
+            return dsc;
+        }
+
+        // Create "op1VN <relop> op2VN" assertion where op2VN is an arbitrary VN
+        // (not a checked bound, not a constant). Both operands must be non-NoVN.
+        static AssertionDsc CreateCompareVN(const Compiler* comp, VNFunc relop, ValueNum op1VN, ValueNum op2VN)
+        {
+            assert(op1VN != ValueNumStore::NoVN);
+            assert(op2VN != ValueNumStore::NoVN);
+
+            AssertionDsc dsc    = CreateEmptyAssertion(comp);
+            dsc.m_assertionKind = FromVNFunc(relop);
+            dsc.m_op1.m_kind    = O1K_VN;
+            dsc.m_op1.m_vn      = op1VN;
+            dsc.m_op2.m_kind    = O2K_VN;
+            dsc.m_op2.m_vn      = op2VN;
             return dsc;
         }
     };

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1037,7 +1037,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                                      ValueNum         preferredBoundVN,
                                      ASSERT_VALARG_TP assertions,
                                      Range*           pRange,
-                                     bool             canUseCheckedBounds)
+                                     bool             canUseCheckedBounds,
+                                     bool             useTransitiveVNRels)
 {
     Range assertedRange = Range(Limit(Limit::keUnknown));
     if (BitVecOps::IsEmpty(comp->apTraits, assertions))
@@ -1060,6 +1061,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         AssertionIndex assertionIndex = GetAssertionIndex(index);
 
         const Compiler::AssertionDsc& curAssertion = comp->optGetAssertion(assertionIndex);
+
 
         Limit      limit(Limit::keUndef);
         genTreeOps cmpOper    = GT_NONE;
@@ -1338,6 +1340,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             }
         }
         // Current assertion is not supported, ignore it
+        // (O2K_VN-based relop assertions are handled in a separate pass below.)
         else
         {
             continue;
@@ -1439,6 +1442,121 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         {
             JITDUMP("invalid range after tightening\n");
             return;
+        }
+    }
+
+    // Second pass: process O2K_VN-based relop assertions transitively.
+    //
+    // For an assertion "normalLclVN <relop> X" (or with X on the LHS), recursively look
+    // up X's bound against the same preferredBoundVN and use it to tighten normalLclVN.
+    // Sound only when normalLclVN is provably non-negative (otherwise applying a bound
+    // u< len from "j s<= i u< len" would be incorrect when j < 0).
+    if (!useTransitiveVNRels || (preferredBoundVN == ValueNumStore::NoVN) ||
+        !pRange->lLimit.IsConstant() || (pRange->lLimit.GetConstant() < 0))
+    {
+        return;
+    }
+
+    BitVecOps::Iter iter2(comp->apTraits, assertions);
+    unsigned        index2 = 0;
+    while (iter2.NextElem(&index2))
+    {
+        const Compiler::AssertionDsc& curAssertion = comp->optGetAssertion(GetAssertionIndex(index2));
+        if (!curAssertion.IsRelop() || !curAssertion.GetOp2().KindIs(Compiler::O2K_VN))
+        {
+            continue;
+        }
+
+        const ValueNum op1VN = curAssertion.GetOp1().GetVN();
+        const ValueNum op2VN = curAssertion.GetOp2().GetVN();
+
+        bool       isUnsigned;
+        genTreeOps cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
+        ValueNum   otherVN;
+
+        if (op1VN == normalLclVN)
+        {
+            otherVN = op2VN;
+        }
+        else if (op2VN == normalLclVN)
+        {
+            // Normalize so that normalLclVN is on the LHS of the relop.
+            cmpOper = GenTree::SwapRelop(cmpOper);
+            otherVN = op1VN;
+        }
+        else
+        {
+            continue;
+        }
+
+        // O2K_VN assertions today are only created for signed relops; bail otherwise.
+        if (isUnsigned || (otherVN == normalLclVN) || (otherVN == preferredBoundVN))
+        {
+            continue;
+        }
+
+        // Recursively resolve otherVN's range against preferredBoundVN.
+        // useTransitiveVNRels=false prevents further levels of indirection.
+        Range otherRange = Range(Limit(Limit::keUndef));
+        MergeEdgeAssertions(comp, otherVN, preferredBoundVN, assertions, &otherRange,
+                            /*canUseCheckedBounds*/ true, /*useTransitiveVNRels*/ false);
+
+        Limit derivedLimit;
+        bool  isUpper;
+        switch (cmpOper)
+        {
+            case GT_LE:
+                derivedLimit = otherRange.uLimit;
+                isUpper      = true;
+                break;
+            case GT_LT:
+                derivedLimit = otherRange.uLimit;
+                isUpper      = true;
+                if (!derivedLimit.AddConstant(-1))
+                {
+                    continue;
+                }
+                break;
+            case GT_GE:
+                derivedLimit = otherRange.lLimit;
+                isUpper      = false;
+                break;
+            case GT_GT:
+                derivedLimit = otherRange.lLimit;
+                isUpper      = false;
+                if (!derivedLimit.AddConstant(1))
+                {
+                    continue;
+                }
+                break;
+            default:
+                continue;
+        }
+
+        // Require a symbolic limit referencing preferredBoundVN. Generic constant
+        // ranges (e.g. [0, INT32_MAX]) are too loose to help and risk overwriting
+        // a useful symbolic limit on pRange.
+        if (!derivedLimit.IsBinOpArray() || (derivedLimit.vn != preferredBoundVN))
+        {
+            continue;
+        }
+
+        Range copy = *pRange;
+        if (isUpper)
+        {
+            copy.uLimit = TightenLimit(derivedLimit, copy.uLimit, preferredBoundVN, false);
+        }
+        else
+        {
+            copy.lLimit = TightenLimit(derivedLimit, copy.lLimit, preferredBoundVN, true);
+        }
+
+        JITDUMP("Tightening pRange via transitive O2K_VN: [%s] -> [%s]\n", pRange->ToString(comp),
+                copy.ToString(comp));
+
+        if (copy.IsValid())
+        {
+            *pRange = copy;
         }
     }
 }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -825,7 +825,8 @@ private:
                                     ValueNum         preferredBoundVN,
                                     ASSERT_VALARG_TP assertions,
                                     Range*           pRange,
-                                    bool             canUseCheckedBounds = true);
+                                    bool             canUseCheckedBounds  = true,
+                                    bool             useTransitiveVNRels  = true);
 
     // The maximum possible value of the given "limit". If such a value could not be determined
     // return "false". For example: CORINFO_Array_MaxLength for array length.

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -431,6 +431,7 @@ ValueNumStore::ValueNumStore(Compiler* comp, CompAllocator alloc)
     , m_nextChunkBase(0)
     , m_fixedPointMapSels(alloc, 8)
     , m_checkedBoundVNs(alloc)
+    , m_checkedIndexVNs(alloc)
     , m_chunks(alloc, 8)
     , m_intCnsMap(nullptr)
     , m_longCnsMap(nullptr)
@@ -7727,6 +7728,26 @@ void ValueNumStore::SetVNIsCheckedBound(ValueNum vn)
     m_checkedBoundVNs.AddOrUpdate(vn, true);
 }
 
+bool ValueNumStore::IsVNCheckedIndex(ValueNum vn)
+{
+    if (vn == NoVN)
+    {
+        return false;
+    }
+
+    bool dummy;
+    return m_checkedIndexVNs.TryGetValue(vn, &dummy);
+}
+
+void ValueNumStore::SetVNIsCheckedIndex(ValueNum vn)
+{
+    // Used to flag VNs that have appeared as the index of some GT_BOUNDS_CHECK so that
+    // assertion-prop can opportunistically create transitive "X <relop> Y" assertions
+    // involving such VNs (which are likely to participate in BCE later).
+    assert(!IsVNConstant(vn));
+    m_checkedIndexVNs.AddOrUpdate(vn, true);
+}
+
 #ifdef FEATURE_HW_INTRINSICS
 simd8_t GetConstantSimd8(ValueNumStore* vns, var_types baseType, ValueNum argVN)
 {
@@ -13346,6 +13367,15 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         if ((lengthVN != ValueNumStore::NoVN) && !vnStore->IsVNConstant(lengthVN))
                         {
                             vnStore->SetVNIsCheckedBound(lengthVN);
+                        }
+
+                        // Also record the index VN so that assertion-prop can create transitive
+                        // "X <relop> indexVN" assertions for later BCE elimination.
+                        ValueNum indexVN =
+                            vnStore->VNNormalValue(tree->AsBoundsChk()->GetIndex()->gtVNPair.GetConservative());
+                        if ((indexVN != ValueNumStore::NoVN) && !vnStore->IsVNConstant(indexVN))
+                        {
+                            vnStore->SetVNIsCheckedIndex(indexVN);
                         }
                     }
                     break;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1073,12 +1073,22 @@ public:
     // of the length argument to a GT_BOUNDS_CHECK node.
     bool IsVNCheckedBound(ValueNum vn);
 
+    // Returns true if the VN is known to appear as the conservative value number of the index
+    // argument to some GT_BOUNDS_CHECK node, or as one side of an existing range-relevant
+    // comparison. Used to gate creation of "X <relop> Y" assertions to those likely useful
+    // for transitive bounds-check elimination.
+    bool IsVNCheckedIndex(ValueNum vn);
+
     // Returns true if the VN is known to be a cast to ulong
     bool IsVNCastToULong(ValueNum vn, ValueNum* castedOp);
 
     // Record that a VN is known to appear as the conservative value number of the length
     // argument to a GT_BOUNDS_CHECK node.
     void SetVNIsCheckedBound(ValueNum vn);
+
+    // Record that a VN is known to appear as the conservative value number of the index
+    // argument to a GT_BOUNDS_CHECK node.
+    void SetVNIsCheckedIndex(ValueNum vn);
 
     // Information about the individual components of a value number representing an unsigned
     // comparison of some value against a checked bound VN.
@@ -1623,6 +1633,9 @@ private:
 
     // This is the set of value numbers that have been flagged as arguments to bounds checks, in the length position.
     CheckedBoundVNSet m_checkedBoundVNs;
+
+    // This is the set of value numbers that have been flagged as arguments to bounds checks, in the index position.
+    CheckedBoundVNSet m_checkedIndexVNs;
 
     // This is a map from "chunk number" to the attributes of the chunk.
     JitExpandArrayStack<Chunk*> m_chunks;


### PR DESCRIPTION
Closes #112694

```cs
void Test(byte[] arr, int i, int j)
{
    if (j <= i && j >= 0)
    {
        arr[i] = 0;
        arr[j] = 0; // <-- redundant bounds check
    }
}
```

```diff
       cmp      edx, esi
       jg       SHORT G_M7310_IG04
       test     edx, edx
       jl       SHORT G_M7310_IG04
       mov      eax, dword ptr [rdi+0x08]
       cmp      esi, eax
       jae      SHORT G_M7310_IG05
-      mov      ecx, esi
-      mov      byte  ptr [rdi+rcx+0x10], 0
-      cmp      edx, eax
-      jae      SHORT G_M7310_IG05
+      mov      eax, esi
+      mov      byte  ptr [rdi+rax+0x10], 0
       mov      eax, edx
       mov      byte  ptr [rdi+rax+0x10], 0
```
