### PR TITLE
Do GenTree::Compare checks last when a cheaper check is available first

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3019,8 +3019,8 @@ public:
 
         for (; (i1 != end1) && (i2 != end2); ++i1, ++i2)
         {
-            if (!Compare(i1->GetNode(), i2->GetNode()) || (i1->GetOffset() != i2->GetOffset()) ||
-                (i1->GetType() != i2->GetType()))
+            if ((i1->GetOffset() != i2->GetOffset()) || (i1->GetType() != i2->GetType()) ||
+                !Compare(i1->GetNode(), i2->GetNode()))
             {
                 return false;
             }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11613,7 +11613,7 @@ bool Lowering::TryMakeIndirsAdjacent(GenTreeIndir* prevIndir, GenTreeIndir* indi
                 bool distinct = (storeOffs + (target_ssize_t)store->Size() <= offs) ||
                                 (offs + (target_ssize_t)indir->Size() <= storeOffs);
 
-                if (checkLocal && GenTree::Compare(indirAddr, storeAddr) && distinct)
+                if (checkLocal && distinct && GenTree::Compare(indirAddr, storeAddr))
                 {
                     JITDUMP("Cannot interfere with [%06u] since they are off the same local V%02u and indir range "
                             "[%03u..%03u) does not interfere with store range [%03u..%03u)\n",


### PR DESCRIPTION
`GenTree::Compare` is complex and expensive, we often have an earlier out available so use it where possible