### PR TITLE
Revert "Simplify TrimmerSingleWarn intermediate assembly update using MSBuild item Update"

### DIFF
--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -227,9 +227,19 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ItemGroup>
       <!-- Don't collapse to a single warning for the intermediate assembly.
            This sets metadata on the items in ResolvedFileToPublish that came from IntermediateAssembly. -->
-      <ResolvedFileToPublish Update="@(IntermediateAssembly)">
-        <TrimmerSingleWarn Condition=" '%(ResolvedFileToPublish.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
-      </ResolvedFileToPublish>
+      <!-- Find ResolvedFileToPublish _except_ IntermediateAssembly -->
+      <__SingleWarnIntermediateAssembly Include="@(ResolvedFileToPublish)" />
+      <__SingleWarnIntermediateAssembly Remove="@(IntermediateAssembly)" />
+      <!-- Subtract these from ResolvedFileToPublish, to get the intersection. -->
+      <_SingleWarnIntermediateAssembly Include="@(ResolvedFileToPublish)" />
+      <_SingleWarnIntermediateAssembly Remove="@(__SingleWarnIntermediateAssembly)" />
+      <!-- Set metadata on the intersection. -->
+      <_SingleWarnIntermediateAssembly>
+        <TrimmerSingleWarn Condition=" '%(_SingleWarnIntermediateAssembly.TrimmerSingleWarn)' == '' ">false</TrimmerSingleWarn>
+      </_SingleWarnIntermediateAssembly>
+      <!-- Replace these items in ResolvedFileToPublish. -->
+      <ResolvedFileToPublish Remove="@(_SingleWarnIntermediateAssembly)" />
+      <ResolvedFileToPublish Include="@(_SingleWarnIntermediateAssembly)" />
 
       <!-- Don't collapse to a single warning for project references -->
       <ResolvedFileToPublish Condition=" '%(ResolvedFileToPublish.ProjectReferenceOriginalItemSpec)' != '' ">


### PR DESCRIPTION
Reverts dotnet/runtime#125630

The `Update` in a target doesn't work (see https://github.com/dotnet/msbuild/issues/2835 for the MSBuild behavior).

Fixes the dependency flow issue here: https://github.com/dotnet/sdk/pull/53847#issuecomment-4355555116.