### PR TITLE
Don't report a interp->native transition when it is done from a pinvoke method

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -308,14 +308,14 @@ void InvokeUnmanagedCalliWithTransition(PCODE ftn, void *cookie, int8_t *stack, 
     {
         GCX_PREEMP();
 #ifdef PROFILING_SUPPORTED
-        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub())
+        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub() && !pFrame->startIp->Method->methodHnd->IsPInvoke())
         {
             ProfilerManagedToUnmanagedTransitionMD(pFrame->startIp->Method->methodHnd, COR_PRF_TRANSITION_CALL);
         }
 #endif
         InvokeUnmanagedCalli(ftn, cookie, pArgs, pRet);
 #ifdef PROFILING_SUPPORTED
-        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub())
+        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub() && !pFrame->startIp->Method->methodHnd->IsPInvoke())
         {
             ProfilerUnmanagedToManagedTransitionMD(pFrame->startIp->Method->methodHnd, COR_PRF_TRANSITION_CALL);
         }


### PR DESCRIPTION

We didn't report these transitions when they were triggered from ILStubs because they already explicitly do this. Following the change of using transient IL belonging to the actual PInvoke method rather than separate ILStub methods (which should contain the same logic as the ILStub used to), we would now report the same event twice. We need therefore to also ignore the case where we are doing a PInvoke call from an actual PInvoke method.

Fixes src/tests/profiler/transitions/transitions.csproj which regressed after https://github.com/dotnet/runtime/pull/126509 on interpreter.