### PR TITLE
Remove DacDbi GetAppDomainObject API from native and cDAC

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -664,26 +664,6 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain vm
     return hr;
 }
 
-// Get the managed AppDomain object for an AppDomain.
-HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal)
-{
-    DD_ENTER_MAY_THROW;
-
-    HRESULT hr = S_OK;
-    EX_TRY
-    {
-
-        AppDomain* pAppDomain = vmAppDomain.GetDacPtr();
-        OBJECTHANDLE hAppDomainManagedObject = pAppDomain->GetRawExposedObjectHandleForDebugger();
-        VMPTR_OBJECTHANDLE vmObj = VMPTR_OBJECTHANDLE::NullPtr();
-        vmObj.SetDacTargetPtr(hAppDomainManagedObject);
-        *pRetVal = vmObj;
-
-    }
-    EX_CATCH_HRESULT(hr);
-    return hr;
-}
-
 // Get the full AD friendly name for the given EE AppDomain.
 HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName)
 {

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -87,9 +87,6 @@ public:
     // Get the AppDomain ID for an AppDomain.
     HRESULT STDMETHODCALLTYPE GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal);
 
-    // Get the managed AppDomain object for an AppDomain.
-    HRESULT STDMETHODCALLTYPE GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal);
-
     // Get the full AD friendly name for the appdomain.
     HRESULT STDMETHODCALLTYPE GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName);
 

--- a/src/coreclr/debug/di/rsappdomain.cpp
+++ b/src/coreclr/debug/di/rsappdomain.cpp
@@ -702,8 +702,8 @@ HRESULT CordbAppDomain::GetName(ULONG32 cchName,
 }
 
 /*
- * GetObject returns the runtime app domain object.
- * Note: this is lazily initialized and may be NULL
+ * GetObject always returns S_FALSE with a null object.
+ * The runtime AppDomain object is not available through this API.
  */
 HRESULT CordbAppDomain::GetObject(ICorDebugValue **ppObject)
 {

--- a/src/coreclr/debug/di/rsappdomain.cpp
+++ b/src/coreclr/debug/di/rsappdomain.cpp
@@ -714,24 +714,11 @@ HRESULT CordbAppDomain::GetObject(ICorDebugValue **ppObject)
     ATT_REQUIRE_STOPPED_MAY_FAIL(GetProcess());
 
     _ASSERTE(!m_vmAppDomain.IsNull());
-    IDacDbiInterface * pDac = NULL;
     HRESULT hr = S_OK;
     EX_TRY
     {
-        pDac = m_pProcess->GetDAC();
-        VMPTR_OBJECTHANDLE vmObjHandle;
-        IfFailThrow(pDac->GetAppDomainObject(m_vmAppDomain, &vmObjHandle));
-        if (!vmObjHandle.IsNull())
-        {
-            ICorDebugReferenceValue * pRefValue = NULL;
-            hr = CordbReferenceValue::BuildFromGCHandle(this, vmObjHandle, &pRefValue);
-            *ppObject = pRefValue;
-        }
-        else
-        {
-            *ppObject = NULL;
-            hr = S_FALSE;
-        }
+        *ppObject = NULL;
+        hr = S_FALSE;
     }
     EX_CATCH_HRESULT(hr);
 

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -266,23 +266,6 @@ public:
     virtual HRESULT STDMETHODCALLTYPE GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal) = 0;
 
     //
-    // Get the managed AppDomain object for an AppDomain.
-    //
-    // Arguments:
-    //  vmAppDomain  - VM pointer to the AppDomain object of interest
-    //  pRetVal - [out] Objecthandle for the managed app domain object or the Null VMPTR if there is no object created yet.
-    //
-    // Return Value:
-    //    S_OK on success; otherwise, an appropriate failure HRESULT.
-    //
-    // Notes:
-    //   The AppDomain managed object is lazily constructed on the AppDomain the first time
-    //   it is requested. It may be NULL.
-    //
-    virtual HRESULT STDMETHODCALLTYPE GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
-
-
-    //
     // Get the full AD friendly name for the given EE AppDomain.
     //
     // Arguments:

--- a/src/coreclr/inc/dacdbi.idl
+++ b/src/coreclr/inc/dacdbi.idl
@@ -202,7 +202,6 @@ interface IDacDbiInterface : IUnknown
 
     // App Domains
     HRESULT GetAppDomainId([in] VMPTR_AppDomain vmAppDomain, [out] ULONG * pRetVal);
-    HRESULT GetAppDomainObject([in] VMPTR_AppDomain vmAppDomain, [out] VMPTR_OBJECTHANDLE * pRetVal);
     HRESULT GetAppDomainFullName([in] VMPTR_AppDomain vmAppDomain, [in] IDacDbiStringHolder pStrName);
     HRESULT GetModuleSimpleName([in] VMPTR_Module vmModule, [in] IDacDbiStringHolder pStrFilename);
     HRESULT GetAssemblyPath([in] VMPTR_Assembly vmAssembly, [in] IDacDbiStringHolder pStrFilename, [out] BOOL * pResult);

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -676,7 +676,6 @@ public:
     STRINGREF *GetOrInternString(STRINGREF *pString);
 
     OBJECTREF GetRawExposedObject() { LIMITED_METHOD_CONTRACT; return NULL; }
-    OBJECTHANDLE GetRawExposedObjectHandleForDebugger() { LIMITED_METHOD_DAC_CONTRACT; return (OBJECTHANDLE)NULL; }
 
 #ifndef DACCESS_COMPILE
     PTR_NativeImage GetNativeImage(LPCUTF8 compositeFileName);

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -675,8 +675,6 @@ public:
     STRINGREF *IsStringInterned(STRINGREF *pString);
     STRINGREF *GetOrInternString(STRINGREF *pString);
 
-    OBJECTREF GetRawExposedObject() { LIMITED_METHOD_CONTRACT; return NULL; }
-
 #ifndef DACCESS_COMPILE
     PTR_NativeImage GetNativeImage(LPCUTF8 compositeFileName);
     PTR_NativeImage SetNativeImage(LPCUTF8 compositeFileName, PTR_NativeImage pNativeImage);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -120,9 +120,6 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         return hr;
     }
 
-    public int GetAppDomainObject(ulong vmAppDomain, ulong* pRetVal)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetAppDomainObject(vmAppDomain, pRetVal) : HResults.E_NOTIMPL;
-
     public int GetAppDomainFullName(ulong vmAppDomain, nint pStrName)
     {
         int hr = HResults.S_OK;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -167,9 +167,6 @@ public unsafe partial interface IDacDbiInterface
     int GetAppDomainId(ulong vmAppDomain, uint* pRetVal);
 
     [PreserveSig]
-    int GetAppDomainObject(ulong vmAppDomain, ulong* pRetVal);
-
-    [PreserveSig]
     int GetAppDomainFullName(ulong vmAppDomain, nint pStrName);
 
     [PreserveSig]


### PR DESCRIPTION
GetRawExposedObjectHandleForDebugger() always returned NULL, making GetAppDomainObject a no-op. 
This pr removes it from all layers:
 - IDacDbiInterface (abstract interface + IDL)
 - DacDbiInterfaceImpl (native implementation)
 - cDAC managed interface and implementation
 - AppDomain::GetRawExposedObjectHandleForDebugger (sole consumer)
 - CordbAppDomain::GetObject call site (simplified, since deletion created new dead code)