### PR TITLE
Hide Environment.CallEntryPoint in unhandled exception message

### DIFF
--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -2577,8 +2577,10 @@ void StackTraceInfo::AppendElement(OBJECTREF pThrowable, UINT_PTR currentIP, UIN
         return;
     }
 
-    if ((pFunc != NULL && pFunc->IsDiagnosticsHidden()))
+    if (pFunc != NULL && (pFunc->IsDiagnosticsHidden() || pFunc == g_pEnvironmentCallEntryPointMethodDesc))
+    {
         return;
+    }
 
     struct
     {


### PR DESCRIPTION
The idea in #126222 was to hide CallEntryPoint helper in the unhandled exception stacktraces, but it did not actually happen.
