### PR TITLE
Reorder static fields in LoggingEventSource to prevent reentrant bug in FilterSpec parsing

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Extensions.Logging.EventSource
         // s_semicolon and s_colon must be declared before Instance because the Instance
         // constructor can trigger OnEventCommand re-entrantly (via EventPipe enable during
         // the base EventSource constructor), which calls ParseFilterSpec.
-        // Static field initializers execute in declaration order, so if these were declared after 
+        // Static field initializers execute in declaration order, so if these were declared after
         // Instance they would still be null during the constructor.
         // See: https://github.com/dotnet/roslyn/issues/77005
         private static readonly char[] s_semicolon = new[] { ';' };

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -112,14 +112,16 @@ namespace Microsoft.Extensions.Logging.EventSource
             public const EventKeywords JsonMessage = (EventKeywords)8;
         }
 
-        // s_semicolon and s_colon must be declared before Instance because the Instance
+        // Separators are in a nested class so their initialization is guaranteed to complete
+        // before first use, regardless of declaration order in the outer class.  The Instance
         // constructor can trigger OnEventCommand re-entrantly (via EventPipe enable during
-        // the base EventSource constructor), which calls ParseFilterSpec.
-        // Static field initializers execute in declaration order, so if these were declared after
-        // Instance they would still be null during the constructor.
+        // the base EventSource constructor), which calls ParseFilterSpec and needs these arrays.
         // See: https://github.com/dotnet/roslyn/issues/77005
-        private static readonly char[] s_semicolon = new[] { ';' };
-        private static readonly char[] s_colon = new[] { ':' };
+        private static class Separators
+        {
+            internal static readonly char[] Semicolon = new[] { ';' };
+            internal static readonly char[] Colon = new[] { ':' };
+        }
 
         /// <summary>
         ///  The one and only instance of the LoggingEventSource.
@@ -433,7 +435,7 @@ namespace Microsoft.Extensions.Logging.EventSource
 
             var rules = new List<LoggerFilterRule>();
             int ruleStringsStartIndex = 0;
-            string[] ruleStrings = filterSpec.Split(s_semicolon, StringSplitOptions.RemoveEmptyEntries);
+            string[] ruleStrings = filterSpec.Split(Separators.Semicolon, StringSplitOptions.RemoveEmptyEntries);
             if (ruleStrings.Length > 0 && ruleStrings[0].Equals(UseAppFilters, StringComparison.OrdinalIgnoreCase))
             {
                 // Avoid adding default rule to disable event source loggers
@@ -448,7 +450,7 @@ namespace Microsoft.Extensions.Logging.EventSource
             {
                 string rule = ruleStrings[i];
                 LogLevel level = defaultLevel;
-                string[] parts = rule.Split(s_colon, 2);
+                string[] parts = rule.Split(Separators.Colon, 2);
                 string loggerName = parts[0];
                 if (loggerName.Length == 0)
                 {

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -112,6 +112,15 @@ namespace Microsoft.Extensions.Logging.EventSource
             public const EventKeywords JsonMessage = (EventKeywords)8;
         }
 
+        // s_semicolon and s_colon must be declared before Instance because the Instance
+        // constructor can trigger OnEventCommand re-entrantly (via EventPipe enable during
+        // the base EventSource constructor), which calls ParseFilterSpec, which uses these
+        // fields. Static field initializers execute in declaration order, so if these were
+        // declared after Instance they would still be null during the constructor.
+        // See: https://github.com/dotnet/roslyn/issues/77005
+        private static readonly char[] s_semicolon = new[] { ';' };
+        private static readonly char[] s_colon = new[] { ':' };
+
         /// <summary>
         ///  The one and only instance of the LoggingEventSource.
         /// </summary>
@@ -125,8 +134,6 @@ namespace Microsoft.Extensions.Logging.EventSource
         private const string UseAppFilters = "UseAppFilters";
         private const string WriteEventCoreSuppressionJustification = "WriteEventCore is safe when eventData object is a primitive type which is in this case.";
         private const string WriteEventDynamicDependencySuppressionJustification = "DynamicDependency attribute will ensure that the required properties are not trimmed.";
-        private static readonly char[] s_semicolon = new[] { ';' };
-        private static readonly char[] s_colon = new[] { ':' };
 
         // This event source uses IEnumerable<T> as an event parameter type which is only supported by EtwSelfDescribingEventFormat.
         private LoggingEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat)

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/src/LoggingEventSource.cs
@@ -114,9 +114,9 @@ namespace Microsoft.Extensions.Logging.EventSource
 
         // s_semicolon and s_colon must be declared before Instance because the Instance
         // constructor can trigger OnEventCommand re-entrantly (via EventPipe enable during
-        // the base EventSource constructor), which calls ParseFilterSpec, which uses these
-        // fields. Static field initializers execute in declaration order, so if these were
-        // declared after Instance they would still be null during the constructor.
+        // the base EventSource constructor), which calls ParseFilterSpec.
+        // Static field initializers execute in declaration order, so if these were declared after 
+        // Instance they would still be null during the constructor.
         // See: https://github.com/dotnet/roslyn/issues/77005
         private static readonly char[] s_semicolon = new[] { ';' };
         private static readonly char[] s_colon = new[] { ':' };

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/EventSourceLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/EventSourceLoggerTest.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.Extensions.Logging.EventSource;
 using Xunit;
 using Newtonsoft.Json;
@@ -758,6 +759,59 @@ namespace Microsoft.Extensions.Logging.Test
             {
                 Assert.True(eventJson.Contains(fragments[i]), $"Event data '{eventJson}' does not contain expected fragment {fragments[i]}");
             }
+        }
+
+        /// <summary>
+        /// Regression test for https://github.com/dotnet/runtime/issues/127681
+        /// Verifies that ParseFilterSpec correctly splits on semicolons when the
+        /// EventSource is first enabled during its own type initializer. This requires
+        /// a fresh process because LoggingEventSource.Instance is a singleton.
+        /// </summary>
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        public void FilterSpec_ParsedCorrectly_WhenEnabledDuringTypeInitializer()
+        {
+            RemoteExecutor.Invoke(static () =>
+            {
+                // Add a listener with a multi-rule FilterSpec BEFORE LoggingEventSource is created
+                // to test the reentrancy of ParseFilterSpec when LoggingEventSource is enabled
+                using var listener = new PreEnableListener("Cat1:Warning;Cat2:Error");
+
+                using ILoggerFactory factory = LoggerFactory.Create(b => b.AddEventSourceLogger());
+                ILogger cat1 = factory.CreateLogger("Cat1");
+                ILogger cat2 = factory.CreateLogger("Cat2");
+
+                Assert.True(cat1.IsEnabled(LogLevel.Warning), "Cat1 should be enabled at Warning");
+                Assert.False(cat1.IsEnabled(LogLevel.Information), "Cat1 should NOT be enabled at Information");
+                Assert.True(cat2.IsEnabled(LogLevel.Error), "Cat2 should be enabled at Error");
+                Assert.False(cat2.IsEnabled(LogLevel.Warning), "Cat2 should NOT be enabled at Warning");
+            }).Dispose();
+        }
+
+        /// <summary>
+        /// EventListener that enables LoggingEventSource with a given FilterSpec
+        /// as soon as it sees the source being created (via OnEventSourceCreated).
+        /// Used by the RemoteExecutor regression test to exercise the deferred-command
+        /// path during type initialization.
+        /// </summary>
+        private class PreEnableListener : EventListener
+        {
+            private readonly string _filterSpec;
+
+            public PreEnableListener(string filterSpec)
+            {
+                _filterSpec = filterSpec;
+            }
+
+            protected override void OnEventSourceCreated(System.Diagnostics.Tracing.EventSource eventSource)
+            {
+                if (eventSource.Name == "Microsoft-Extensions-Logging")
+                {
+                    var args = new Dictionary<string, string> { ["FilterSpecs"] = _filterSpec };
+                    EnableEvents(eventSource, EventLevel.Verbose, LoggingEventSource.Keywords.JsonMessage, args);
+                }
+            }
+
+            protected override void OnEventWritten(EventWrittenEventArgs eventData) { }
         }
 
         private class TestEventListener : EventListener

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/tests/Microsoft.Extensions.Logging.EventSource.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableAotAnalyzer>false</EnableAotAnalyzer>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/127681