### PR TITLE
Fix stale lastThrownObjectHandle in DAC GetThreadData during active exception dispatch

### DIFF
--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -190,6 +190,23 @@ ThreadData GetThreadData(TargetPointer address)
         allocContextLimit = target.ReadPointer(threadLocals + /* RuntimeThreadLocals::AllocContext offset */ + /* GCAllocContext::Limit offset */);
     }
 
+    // Prefer the active exception from ExInfo (pseudo-handle to m_exception field).
+    // After the removal of SetThrowable/m_hThrowable, m_LastThrownObjectHandle is only
+    // updated after exception dispatch completes, so during active dispatch it may be stale.
+    TargetPointer lastThrownObjectHandle = TargetPointer.Null;
+    if (exceptionTrackerAddr != TargetPointer.Null)
+    {
+        TargetPointer thrownObject = target.ReadPointer(exceptionTrackerAddr + /* ExceptionInfo::ThrownObject offset */);
+        if (thrownObject != TargetPointer.Null)
+        {
+            lastThrownObjectHandle = exceptionTrackerAddr + /* ExceptionInfo::ThrownObject field offset */;
+        }
+    }
+    if (lastThrownObjectHandle == TargetPointer.Null)
+    {
+        lastThrownObjectHandle = target.ReadPointer(address + /* Thread::LastThrownObject offset */);
+    }
+
     ulong threadLinkoffset = ... // offset from Thread data descriptor
     return new ThreadData(
         Id: target.Read<uint>(address + /* Thread::Id offset */),
@@ -199,7 +216,7 @@ ThreadData GetThreadData(TargetPointer address)
         AllocContextPointer: allocContextPointer,
         AllocContextLimit: allocContextLimit,
         Frame: target.ReadPointer(address + /* Thread::Frame offset */),
-        LastThrownObjectHandle : target.ReadPointer(address + /* Thread::LastThrownObject offset */),
+        LastThrownObjectHandle : lastThrownObjectHandle,
         FirstNestedException : firstNestedException,
         NextThread: target.ReadPointer(address + /* Thread::LinkNext offset */) - threadLinkOffset;
     );
@@ -285,12 +302,14 @@ TargetPointer IThread.GetCurrentExceptionHandle(TargetPointer threadPointer)
     TargetPointer exceptionTrackerPtr = target.ReadPointer(threadPointer + /*Thread::ExceptionTracker offset */);
     if (exceptionTrackerPtr == TargetPointer.Null)
         return TargetPointer.Null;
-    TargetPointer thrownObjectHandle = target.ReadPointer(exceptionTrackerPtr + /* ExceptionInfo::ThrownObjectHandle offset */);
+    TargetPointer thrownObject = target.ReadPointer(exceptionTrackerPtr + /* ExceptionInfo::ThrownObject offset */);
 
-    if (thrownObjectHandle == TargetPointer.Null || target.ReadPointer(thrownObjectHandle) == TargetPointer.Null)
+    if (thrownObject == TargetPointer.Null)
         return TargetPointer.Null;
 
-    return thrownObjectHandle;
+    // Return the address of the ThrownObject field as a pseudo-handle.
+    // Callers dereference this address to read the exception Object*.
+    return exceptionTrackerPtr + /* ExceptionInfo::ThrownObject field offset */;
 }
 
 byte[] IThread.GetWatsonBuckets(TargetPointer threadPointer)

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -893,8 +893,19 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
     // TEB is no longer provided by the runtime. Consumers should look up the TEB
     // from the OS thread ID via the debugger's native API (e.g., IDebuggerServices::GetThreadTeb).
     threadData->teb = (CLRDATA_ADDRESS)NULL;
-    threadData->lastThrownObjectHandle =
-        TO_CDADDR(thread->m_LastThrownObjectHandle);
+    // Prefer the active exception from ExInfo (pseudo-handle to m_exception field).
+    // After the removal of SetThrowable/m_hThrowable, m_LastThrownObjectHandle is only
+    // updated after exception dispatch completes, so during active dispatch it may be
+    // stale.  GetThrowableAsPseudoHandle returns the address of ExInfo::m_exception
+    // which has the same dereference semantics as a real GC handle.
+    {
+        OBJECTHANDLE ohException = thread->GetThrowableAsPseudoHandle();
+        if (ohException == (OBJECTHANDLE)NULL)
+        {
+            ohException = thread->m_LastThrownObjectHandle;
+        }
+        threadData->lastThrownObjectHandle = TO_CDADDR(ohException);
+    }
     threadData->nextThread =
         HOST_CDADDR(ThreadStore::s_pThreadStore->m_ThreadList.GetNext(thread));
     if (thread->m_ExceptionState.m_pCurrentTracker)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -88,9 +88,10 @@ internal readonly struct Thread_1 : IThread
         TargetPointer address = _target.ReadPointer(thread.ExceptionTracker);
         TargetPointer firstNestedException = TargetPointer.Null;
         bool hasUnhandledException = false;
+        Data.ExceptionInfo? exceptionInfo = null;
         if (address != TargetPointer.Null)
         {
-            Data.ExceptionInfo exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(address);
+            exceptionInfo = _target.ProcessedData.GetOrAdd<Data.ExceptionInfo>(address);
             firstNestedException = exceptionInfo.PreviousNestedInfo;
 
             if (exceptionInfo.ThrownObject != TargetPointer.Null)
@@ -104,6 +105,16 @@ internal readonly struct Thread_1 : IThread
         if (thread.LastThrownObjectIsUnhandled != 0)
             hasUnhandledException = true;
 
+        // Prefer the active exception from ExInfo (pseudo-handle to m_exception field).
+        // After the removal of SetThrowable/m_hThrowable, m_LastThrownObjectHandle is only
+        // updated after exception dispatch completes, so during active dispatch it may be
+        // stale.  The pseudo-handle has the same dereference semantics as a real GC handle.
+        TargetPointer lastThrownObjectHandle = GetActiveExceptionPseudoHandle(exceptionInfo, address);
+        if (lastThrownObjectHandle == TargetPointer.Null)
+        {
+            lastThrownObjectHandle = thread.LastThrownObject.Handle;
+        }
+
         return new ThreadData(
             threadPointer,
             thread.Id,
@@ -115,7 +126,7 @@ internal readonly struct Thread_1 : IThread
             thread.Frame,
             firstNestedException,
             thread.ExposedObject.Handle,
-            thread.LastThrownObject.Handle,
+            lastThrownObjectHandle,
             thread.CurrentCustomDebuggerNotification.Handle,
             thread.LastThrownObjectIsUnhandled != 0,
             hasUnhandledException,
@@ -218,17 +229,25 @@ internal readonly struct Thread_1 : IThread
         return (thread, exceptionInfo, exceptionTrackerPtr);
     }
 
-    TargetPointer IThread.GetCurrentExceptionHandle(TargetPointer threadPointer)
+    /// <summary>
+    /// Returns the target address of the ExInfo::m_exception field as a pseudo-handle
+    /// if there is an active exception tracker with a non-null thrown object.
+    /// Callers dereference this address to read the exception Object*, just like a real
+    /// GC handle.  Returns TargetPointer.Null when no active exception is present.
+    /// </summary>
+    private TargetPointer GetActiveExceptionPseudoHandle(Data.ExceptionInfo? exceptionInfo, TargetPointer exceptionTrackerAddr)
     {
-        var (_, exceptionInfo, exceptionTrackerAddr) = GetThreadExceptionInfo(threadPointer);
-
         if (exceptionInfo is null || exceptionInfo.ThrownObject == TargetPointer.Null)
             return TargetPointer.Null;
 
-        // Return the target address of the ThrownObject field as a pseudo-handle.
-        // Callers dereference this address to read the exception Object*.
         Target.TypeInfo type = _target.GetTypeInfo(DataType.ExceptionInfo);
         return exceptionTrackerAddr + (ulong)type.Fields[nameof(Data.ExceptionInfo.ThrownObject)].Offset;
+    }
+
+    TargetPointer IThread.GetCurrentExceptionHandle(TargetPointer threadPointer)
+    {
+        var (_, exceptionInfo, exceptionTrackerAddr) = GetThreadExceptionInfo(threadPointer);
+        return GetActiveExceptionPseudoHandle(exceptionInfo, exceptionTrackerAddr);
     }
 
     byte[] IThread.GetWatsonBuckets(TargetPointer threadPointer)

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
@@ -277,6 +277,12 @@ internal sealed class MockThread : TypedView
     }
 
     public ulong FrameAddress => GetFieldAddress(FrameFieldName);
+
+    public ulong LastThrownObject
+    {
+        get => ReadPointerField(LastThrownObjectFieldName);
+        set => WritePointerField(LastThrownObjectFieldName, value);
+    }
 }
 
 internal sealed class MockThreadBuilder

--- a/src/native/managed/cdac/tests/ThreadTests.cs
+++ b/src/native/managed/cdac/tests/ThreadTests.cs
@@ -270,4 +270,60 @@ public unsafe class ThreadTests
         TargetPointer thrownObjectHandle = contract.GetCurrentExceptionHandle(new TargetPointer(thread!.Address));
         Assert.Equal(TargetPointer.Null, thrownObjectHandle);
     }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetThreadData_LastThrownObjectHandle_ActiveException(MockTarget.Architecture arch)
+    {
+        // When an active exception is being dispatched (ExInfo has a non-null ThrownObject),
+        // GetThreadData should return a pseudo-handle to the ExInfo's ThrownObject field
+        // instead of the (potentially stale) m_LastThrownObjectHandle.
+        MockThread? thread = null;
+        MockExceptionInfo? exceptionInfo = null;
+        TargetPointer activeException = new(0xBEEF_0001);
+
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            threadBuilder =>
+            {
+                thread = threadBuilder.AddThread(1, 1234);
+                exceptionInfo = threadBuilder.GetExceptionInfo(thread);
+                exceptionInfo!.ThrownObject = (ulong)activeException;
+                // Set a stale handle to verify it is NOT returned
+                thread.LastThrownObject = 0xDEAD_0001;
+            });
+
+        IThread contract = target.Contracts.Thread;
+        ThreadData data = contract.GetThreadData(new TargetPointer(thread!.Address));
+        // Should return the pseudo-handle (address of ThrownObject field), not the stale handle
+        Assert.NotEqual(TargetPointer.Null, data.LastThrownObjectHandle);
+        Assert.NotEqual(new TargetPointer(0xDEAD_0001), data.LastThrownObjectHandle);
+        // Dereferencing the pseudo-handle should yield the active exception object
+        Assert.Equal(activeException, target.ReadPointer(data.LastThrownObjectHandle));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetThreadData_LastThrownObjectHandle_NoActiveException(MockTarget.Architecture arch)
+    {
+        // When no active exception is being dispatched (ExInfo ThrownObject is null),
+        // GetThreadData should fall back to m_LastThrownObjectHandle.
+        MockThread? thread = null;
+        MockExceptionInfo? exceptionInfo = null;
+        TargetPointer lastThrownHandle = new(0xCAFE_0001);
+
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            threadBuilder =>
+            {
+                thread = threadBuilder.AddThread(1, 1234);
+                exceptionInfo = threadBuilder.GetExceptionInfo(thread);
+                exceptionInfo!.ThrownObject = 0;
+                thread.LastThrownObject = (ulong)lastThrownHandle;
+            });
+
+        IThread contract = target.Contracts.Thread;
+        ThreadData data = contract.GetThreadData(new TargetPointer(thread!.Address));
+        Assert.Equal(lastThrownHandle, data.LastThrownObjectHandle);
+    }
 }


### PR DESCRIPTION
After #127300 removed ExInfo::m_hThrowable and SetThrowable(), Thread::m_LastThrownObjectHandle is no longer updated during active exception dispatch. This causes a staleclastThrownObjectHandle to ge returned by GetThreadData when a debugger breaks into the target mid-dispatch. 

When debugging a .NET 11 process with SOS (e.g. via dotnet-dump or WinDbg), the following commands fail if the debuggee is stopped during exception dispatch (for example, with SXE CLR):

- !PrintException — reports "Invalid exception object" because it dereferences the stale handle and gets a null or recycled pointer
- !Threads — shows no exception column for threads that are actively throwing
- !clrstack -a with exception context — may show incomplete or missing exception info