### PR TITLE
Allow HostFactoryResolver to listen on arbitrary events

### DIFF
--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.slnx
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.slnx
@@ -1279,6 +1279,14 @@
       <Build Solution="Checked|x64" Project="false" />
       <Build Solution="Checked|x86" Project="false" />
     </Project>
+    <Project Path="tests/ArbitraryDiagnosticEventPatternTestSite/ArbitraryDiagnosticEventPatternTestSite.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="tests/BuildWebHostInvalidSignature/BuildWebHostInvalidSignature.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.Hosting
 {

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 
 namespace Microsoft.Extensions.Hosting
 {
@@ -63,6 +64,7 @@ namespace Microsoft.Extensions.Hosting
                                                                  TimeSpan? waitTimeout = null,
                                                                  bool stopApplication = true,
                                                                  Action<object>? configureHostBuilder = null,
+                                                                 Dictionary<string, Action<object?>>? arbitraryActions = null,
                                                                  Action<Exception?>? entrypointCompleted = null)
         {
             if (assembly.EntryPoint is null)
@@ -89,7 +91,7 @@ namespace Microsoft.Extensions.Hosting
                 return null;
             }
 
-            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, entrypointCompleted).CreateHost();
+            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, arbitraryActions, entrypointCompleted).CreateHost();
         }
 
         private static Func<string[], T>? ResolveFactory<T>(Assembly assembly, string name)
@@ -203,16 +205,18 @@ namespace Microsoft.Extensions.Hosting
             private readonly TaskCompletionSource<object> _hostTcs = new();
             private IDisposable? _disposable;
             private readonly Action<object>? _configure;
+            private readonly Dictionary<string, Action<object?>>? _arbitraryActions;
             private readonly Action<Exception?>? _entrypointCompleted;
             private static readonly AsyncLocal<HostingListener> _currentListener = new();
 
-            public HostingListener(string[] args, MethodInfo entryPoint, TimeSpan waitTimeout, bool stopApplication, Action<object>? configure, Action<Exception?>? entrypointCompleted)
+            public HostingListener(string[] args, MethodInfo entryPoint, TimeSpan waitTimeout, bool stopApplication, Action<object>? configure, Dictionary<string, Action<object?>>? arbitraryActions, Action<Exception?>? entrypointCompleted)
             {
                 _args = args;
                 _entryPoint = entryPoint;
                 _waitTimeout = waitTimeout;
                 _stopApplication = stopApplication;
                 _configure = configure;
+                _arbitraryActions = arbitraryActions;
                 _entrypointCompleted = entrypointCompleted;
             }
 
@@ -332,8 +336,7 @@ namespace Microsoft.Extensions.Hosting
                 {
                     _configure?.Invoke(value.Value!);
                 }
-
-                if (value.Key == "HostBuilt")
+                else if (value.Key == "HostBuilt")
                 {
                     _hostTcs.TrySetResult(value.Value!);
 
@@ -342,6 +345,10 @@ namespace Microsoft.Extensions.Hosting
                         // Stop the host from running further
                         ThrowHostAborted();
                     }
+                }
+                else if (_arbitraryActions?.TryGetValue(value.Key, out var arbitraryAction) == true)
+                {
+                    arbitraryAction.Invoke(value.Value);
                 }
             }
 

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Extensions.Hosting
                                                                  TimeSpan? waitTimeout = null,
                                                                  bool stopApplication = true,
                                                                  Action<object>? configureHostBuilder = null,
-                                                                 Dictionary<string, Action<object?>>? arbitraryActions = null,
-                                                                 Action<Exception?>? entrypointCompleted = null)
+                                                                 Action<Exception?>? entrypointCompleted = null,
+                                                                 Dictionary<string, Action<object?>>? arbitraryActions = null)
         {
             if (assembly.EntryPoint is null)
             {
@@ -90,7 +90,7 @@ namespace Microsoft.Extensions.Hosting
                 return null;
             }
 
-            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, arbitraryActions, entrypointCompleted).CreateHost();
+            return args => new HostingListener(args, assembly.EntryPoint, waitTimeout ?? s_defaultWaitTimeout, stopApplication, configureHostBuilder, entrypointCompleted, arbitraryActions).CreateHost();
         }
 
         private static Func<string[], T>? ResolveFactory<T>(Assembly assembly, string name)
@@ -204,19 +204,26 @@ namespace Microsoft.Extensions.Hosting
             private readonly TaskCompletionSource<object> _hostTcs = new();
             private IDisposable? _disposable;
             private readonly Action<object>? _configure;
-            private readonly Dictionary<string, Action<object?>>? _arbitraryActions;
             private readonly Action<Exception?>? _entrypointCompleted;
+            private readonly Dictionary<string, Action<object?>>? _arbitraryActions;
             private static readonly AsyncLocal<HostingListener> _currentListener = new();
 
-            public HostingListener(string[] args, MethodInfo entryPoint, TimeSpan waitTimeout, bool stopApplication, Action<object>? configure, Dictionary<string, Action<object?>>? arbitraryActions, Action<Exception?>? entrypointCompleted)
+            public HostingListener(
+                string[] args,
+                MethodInfo entryPoint,
+                TimeSpan waitTimeout,
+                bool stopApplication,
+                Action<object>? configure,
+                Action<Exception?>? entrypointCompleted,
+                Dictionary<string, Action<object?>>? arbitraryActions)
             {
                 _args = args;
                 _entryPoint = entryPoint;
                 _waitTimeout = waitTimeout;
                 _stopApplication = stopApplication;
                 _configure = configure;
-                _arbitraryActions = arbitraryActions;
                 _entrypointCompleted = entrypointCompleted;
+                _arbitraryActions = arbitraryActions;
             }
 
             public object CreateHost()

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/src/HostFactoryResolver.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Extensions.Hosting
                                                                  bool stopApplication = true,
                                                                  Action<object>? configureHostBuilder = null,
                                                                  Action<Exception?>? entrypointCompleted = null,
-                                                                 Dictionary<string, Action<object?>>? arbitraryActions = null)
+                                                                 IDictionary<string, Action<object?>>? arbitraryActions = null)
         {
             if (assembly.EntryPoint is null)
             {
@@ -205,7 +205,7 @@ namespace Microsoft.Extensions.Hosting
             private IDisposable? _disposable;
             private readonly Action<object>? _configure;
             private readonly Action<Exception?>? _entrypointCompleted;
-            private readonly Dictionary<string, Action<object?>>? _arbitraryActions;
+            private readonly IDictionary<string, Action<object?>>? _arbitraryActions;
             private static readonly AsyncLocal<HostingListener> _currentListener = new();
 
             public HostingListener(
@@ -215,7 +215,7 @@ namespace Microsoft.Extensions.Hosting
                 bool stopApplication,
                 Action<object>? configure,
                 Action<Exception?>? entrypointCompleted,
-                Dictionary<string, Action<object?>>? arbitraryActions)
+                IDictionary<string, Action<object?>>? arbitraryActions)
             {
                 _args = args;
                 _entryPoint = entryPoint;

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/ArbitraryDiagnosticEventPatternTestSite.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/ArbitraryDiagnosticEventPatternTestSite.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <EnableDefaultItems>true</EnableDefaultItems>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MockHostTypes\MockHostTypes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/Program.cs
@@ -10,10 +10,10 @@ namespace ArbitraryDiagnosticEventPatternTestSite
     {
         public static void Main(string[] args)
         {
-            var listener = new DiagnosticListener("Microsoft.Extensions.Hosting");
+            using var listener = new DiagnosticListener("Microsoft.Extensions.Hosting");
             listener.Write("CustomEvent", 42);
 
-            var host = new HostBuilder().Build();
+            new HostBuilder().Build().Dispose();
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/Program.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/ArbitraryDiagnosticEventPatternTestSite/Program.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using Microsoft.Extensions.Hosting;
+
+namespace ArbitraryDiagnosticEventPatternTestSite
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var listener = new DiagnosticListener("Microsoft.Extensions.Hosting");
+            listener.Write("CustomEvent", 42);
+
+            var host = new HostBuilder().Build();
+        }
+    }
+}

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [InlineData(false)]
         public void ArbitraryActionsCustomEventCallbackIsCalled(bool stopApplication)
         {
-            var callbackCalled = new ManualResetEventSlim(false);
+            using var callbackCalled = new ManualResetEventSlim(false);
             object? callbackValue = null;
             void CustomCallback(object? value)
             {
@@ -190,7 +190,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                 arbitraryActions: arbitraryActions);
 
             Assert.NotNull(factory);
-            Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
+            using var host = Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
             Assert.True(callbackCalled.Wait(s_WaitTimeout));
             Assert.Equal(42, callbackValue);
         }

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/HostFactoryResolverTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Configuration;
 using MockHostTypes;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Threading;
@@ -161,6 +162,57 @@ namespace Microsoft.Extensions.Hosting.Tests
             Assert.NotNull(factory);
             Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
             Assert.True(called);
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ArbitraryDiagnosticEventPatternTestSite.Program))]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ArbitraryActionsCustomEventCallbackIsCalled(bool stopApplication)
+        {
+            var callbackCalled = new ManualResetEventSlim(false);
+            object? callbackValue = null;
+            void CustomCallback(object? value)
+            {
+                callbackValue = value;
+                callbackCalled.Set();
+            }
+
+            var arbitraryActions = new Dictionary<string, Action<object?>>
+            {
+                ["CustomEvent"] = CustomCallback
+            };
+
+            var factory = HostFactoryResolver.ResolveHostFactory(
+                typeof(ArbitraryDiagnosticEventPatternTestSite.Program).Assembly,
+                waitTimeout: s_WaitTimeout,
+                stopApplication: stopApplication,
+                arbitraryActions: arbitraryActions);
+
+            Assert.NotNull(factory);
+            Assert.IsAssignableFrom<IHost>(factory(Array.Empty<string>()));
+            Assert.True(callbackCalled.Wait(s_WaitTimeout));
+            Assert.Equal(42, callbackValue);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(ArbitraryDiagnosticEventPatternTestSite.Program))]
+        public void ArbitraryActionsExceptionIsPropagated()
+        {
+            var arbitraryActions = new Dictionary<string, Action<object?>>
+            {
+                ["CustomEvent"] = _ => throw new InvalidOperationException("arbitrary action failed")
+            };
+
+            var factory = HostFactoryResolver.ResolveHostFactory(
+                typeof(ArbitraryDiagnosticEventPatternTestSite.Program).Assembly,
+                waitTimeout: s_WaitTimeout,
+                stopApplication: true,
+                arbitraryActions: arbitraryActions);
+
+            Assert.NotNull(factory);
+            var exception = Assert.Throws<InvalidOperationException>(() => factory(Array.Empty<string>()));
+            Assert.Equal("arbitrary action failed", exception.Message);
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/tests/Microsoft.Extensions.HostFactoryResolver.Tests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="CreateHostBuilderPatternTestSite\CreateHostBuilderPatternTestSite.csproj" />
     <ProjectReference Include="CreateWebHostBuilderInvalidSignature\CreateWebHostBuilderInvalidSignature.csproj" />
     <ProjectReference Include="CreateWebHostBuilderPatternTestSite\CreateWebHostBuilderPatternTestSite.csproj" />
+    <ProjectReference Include="ArbitraryDiagnosticEventPatternTestSite\ArbitraryDiagnosticEventPatternTestSite.csproj" />
     <ProjectReference Include="NoSpecialEntryPointPattern\NoSpecialEntryPointPattern.csproj" />
     <ProjectReference Include="NoSpecialEntryPointPatternBuildsThenThrows\NoSpecialEntryPointPatternBuildsThenThrows.csproj" />
     <ProjectReference Include="NoSpecialEntryPointPatternThrows\NoSpecialEntryPointPatternThrows.csproj" />


### PR DESCRIPTION
I needed this to prototype the change in https://github.com/dotnet/aspnetcore/pull/66527/.

Whether or not we will need to use that in aspnet is to be decided when https://github.com/dotnet/aspnetcore/issues/66574 is reviewed.

The change here is in internal class which is consumed via an internal source-only package (that package isn't shipped to nuget.org). The PR doesn't introduce any behavior changes to runtime. It will only allow aspnetcore to hook additional delegates, which will allow us to fire HostApplicationBuilderCreated event when the user calls WebApplication.CreateBuilder, and gives us the opportunity in the testing library to add early configuration sources that users expect to be available before `Build()` is called.