### PR TITLE
Enable EventSource in System.Threading.Tasks.Tests

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs
@@ -39,8 +39,9 @@ namespace System.Threading.Tasks.Tests
         // single-threaded WASM this throws PlatformNotSupportedException from
         // RuntimeFeature.ThrowIfMultithreadingIsNotSupported(), so gate the tests on both
         // runtime async support and threading support.
+        // Some tests rely on GetMethodFromNativeIP which is not supported on NativeAOT.
         public static bool IsRuntimeAsyncAndThreadingSupported =>
-            PlatformDetection.IsRuntimeAsyncSupported && PlatformDetection.IsMultithreadingSupported;
+            PlatformDetection.IsRuntimeAsyncSupported && PlatformDetection.IsMultithreadingSupported && PlatformDetection.IsNotNativeAot;
 
         private const string AsyncProfilerEventSourceName = "System.Runtime.CompilerServices.AsyncProfilerEventSource";
         private const int AsyncEventsId = 1;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Threading.Tasks.Tests.csproj
@@ -7,6 +7,7 @@
     <!-- https://github.com/dotnet/runtime/issues/126862 -->
     <EnableTrimAnalyzer>false</EnableTrimAnalyzer>
     <EnableAotAnalyzer>false</EnableAotAnalyzer>
+    <EventSourceSupport Condition="'$(TestNativeAot)' == 'true'">true</EventSourceSupport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
     <_WasmPThreadPoolUnusedSize>10</_WasmPThreadPoolUnusedSize>


### PR DESCRIPTION
Might fix native AOT outerloops:

```
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CallstackSimulation_HandledException
Expected at least one ResumeAsyncCallstack event
   at System.Threading.Tasks.Tests.AsyncProfilerTests.AssertCallstackSimulationReachesZero(ConcurrentQueue`1 events) in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 653
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_WrapperIndexMatchesCallstack
Assert.All() Failure: 3 out of 3 items in the collection did not pass.
[0]: Item:  Tuple ("WrapperTestC", -1)
     Error: WrapperTestC did not find Continuation_Wrapper_N on stack (slot=-1)
[1]: Item:  Tuple ("WrapperTestB", -1)
     Error: WrapperTestB did not find Continuation_Wrapper_N on stack (slot=-1)
[2]: Item:  Tuple ("WrapperTestA", -1)
     Error: WrapperTestA did not find Continuation_Wrapper_N on stack (slot=-1)
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_WrapperIndexMatchesCallstack() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1281
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_UnhandledExceptionUnwind
Assert.Contains() Failure: Item not found in collection
Collection: []
Not found:  ResumeAsyncContext
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_UnhandledExceptionUnwind() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1217
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId
Expected periodic timer to flush core lifecycle events within timeout
   at System.Threading.Tasks.Tests.AsyncProfilerTests.<>c__DisplayClass102_0.<RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId>b__1() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1439
   at System.Diagnostics.Tracing.TestEventListener.RunWithCallback(Action`1 handler, Action body) in /_/src/libraries/Common/tests/System/Diagnostics/Tracing/TestEventListener.cs:line 116
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1396
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_ResetAsyncThreadContextEvent
Assert.Contains() Failure: Item not found in collection
Collection: []
Not found:  ResetAsyncThreadContext
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
Unhandled exception. Xunit.Sdk.TrueException: Expected first flush of core lifecycle events within timeout
   at Xunit.Assert.True(Nullable`1, String) in /_/src/arcade/src/Microsoft.DotNet.XUnitAssert/src/BooleanAsserts.cs:line 135
   at System.Threading.Tasks.Tests.AsyncProfilerTests.<>c__DisplayClass102_0.<RuntimeAsync_PeriodicTimerFlush_PreservesOwnerThreadId>b__2() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1425
   at System.Threading.Thread.StartThread(IntPtr) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.cs:line 443
   at System.Threading.Thread.ThreadEntryPoint(IntPtr) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Threading/Thread.NativeAot.Unix.cs:line 92
DOTNET_DbgEnableMiniDump is set and the createdump binary does not exist: ./createdump
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CallstackNativeIPDeltaRoundtrip
Assert.NotEmpty() Failure: Collection was empty
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CallstackNativeIPDeltaRoundtrip() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1715
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CreateAndFirstResumeCallstacksMatch
Assert.NotEmpty() Failure: Collection was empty
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CreateAndFirstResumeCallstacksMatch() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 1071
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_CallstackSimulation_UnhandledException
Expected at least one ResumeAsyncCallstack event
   at System.Threading.Tasks.Tests.AsyncProfilerTests.AssertCallstackSimulationReachesZero(ConcurrentQueue`1 events) in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 653
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
[FAIL] System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_ContextEventIdLifecycle
Expected at least one CreateAsyncContext with id
   at System.Threading.Tasks.Tests.AsyncProfilerTests.RuntimeAsync_ContextEventIdLifecycle() in /_/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/AsyncProfilerTests.cs:line 781
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
./RunTests.sh: line 173:    18 Aborted                 (core dumped) ./System.Threading.Tasks.Tests -notrait category=IgnoreForCI -notrait category=OuterLoop -notrait category=failing -xml testResults.xml $RSP_FILE
/root/helix/work/workitem/e
----- end Mon May 4 11:48:57 AM UTC 2026 ----- exit code 134 ----------------------------------------------------------
exit code 134 means SIGABRT Abort. Managed or native assert, or runtime check such as heap corruption, caused call to abort(). Core dumped.
```