### PR TITLE
Group Renovate container image digest updates into a single PR

### DIFF
--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -37,6 +37,8 @@
         "eng/pipelines/libraries/helix-queues-setup.yml"
       ],
       "pinDigests": true,
+      "groupName": "container image digests",
+      "groupSlug": "container-image-digests",
       "commitMessageTopic": "container image digests"
     }
   ]


### PR DESCRIPTION
Renovate was updating container image digests with individual PRs (e.g. https://github.com/dotnet/runtime/pull/127739, https://github.com/dotnet/runtime/pull/127738).

This is the default behavior of Renovate, to create a separate PR for each dependency name. This is prevented by adding a `groupName` to the package rule. This ensures that all digest pinning is grouped together as one unit. A `groupSlug` is also defined to explicitly define the programmatic name that would be used for things like branch name.