### PR TITLE
[clr-interp] Fix debugger MethodEnter counter and INTOP_DEBUG_METHOD_ENTER assert

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -4176,9 +4176,9 @@ void DebuggerController::DispatchMethodEnter(void * pIP, FramePointer fp)
     {
         if (p->m_fEnableMethodEnter)
         {
+            ++count;
             if ((p->GetThread() == NULL) || (p->GetThread() == pThread))
             {
-                ++count;
                 p->TriggerMethodEnter(pThread, dji, (const BYTE *) pIP, fp);
             }
         }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1438,7 +1438,7 @@ SWITCH_OPCODE:
                         if (seqPointOffset >= 0)
                         {
                             callbackIp = pFrame->startIp->GetByteCodes() + seqPointOffset;
-                            _ASSERTE(*callbackIp == INTOP_DEBUG_SEQ_POINT);
+                            _ASSERTE(*callbackIp == INTOP_DEBUG_SEQ_POINT || *callbackIp == INTOP_BREAKPOINT);
                         }
                         g_pDebugInterface->OnMethodEnter((void*)callbackIp);
                     }


### PR DESCRIPTION
## Description

In `DispatchMethodEnter`, `g_cTotalMethodEnter` is supposed to count every controller with `MethodEnter` enabled regardless of which thread will actually fire the trigger. The increment was inside the per-thread filter, so unbound controllers were not counted, and the post-loop `_ASSERTE(g_cTotalMethodEnter == count)` fired. Move `++count` out of the filter.

In the interpreter dispatch loop, `INTOP_DEBUG_METHOD_ENTER` asserts that the seq-point offset patched into the bytecode by `OnMethodEnter` is `INTOP_DEBUG_SEQ_POINT`. Once the debugger sets a user breakpoint at that sequence point the opcode is overwritten with `INTOP_BREAKPOINT`, which is also valid here, so the assert is updated to support such cases.

This fixes the following interpreter debugger test failures:
- `JMC.jmcChange`
- `JMC.jmcDelegates`
- `JMC.jmcFunceval`
- `Async.AsyncStepInto`