### PR TITLE
[clr-interp] Skip RSLock leak assert for DbgTransportTarget on Unix

### DIFF
--- a/src/coreclr/debug/di/dbgtransportmanager.cpp
+++ b/src/coreclr/debug/di/dbgtransportmanager.cpp
@@ -74,7 +74,9 @@ DbgTransportTarget::DbgTransportTarget()
 // Initialization routine called only by the DbgTransportManager.
 HRESULT DbgTransportTarget::Init()
 {
-    m_sLock.Init("DbgTransportTarget Lock", RSLock::cLockFlat, RSLock::LL_DBG_TRANSPORT_TARGET_LOCK);
+    // The Unix loader does not invoke DbgDllMain DLL_PROCESS_DETACH for mscordbi at process exit,
+    // so Shutdown() may never run. Mark the lock as allowing leak to skip the destructor assert.
+    m_sLock.Init("DbgTransportTarget Lock", RSLock::cLockFlat | RSLock::cLockAllowLeak, RSLock::LL_DBG_TRANSPORT_TARGET_LOCK);
 
     return S_OK;
 }

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -716,6 +716,10 @@ public:
         // to count this lock in m_cTotalDbgApiLocks, which is asserted to be 0 on entry
         // to public APIs.  Example of such a lock: LL_SHIM_PROCESS_DISPOSE_LOCK
         cLockNonDbgApi  = 0x00000004,
+
+        // Skip the leak assert in the destructor. Use for static-lifetime locks
+        // whose owning shutdown path is not guaranteed to run.
+        cLockAllowLeak  = 0x00000008,
     };
 
     // To prevent deadlocks, we order all locks.

--- a/src/coreclr/debug/di/rspriv.inl
+++ b/src/coreclr/debug/di/rspriv.inl
@@ -504,9 +504,9 @@ inline RSLock::RSLock()
 
 inline RSLock::~RSLock()
 {
-    // If this lock is still ininitialized, then no body ever deleted the critical section
-    // for it and we're leaking.
-    CONSISTENCY_CHECK_MSGF(!IsInit(), ("Leaking Critical section for RS Lock '%s'", m_szTag));
+    // If this lock is still initialized, then nobody ever deleted the critical section
+    // for it and we're leaking. cLockAllowLeak opts out of this assert.
+    CONSISTENCY_CHECK_MSGF(!IsInit() || (m_eAttr & cLockAllowLeak), ("Leaking Critical section for RS Lock '%s'", m_szTag));
 }
 #endif
 


### PR DESCRIPTION
## Description

The static `g_DbgTransportTarget` instance is destroyed after the host process's `main()` returns. On Unix (desktop interpreter) the dynamic loader does not invoke `DbgDllMain(DLL_PROCESS_DETACH)` for `mscordbi.dylib`, so `DbgTransportTarget::Shutdown()` may never run and the embedded `RSLock m_sLock` is left in its initialized state. In debug builds the `RSLock` destructor asserts that the lock was `Destroy()`'d before destruction, so the host process aborts.

## Implementation

The shutdown path can't be made reliable on Unix without changes outside `mscordbi`, so the fix opts the lock out of the destructor assert instead of trying to release it:

- Add a new `RSLock` attribute `cLockAllowLeak` (`src/coreclr/debug/di/rspriv.h`) for static-lifetime locks whose owning shutdown path is not guaranteed to run.
- Update `~RSLock()` (`src/coreclr/debug/di/rspriv.inl`) so the existing `CONSISTENCY_CHECK_MSGF` leak assert is bypassed when `cLockAllowLeak` is set; behavior for all other locks is unchanged.
- Initialize `DbgTransportTarget::m_sLock` with `cLockFlat | cLockAllowLeak` (`src/coreclr/debug/di/dbgtransportmanager.cpp`) so the static instance no longer trips the assert when destructed after `main()` returns.

## Test impact

Locally on osx-arm64 `Debugger.Tests --clrinterpreter` the xunit fail count drops from 230 to 65:
- `Inspection.BasicInspection`, `Inspection.EnumNames`, `Inspection.GenericInterfaces`, `Inspection.GenericSharedStatic`, `Inspection.GenericStatics`, `Inspection.NestedGenerics`, `Inspection.inspect_SetVars`
- `Stackwalking.ClrMethods`
- `Stepping.setIPTestwithUnvaildPos`, `Stepping.stepin`, `Stepping.stepover`
- `Async.AsyncStepInto`
