### PR TITLE
[clr-interp] Fix EnC failure when adding a generic method to a generic type

### DIFF
--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -692,6 +692,10 @@ HRESULT EEClass::AddMethod(MethodTable* pMT, mdMethodDef methodDef, MethodDesc**
     }
 
     // If the type is generic, then we need to update all existing instantiated types
+    //
+    // This code contains a race condition bug. Types that began loading before the metadata edit
+    // and are still loading at this point may not get updated. We assume that this issue does not
+    // have a meaningful impact on overall metadata update reliability.
     if (pMT->IsGenericTypeDefinition())
     {
         LOG((LF_ENC, LL_INFO100, "EEClass::AddMethod Looking for existing instantiations in all assemblies\n"));

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -705,23 +705,33 @@ HRESULT EEClass::AddMethod(MethodTable* pMT, mdMethodDef methodDef, MethodDesc**
             Module* pMod = pAssembly->GetModule();
             LOG((LF_ENC, LL_INFO100, "EEClass::AddMethod Checking: %s mod:%p\n", pMod->GetDebugName(), pMod));
 
-            EETypeHashTable* paramTypes = pMod->GetAvailableParamTypes();
-            CrstHolder ch(pMod->GetClassLoader()->GetAvailableTypesLock());
-
-            EETypeHashTable::Iterator it(paramTypes);
-            EETypeHashEntry* pEntry;
-            while (paramTypes->FindNext(&it, &pEntry))
+            InlineSArray<MethodTable*, 8> instantiations;
             {
-                TypeHandle th = pEntry->GetTypeHandle();
-                if (th.IsTypeDesc())
-                    continue;
+                EETypeHashTable* paramTypes = pMod->GetAvailableParamTypes();
+                CrstHolder ch(pMod->GetClassLoader()->GetAvailableTypesLock());
 
-                // Only update instantiations of the generic MethodTable we updated above.
-                MethodTable* pMTMaybe = th.AsMethodTable();
-                if (!pMTMaybe->IsCanonicalMethodTable() || !pMT->HasSameTypeDefAs(pMTMaybe))
+                EETypeHashTable::Iterator it(paramTypes);
+                EETypeHashEntry* pEntry;
+                while (paramTypes->FindNext(&it, &pEntry))
                 {
-                    continue;
+                    TypeHandle th = pEntry->GetTypeHandle();
+                    if (th.IsTypeDesc())
+                        continue;
+
+                    // Only update instantiations of the generic MethodTable we updated above.
+                    MethodTable* pMTMaybe = th.AsMethodTable();
+                    if (!pMTMaybe->IsCanonicalMethodTable() || !pMT->HasSameTypeDefAs(pMTMaybe))
+                    {
+                        continue;
+                    }
+
+                    instantiations.Append(pMTMaybe);
                 }
+            }
+
+            for (COUNT_T i = 0; i < instantiations.GetCount(); i++)
+            {
+                MethodTable* pMTMaybe = instantiations[i];
 
                 // Create a primary MethodDesc on this instantiation.
                 MethodDesc* pNewMDUnused;


### PR DESCRIPTION
## Description

Adding a generic method to an existing generic type during Edit and Continue currently fails. `EEClass::AddMethod` takes `m_AvailableTypesLock` and then calls into code that needs the same lock to publish the new method's generic parameters. 

The other lock that protects type-loader tables, `m_AvailableClassLock`, is already configured to allow this kind of nested take. Configure `m_AvailableTypesLock` the same way. The other places that use this lock take and release it as a single unit, so they are unaffected.

Tests:
- CrossPlatformEnC.AddGenericInstanceMethodOnGenericType
- CrossPlatformEnC.AddGenericStaticMethodOnGenericType
- CrossPlatformEnC.GenericMethodsWithExpressions