### PR TITLE
Fix arg iteration for reverse pinvokes

### DIFF
--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1904,7 +1904,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
         PInvoke::GetCallingConvention_IgnoreErrors(pMD, &unmanagedCallConv, NULL);
         hasUnmanagedCallConv = true;
     }
-    else if (pMD != NULL && pMD->IsILStub())
+    else if (pMD != NULL && pMD->IsILStub() && !pMD->AsDynamicMethodDesc()->IsReversePInvokeStub())
     {
         MethodDesc* pTargetMD = pMD->AsDynamicMethodDesc()->GetILStubResolver()->GetStubTargetMethodDesc();
         if (pTargetMD != NULL && pTargetMD->IsPInvoke())
@@ -1918,13 +1918,8 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
             }
 #endif
         }
-        else if (pMD->AsDynamicMethodDesc()->IsReversePInvokeStub())
-        {
-            unmanagedCallConv = CallConv::GetDefaultUnmanagedCallingConvention();
-            hasUnmanagedCallConv = true;
-        }
     }
-    else if (pMD != NULL && pMD->HasUnmanagedCallersOnlyAttribute())
+    else if (pMD != NULL && !pMD->IsILStub() && pMD->HasUnmanagedCallersOnlyAttribute())
     {
         if (CallConv::TryGetCallingConventionFromUnmanagedCallersOnly(pMD, &unmanagedCallConv))
         {

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1918,6 +1918,11 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
             }
 #endif
         }
+        else if (pMD->AsDynamicMethodDesc()->IsReversePInvokeStub())
+        {
+            unmanagedCallConv = CallConv::GetDefaultUnmanagedCallingConvention();
+            hasUnmanagedCallConv = true;
+        }
     }
     else if (pMD != NULL && pMD->HasUnmanagedCallersOnlyAttribute())
     {


### PR DESCRIPTION
Fixes Interop/StructMarshalling/ReversePInvoke/MarshalSeqStruct/ReversePInvoke test

We were generating call stub for `ILStubClass.IL_STUB_ReversePInvoke(ComplexStruct)`. Arg iteration was done using ArgIterator instead of PInvokeArgIterator, ending up with crash in ArgIteratorBase::IsRegPassedStruct. As a fix, we consider these reverse pinvoke il stubs to have unmanaged call convention.