### PR TITLE
Remove [RequiresUnsafe] attribute usages

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/CompilerHelpers/ThrowHelpers.cs
@@ -12,12 +12,10 @@ namespace Internal.Runtime.CompilerHelpers
     {
         [DoesNotReturn]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_ThrowAmbiguousResolutionException")]
-        [RequiresUnsafe]
         private static partial void ThrowAmbiguousResolutionException(MethodTable* targetType, MethodTable* interfaceType, void* methodDesc);
 
         [DoesNotReturn]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void ThrowAmbiguousResolutionException(
             void* method,           // MethodDesc*
             void* interfaceType,    // MethodTable*
@@ -28,12 +26,10 @@ namespace Internal.Runtime.CompilerHelpers
 
         [DoesNotReturn]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_ThrowEntryPointNotFoundException")]
-        [RequiresUnsafe]
         private static partial void ThrowEntryPointNotFoundException(MethodTable* targetType, MethodTable* interfaceType, void* methodDesc);
 
         [DoesNotReturn]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void ThrowEntryPointNotFoundException(
             void* method,           // MethodDesc*
             void* interfaceType,    // MethodTable*
@@ -44,13 +40,11 @@ namespace Internal.Runtime.CompilerHelpers
 
         [DoesNotReturn]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_ThrowMethodAccessException")]
-        [RequiresUnsafe]
         private static partial void ThrowMethodAccessExceptionInternal(void* caller, void* callee);
 
         // implementation of CORINFO_HELP_METHOD_ACCESS_EXCEPTION
         [DoesNotReturn]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void ThrowMethodAccessException(
             void* caller,   // MethodDesc*
             void* callee)   // MethodDesc*
@@ -60,13 +54,11 @@ namespace Internal.Runtime.CompilerHelpers
 
         [DoesNotReturn]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_ThrowFieldAccessException")]
-        [RequiresUnsafe]
         private static partial void ThrowFieldAccessExceptionInternal(void* caller, void* callee);
 
         // implementation of CORINFO_HELP_FIELD_ACCESS_EXCEPTION
         [DoesNotReturn]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void ThrowFieldAccessException(
             void* caller,   // MethodDesc*
             void* callee)   // FieldDesc*
@@ -76,13 +68,11 @@ namespace Internal.Runtime.CompilerHelpers
 
         [DoesNotReturn]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ExceptionNative_ThrowClassAccessException")]
-        [RequiresUnsafe]
         private static partial void ThrowClassAccessExceptionInternal(void* caller, void* callee);
 
         // implementation of CORINFO_HELP_CLASS_ACCESS_EXCEPTION
         [DoesNotReturn]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void ThrowClassAccessException(
             void* caller,   // MethodDesc*
             void* callee)   // Type handle

--- a/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
+++ b/src/coreclr/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComActivator.PlatformNotSupported.cs
@@ -16,7 +16,6 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int GetClassFactoryForTypeInternal(ComActivationContextInternal* pCxtInt)
             => throw new PlatformNotSupportedException();
 
@@ -25,7 +24,6 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int RegisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
             => throw new PlatformNotSupportedException();
 
@@ -34,7 +32,6 @@ namespace Internal.Runtime.InteropServices
         /// </summary>
         /// <param name="pCxtInt">Pointer to a <see cref="ComActivationContextInternal"/> instance</param>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int UnregisterClassForTypeInternal(ComActivationContextInternal* pCxtInt)
             => throw new PlatformNotSupportedException();
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/AppContext.CoreCLR.cs
@@ -10,7 +10,6 @@ namespace System
     public static partial class AppContext
     {
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnProcessExit(Exception* pException)
         {
             try
@@ -24,7 +23,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnUnhandledException(object* pException, Exception* pOutException)
         {
             try
@@ -38,7 +36,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void OnFirstChanceException(Exception* pException, Exception* pOutException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -48,7 +48,6 @@ namespace System
         // This is much like the C va_start macro
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
             IntPtr cookie = arglist.Value;
@@ -163,7 +162,6 @@ namespace System
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator); // https://github.com/dotnet/runtime/issues/7317

--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -16,11 +16,9 @@ namespace System
     public abstract partial class Array : ICloneable, IList, IStructuralComparable, IStructuralEquatable
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_CreateInstance")]
-        [RequiresUnsafe]
         private static unsafe partial void InternalCreate(QCallTypeHandle type, int rank, int* pLengths, int* pLowerBounds,
             [MarshalAs(UnmanagedType.Bool)] bool fromArrayType, ObjectHandleOnStack retArray);
 
-        [RequiresUnsafe]
         private static unsafe Array InternalCreate(RuntimeType elementType, int rank, int* pLengths, int* pLowerBounds)
         {
             Array? retArray = null;
@@ -29,7 +27,6 @@ namespace System
             return retArray!;
         }
 
-        [RequiresUnsafe]
         private static unsafe Array InternalCreateFromArrayType(RuntimeType arrayType, int rank, int* pLengths, int* pLowerBounds)
         {
             Array? retArray = null;
@@ -39,14 +36,12 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_Ctor")]
-        [RequiresUnsafe]
         private static unsafe partial void Ctor(MethodTable* pArrayMT, uint dwNumArgs, int* pArgList, ObjectHandleOnStack retArray);
 
         // implementation of CORINFO_HELP_NEW_MDARR and CORINFO_HELP_NEW_MDARR_RARE.
         [StackTraceHidden]
         [DebuggerStepThrough]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static unsafe Array Ctor(MethodTable* pArrayMT, uint dwNumArgs, int* pArgList)
         {
             Array? arr = null;
@@ -309,7 +304,6 @@ namespace System
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal extern CorElementType GetCorElementTypeOfElementType();
 
-        [RequiresUnsafe]
         private unsafe MethodTable* ElementMethodTable => RuntimeHelpers.GetMethodTable(this)->GetArrayElementTypeHandle().AsMethodTable();
 
         private unsafe bool IsValueOfElementType(object value)
@@ -356,10 +350,8 @@ namespace System
             internal readonly delegate*<ref byte, void> ConstructorEntrypoint;
 
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Array_GetElementConstructorEntrypoint")]
-            [RequiresUnsafe]
             private static partial delegate*<ref byte, void> GetElementConstructorEntrypoint(QCallTypeHandle arrayType);
 
-            [RequiresUnsafe]
             private ArrayInitializeCache(delegate*<ref byte, void> constructorEntrypoint)
             {
                 ConstructorEntrypoint = constructorEntrypoint;

--- a/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Buffer.CoreCLR.cs
@@ -14,7 +14,6 @@ namespace System
         private static extern void BulkMoveWithWriteBarrierInternal(ref byte destination, ref byte source, nuint byteCount);
 
         // Used by ilmarshalers.cpp
-        [RequiresUnsafe]
         internal static unsafe void Memcpy(byte* dest, byte* src, int len)
         {
             Debug.Assert(len >= 0, "Negative length in memcpy!");
@@ -22,7 +21,6 @@ namespace System
         }
 
         // Used by ilmarshalers.cpp
-        [RequiresUnsafe]
         internal static unsafe void Memcpy(byte* pDest, int destIndex, byte[] src, int srcIndex, int len)
         {
             Debug.Assert((srcIndex >= 0) && (destIndex >= 0) && (len >= 0), "Index and length must be non-negative!");

--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -483,11 +483,9 @@ namespace System
         private static partial void Construct(ObjectHandleOnStack _this, ObjectHandleOnStack target, IntPtr method);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe void* GetMulticastInvoke(MethodTable* pMT);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Delegate_GetMulticastInvokeSlow")]
-        [RequiresUnsafe]
         private static unsafe partial void* GetMulticastInvokeSlow(MethodTable* pMT);
 
         internal unsafe IntPtr GetMulticastInvoke()
@@ -505,7 +503,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe void* GetInvokeMethod(MethodTable* pMT);
 
         internal unsafe IntPtr GetInvokeMethod()

--- a/src/coreclr/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Environment.CoreCLR.cs
@@ -87,7 +87,6 @@ namespace System
         [DoesNotReturn]
         private static partial void FailFast(StackCrawlMarkHandle mark, string? message, ObjectHandleOnStack exception, string? errorMessage);
 
-        [RequiresUnsafe]
         private static unsafe string[] InitializeCommandLineArgs(char* exePath, int argc, char** argv) // invoked from VM
         {
             string[] commandLineArgs = new string[argc + 1];
@@ -105,7 +104,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InitializeCommandLineArgs(char* exePath, int argc, char** argv, string[]* pResult, Exception* pException)
         {
             try
@@ -122,7 +120,6 @@ namespace System
         internal static partial int GetProcessorCount();
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetResourceString(char* pKey, string* pResult, Exception* pException)
         {
             try
@@ -137,7 +134,6 @@ namespace System
 
         [UnmanagedCallersOnly]
         [StackTraceHidden]
-        [RequiresUnsafe]
         internal static unsafe void CallEntryPoint(IntPtr entryPoint, string[]* pArgument, int* pReturnValue, bool captureException, Exception* pException)
         {
             try
@@ -175,7 +171,6 @@ namespace System
 
         [UnmanagedCallersOnly]
         [StackTraceHidden]
-        [RequiresUnsafe]
         internal static unsafe int ExecuteInDefaultAppDomain(IntPtr entryPoint, char* pArgument, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Exception.CoreCLR.cs
@@ -115,7 +115,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InternalPreserveStackTrace(Exception* pException, Exception* pOutException)
         {
             try
@@ -272,7 +271,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void CreateRuntimeWrappedException(object* pThrownObject, object* pResult, Exception* pException)
         {
             try
@@ -286,7 +284,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void CreateTypeInitializationException(char* pTypeName, Exception* pInnerException, object* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/GC.CoreCLR.cs
@@ -309,11 +309,9 @@ namespace System
         public static int MaxGeneration => GetMaxGeneration();
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_GetNextFinalizableObject")]
-        [RequiresUnsafe]
         private static unsafe partial void* GetNextFinalizeableObject(ObjectHandleOnStack target);
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe uint RunFinalizers()
         {
             Thread currentThread = Thread.CurrentThread;
@@ -764,7 +762,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EnableNoGCRegionCallback")]
-        [RequiresUnsafe]
         private static unsafe partial EnableNoGCRegionCallbackStatus _EnableNoGCRegionCallback(NoGCRegionCallbackFinalizerWorkItem* callback, long totalSize);
 
         internal static long GetGenerationBudget(int generation)
@@ -877,7 +874,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ConfigCallback(void* configurationContext, byte* name, byte* publicKey, GCConfigurationType type, long data)
         {
             // If the public key is null, it means that the corresponding configuration isn't publicly available
@@ -939,7 +935,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "GCInterface_EnumerateConfigurationValues")]
-        [RequiresUnsafe]
         internal static unsafe partial void _EnumerateConfigurationValues(void* configurationDictionary, delegate* unmanaged<void*, byte*, byte*, GCConfigurationType, long, void> callback);
 
         internal enum RefreshMemoryStatus

--- a/src/coreclr/System.Private.CoreLib/src/System/IO/Stream.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/IO/Stream.CoreCLR.cs
@@ -10,7 +10,6 @@ namespace System.IO
     public abstract unsafe partial class Stream
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Stream_HasOverriddenSlow")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool HasOverriddenSlow(MethodTable* pMT, [MarshalAs(UnmanagedType.Bool)] bool isRead);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Math.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Math.CoreCLR.cs
@@ -123,11 +123,9 @@ namespace System
         public static extern double Tanh(double value);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe double ModF(double x, double* intptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe void SinCos(double x, double* sin, double* cos);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/MathF.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/MathF.CoreCLR.cs
@@ -120,11 +120,9 @@ namespace System
         public static extern float Tanh(float x);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe float ModF(float x, float* intptr);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe void SinCos(float x, float* sin, float* cos);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/AssemblyName.CoreCLR.cs
@@ -63,7 +63,6 @@ namespace System.Reflection
 
     public sealed partial class AssemblyName
     {
-        [RequiresUnsafe]
         internal unsafe AssemblyName(NativeAssemblyNameParts* pParts)
             : this()
         {
@@ -147,7 +146,6 @@ namespace System.Reflection
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ParseAsAssemblySpec(char* pAssemblyName, void* pAssemblySpec, Exception* pException)
         {
             try
@@ -179,7 +177,6 @@ namespace System.Reflection
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void CreateAssemblyName(AssemblyName* pResult, NativeAssemblyNameParts* pParts, Exception* pException)
         {
             try
@@ -193,7 +190,6 @@ namespace System.Reflection
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyName_InitializeAssemblySpec")]
-        [RequiresUnsafe]
         private static unsafe partial void InitializeAssemblySpec(NativeAssemblyNameParts* pAssemblyNameParts, void* pAssemblySpec);
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/ConstructorInvoker.CoreCLR.cs
@@ -15,7 +15,6 @@ namespace System.Reflection
             _invokeFunc_RefArgs = InterpretedInvoke;
         }
 
-        [RequiresUnsafe]
         private unsafe object? InterpretedInvoke(object? obj, IntPtr* args)
         {
             return RuntimeMethodHandle.InvokeMethod(obj, (void**)args, _signature!, isConstructor: obj is null);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILGenerator.cs
@@ -757,7 +757,6 @@ namespace System.Reflection.Emit
             return m_exceptionHeader;
         }
 
-        [RequiresUnsafe]
         internal override unsafe void GetEHInfo(int excNumber, void* exc)
         {
             Debug.Assert(m_exceptions != null);
@@ -906,7 +905,6 @@ namespace System.Reflection.Emit
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetCode(byte* code, int codeSize, int maxStackSize)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(codeSize);
@@ -923,7 +921,6 @@ namespace System.Reflection.Emit
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetExceptions(byte* exceptions, int exceptionsSize)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(exceptionsSize);
@@ -940,7 +937,6 @@ namespace System.Reflection.Emit
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetLocalSignature(byte* localSignature, int signatureSize)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(signatureSize);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeAssemblyBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeAssemblyBuilder.cs
@@ -113,7 +113,6 @@ namespace System.Reflection.Emit
         #region DefineDynamicAssembly
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AppDomain_CreateDynamicAssembly")]
-        [RequiresUnsafe]
         private static unsafe partial void CreateDynamicAssembly(ObjectHandleOnStack assemblyLoadContext,
                                                                  NativeAssemblyNameParts* pAssemblyName,
                                                                  AssemblyHashAlgorithm hashAlgId,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Emit/RuntimeTypeBuilder.cs
@@ -126,7 +126,6 @@ namespace System.Reflection.Emit
         internal static partial void SetClassLayout(QCallModule module, int tk, PackingSize iPackingSize, int iTypeSize);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetConstantValue")]
-        [RequiresUnsafe]
         private static unsafe partial void SetConstantValue(QCallModule module, int tk, int corType, void* pValue);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "TypeBuilder_SetPInvokeData", StringMarshalling = StringMarshalling.Utf16)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/InstanceCalliHelper.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/InstanceCalliHelper.cs
@@ -16,197 +16,151 @@ namespace System.Reflection
         // Zero parameter methods such as property getters:
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static bool Call(delegate*<object, bool> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static byte Call(delegate*<object, byte> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static char Call(delegate*<object, char> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static DateTime Call(delegate*<object, DateTime> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static DateTimeOffset Call(delegate*<object, DateTimeOffset> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static decimal Call(delegate*<object, decimal> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static double Call(delegate*<object, double> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static float Call(delegate*<object, float> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static Guid Call(delegate*<object, Guid> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static short Call(delegate*<object, short> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static int Call(delegate*<object, int> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static long Call(delegate*<object, long> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static nint Call(delegate*<object, nint> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static nuint Call(delegate*<object, nuint> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static object? Call(delegate*<object, object?> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static sbyte Call(delegate*<object, sbyte> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static ushort Call(delegate*<object, ushort> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static uint Call(delegate*<object, uint> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static ulong Call(delegate*<object, ulong> fn, object o) => fn(o);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, void> fn, object o) => fn(o);
 
         // One parameter methods with no return such as property setters:
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, bool, void> fn, object o, bool arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, byte, void> fn, object o, byte arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, char, void> fn, object o, char arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, DateTime, void> fn, object o, DateTime arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, DateTimeOffset, void> fn, object o, DateTimeOffset arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, decimal, void> fn, object o, decimal arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, double, void> fn, object o, double arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, float, void> fn, object o, float arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, Guid, void> fn, object o, Guid arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, short, void> fn, object o, short arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, int, void> fn, object o, int arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, long, void> fn, object o, long arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, nint, void> fn, object o, nint arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, nuint, void> fn, object o, nuint arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, void> fn, object o, object? arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, sbyte, void> fn, object o, sbyte arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, ushort, void> fn, object o, ushort arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, uint, void> fn, object o, uint arg1) => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, ulong, void> fn, object o, ulong arg1) => fn(o, arg1);
 
         // Other methods:
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, object?, void> fn, object o, object? arg1, object? arg2)
             => fn(o, arg1, arg2);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, object?, object?, void> fn, object o, object? arg1, object? arg2, object? arg3)
             => fn(o, arg1, arg2, arg3);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, object?, object?, object?, void> fn, object o, object? arg1, object? arg2, object? arg3, object? arg4)
             => fn(o, arg1, arg2, arg3, arg4);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, object?, object?, object?, object?, void> fn, object o, object? arg1, object? arg2, object? arg3, object? arg4, object? arg5)
             => fn(o, arg1, arg2, arg3, arg4, arg5);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, object?, object?, object?, object?, object?, object?, void> fn, object o, object? arg1, object? arg2, object? arg3, object? arg4, object? arg5, object? arg6)
             => fn(o, arg1, arg2, arg3, arg4, arg5, arg6);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, IEnumerable<object>?, void> fn, object o, IEnumerable<object>? arg1)
             => fn(o, arg1);
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static void Call(delegate*<object, IEnumerable<object>?, IEnumerable<object>?, void> fn, object o, IEnumerable<object>? arg1, IEnumerable<object>? arg2)
             => fn(o, arg1, arg2);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/LoaderAllocator.cs
@@ -56,7 +56,6 @@ namespace System.Reflection
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void Create(object* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MdImport.cs
@@ -229,7 +229,6 @@ namespace System.Reflection
 
         #region Static Members
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "MetadataImport_GetMarshalAs")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool GetMarshalAs(
             IntPtr pNativeType,
@@ -335,7 +334,6 @@ namespace System.Reflection
         #endregion
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "MetadataImport_Enum")]
-        [RequiresUnsafe]
         private static unsafe partial void Enum(IntPtr scope, int type, int parent, ref int length, int* shortResult, ObjectHandleOnStack longResult);
 
         public unsafe void Enum(MetadataTokenType type, int parent, out MetadataEnumResult result)
@@ -379,7 +377,6 @@ namespace System.Reflection
             Enum(MetadataTokenType.Event, mdTypeDef, out result);
         }
 
-        [RequiresUnsafe]
         private static unsafe string? ConvertMetadataStringPermitInvalidContent(char* stringMetadataEncoding, int length)
         {
             Debug.Assert(stringMetadataEncoding != null);
@@ -390,7 +387,6 @@ namespace System.Reflection
 
         #region FCalls
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetDefaultValue(
             IntPtr scope,
             int mdToken,
@@ -415,7 +411,6 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetUserString(IntPtr scope, int mdToken, out char* stringMetadataEncoding, out int length);
 
         public unsafe string? GetUserString(int mdToken)
@@ -428,7 +423,6 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetName(IntPtr scope, int mdToken, out byte* name);
 
         public unsafe MdUtf8String GetName(int mdToken)
@@ -438,7 +432,6 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetNamespace(IntPtr scope, int mdToken, out byte* namesp);
 
         public unsafe MdUtf8String GetNamespace(int mdToken)
@@ -448,10 +441,8 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetEventProps(IntPtr scope, int mdToken, out void* name, out int eventAttributes);
 
-        [RequiresUnsafe]
         public unsafe void GetEventProps(int mdToken, out void* name, out EventAttributes eventAttributes)
         {
             ThrowBadImageExceptionForHR(GetEventProps(m_metadataImport2, mdToken, out name, out int eventAttributesRaw));
@@ -468,10 +459,8 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetPropertyProps(IntPtr scope, int mdToken, out void* name, out int propertyAttributes, out ConstArray signature);
 
-        [RequiresUnsafe]
         public unsafe void GetPropertyProps(int mdToken, out void* name, out PropertyAttributes propertyAttributes, out ConstArray signature)
         {
             ThrowBadImageExceptionForHR(GetPropertyProps(m_metadataImport2, mdToken, out name, out int propertyAttributesRaw, out signature));
@@ -614,7 +603,6 @@ namespace System.Reflection
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetPInvokeMap(IntPtr scope,
             int token,
             out int attributes,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -10,7 +10,6 @@ namespace System.Reflection.Metadata
     public static partial class AssemblyExtensions
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalTryGetRawMetadata")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool InternalTryGetRawMetadata(QCallAssembly assembly, ref byte* blob, ref int length);
 
@@ -30,7 +29,6 @@ namespace System.Reflection.Metadata
         /// <para>The caller is responsible for keeping the assembly object alive while accessing the metadata blob.</para>
         /// </remarks>
         [CLSCompliant(false)] // out byte* blob
-        [RequiresUnsafe]
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
         {
             ArgumentNullException.ThrowIfNull(assembly);

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/Metadata/MetadataUpdater.cs
@@ -11,7 +11,6 @@ namespace System.Reflection.Metadata
     public static partial class MetadataUpdater
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_ApplyUpdate")]
-        [RequiresUnsafe]
         private static unsafe partial void ApplyUpdate(QCallAssembly assembly, byte* metadataDelta, int metadataDeltaLength, byte* ilDelta, int ilDeltaLength, byte* pdbDelta, int pdbDeltaLength);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_IsApplyUpdateSupported")]

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodBaseInvoker.CoreCLR.cs
@@ -30,11 +30,9 @@ namespace System.Reflection
             _invokeFunc_RefArgs = InterpretedInvoke_Method;
         }
 
-        [RequiresUnsafe]
         private unsafe object? InterpretedInvoke_Constructor(object? obj, IntPtr* args) =>
             RuntimeMethodHandle.InvokeMethod(obj, (void**)args, _signature!, isConstructor: obj is null);
 
-        [RequiresUnsafe]
         private unsafe object? InterpretedInvoke_Method(object? obj, IntPtr* args) =>
             RuntimeMethodHandle.InvokeMethod(obj, (void**)args, _signature!, isConstructor: false);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodInvoker.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/MethodInvoker.CoreCLR.cs
@@ -31,11 +31,9 @@ namespace System.Reflection
             _invocationFlags = constructor.ComputeAndUpdateInvocationFlags();
         }
 
-        [RequiresUnsafe]
         private unsafe object? InterpretedInvoke_Method(object? obj, IntPtr* args) =>
             RuntimeMethodHandle.InvokeMethod(obj, (void**)args, _signature!, isConstructor: false);
 
-        [RequiresUnsafe]
         private unsafe object? InterpretedInvoke_Constructor(object? obj, IntPtr* args) =>
             RuntimeMethodHandle.InvokeMethod(obj, (void**)args, _signature!, isConstructor: obj is null);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeAssembly.cs
@@ -41,7 +41,6 @@ namespace System.Reflection
             // ensures the RuntimeAssembly is kept alive for as long as the stream lives
             private readonly RuntimeAssembly _manifestAssembly;
 
-            [RequiresUnsafe]
             internal unsafe ManifestResourceStream(RuntimeAssembly manifestAssembly, byte* pointer, long length, long capacity, FileAccess access) : base(pointer, length, capacity, access)
             {
                 _manifestAssembly = manifestAssembly;
@@ -268,7 +267,6 @@ namespace System.Reflection
 
         // GetResource will return a pointer to the resources in memory.
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_GetResource", StringMarshalling = StringMarshalling.Utf16)]
-        [RequiresUnsafe]
         private static unsafe partial byte* GetResource(QCallAssembly assembly,
                                                        string resourceName,
                                                        out uint length);
@@ -397,7 +395,6 @@ namespace System.Reflection
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AssemblyNative_InternalLoad")]
-        [RequiresUnsafe]
         private static unsafe partial void InternalLoad(NativeAssemblyNameParts* pAssemblyNameParts,
                                                 ObjectHandleOnStack requestingAssembly,
                                                 StackCrawlMarkHandle stackMark,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeCustomAttributeData.cs
@@ -1835,7 +1835,6 @@ namespace System.Reflection
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "CustomAttribute_ParseAttributeUsageAttribute")]
         [SuppressGCTransition]
-        [RequiresUnsafe]
         private static partial int ParseAttributeUsageAttribute(
             IntPtr pData,
             int cData,

--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/TypeNameResolver.CoreCLR.cs
@@ -131,7 +131,6 @@ namespace System.Reflection
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetTypeHelper(char* pTypeName, RuntimeAssembly* pRequestingAssembly, bool throwOnError, bool requireAssemblyQualifiedName, IntPtr unsafeAccessorMethod, RuntimeType* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -289,15 +289,12 @@ namespace System.Runtime.CompilerServices
 
 #if !NATIVEAOT
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AsyncHelpers_AddContinuationToExInternal")]
-        [RequiresUnsafe]
         private static unsafe partial void AddContinuationToExInternal(void* diagnosticIP, ObjectHandleOnStack ex);
 
-        [RequiresUnsafe]
         internal static unsafe void AddContinuationToExInternal(void* diagnosticIP, Exception e)
             => AddContinuationToExInternal(diagnosticIP, ObjectHandleOnStack.Create(ref e));
 #endif
 
-        [RequiresUnsafe]
         private static unsafe Continuation AllocContinuation(Continuation prevContinuation, MethodTable* contMT)
         {
 #if NATIVEAOT
@@ -310,7 +307,6 @@ namespace System.Runtime.CompilerServices
         }
 
 #if !NATIVEAOT
-        [RequiresUnsafe]
         private static unsafe Continuation AllocContinuationMethod(Continuation prevContinuation, MethodTable* contMT, int keepAliveOffset, MethodDesc* method)
         {
             LoaderAllocator loaderAllocator = RuntimeMethodHandle.GetLoaderAllocator(new RuntimeMethodHandleInternal((IntPtr)method));
@@ -320,7 +316,6 @@ namespace System.Runtime.CompilerServices
             return newContinuation;
         }
 
-        [RequiresUnsafe]
         private static unsafe Continuation AllocContinuationClass(Continuation prevContinuation, MethodTable* contMT, int keepAliveOffset, MethodTable* methodTable)
         {
             IntPtr loaderAllocatorHandle = methodTable->GetLoaderAllocatorHandle();

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/CastHelpers.cs
@@ -15,11 +15,9 @@ namespace System.Runtime.CompilerServices
         internal static int[]? s_table;
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThrowInvalidCastException")]
-        [RequiresUnsafe]
         private static partial void ThrowInvalidCastExceptionInternal(void* fromTypeHnd, void* toTypeHnd);
 
         [DoesNotReturn]
-        [RequiresUnsafe]
         internal static void ThrowInvalidCastException(void* fromTypeHnd, void* toTypeHnd)
         {
             ThrowInvalidCastExceptionInternal(fromTypeHnd, toTypeHnd);
@@ -27,7 +25,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DoesNotReturn]
-        [RequiresUnsafe]
         internal static void ThrowInvalidCastException(object fromType, void* toTypeHnd)
         {
             ThrowInvalidCastExceptionInternal(RuntimeHelpers.GetMethodTable(fromType), toTypeHnd);
@@ -36,12 +33,10 @@ namespace System.Runtime.CompilerServices
         }
 
         [LibraryImport(RuntimeHelpers.QCall)]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool IsInstanceOf_NoCacheLookup(void *toTypeHnd, [MarshalAs(UnmanagedType.Bool)] bool throwCastException, ObjectHandleOnStack obj);
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static object? IsInstanceOfAny_NoCacheLookup(void* toTypeHnd, object obj)
         {
             if (IsInstanceOf_NoCacheLookup(toTypeHnd, false, ObjectHandleOnStack.Create(ref obj)))
@@ -52,7 +47,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static object ChkCastAny_NoCacheLookup(void* toTypeHnd, object obj)
         {
             IsInstanceOf_NoCacheLookup(toTypeHnd, true, ObjectHandleOnStack.Create(ref obj));
@@ -63,7 +57,6 @@ namespace System.Runtime.CompilerServices
         // Unlike the IsInstanceOfInterface and IsInstanceOfClass functions,
         // this test must deal with all kinds of type tests
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object? IsInstanceOfAny(void* toTypeHnd, object? obj)
         {
             if (obj != null)
@@ -95,7 +88,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static object? IsInstanceOfInterface(void* toTypeHnd, object? obj)
         {
             const int unrollSize = 4;
@@ -165,7 +157,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static object? IsInstanceOfClass(void* toTypeHnd, object? obj)
         {
             if (obj == null || RuntimeHelpers.GetMethodTable(obj) == toTypeHnd)
@@ -217,7 +208,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static object? IsInstance_Helper(void* toTypeHnd, object obj)
         {
             CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
@@ -238,7 +228,6 @@ namespace System.Runtime.CompilerServices
         // Unlike the ChkCastInterface and ChkCastClass functions,
         // this test must deal with all kinds of type tests
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object? ChkCastAny(void* toTypeHnd, object? obj)
         {
             CastResult result;
@@ -268,7 +257,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static object? ChkCast_Helper(void* toTypeHnd, object obj)
         {
             CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)toTypeHnd);
@@ -282,7 +270,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static object? ChkCastInterface(void* toTypeHnd, object? obj)
         {
             const int unrollSize = 4;
@@ -349,7 +336,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static object? ChkCastClass(void* toTypeHnd, object? obj)
         {
             if (obj == null || RuntimeHelpers.GetMethodTable(obj) == toTypeHnd)
@@ -363,7 +349,6 @@ namespace System.Runtime.CompilerServices
         // Optimized helper for classes. Assumes that the trivial cases
         // has been taken care of by the inlined check
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static object? ChkCastClassSpecial(void* toTypeHnd, object obj)
         {
             MethodTable* mt = RuntimeHelpers.GetMethodTable(obj);
@@ -410,7 +395,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte Unbox(MethodTable* toTypeHnd, object obj)
         {
             // This will throw NullReferenceException if obj is null.
@@ -433,7 +417,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref object? LdelemaRef(object?[] array, nint index, void* type)
         {
             // This will throw NullReferenceException if array is null.
@@ -484,7 +467,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static void StelemRef_Helper(ref object? element, void* elementType, object obj)
         {
             CastResult result = CastCache.TryGet(s_table!, (nuint)RuntimeHelpers.GetMethodTable(obj), (nuint)elementType);
@@ -498,7 +480,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static void StelemRef_Helper_NoCacheLookup(ref object? element, void* elementType, object obj)
         {
             Debug.Assert(obj != null);
@@ -531,7 +512,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static void ArrayTypeCheck_Helper(object obj, void* elementType)
         {
             Debug.Assert(obj != null);
@@ -544,7 +524,6 @@ namespace System.Runtime.CompilerServices
 
         // Helpers for boxing
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object? Box_Nullable(MethodTable* srcMT, ref byte nullableData)
         {
             Debug.Assert(srcMT->IsNullable);
@@ -561,7 +540,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object Box(MethodTable* typeMT, ref byte unboxedData)
         {
             Debug.Assert(typeMT != null);
@@ -605,7 +583,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static bool IsNullableForType(MethodTable* typeMT, MethodTable* boxedMT)
         {
             if (!typeMT->IsNullable)
@@ -634,7 +611,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static void Unbox_Nullable_NotIsNullableForType(ref byte destPtr, MethodTable* typeMT, object obj)
         {
             // Also allow true nullables to be unboxed normally.
@@ -647,7 +623,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static void Unbox_Nullable(ref byte destPtr, MethodTable* typeMT, object? obj)
         {
             if (obj == null)
@@ -682,7 +657,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object? ReboxFromNullable(MethodTable* srcMT, object src)
         {
             ref byte nullableData = ref src.GetRawData();
@@ -691,7 +665,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static ref byte Unbox_Helper(MethodTable* pMT1, object obj)
         {
             // must be a value type
@@ -713,7 +686,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static void Unbox_TypeTest_Helper(MethodTable *pMT1, MethodTable *pMT2)
         {
             if ((!pMT1->IsPrimitive || !pMT2->IsPrimitive ||
@@ -728,7 +700,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static void Unbox_TypeTest(MethodTable *pMT1, MethodTable *pMT2)
         {
             if (pMT1 == pMT2)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericsHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericsHelpers.cs
@@ -29,7 +29,6 @@ internal static unsafe partial class GenericsHelpers
     }
 
     [DebuggerHidden]
-    [RequiresUnsafe]
     public static IntPtr MethodWithSlotAndModule(IntPtr methodHnd, GenericHandleArgs * pArgs)
     {
         return GenericHandleWorker(methodHnd, IntPtr.Zero, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);
@@ -42,7 +41,6 @@ internal static unsafe partial class GenericsHelpers
     }
 
     [DebuggerHidden]
-    [RequiresUnsafe]
     public static IntPtr ClassWithSlotAndModule(IntPtr classHnd, GenericHandleArgs * pArgs)
     {
         return GenericHandleWorker(IntPtr.Zero, classHnd, pArgs->signature, pArgs->dictionaryIndexAndSlot, pArgs->module);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/InitHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/InitHelpers.cs
@@ -12,19 +12,16 @@ namespace System.Runtime.CompilerServices
     internal static unsafe partial class InitHelpers
     {
         [LibraryImport(RuntimeHelpers.QCall)]
-        [RequiresUnsafe]
         private static partial void InitClassHelper(MethodTable* mt);
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         internal static void InitClassSlow(MethodTable* mt)
         {
             InitClassHelper(mt);
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static void InitClass(MethodTable* mt)
         {
             if (mt->AuxiliaryData->IsClassInited)
@@ -34,7 +31,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static void InitInstantiatedClass(MethodTable* mt, MethodDesc* methodDesc)
         {
             MethodTable *pTemplateMT = methodDesc->MethodTable;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -198,7 +198,6 @@ namespace System.Runtime.CompilerServices
         internal static partial void CompileMethod(RuntimeMethodHandleInternal method);
 
         [LibraryImport(QCall, EntryPoint = "ReflectionInvocation_PrepareMethod")]
-        [RequiresUnsafe]
         private static unsafe partial void PrepareMethod(RuntimeMethodHandleInternal method, IntPtr* pInstantiation, int cInstantiation);
 
         public static void PrepareMethod(RuntimeMethodHandle method) => PrepareMethod(method, null);
@@ -449,7 +448,6 @@ namespace System.Runtime.CompilerServices
         /// <param name="data">A reference to the data to box.</param>
         /// <returns>A boxed instance of the value at <paramref name="data"/>.</returns>
         /// <remarks>This method includes proper handling for nullable value types as well.</remarks>
-        [RequiresUnsafe]
         internal static unsafe object? Box(MethodTable* methodTable, ref byte data) =>
             methodTable->IsNullable ? CastHelpers.Box_Nullable(methodTable, ref data) : CastHelpers.Box(methodTable, ref data);
 
@@ -465,11 +463,9 @@ namespace System.Runtime.CompilerServices
         // GC.KeepAlive(o);
         //
         [Intrinsic]
-        [RequiresUnsafe]
         internal static unsafe MethodTable* GetMethodTable(object obj) => GetMethodTable(obj);
 
         [LibraryImport(QCall, EntryPoint = "MethodTable_AreTypesEquivalent")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool AreTypesEquivalent(MethodTable* pMTa, MethodTable* pMTb);
 
@@ -524,11 +520,9 @@ namespace System.Runtime.CompilerServices
         private static partial IntPtr AllocateTypeAssociatedMemoryAligned(QCallTypeHandle type, uint size, uint alignment);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe TailCallArgBuffer* GetTailCallArgBuffer();
 
         [LibraryImport(QCall, EntryPoint = "TailCallHelp_AllocTailCallArgBufferInternal")]
-        [RequiresUnsafe]
         private static unsafe partial TailCallArgBuffer* AllocTailCallArgBufferInternal(int size);
 
         private const int TAILCALLARGBUFFER_ACTIVE = 0;
@@ -536,7 +530,6 @@ namespace System.Runtime.CompilerServices
         private const int TAILCALLARGBUFFER_INACTIVE = 2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // To allow unrolling of Span.Clear
-        [RequiresUnsafe]
         private static unsafe TailCallArgBuffer* AllocTailCallArgBuffer(int size, IntPtr gcDesc)
         {
             TailCallArgBuffer* buffer = GetTailCallArgBuffer();
@@ -566,11 +559,9 @@ namespace System.Runtime.CompilerServices
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe TailCallTls* GetTailCallInfo(IntPtr retAddrSlot, IntPtr* retAddr);
 
         [StackTraceHidden]
-        [RequiresUnsafe]
         private static unsafe void DispatchTailCalls(
             IntPtr callersRetAddrSlot,
             delegate*<TailCallArgBuffer*, ref byte, PortableTailCallFrame*, void> callTarget,
@@ -653,7 +644,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void CallToString(object* pObj, string* pResult, Exception* pException)
         {
             try
@@ -725,10 +715,8 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [DebuggerHidden]
         [DebuggerStepThrough]
-        [RequiresUnsafe]
         private MethodDescChunk* GetMethodDescChunk() => (MethodDescChunk*)(((byte*)Unsafe.AsPointer<MethodDesc>(ref this)) - (sizeof(MethodDescChunk) + ChunkIndex * sizeof(IntPtr)));
 
-        [RequiresUnsafe]
         public MethodTable* MethodTable => GetMethodDescChunk()->MethodTable;
     }
 
@@ -920,7 +908,6 @@ namespace System.Runtime.CompilerServices
 
         public bool IsCollectible => (Flags & enum_flag_Collectible) != 0;
 
-        [RequiresUnsafe]
         internal static bool AreSameType(MethodTable* mt1, MethodTable* mt2) => mt1 == mt2;
 
         public bool HasDefaultConstructor => (Flags & (enum_flag_HasComponentSize | enum_flag_HasDefaultCtor)) == enum_flag_HasDefaultCtor;
@@ -1024,11 +1011,9 @@ namespace System.Runtime.CompilerServices
         /// Get the MethodTable in the type hierarchy of this MethodTable that has the same TypeDef/Module as parent.
         /// </summary>
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         public extern MethodTable* GetMethodTableMatchingParentClass(MethodTable* parent);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         public extern MethodTable* InstantiationArg0();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -1212,7 +1197,6 @@ namespace System.Runtime.CompilerServices
         private readonly void* m_asTAddr;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public TypeHandle(void* tAddr)
         {
             m_asTAddr = tAddr;
@@ -1238,7 +1222,6 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <remarks>This is only safe to call if <see cref="IsTypeDesc"/> returned <see langword="false"/>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public MethodTable* AsMethodTable()
         {
             Debug.Assert(!IsTypeDesc);
@@ -1251,7 +1234,6 @@ namespace System.Runtime.CompilerServices
         /// </summary>
         /// <remarks>This is only safe to call if <see cref="IsTypeDesc"/> returned <see langword="true"/>.</remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public TypeDesc* AsTypeDesc()
         {
             Debug.Assert(IsTypeDesc);
@@ -1324,12 +1306,10 @@ namespace System.Runtime.CompilerServices
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "TypeHandle_CanCastTo_NoCacheLookup")]
-        [RequiresUnsafe]
         private static partial Interop.BOOL CanCastTo_NoCacheLookup(void* fromTypeHnd, void* toTypeHnd);
 
         [SuppressGCTransition]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "TypeHandle_GetCorElementType")]
-        [RequiresUnsafe]
         private static partial int GetCorElementType(void* typeHnd);
     }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticsHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/StaticsHelpers.cs
@@ -15,7 +15,6 @@ namespace System.Runtime.CompilerServices
         private static partial void GetThreadStaticsByIndex(ByteRefOnStack result, int index, [MarshalAs(UnmanagedType.Bool)] bool gcStatics);
 
         [LibraryImport(RuntimeHelpers.QCall)]
-        [RequiresUnsafe]
         private static partial void GetThreadStaticsByMethodTable(ByteRefOnStack result, MethodTable* pMT, [MarshalAs(UnmanagedType.Bool)] bool gcStatics);
 
         [Intrinsic]
@@ -23,7 +22,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static ref byte GetNonGCStaticBaseSlow(MethodTable* mt)
         {
             InitHelpers.InitClassSlow(mt);
@@ -31,7 +29,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetNonGCStaticBase(MethodTable* mt)
         {
             ref byte nonGCStaticBase = ref VolatileReadAsByref(ref mt->AuxiliaryData->GetDynamicStaticsInfo()._pNonGCStatics);
@@ -43,7 +40,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetDynamicNonGCStaticBase(DynamicStaticsInfo* dynamicStaticsInfo)
         {
             ref byte nonGCStaticBase = ref VolatileReadAsByref(ref dynamicStaticsInfo->_pNonGCStatics);
@@ -56,7 +52,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static ref byte GetGCStaticBaseSlow(MethodTable* mt)
         {
             InitHelpers.InitClassSlow(mt);
@@ -64,7 +59,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetGCStaticBase(MethodTable* mt)
         {
             ref byte gcStaticBase = ref VolatileReadAsByref(ref mt->AuxiliaryData->GetDynamicStaticsInfo()._pGCStatics);
@@ -76,7 +70,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetDynamicGCStaticBase(DynamicStaticsInfo* dynamicStaticsInfo)
         {
             ref byte gcStaticBase = ref VolatileReadAsByref(ref dynamicStaticsInfo->_pGCStatics);
@@ -162,7 +155,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static ref byte GetNonGCThreadStaticBaseSlow(MethodTable* mt)
         {
             ByteRef result = default;
@@ -172,7 +164,6 @@ namespace System.Runtime.CompilerServices
 
         [DebuggerHidden]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private static ref byte GetGCThreadStaticBaseSlow(MethodTable* mt)
         {
             ByteRef result = default;
@@ -228,7 +219,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetNonGCThreadStaticBase(MethodTable* mt)
         {
             int index = mt->AuxiliaryData->GetThreadStaticsInfo()._nonGCTlsIndex;
@@ -239,7 +229,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetGCThreadStaticBase(MethodTable* mt)
         {
             int index = mt->AuxiliaryData->GetThreadStaticsInfo()._gcTlsIndex;
@@ -250,7 +239,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetDynamicNonGCThreadStaticBase(ThreadStaticsInfo* threadStaticsInfo)
         {
             int index = threadStaticsInfo->_nonGCTlsIndex;
@@ -261,7 +249,6 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static ref byte GetDynamicGCThreadStaticBase(ThreadStaticsInfo* threadStaticsInfo)
         {
             int index = threadStaticsInfo->_gcTlsIndex;
@@ -292,14 +279,12 @@ namespace System.Runtime.CompilerServices
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static unsafe ref byte StaticFieldAddress_Dynamic(StaticFieldAddressArgs* pArgs)
         {
             return ref Unsafe.Add(ref pArgs->staticBaseHelper(pArgs->arg0), pArgs->offset);
         }
 
         [DebuggerHidden]
-        [RequiresUnsafe]
         private static unsafe ref byte StaticFieldAddressUnbox_Dynamic(StaticFieldAddressArgs* pArgs)
         {
             object boxedObject = Unsafe.As<byte, object>(ref Unsafe.Add(ref pArgs->staticBaseHelper(pArgs->arg0), pArgs->offset));

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/InternalCalls.cs
@@ -16,38 +16,32 @@ namespace System.Runtime.ExceptionServices
     {
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "SfiInit")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpSfiInit(ref StackFrameIterator pThis, void* pStackwalkCtx, [MarshalAs(UnmanagedType.U1)] bool instructionFault, bool* fIsExceptionIntercepted);
 
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "SfiNext")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpSfiNext(ref StackFrameIterator pThis, uint* uExCollideClauseIdx, bool* fUnwoundReversePInvoke, bool* fIsExceptionIntercepted);
 
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "CallFilterFunclet")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpCallFilterFunclet(
             ObjectHandleOnStack exceptionObj, byte* pFilterIP, void* pvRegDisplay);
 
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AppendExceptionStackFrame")]
-        [RequiresUnsafe]
         internal static unsafe partial void RhpAppendExceptionStackFrame(ObjectHandleOnStack exceptionObj, IntPtr ip, UIntPtr sp, int flags, EH.ExInfo* exInfo);
 
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EHEnumInitFromStackFrameIterator")]
         [SuppressGCTransition]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpEHEnumInitFromStackFrameIterator(ref StackFrameIterator pFrameIter, out EH.MethodRegionInfo pMethodRegionInfo, void* pEHEnum);
 
         [StackTraceHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EHEnumNext")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.U1)]
         internal static unsafe partial bool RhpEHEnumNext(void* pEHEnum, void* pEHClause);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.CoreCLR.cs
@@ -27,7 +27,6 @@ namespace System.Runtime.InteropServices
         [SuppressGCTransition]
         private static partial void GetIUnknownImplInternal(out IntPtr fpQueryInterface, out IntPtr fpAddRef, out IntPtr fpRelease);
 
-        [RequiresUnsafe]
         internal static unsafe void GetUntrackedIUnknownImpl(out delegate* unmanaged[MemberFunction]<IntPtr, uint> fpAddRef, out delegate* unmanaged[MemberFunction]<IntPtr, uint> fpRelease)
         {
             fpAddRef = fpRelease = GetUntrackedAddRefRelease();
@@ -35,7 +34,6 @@ namespace System.Runtime.InteropServices
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ComWrappers_GetUntrackedAddRefRelease")]
         [SuppressGCTransition]
-        [RequiresUnsafe]
         private static unsafe partial delegate* unmanaged[MemberFunction]<IntPtr, uint> GetUntrackedAddRefRelease();
 
         internal static IntPtr DefaultIUnknownVftblPtr { get; } = CreateDefaultIUnknownVftbl();
@@ -69,7 +67,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int CallICustomQueryInterface(ManagedObjectWrapperHolder* pHolder, Guid* pIid, IntPtr* ppObject, Exception* pException)
         {
             try
@@ -103,7 +100,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetOrCreateComInterfaceForObjectWithGlobalMarshallingInstance(object* pObj, IntPtr* pResult, Exception* pException)
         {
             try
@@ -136,7 +132,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetOrCreateObjectForComInstanceWithGlobalMarshallingInstance(IntPtr comObject, int flags, object* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorToEnumVariantMarshaler.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/CustomMarshalers/EnumeratorToEnumVariantMarshaler.cs
@@ -49,7 +49,6 @@ namespace System.Runtime.InteropServices.CustomMarshalers
         }
 
         [System.Runtime.InteropServices.UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InternalMarshalNativeToManaged(IntPtr pNativeData, object* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/DynamicInterfaceCastableHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/DynamicInterfaceCastableHelpers.cs
@@ -24,7 +24,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void IsInterfaceImplemented(IDynamicInterfaceCastable* pCastable, RuntimeType* pInterfaceType, bool throwIfNotImplemented, bool* pResult, Exception* pException)
         {
             try
@@ -58,7 +57,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetInterfaceImplementation(IDynamicInterfaceCastable* pCastable, RuntimeType* pInterfaceType, RuntimeType* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/IDispatchHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/IDispatchHelpers.cs
@@ -13,7 +13,6 @@ namespace System.Runtime.InteropServices
         private const int DispatchExPropertyCanWrite = 2;
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int GetDispatchExPropertyFlags(PropertyInfo* pMemberInfo, Exception* pException)
         {
             try
@@ -40,7 +39,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchParameterInfoName(ParameterInfo* pParameterInfo, string* pResult, Exception* pException)
         {
             try
@@ -54,7 +52,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchMemberInfoName(MemberInfo* pMemberInfo, string* pResult, Exception* pException)
         {
             try
@@ -68,7 +65,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int GetDispatchMemberInfoType(MemberInfo* pMemberInfo, Exception* pException)
         {
             try
@@ -83,7 +79,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void HasDispatchCustomAttribute(MemberInfo* pMemberInfo, Type* pAttributeType, bool* pResult, Exception* pException)
         {
             try
@@ -97,7 +92,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchMemberParameters(MemberInfo* pMemberInfo, ParameterInfo[]* pResult, Exception* pException)
         {
             try
@@ -118,7 +112,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchPropertyTokenAndModule(PropertyInfo* pPropertyInfo, int* pToken, RuntimeModule* pModule, Exception* pException)
         {
             try
@@ -133,7 +126,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchPropertyAccessor(PropertyInfo* pPropertyInfo, bool getter, bool nonPublic, IntPtr* pResult, Exception* pException)
         {
             try
@@ -148,7 +140,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchFieldValue(FieldInfo* pFieldInfo, object* pTarget, object* pResult, Exception* pException)
         {
             try
@@ -162,7 +153,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void SetDispatchFieldValue(FieldInfo* pFieldInfo, object* pTarget, object* pValue, int invokeAttr, Binder* pBinder, Globalization.CultureInfo* pCulture, Exception* pException)
         {
             try
@@ -181,7 +171,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchPropertyValue(PropertyInfo* pPropertyInfo, object* pTarget, int invokeAttr, Binder* pBinder, object[]* pIndexArgs, Globalization.CultureInfo* pCulture, object* pResult, Exception* pException)
         {
             try
@@ -200,7 +189,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void SetDispatchPropertyValue(PropertyInfo* pPropertyInfo, object* pTarget, object* pValue, int invokeAttr, Binder* pBinder, object[]* pIndexArgs, Globalization.CultureInfo* pCulture, Exception* pException)
         {
             try
@@ -220,7 +208,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InvokeDispatchMethodInfo(MethodInfo* pMemberInfo, object* pTarget, int invokeAttr, Binder* pBinder, object[]* pArgs, Globalization.CultureInfo* pCulture, object* pResult, Exception* pException)
         {
             try
@@ -240,7 +227,6 @@ namespace System.Runtime.InteropServices
 
         [RequiresUnreferencedCode("The member might be removed")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InvokeDispatchReflectMember(IReflect* pReflectionObject, string* pName, int invokeAttr, Binder* pBinder, object* pTarget, object[]* pArgs, ParameterModifier[]* pModifiers, Globalization.CultureInfo* pCulture, string[]* pNamedParams, object* pResult, Exception* pException)
         {
             try
@@ -263,7 +249,6 @@ namespace System.Runtime.InteropServices
 
         [RequiresUnreferencedCode("The member might be removed")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchProperties(IReflect* pReflectionObject, int bindingFlags, PropertyInfo[]* pResult, Exception* pException)
         {
             try
@@ -278,7 +263,6 @@ namespace System.Runtime.InteropServices
 
         [RequiresUnreferencedCode("The member might be removed")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchFields(IReflect* pReflectionObject, int bindingFlags, FieldInfo[]* pResult, Exception* pException)
         {
             try
@@ -293,7 +277,6 @@ namespace System.Runtime.InteropServices
 
         [RequiresUnreferencedCode("The member might be removed")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchMethods(IReflect* pReflectionObject, int bindingFlags, MethodInfo[]* pResult, Exception* pException)
         {
             try
@@ -307,7 +290,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetDispatchInnerException(Exception* pExceptionObject, Exception* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.CoreCLR.cs
@@ -38,7 +38,6 @@ namespace System.Runtime.InteropServices.Java
         /// runtime code when cross-reference marking is required.
         /// Additionally, this callback must be implemented in unmanaged code.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
             ArgumentNullException.ThrowIfNull(markCrossReferences);
@@ -63,7 +62,6 @@ namespace System.Runtime.InteropServices.Java
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -84,7 +82,6 @@ namespace System.Runtime.InteropServices.Java
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void* GetContext(GCHandle obj)
         {
             IntPtr handle = GCHandle.ToIntPtr(obj);
@@ -106,7 +103,6 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)
@@ -125,16 +121,13 @@ namespace System.Runtime.InteropServices.Java
         private static partial bool InitializeInternal(IntPtr callback);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "JavaMarshal_CreateReferenceTrackingHandle")]
-        [RequiresUnsafe]
         private static unsafe partial IntPtr CreateReferenceTrackingHandleInternal(ObjectHandleOnStack obj, void* context);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "JavaMarshal_FinishCrossReferenceProcessing")]
-        [RequiresUnsafe]
         private static unsafe partial void FinishCrossReferenceProcessing(MarkCrossReferencesArgs* crossReferences, nuint length, void* unreachableObjectHandles);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "JavaMarshal_GetContext")]
         [SuppressGCTransition]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool GetContextInternal(IntPtr handle, out void* context);
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.CoreCLR.cs
@@ -1058,7 +1058,6 @@ namespace System.Runtime.InteropServices
 
 #if DEBUG // Used for testing in Checked or Debug
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "MarshalNative_GetIsInCooperativeGCModeFunctionPointer")]
-        [RequiresUnsafe]
         internal static unsafe partial delegate* unmanaged<int> GetIsInCooperativeGCModeFunctionPointer();
 #endif
     }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeLibrary.CoreCLR.cs
@@ -27,7 +27,6 @@ namespace System.Runtime.InteropServices
                                                  [MarshalAs(UnmanagedType.Bool)] bool throwOnError);
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe IntPtr LoadLibraryCallbackStub(char* pLibraryName, Assembly* pAssembly, bool hasDllImportSearchPathFlags, uint dllImportSearchPathFlags, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.CoreCLR.cs
@@ -111,7 +111,6 @@ namespace System.Runtime.Loader
         // This method is invoked by the VM when using the host-provided assembly load context
         // implementation.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe IntPtr ResolveUnmanagedDll(char* pUnmanagedDllName, IntPtr gchAssemblyLoadContext, Exception* pException)
         {
             try
@@ -129,7 +128,6 @@ namespace System.Runtime.Loader
         // This method is invoked by the VM to resolve a native library using the ResolvingUnmanagedDll event
         // after trying all other means of resolution.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe IntPtr ResolveUnmanagedDllUsingEvent(char* pUnmanagedDllName, Assembly* pAssembly, IntPtr gchAssemblyLoadContext, Exception* pException)
         {
             try
@@ -203,7 +201,6 @@ namespace System.Runtime.Loader
         /// Called by the runtime to start an assembly load activity for tracing
         /// </summary>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void StartAssemblyLoad(Guid* activityId, Guid* relatedActivityId, Exception* pException)
         {
             try
@@ -224,7 +221,6 @@ namespace System.Runtime.Loader
         /// Called by the runtime to stop an assembly load activity for tracing
         /// </summary>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void StopAssemblyLoad(Guid* activityId, Exception* pException)
         {
             try
@@ -242,7 +238,6 @@ namespace System.Runtime.Loader
         /// Called by the runtime to make sure the default ALC is initialized
         /// </summary>
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InitializeDefaultContext(Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -67,7 +67,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe RuntimeType GetRuntimeType(MethodTable* pMT)
         {
             return pMT->AuxiliaryData->ExposedClassObject ?? GetRuntimeTypeFromHandleSlow((IntPtr)pMT);
@@ -276,14 +275,12 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_CreateInstanceForAnotherGenericParameter")]
-        [RequiresUnsafe]
         private static partial void CreateInstanceForAnotherGenericParameter(
             QCallTypeHandle baseType,
             IntPtr* pTypeHandles,
             int cTypeHandles,
             ObjectHandleOnStack instantiatedObject);
 
-        [RequiresUnsafe]
         internal static unsafe object InternalAlloc(MethodTable* pMT)
         {
             object? result = null;
@@ -300,12 +297,10 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_InternalAlloc")]
-        [RequiresUnsafe]
         private static unsafe partial void InternalAlloc(MethodTable* pMT, ObjectHandleOnStack result);
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static object InternalAllocNoChecks(MethodTable* pMT)
         {
             return InternalAllocNoChecks_FastPath(pMT) ?? InternalAllocNoChecksWorker(pMT);
@@ -320,11 +315,9 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_InternalAllocNoChecks")]
-        [RequiresUnsafe]
         private static unsafe partial void InternalAllocNoChecks(MethodTable* pMT, ObjectHandleOnStack result);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern object? InternalAllocNoChecks_FastPath(MethodTable* pMT);
 
         /// <summary>
@@ -332,7 +325,6 @@ namespace System
         /// semantics. This method will ensure the type object is fully initialized within
         /// the VM, but it will not call any static ctors on the type.
         /// </summary>
-        [RequiresUnsafe]
         internal static void GetActivationInfo(
             RuntimeType rt,
             out delegate*<void*, object> pfnAllocator,
@@ -362,7 +354,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetActivationInfo")]
-        [RequiresUnsafe]
         private static partial void GetActivationInfo(
             ObjectHandleOnStack pRuntimeType,
             delegate*<void*, object>* ppfnAllocator,
@@ -467,7 +458,6 @@ namespace System
         internal static extern int GetToken(RuntimeType type);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetMethodAt")]
-        [RequiresUnsafe]
         private static unsafe partial IntPtr GetMethodAt(MethodTable* pMT, int slot);
 
         internal static RuntimeMethodHandleInternal GetMethodAt(RuntimeType type, int slot)
@@ -546,7 +536,6 @@ namespace System
         private static extern void GetNextIntroducedMethod(ref RuntimeMethodHandleInternal method);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetFields")]
-        [RequiresUnsafe]
         private static partial Interop.BOOL GetFields(MethodTable* pMT, Span<IntPtr> data, ref int usedCount);
 
         internal static bool GetFields(RuntimeType type, Span<IntPtr> buffer, out int count)
@@ -568,7 +557,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_GetInterfaces")]
-        [RequiresUnsafe]
         private static unsafe partial void GetInterfaces(MethodTable* pMT, ObjectHandleOnStack result);
 
         internal static Type[] GetInterfaces(RuntimeType type)
@@ -671,7 +659,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe void* GetUtf8NameInternal(MethodTable* pMT);
 
         // Since the returned string is a pointer into metadata, the caller should
@@ -766,7 +753,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_Instantiate")]
-        [RequiresUnsafe]
         private static partial void Instantiate(QCallTypeHandle handle, IntPtr* pInst, int numGenericArgs, ObjectHandleOnStack type);
 
         internal RuntimeType Instantiate(RuntimeType inst)
@@ -828,7 +814,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeTypeHandle_MakeFunctionPointer")]
-        [RequiresUnsafe]
         private static partial void MakeFunctionPointer(nint* retAndParamTypes, int numArgs, [MarshalAs(UnmanagedType.Bool)] bool isUnmanaged, ObjectHandleOnStack type);
 
         internal RuntimeType MakeFunctionPointer(Type[] parameterTypes, bool isUnmanaged)
@@ -1124,7 +1109,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe MethodTable* GetMethodTable(RuntimeMethodHandleInternal method);
 
         internal static unsafe RuntimeType GetDeclaringType(RuntimeMethodHandleInternal method)
@@ -1176,7 +1160,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern void* GetUtf8NameInternal(RuntimeMethodHandleInternal method);
 
         // Since the returned string is a pointer into metadata, the caller should
@@ -1195,12 +1178,10 @@ namespace System
         [DebuggerStepThrough]
         [DebuggerHidden]
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_InvokeMethod")]
-        [RequiresUnsafe]
         private static partial void InvokeMethod(ObjectHandleOnStack target, void** arguments, ObjectHandleOnStack sig, Interop.BOOL isConstructor, ObjectHandleOnStack result);
 
         [DebuggerStepThrough]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static object? InvokeMethod(object? target, void** arguments, Signature sig, bool isConstructor)
         {
             object? result = null;
@@ -1541,7 +1522,6 @@ namespace System
        }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern void* GetUtf8NameInternal(RuntimeFieldHandleInternal field);
 
         // Since the returned string is a pointer into metadata, the caller should
@@ -1561,7 +1541,6 @@ namespace System
         internal static extern FieldAttributes GetAttributes(RuntimeFieldHandleInternal field);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern MethodTable* GetApproxDeclaringMethodTable(RuntimeFieldHandleInternal field);
 
         internal static RuntimeType GetApproxDeclaringType(RuntimeFieldHandleInternal field)
@@ -1590,7 +1569,6 @@ namespace System
         internal static extern IntPtr GetStaticFieldAddress(RtFieldInfo field);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeFieldHandle_GetRVAFieldInfo")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static partial bool GetRVAFieldInfo(RuntimeFieldHandleInternal field, out void* address, out uint size);
 
@@ -1646,7 +1624,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeFieldHandle_GetValueDirect")]
-        [RequiresUnsafe]
         private static partial void GetValueDirect(
             IntPtr fieldDesc,
             void* pTypedRef,
@@ -1688,7 +1665,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeFieldHandle_SetValueDirect")]
-        [RequiresUnsafe]
         private static partial void SetValueDirect(
             IntPtr fieldDesc,
             void* pTypedRef,
@@ -1708,7 +1684,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe RuntimeFieldHandleInternal GetStaticFieldForGenericType(RuntimeFieldHandleInternal field, MethodTable* pMT);
 
         internal static RuntimeFieldHandleInternal GetStaticFieldForGenericType(RuntimeFieldHandleInternal field, RuntimeType declaringType)
@@ -1743,14 +1718,12 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeFieldHandle_GetEnCFieldAddr")]
-        [RequiresUnsafe]
         private static partial void* GetEnCFieldAddr(ObjectHandleOnStack tgt, void* pFD);
 
         // implementation of CORINFO_HELP_GETFIELDADDR
         [StackTraceHidden]
         [DebuggerStepThrough]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static unsafe void* GetFieldAddr(object tgt, void* pFD)
         {
             void* addr = GetEnCFieldAddr(ObjectHandleOnStack.Create(ref tgt), pFD);
@@ -1763,7 +1736,6 @@ namespace System
         [StackTraceHidden]
         [DebuggerStepThrough]
         [DebuggerHidden]
-        [RequiresUnsafe]
         internal static unsafe void* GetStaticFieldAddr(void* pFD)
         {
             object? nullTarget = null;
@@ -1910,7 +1882,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveType")]
-        [RequiresUnsafe]
         private static partial void ResolveType(QCallModule module,
                                                             int typeToken,
                                                             IntPtr* typeInstArgs,
@@ -1963,7 +1934,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveMethod")]
-        [RequiresUnsafe]
         private static partial RuntimeMethodHandleInternal ResolveMethod(QCallModule module,
                                                         int methodToken,
                                                         IntPtr* typeInstArgs,
@@ -2018,7 +1988,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_ResolveField")]
-        [RequiresUnsafe]
         private static partial void ResolveField(QCallModule module,
                                                       int fieldToken,
                                                       IntPtr* typeInstArgs,
@@ -2038,7 +2007,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ModuleHandle_GetPEKind")]
-        [RequiresUnsafe]
         private static partial void GetPEKind(QCallModule handle, int* peKind, int* machine);
 
         // making this internal, used by Module.GetPEKind
@@ -2082,7 +2050,6 @@ namespace System
         #endregion
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Signature_Init")]
-        [RequiresUnsafe]
         private static partial void Init(
             ObjectHandleOnStack _this,
             void* pCorSig, int cCorSig,
@@ -2090,7 +2057,6 @@ namespace System
             RuntimeMethodHandleInternal methodHandle);
 
         [MemberNotNull(nameof(_returnTypeORfieldType))]
-        [RequiresUnsafe]
         private void Init(
             void* pCorSig, int cCorSig,
             RuntimeFieldHandleInternal fieldHandle,
@@ -2136,7 +2102,6 @@ namespace System
             GC.KeepAlive(fieldHandle);
         }
 
-        [RequiresUnsafe]
         public Signature(void* pCorSig, int cCorSig, RuntimeType declaringType)
         {
             _declaringType = declaringType;
@@ -2158,7 +2123,6 @@ namespace System
         internal RuntimeType FieldType => _returnTypeORfieldType;
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "Signature_AreEqual")]
-        [RequiresUnsafe]
         private static partial Interop.BOOL AreEqual(
             void* sig1, int csig1, QCallTypeHandle type1,
             void* sig2, int csig2, QCallTypeHandle type2);
@@ -2171,7 +2135,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetParameterOffsetInternal(void* sig, int csig, int parameterIndex);
 
         internal int GetParameterOffset(int parameterIndex)
@@ -2184,7 +2147,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetTypeParameterOffsetInternal(void* sig, int csig, int offset, int index);
 
         internal int GetTypeParameterOffset(int offset, int index)
@@ -2203,7 +2165,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int GetCallingConventionFromFunctionPointerAtOffsetInternal(void* sig, int csig, int offset);
 
         internal SignatureCallingConvention GetCallingConventionFromFunctionPointerAtOffset(int offset)
@@ -2261,7 +2222,6 @@ namespace System
         internal abstract RuntimeType? GetJitContext(out int securityControlFlags);
         internal abstract byte[] GetCodeInfo(out int stackSize, out int initLocals, out int EHCount);
         internal abstract byte[] GetLocalsSignature();
-        [RequiresUnsafe]
         internal abstract unsafe void GetEHInfo(int EHNumber, void* exception);
         internal abstract byte[]? GetRawEHInfo();
         // token resolution
@@ -2272,7 +2232,6 @@ namespace System
         internal abstract MethodInfo GetDynamicMethod();
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetJitContext(Resolver* pResolver, int* pSecurityControlFlags, RuntimeType* ppResult, Exception* pException)
         {
             try
@@ -2286,7 +2245,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetCodeInfo(Resolver* pResolver, int* pStackSize, int* pInitLocals, int* pEHCount, byte[]* ppResult, Exception* pException)
         {
             try
@@ -2300,7 +2258,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetLocalsSignature(Resolver* pResolver, byte[]* ppResult, Exception* pException)
         {
             try
@@ -2314,7 +2271,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetStringLiteral(Resolver* pResolver, int token, string* ppResult, Exception* pException)
         {
             try
@@ -2328,7 +2284,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void ResolveToken(Resolver* pResolver, int token, IntPtr* pTypeHandle, IntPtr* pMethodHandle, IntPtr* pFieldHandle, Exception* pException)
         {
             try
@@ -2342,7 +2297,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void ResolveSignature(Resolver* pResolver, int token, int fromMethod, byte[]* ppResult, Exception* pException)
         {
             try
@@ -2356,7 +2310,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetEHInfo(Resolver* pResolver, int EHNumber, byte[]* ppRawEHInfo, void* parsedEHInfo, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.BoxCache.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.BoxCache.cs
@@ -105,7 +105,6 @@ namespace System
             /// Given a RuntimeType, returns information about how to box instances
             /// of it via calli semantics.
             /// </summary>
-            [RequiresUnsafe]
             private static void GetBoxInfo(
                 RuntimeType rt,
                 out delegate*<void*, object> pfnAllocator,
@@ -132,7 +131,6 @@ namespace System
             }
 
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_GetBoxInfo")]
-            [RequiresUnsafe]
             private static partial void GetBoxInfo(
                 QCallTypeHandle type,
                 delegate*<void*, object>* ppfnAllocator,

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -150,7 +150,6 @@ namespace System
                 private readonly MdUtf8String m_name;
                 private readonly MemberListType m_listType;
 
-                [RequiresUnsafe]
                 public unsafe Filter(byte* pUtf8Name, int cUtf8Name, MemberListType listType)
                 {
                     m_name = new MdUtf8String(pUtf8Name, cUtf8Name);
@@ -3416,7 +3415,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionInvocation_GetGuid")]
-        [RequiresUnsafe]
         private static unsafe partial void GetGuid(MethodTable* pMT, Guid* result);
 
 #if FEATURE_COMINTEROP
@@ -4369,14 +4367,12 @@ namespace System
     internal readonly unsafe partial struct MdUtf8String
     {
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "MdUtf8String_EqualsCaseInsensitive")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static partial bool EqualsCaseInsensitive(void* szLhs, void* szRhs, int cSz);
 
         private readonly byte* m_pStringHeap;        // This is the raw UTF8 string.
         private readonly int m_StringHeapByteLength;
 
-        [RequiresUnsafe]
         internal MdUtf8String(void* pStringHeap)
         {
             byte* pStringBytes = (byte*)pStringHeap;
@@ -4392,7 +4388,6 @@ namespace System
             m_pStringHeap = pStringBytes;
         }
 
-        [RequiresUnsafe]
         internal MdUtf8String(byte* pUtf8String, int cUtf8String)
         {
             m_pStringHeap = pUtf8String;

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CreateUninitializedCache.CoreCLR.cs
@@ -57,7 +57,6 @@ namespace System
             /// Given a RuntimeType, returns information about how to create uninitialized instances
             /// of it via calli semantics.
             /// </summary>
-            [RequiresUnsafe]
             private static void GetCreateUninitializedInfo(
                 RuntimeType rt,
                 out delegate*<void*, object> pfnAllocator,
@@ -77,7 +76,6 @@ namespace System
             }
 
             [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ReflectionSerialization_GetCreateUninitializedObjectInfo")]
-            [RequiresUnsafe]
             private static partial void GetCreateUninitializedInfo(
                 QCallTypeHandle type,
                 delegate*<void*, object>* ppfnAllocator,

--- a/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StartupHookProvider.CoreCLR.cs
@@ -14,7 +14,6 @@ namespace System
     internal static partial class StartupHookProvider
     {
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ManagedStartup(char* pDiagnosticStartupHooks, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs
@@ -12,7 +12,6 @@ namespace System
     public partial class String
     {
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         internal static extern unsafe string FastAllocateString(MethodTable *pMT, nint length);
 
         [DebuggerHidden]
@@ -51,7 +50,6 @@ namespace System
             }
         }
 
-        [RequiresUnsafe]
         internal unsafe int GetBytesFromEncoding(byte* pbNativeBuffer, int cbNativeBuffer, Encoding encoding)
         {
             // encoding == Encoding.UTF8

--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -322,7 +322,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe IntPtr ConvertToNative(string* pStr, Exception* pException)
         {
             try
@@ -732,7 +731,6 @@ namespace System.StubHelpers
     internal static unsafe partial class MngdRefCustomMarshaler
     {
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static void ConvertContentsToNative(ICustomMarshaler* pMarshaler, object* pManagedHome, IntPtr* pNativeHome, Exception* pException)
         {
             try
@@ -745,7 +743,6 @@ namespace System.StubHelpers
             }
         }
 
-        [RequiresUnsafe]
         internal static void ConvertContentsToNative(ICustomMarshaler marshaler, in object pManagedHome, IntPtr* pNativeHome)
         {
             // COMPAT: We never pass null to MarshalManagedToNative.
@@ -759,7 +756,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static void ConvertContentsToManaged(ICustomMarshaler* pMarshaler, object* pManagedHome, IntPtr* pNativeHome, Exception* pException)
         {
             try
@@ -772,7 +768,6 @@ namespace System.StubHelpers
             }
         }
 
-        [RequiresUnsafe]
         internal static void ConvertContentsToManaged(ICustomMarshaler marshaler, ref object? pManagedHome, IntPtr* pNativeHome)
         {
             // COMPAT: We never pass null to MarshalNativeToManaged.
@@ -786,7 +781,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static void ClearNative(ICustomMarshaler* pMarshaler, object* pManagedHome, IntPtr* pNativeHome, Exception* pException)
         {
             try
@@ -799,7 +793,6 @@ namespace System.StubHelpers
             }
         }
 
-        [RequiresUnsafe]
         internal static void ClearNative(ICustomMarshaler marshaler, ref object _, IntPtr* pNativeHome)
         {
             // COMPAT: We never pass null to CleanUpNativeData.
@@ -819,7 +812,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static void ClearManaged(ICustomMarshaler* pMarshaler, object* pManagedHome, IntPtr* pNativeHome, Exception* pException)
         {
             try
@@ -832,7 +824,6 @@ namespace System.StubHelpers
             }
         }
 
-        [RequiresUnsafe]
         internal static void ClearManaged(ICustomMarshaler marshaler, in object pManagedHome, IntPtr* _)
         {
             // COMPAT: We never pass null to CleanUpManagedData.
@@ -846,7 +837,6 @@ namespace System.StubHelpers
 
         [UnmanagedCallersOnly]
         [UnconditionalSuppressMessage("Trimming", "IL2075", Justification = "Custom marshaler GetInstance method is preserved by ILLink (see MarkCustomMarshalerGetInstance).")]
-        [RequiresUnsafe]
         internal static void GetCustomMarshalerInstance(void* pMT, byte* pCookie, int cCookieBytes, object* pResult, Exception* pException)
         {
             try
@@ -2257,7 +2247,6 @@ namespace System.StubHelpers
 
         [SupportedOSPlatform("windows")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void GetIEnumeratorToEnumVariantMarshaler(object* pResult, Exception* pException)
         {
             try
@@ -2272,7 +2261,6 @@ namespace System.StubHelpers
 
         [SupportedOSPlatform("windows")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe int CallICustomQueryInterface(ICustomQueryInterface* pObject, Guid* pIid, IntPtr* ppObject, Exception* pException)
         {
             try
@@ -2288,7 +2276,6 @@ namespace System.StubHelpers
 
         [SupportedOSPlatform("windows")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InvokeConnectionPointProviderMethod(
             object* pProvider,
             delegate*<object, object?, void> providerMethodEntryPoint,
@@ -2385,11 +2372,9 @@ namespace System.StubHelpers
         // Profiler helpers
         //-------------------------------------------------------
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "StubHelpers_ProfilerBeginTransitionCallback")]
-        [RequiresUnsafe]
         internal static unsafe partial void* ProfilerBeginTransitionCallback(void* pTargetMD);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "StubHelpers_ProfilerEndTransitionCallback")]
-        [RequiresUnsafe]
         internal static unsafe partial void ProfilerEndTransitionCallback(void* pTargetMD);
 #endif // PROFILING_SUPPORTED
 
@@ -2412,7 +2397,6 @@ namespace System.StubHelpers
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "StubHelpers_CreateLayoutClassMarshalStubs")]
         internal static unsafe partial void CreateLayoutClassMarshalStubs(QCallTypeHandle th, out delegate*<ref byte, byte*, ref CleanupWorkListElement?, void> pConvertToUnmanaged, out delegate*<ref byte, byte*, ref CleanupWorkListElement?, void> pConvertToManaged, out delegate*<ref byte, byte*, ref CleanupWorkListElement?, void> pFree);
 
-        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToUnmanaged(object obj, byte* pNative, ref CleanupWorkListElement? pCleanupWorkList)
         {
             RuntimeType type = (RuntimeType)obj.GetType();
@@ -2422,7 +2406,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToUnmanaged(object* obj, byte* pNative, Exception* pException)
         {
             try
@@ -2435,7 +2418,6 @@ namespace System.StubHelpers
             }
         }
 
-        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToManaged(object obj, byte* pNative)
         {
             RuntimeType type = (RuntimeType)obj.GetType();
@@ -2445,7 +2427,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void LayoutTypeConvertToManaged(object* obj, byte* pNative, Exception* pException)
         {
             try
@@ -2567,7 +2548,6 @@ namespace System.StubHelpers
     internal static class CultureInfoMarshaler
     {
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void GetCurrentCulture(bool bUICulture, object* pResult, Exception* pException)
         {
             try
@@ -2583,7 +2563,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void SetCurrentCulture(bool bUICulture, Globalization.CultureInfo* pValue, Exception* pException)
         {
             try
@@ -2600,7 +2579,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void CreateCultureInfo(int culture, object* pResult, Exception* pException)
         {
             try
@@ -2646,7 +2624,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void ConvertToManaged(int oleColor, object* pResult, Exception* pException)
         {
             try
@@ -2660,7 +2637,6 @@ namespace System.StubHelpers
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void ConvertToNative(object* pSrcObj, int* pResult, Exception* pException)
         {
             try

--- a/src/coreclr/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Text/StringBuilder.CoreCLR.cs
@@ -25,7 +25,6 @@ namespace System.Text
             return newCapacity;
         }
 
-        [RequiresUnsafe]
         internal unsafe void ReplaceBufferInternal(char* newBuffer, int newLength)
         {
             ArgumentOutOfRangeException.ThrowIfGreaterThan(newLength, m_MaxCapacity, "capacity");
@@ -56,7 +55,6 @@ namespace System.Text
             m_ChunkOffset = 0;
         }
 
-        [RequiresUnsafe]
         internal unsafe void ReplaceBufferAnsiInternal(sbyte* newBuffer, int newLength)
         {
             ArgumentOutOfRangeException.ThrowIfGreaterThan(newLength, m_MaxCapacity, "capacity");

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Interlocked.CoreCLR.cs
@@ -135,7 +135,6 @@ namespace System.Threading
         // return type of the method.
         // The important part is avoiding `ref *location` that is reported as byref to the GC.
         [Intrinsic]
-        [RequiresUnsafe]
         internal static unsafe int CompareExchange(int* location1, int value, int comparand)
         {
 #if TARGET_X86 || TARGET_AMD64 || TARGET_ARM64 || TARGET_RISCV64
@@ -147,7 +146,6 @@ namespace System.Threading
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         private static extern unsafe int CompareExchange32Pointer(int* location1, int value, int comparand);
 
         /// <summary>Compares two 64-bit signed integers for equality and, if they are equal, replaces the first value.</summary>

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -109,11 +109,9 @@ namespace System.Threading
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_Start")]
-        [RequiresUnsafe]
         private static unsafe partial Interop.BOOL StartInternal(ThreadHandle t, int stackSize, int priority, Interop.BOOL isThreadPool, char* pThreadName, ObjectHandleOnStack exception);
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void StartCallback(Thread* pThread)
         {
             StartHelper? startHelper = pThread->_startHelper;
@@ -587,7 +585,6 @@ namespace System.Threading
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnThreadExited(Thread* pThread, Exception* pException)
         {
             try
@@ -601,7 +598,6 @@ namespace System.Threading
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ThreadNative_ReentrantWaitAny")]
-        [RequiresUnsafe]
         internal static unsafe partial int ReentrantWaitAny([MarshalAs(UnmanagedType.Bool)] bool alertable, int timeout, int count, IntPtr* handles);
 
         internal static void CheckForPendingInterrupt()

--- a/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/ValueType.cs
@@ -70,7 +70,6 @@ namespace System
 
         // Return true if the valuetype does not contain pointer, is tightly packed,
         // does not have floating point number field and does not override Equals method.
-        [RequiresUnsafe]
         private static unsafe bool CanCompareBitsOrUseFastGetHashCode(MethodTable* pMT)
         {
             MethodTableAuxiliaryData* pAuxData = pMT->AuxiliaryData;
@@ -84,7 +83,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "MethodTable_CanCompareBitsOrUseFastGetHashCode")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static unsafe partial bool CanCompareBitsOrUseFastGetHashCodeHelper(MethodTable* pMT);
 
@@ -164,7 +162,6 @@ namespace System
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "ValueType_GetHashCodeStrategy")]
-        [RequiresUnsafe]
         private static unsafe partial ValueTypeHashCodeStrategy GetHashCodeStrategy(
             MethodTable* pMT, ObjectHandleOnStack objHandle, out uint fieldOffset, out uint fieldSize, out MethodTable* fieldMT);
 

--- a/src/coreclr/System.Private.CoreLib/src/System/__ComObject.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/__ComObject.cs
@@ -110,7 +110,6 @@ namespace System
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ReleaseAllData(__ComObject* pComObject, Exception* pException)
         {
             try

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -15,7 +15,6 @@ namespace System
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_ArgIterator);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
@@ -17,19 +17,16 @@ namespace System.Reflection.Emit
         public void SetCode(byte[] code, int maxStackSize) { }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetCode(byte* code, int codeSize, int maxStackSize) { }
 
         public void SetExceptions(byte[] exceptions) { }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetExceptions(byte* exceptions, int exceptionsSize) { }
 
         public void SetLocalSignature(byte[] localSignature) { }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe void SetLocalSignature(byte* localSignature, int signatureSize) { }
 
         public int GetTokenFor(RuntimeMethodHandle method)

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -17,7 +17,6 @@ namespace System.Reflection.Metadata
         //     associated, is alive. The caller is responsible for keeping the assembly object alive while accessing the
         //     metadata blob.
         [CLSCompliant(false)] // out byte* blob
-        [RequiresUnsafe]
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
         {
             ArgumentNullException.ThrowIfNull(assembly);

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.NativeAot.cs
@@ -38,7 +38,6 @@ namespace System.Runtime.InteropServices.Java
         /// runtime code when cross-reference marking is required.
         /// Additionally, this callback must be implemented in unmanaged code.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
             ArgumentNullException.ThrowIfNull(markCrossReferences);
@@ -63,7 +62,6 @@ namespace System.Runtime.InteropServices.Java
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -82,7 +80,6 @@ namespace System.Runtime.InteropServices.Java
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void* GetContext(GCHandle obj)
         {
             IntPtr handle = GCHandle.ToIntPtr(obj);
@@ -103,7 +100,6 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
+++ b/src/libraries/System.Diagnostics.Tracing/ref/System.Diagnostics.Tracing.cs
@@ -204,13 +204,11 @@ namespace System.Diagnostics.Tracing
         protected void WriteEvent(int eventId, string? arg1, string? arg2, string? arg3) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("EventSource will serialize the whole object graph. Trimmer will not safely handle this case because properties may be trimmed. This can be suppressed if the object is a primitive type")]
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         protected unsafe void WriteEventCore(int eventId, int eventDataCount, System.Diagnostics.Tracing.EventSource.EventData* data) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("EventSource will serialize the whole object graph. Trimmer will not safely handle this case because properties may be trimmed. This can be suppressed if the object is a primitive type")]
         protected void WriteEventWithRelatedActivityId(int eventId, System.Guid relatedActivityId, params object?[] args) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("EventSource will serialize the whole object graph. Trimmer will not safely handle this case because properties may be trimmed. This can be suppressed if the object is a primitive type")]
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         protected unsafe void WriteEventWithRelatedActivityIdCore(int eventId, System.Guid* relatedActivityId, int eventDataCount, System.Diagnostics.Tracing.EventSource.EventData* data) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("EventSource will serialize the whole object graph. Trimmer will not safely handle this case because properties may be trimmed. This can be suppressed if the object is a primitive type")]
         public void Write<[System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute(System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes.PublicProperties)] T>(string? eventName, System.Diagnostics.Tracing.EventSourceOptions options, T data) { }

--- a/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
+++ b/src/libraries/System.Numerics.Vectors/ref/System.Numerics.Vectors.cs
@@ -390,13 +390,10 @@ namespace System.Numerics
         public static System.Numerics.Vector<T> LessThanOrEqual<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         public static System.Numerics.Vector<T> LessThan<T>(System.Numerics.Vector<T> left, System.Numerics.Vector<T> right) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
         public static System.Numerics.Vector<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -494,40 +491,28 @@ namespace System.Numerics
         public static (System.Numerics.Vector<float> Sin, System.Numerics.Vector<float> Cos) SinCos(System.Numerics.Vector<float> vector) { throw null; }
         public static System.Numerics.Vector<T> SquareRoot<T>(System.Numerics.Vector<T> value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(this System.Numerics.Vector2 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(this System.Numerics.Vector3 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(this System.Numerics.Vector4 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(this System.Numerics.Vector2 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(this System.Numerics.Vector3 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(this System.Numerics.Vector4 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Numerics.Vector<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(this System.Numerics.Vector2 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(this System.Numerics.Vector3 source, float* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(this System.Numerics.Vector4 source, float* destination) { throw null; }
         public static void StoreUnsafe<T>(this System.Numerics.Vector<T> source, ref T destination) { throw null; }
         public static void StoreUnsafe(this System.Numerics.Vector2 source, ref float destination) { throw null; }
@@ -703,13 +688,10 @@ namespace System.Numerics
         public static bool LessThanOrEqualAll(System.Numerics.Vector2 left, System.Numerics.Vector2 right) { throw null; }
         public static bool LessThanOrEqualAny(System.Numerics.Vector2 left, System.Numerics.Vector2 right) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector2 Load(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector2 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector2 LoadAlignedNonTemporal(float* source) { throw null; }
         public static System.Numerics.Vector2 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]
@@ -874,13 +856,10 @@ namespace System.Numerics
         public static bool LessThanOrEqualAll(System.Numerics.Vector3 left, System.Numerics.Vector3 right) { throw null; }
         public static bool LessThanOrEqualAny(System.Numerics.Vector3 left, System.Numerics.Vector3 right) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector3 Load(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector3 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector3 LoadAlignedNonTemporal(float* source) { throw null; }
         public static System.Numerics.Vector3 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]
@@ -1049,13 +1028,10 @@ namespace System.Numerics
         public static System.Numerics.Vector4 Log(System.Numerics.Vector4 vector) { throw null; }
         public static System.Numerics.Vector4 Log2(System.Numerics.Vector4 vector) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector4 Load(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector4 LoadAligned(float* source) { throw null; }
         [CLSCompliant(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector4 LoadAlignedNonTemporal(float* source) { throw null; }
         public static System.Numerics.Vector4 LoadUnsafe(ref readonly float source) { throw null; }
         [CLSCompliant(false)]

--- a/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
+++ b/src/libraries/System.Private.CoreLib/src/Internal/Runtime/InteropServices/ComponentActivator.cs
@@ -178,7 +178,6 @@ namespace Internal.Runtime.InteropServices
         [UnsupportedOSPlatform("maccatalyst")]
         [UnsupportedOSPlatform("tvos")]
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         public static unsafe int LoadAssemblyBytes(byte* assembly, nint assemblyByteLength, byte* symbols, nint symbolsByteLength, IntPtr loadContext, IntPtr reserved)
         {
             if (!IsSupported)

--- a/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/AppContext.cs
@@ -197,7 +197,6 @@ namespace System
         }
 #elif !NATIVEAOT
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         internal static unsafe void Setup(char** pNames, char** pValues, int count, Exception* pException)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffer.cs
@@ -101,7 +101,6 @@ namespace System
         // Please do not edit unless intentional.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy)
         {
             if (sourceBytesToCopy > destinationSizeInBytes)
@@ -116,7 +115,6 @@ namespace System
         // Please do not edit unless intentional.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy)
         {
             if (sourceBytesToCopy > destinationSizeInBytes)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -794,7 +794,6 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx512BW))]
         [CompExactlyDependsOn(typeof(Avx512Vbmi))]
-        [RequiresUnsafe]
         private static unsafe void Avx512Decode<TBase64Decoder, T>(TBase64Decoder decoder, ref T* srcBytes, ref byte* destBytes, T* srcEnd, int sourceLength, int destLength, T* srcStart, byte* destStart)
             where TBase64Decoder : IBase64Decoder<T>
             where T : unmanaged
@@ -862,7 +861,6 @@ namespace System.Buffers.Text
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx2))]
-        [RequiresUnsafe]
         private static unsafe void Avx2Decode<TBase64Decoder, T>(TBase64Decoder decoder, ref T* srcBytes, ref byte* destBytes, T* srcEnd, int sourceLength, int destLength, T* srcStart, byte* destStart)
             where TBase64Decoder : IBase64Decoder<T>
             where T : unmanaged
@@ -984,7 +982,6 @@ namespace System.Buffers.Text
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-        [RequiresUnsafe]
         private static unsafe void AdvSimdDecode<TBase64Decoder, T>(TBase64Decoder decoder, ref T* srcBytes, ref byte* destBytes, T* srcEnd, int sourceLength, int destLength, T* srcStart, byte* destStart)
             where TBase64Decoder : IBase64Decoder<T>
             where T : unmanaged
@@ -1126,7 +1123,6 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
         [CompExactlyDependsOn(typeof(Ssse3))]
-        [RequiresUnsafe]
         private static unsafe void Vector128Decode<TBase64Decoder, T>(TBase64Decoder decoder, ref T* srcBytes, ref byte* destBytes, T* srcEnd, int sourceLength, int destLength, T* srcStart, byte* destStart)
             where TBase64Decoder : IBase64Decoder<T>
             where T : unmanaged
@@ -1306,7 +1302,6 @@ namespace System.Buffers.Text
 #endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe void WriteThreeLowOrderBytes(byte* destination, int value)
         {
             destination[0] = (byte)(value >> 16);
@@ -1484,7 +1479,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector512(byte* src, byte* srcStart, int sourceLength, out Vector512<sbyte> str)
             {
                 AssertRead<Vector512<sbyte>>(src, srcStart, sourceLength);
@@ -1494,7 +1488,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadAvxVector256(byte* src, byte* srcStart, int sourceLength, out Vector256<sbyte> str)
             {
                 AssertRead<Vector256<sbyte>>(src, srcStart, sourceLength);
@@ -1503,7 +1496,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector128(byte* src, byte* srcStart, int sourceLength, out Vector128<byte> str)
             {
                 AssertRead<Vector128<sbyte>>(src, srcStart, sourceLength);
@@ -1513,7 +1505,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadArmVector128x4(byte* src, byte* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4)
             {
@@ -1525,7 +1516,6 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeFourElements(byte* source, ref sbyte decodingMap)
             {
                 // The 'source' span expected to have at least 4 elements, and the 'decodingMap' consists 256 sbytes
@@ -1551,7 +1541,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeRemaining(byte* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3)
             {
                 uint t0;
@@ -1659,7 +1648,6 @@ namespace System.Buffers.Text
                 default(Base64DecoderByte).TryDecode256Core(str, hiNibbles, maskSlashOrUnderscore, lutLow, lutHigh, lutShift, shiftForUnderscore, out result);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector512(ushort* src, ushort* srcStart, int sourceLength, out Vector512<sbyte> str)
             {
                 AssertRead<Vector512<ushort>>(src, srcStart, sourceLength);
@@ -1677,7 +1665,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadAvxVector256(ushort* src, ushort* srcStart, int sourceLength, out Vector256<sbyte> str)
             {
                 AssertRead<Vector256<sbyte>>(src, srcStart, sourceLength);
@@ -1695,7 +1682,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector128(ushort* src, ushort* srcStart, int sourceLength, out Vector128<byte> str)
             {
                 AssertRead<Vector128<sbyte>>(src, srcStart, sourceLength);
@@ -1713,7 +1699,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadArmVector128x4(ushort* src, ushort* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4)
             {
@@ -1737,7 +1722,6 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeFourElements(ushort* source, ref sbyte decodingMap)
             {
                 // The 'source' span expected to have at least 4 elements, and the 'decodingMap' consists 256 sbytes
@@ -1768,7 +1752,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeRemaining(ushort* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3)
             {
                 uint t0;

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64EncoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64EncoderHelper.cs
@@ -135,7 +135,6 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx512BW))]
         [CompExactlyDependsOn(typeof(Avx512Vbmi))]
-        [RequiresUnsafe]
         private static unsafe void Avx512Encode<TBase64Encoder, T>(TBase64Encoder encoder, ref byte* srcBytes, ref T* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, T* destStart)
             where TBase64Encoder : IBase64Encoder<T>
             where T : unmanaged
@@ -210,7 +209,6 @@ namespace System.Buffers.Text
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx2))]
-        [RequiresUnsafe]
         private static unsafe void Avx2Encode<TBase64Encoder, T>(TBase64Encoder encoder, ref byte* srcBytes, ref T* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, T* destStart)
             where TBase64Encoder : IBase64Encoder<T>
             where T : unmanaged
@@ -383,7 +381,6 @@ namespace System.Buffers.Text
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-        [RequiresUnsafe]
         private static unsafe void AdvSimdEncode<TBase64Encoder, T>(TBase64Encoder encoder, ref byte* srcBytes, ref T* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, T* destStart)
             where TBase64Encoder : IBase64Encoder<T>
             where T : unmanaged
@@ -444,7 +441,6 @@ namespace System.Buffers.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-        [RequiresUnsafe]
         private static unsafe void Vector128Encode<TBase64Encoder, T>(TBase64Encoder encoder, ref byte* srcBytes, ref T* destBytes, byte* srcEnd, int sourceLength, int destLength, byte* srcStart, T* destStart)
             where TBase64Encoder : IBase64Encoder<T>
             where T : unmanaged
@@ -634,7 +630,6 @@ namespace System.Buffers.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe uint Encode(byte* threeBytes, ref byte encodingMap)
         {
             uint t0 = threeBytes[0];
@@ -665,7 +660,6 @@ namespace System.Buffers.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, ushort* dest, ref byte encodingMap)
         {
             uint t0 = oneByte[0];
@@ -690,7 +684,6 @@ namespace System.Buffers.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, ushort* dest, ref byte encodingMap)
         {
             uint t0 = twoBytes[0];
@@ -737,7 +730,6 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int srcLength) => Base64.GetMaxEncodedToUtf8Length(srcLength);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, byte* dest, ref byte encodingMap)
             {
                 uint t0 = oneByte[0];
@@ -752,7 +744,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, byte* dest, ref byte encodingMap)
             {
                 uint t0 = twoBytes[0];
@@ -770,7 +761,6 @@ namespace System.Buffers.Text
 
 #if NET
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector512ToDestination(byte* dest, byte* destStart, int destLength, Vector512<byte> str)
             {
                 AssertWrite<Vector512<sbyte>>(dest, destStart, destLength);
@@ -779,7 +769,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe void StoreVector256ToDestination(byte* dest, byte* destStart, int destLength, Vector256<byte> str)
             {
                 AssertWrite<Vector256<sbyte>>(dest, destStart, destLength);
@@ -787,7 +776,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector128ToDestination(byte* dest, byte* destStart, int destLength, Vector128<byte> str)
             {
                 AssertWrite<Vector128<sbyte>>(dest, destStart, destLength);
@@ -796,7 +784,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe void StoreArmVector128x4ToDestination(byte* dest, byte* destStart, int destLength,
                 Vector128<byte> res1, Vector128<byte> res2, Vector128<byte> res3, Vector128<byte> res4)
             {
@@ -806,7 +793,6 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeThreeAndWrite(byte* threeBytes, byte* destination, ref byte encodingMap)
             {
                 uint result = Encode(threeBytes, ref encodingMap);
@@ -838,7 +824,6 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int _) => 0;  // not used for char encoding
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, ushort* dest, ref byte encodingMap)
             {
                 Base64Helper.EncodeOneOptionallyPadTwo(oneByte, dest, ref encodingMap);
@@ -847,7 +832,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, ushort* dest, ref byte encodingMap)
             {
                 Base64Helper.EncodeTwoOptionallyPadOne(twoBytes, dest, ref encodingMap);
@@ -856,7 +840,6 @@ namespace System.Buffers.Text
 
 #if NET
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector512ToDestination(ushort* dest, ushort* destStart, int destLength, Vector512<byte> str)
             {
                 AssertWrite<Vector512<short>>(dest, destStart, destLength);
@@ -866,7 +849,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector256ToDestination(ushort* dest, ushort* destStart, int destLength, Vector256<byte> str)
             {
                 AssertWrite<Vector256<short>>(dest, destStart, destLength);
@@ -876,7 +858,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector128ToDestination(ushort* dest, ushort* destStart, int destLength, Vector128<byte> str)
             {
                 AssertWrite<Vector128<short>>(dest, destStart, destLength);
@@ -887,7 +868,6 @@ namespace System.Buffers.Text
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe void StoreArmVector128x4ToDestination(ushort* dest, ushort* destStart, int destLength,
                 Vector128<byte> res1, Vector128<byte> res2, Vector128<byte> res3, Vector128<byte> res4)
             {
@@ -902,7 +882,6 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeThreeAndWrite(byte* threeBytes, ushort* destination, ref byte encodingMap)
             {
                 uint t0 = threeBytes[0];

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64Helper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64Helper.cs
@@ -13,7 +13,6 @@ namespace System.Buffers.Text
     internal static partial class Base64Helper
     {
         [Conditional("DEBUG")]
-        [RequiresUnsafe]
         internal static unsafe void AssertRead<TVector>(byte* src, byte* srcStart, int srcLength)
         {
             int vectorElements = Unsafe.SizeOf<TVector>();
@@ -28,7 +27,6 @@ namespace System.Buffers.Text
         }
 
         [Conditional("DEBUG")]
-        [RequiresUnsafe]
         internal static unsafe void AssertWrite<TVector>(byte* dest, byte* destStart, int destLength)
         {
             int vectorElements = Unsafe.SizeOf<TVector>();
@@ -43,7 +41,6 @@ namespace System.Buffers.Text
         }
 
         [Conditional("DEBUG")]
-        [RequiresUnsafe]
         internal static unsafe void AssertRead<TVector>(ushort* src, ushort* srcStart, int srcLength)
         {
             int vectorElements = Unsafe.SizeOf<TVector>();
@@ -58,7 +55,6 @@ namespace System.Buffers.Text
         }
 
         [Conditional("DEBUG")]
-        [RequiresUnsafe]
         internal static unsafe void AssertWrite<TVector>(ushort* dest, ushort* destStart, int destLength)
         {
             int vectorElements = Unsafe.SizeOf<TVector>();
@@ -182,22 +178,15 @@ namespace System.Buffers.Text
             int GetMaxSrcLength(int srcLength, int destLength);
             int GetMaxEncodedLength(int srcLength);
             uint GetInPlaceDestinationLength(int encodedLength, int leftOver);
-            [RequiresUnsafe]
             unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, T* dest, ref byte encodingMap);
-            [RequiresUnsafe]
             unsafe void EncodeTwoOptionallyPadOne(byte* oneByte, T* dest, ref byte encodingMap);
-            [RequiresUnsafe]
             unsafe void EncodeThreeAndWrite(byte* threeBytes, T* destination, ref byte encodingMap);
             int IncrementPadTwo { get; }
             int IncrementPadOne { get; }
 #if NET
-            [RequiresUnsafe]
             unsafe void StoreVector512ToDestination(T* dest, T* destStart, int destLength, Vector512<byte> str);
-            [RequiresUnsafe]
             unsafe void StoreVector256ToDestination(T* dest, T* destStart, int destLength, Vector256<byte> str);
-            [RequiresUnsafe]
             unsafe void StoreVector128ToDestination(T* dest, T* destStart, int destLength, Vector128<byte> str);
-            [RequiresUnsafe]
             unsafe void StoreArmVector128x4ToDestination(T* dest, T* destStart, int destLength, Vector128<byte> res1,
                 Vector128<byte> res2, Vector128<byte> res3, Vector128<byte> res4);
 #endif // NET
@@ -241,19 +230,13 @@ namespace System.Buffers.Text
                 Vector256<sbyte> lutShift,
                 Vector256<sbyte> shiftForUnderscore,
                 out Vector256<sbyte> result);
-            [RequiresUnsafe]
             unsafe bool TryLoadVector512(T* src, T* srcStart, int sourceLength, out Vector512<sbyte> str);
-            [RequiresUnsafe]
             unsafe bool TryLoadAvxVector256(T* src, T* srcStart, int sourceLength, out Vector256<sbyte> str);
-            [RequiresUnsafe]
             unsafe bool TryLoadVector128(T* src, T* srcStart, int sourceLength, out Vector128<byte> str);
-            [RequiresUnsafe]
             unsafe bool TryLoadArmVector128x4(T* src, T* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4);
 #endif // NET
-            [RequiresUnsafe]
             unsafe int DecodeFourElements(T* source, ref sbyte decodingMap);
-            [RequiresUnsafe]
             unsafe int DecodeRemaining(T* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3);
             int IndexOfAnyExceptWhiteSpace(ReadOnlySpan<T> span);
             OperationStatus DecodeWithWhiteSpaceBlockwiseWrapper<TTBase64Decoder>(TTBase64Decoder decoder, ReadOnlySpan<T> source,

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
@@ -445,36 +445,30 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector512(byte* src, byte* srcStart, int sourceLength, out Vector512<sbyte> str) =>
                 default(Base64DecoderByte).TryLoadVector512(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadAvxVector256(byte* src, byte* srcStart, int sourceLength, out Vector256<sbyte> str) =>
                 default(Base64DecoderByte).TryLoadAvxVector256(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector128(byte* src, byte* srcStart, int sourceLength, out Vector128<byte> str) =>
                 default(Base64DecoderByte).TryLoadVector128(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadArmVector128x4(byte* src, byte* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4) =>
                 default(Base64DecoderByte).TryLoadArmVector128x4(src, srcStart, sourceLength, out str1, out str2, out str3, out str4);
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeFourElements(byte* source, ref sbyte decodingMap) =>
                 default(Base64DecoderByte).DecodeFourElements(source, ref decodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeRemaining(byte* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3) =>
                 default(Base64DecoderByte).DecodeRemaining(srcEnd, ref decodingMap, remaining, out t2, out t3);
 
@@ -536,36 +530,30 @@ namespace System.Buffers.Text
                 default(Base64UrlDecoderByte).TryDecode256Core(str, hiNibbles, maskSlashOrUnderscore, lutLow, lutHigh, lutShift, shiftForUnderscore, out result);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector512(ushort* src, ushort* srcStart, int sourceLength, out Vector512<sbyte> str) =>
                 default(Base64DecoderChar).TryLoadVector512(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadAvxVector256(ushort* src, ushort* srcStart, int sourceLength, out Vector256<sbyte> str) =>
                 default(Base64DecoderChar).TryLoadAvxVector256(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe bool TryLoadVector128(ushort* src, ushort* srcStart, int sourceLength, out Vector128<byte> str) =>
                 default(Base64DecoderChar).TryLoadVector128(src, srcStart, sourceLength, out str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe bool TryLoadArmVector128x4(ushort* src, ushort* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4) =>
                 default(Base64DecoderChar).TryLoadArmVector128x4(src, srcStart, sourceLength, out str1, out str2, out str3, out str4);
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeFourElements(ushort* source, ref sbyte decodingMap) =>
                 default(Base64DecoderChar).DecodeFourElements(source, ref decodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe int DecodeRemaining(ushort* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3) =>
                 default(Base64DecoderChar).DecodeRemaining(srcEnd, ref decodingMap, remaining, out t2, out t3);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
@@ -244,7 +244,6 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int srcLength) => GetEncodedLength(srcLength);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, byte* dest, ref byte encodingMap)
             {
                 uint t0 = oneByte[0];
@@ -269,7 +268,6 @@ namespace System.Buffers.Text
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, byte* dest, ref byte encodingMap)
             {
                 uint t0 = twoBytes[0];
@@ -288,31 +286,26 @@ namespace System.Buffers.Text
 
 #if NET
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector512ToDestination(byte* dest, byte* destStart, int destLength, Vector512<byte> str) =>
                 default(Base64EncoderByte).StoreVector512ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(Avx2))]
-            [RequiresUnsafe]
             public unsafe void StoreVector256ToDestination(byte* dest, byte* destStart, int destLength, Vector256<byte> str) =>
                 default(Base64EncoderByte).StoreVector256ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector128ToDestination(byte* dest, byte* destStart, int destLength, Vector128<byte> str) =>
                 default(Base64EncoderByte).StoreVector128ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe void StoreArmVector128x4ToDestination(byte* dest, byte* destStart, int destLength,
                 Vector128<byte> res1, Vector128<byte> res2, Vector128<byte> res3, Vector128<byte> res4) =>
                 default(Base64EncoderByte).StoreArmVector128x4ToDestination(dest, destStart, destLength, res1, res2, res3, res4);
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeThreeAndWrite(byte* threeBytes, byte* destination, ref byte encodingMap) =>
                 default(Base64EncoderByte).EncodeThreeAndWrite(threeBytes, destination, ref encodingMap);
         }
@@ -341,41 +334,34 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int _) => 0;  // not used for char encoding
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, ushort* dest, ref byte encodingMap) =>
                 Base64Helper.EncodeOneOptionallyPadTwo(oneByte, dest, ref encodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, ushort* dest, ref byte encodingMap) =>
                 Base64Helper.EncodeTwoOptionallyPadOne(twoBytes, dest, ref encodingMap);
 
 #if NET
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector512ToDestination(ushort* dest, ushort* destStart, int destLength, Vector512<byte> str) =>
                 default(Base64EncoderChar).StoreVector512ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector256ToDestination(ushort* dest, ushort* destStart, int destLength, Vector256<byte> str) =>
                 default(Base64EncoderChar).StoreVector256ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void StoreVector128ToDestination(ushort* dest, ushort* destStart, int destLength, Vector128<byte> str) =>
                 default(Base64EncoderChar).StoreVector128ToDestination(dest, destStart, destLength, str);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             [CompExactlyDependsOn(typeof(AdvSimd.Arm64))]
-            [RequiresUnsafe]
             public unsafe void StoreArmVector128x4ToDestination(ushort* dest, ushort* destStart, int destLength,
                 Vector128<byte> res1, Vector128<byte> res2, Vector128<byte> res3, Vector128<byte> res4) =>
                 default(Base64EncoderChar).StoreArmVector128x4ToDestination(dest, destStart, destLength, res1, res2, res3, res4);
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             public unsafe void EncodeThreeAndWrite(byte* threeBytes, ushort* destination, ref byte encodingMap) =>
                 default(Base64EncoderChar).EncodeThreeAndWrite(threeBytes, destination, ref encodingMap);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -362,7 +362,6 @@ Div1Word:
             /// <param name="den">64-bit divisor</param>
             /// <returns>Returns quotient. Remainder overwrites lower 64-bits of dividend.</returns>
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             private static unsafe ulong Div128By64(Buf16* bufNum, ulong den)
             {
                 Debug.Assert(den > bufNum->High64);
@@ -606,7 +605,6 @@ PosRem:
             /// <param name="hiRes">Index of last non-zero value in bufRes</param>
             /// <param name="scale">Scale factor for this value, range 0 - 2 * DEC_SCALE_MAX</param>
             /// <returns>Returns new scale factor. bufRes updated in place, always 3 uints.</returns>
-            [RequiresUnsafe]
             private static unsafe int ScaleResult(Buf24* bufRes, uint hiRes, int scale)
             {
                 Debug.Assert(hiRes < Buf24.Length);
@@ -768,7 +766,6 @@ ThrowOverflow:
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            [RequiresUnsafe]
             private static unsafe uint DivByConst(uint* result, uint hiRes, out uint quotient, out uint remainder, uint power)
             {
                 uint high = result[hiRes];

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -378,7 +378,6 @@ namespace System.Diagnostics.Tracing
             /// sufficient space for this ID.   By doing this, we preserve the fact that this activity
             /// is a child (of unknown depth) from that ancestor.
             /// </summary>
-            [RequiresUnsafe]
             private unsafe void CreateOverflowGuid(Guid* outPtr)
             {
                 // Search backwards for an ancestor that has sufficient space to put the ID.
@@ -427,7 +426,6 @@ namespace System.Diagnostics.Tracing
             /// is the maximum number of bytes that fit in a GUID) if the path did not fit.
             /// If 'overflow' is true, then the number is encoded as an 'overflow number (which has a
             /// special (longer prefix) that indicates that this ID is allocated differently
-            [RequiresUnsafe]
             private static unsafe int AddIdToGuid(Guid* outPtr, int whereToAddId, uint id, bool overflow = false)
             {
                 byte* ptr = (byte*)outPtr;
@@ -503,7 +501,6 @@ namespace System.Diagnostics.Tracing
             /// Thus if it is non-zero it adds to the current byte, otherwise it advances and writes
             /// the new byte (in the high bits) of the next byte.
             /// </summary>
-            [RequiresUnsafe]
             private static unsafe void WriteNibble(ref byte* ptr, byte* endPtr, uint value)
             {
                 Debug.Assert(value < 16);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipe.Internal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipe.Internal.cs
@@ -15,7 +15,6 @@ namespace System.Diagnostics.Tracing
         // These PInvokes are used by the configuration APIs to interact with EventPipe.
         //
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_Enable")]
-        [RequiresUnsafe]
         private static unsafe partial ulong Enable(
             char* outputFile,
             EventPipeSerializationFormat format,
@@ -30,13 +29,11 @@ namespace System.Diagnostics.Tracing
         // These PInvokes are used by EventSource to interact with the EventPipe.
         //
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_CreateProvider", StringMarshalling = StringMarshalling.Utf16)]
-        [RequiresUnsafe]
         internal static unsafe partial IntPtr CreateProvider(string providerName,
             delegate* unmanaged<byte*, int, byte, long, long, Interop.Advapi32.EVENT_FILTER_DESCRIPTOR*, void*, void> callbackFunc,
             void* callbackContext);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_DefineEvent")]
-        [RequiresUnsafe]
         internal static unsafe partial IntPtr DefineEvent(IntPtr provHandle, uint eventID, long keywords, uint eventVersion, uint level, void *pMetadata, uint metadataLength);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetProvider", StringMarshalling = StringMarshalling.Utf16)]
@@ -49,19 +46,16 @@ namespace System.Diagnostics.Tracing
         internal static partial int EventActivityIdControl(uint controlCode, ref Guid activityId);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_WriteEventData")]
-        [RequiresUnsafe]
         internal static unsafe partial void WriteEventData(IntPtr eventHandle, EventProvider.EventData* pEventData, uint dataCount, Guid* activityId, Guid* relatedActivityId);
 
         //
         // These PInvokes are used as part of the EventPipeEventDispatcher.
         //
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetSessionInfo")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetSessionInfo(ulong sessionID, EventPipeSessionInfo* pSessionInfo);
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "EventPipeInternal_GetNextEvent")]
-        [RequiresUnsafe]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe partial bool GetNextEvent(ulong sessionID, EventPipeEventInstanceData* pInstance);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeEventProvider.cs
@@ -18,7 +18,6 @@ namespace System.Diagnostics.Tracing
             _eventProvider = new WeakReference<EventProvider>(eventProvider);
         }
 
-        [RequiresUnsafe]
         protected override unsafe void HandleEnableNotification(
                                     EventProvider target,
                                     byte* additionalData,
@@ -61,7 +60,6 @@ namespace System.Diagnostics.Tracing
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void Callback(byte* sourceId, int isEnabled, byte level,
             long matchAnyKeywords, long matchAllKeywords, Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData, void* callbackContext)
         {
@@ -102,7 +100,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // Write an event.
-        [RequiresUnsafe]
         internal override unsafe EventProvider.WriteEventErrorCode EventWriteTransfer(
             in EventDescriptor eventDescriptor,
             IntPtr eventHandle,
@@ -141,7 +138,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // Define an EventPipeEvent handle.
-        [RequiresUnsafe]
         internal override unsafe IntPtr DefineEventHandle(uint eventID, string eventName, long keywords, uint eventVersion, uint level,
             byte* pMetadata, uint metadataLength)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeMetadataGenerator.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventPipeMetadataGenerator.cs
@@ -221,7 +221,6 @@ namespace System.Diagnostics.Tracing
 
         // Copy src to buffer and modify the offset.
         // Note: We know the buffer size ahead of time to make sure no buffer overflow.
-        [RequiresUnsafe]
         internal static unsafe void WriteToBuffer(byte* buffer, uint bufferLength, ref uint offset, byte* src, uint srcLength)
         {
             Debug.Assert(bufferLength >= (offset + srcLength));
@@ -232,7 +231,6 @@ namespace System.Diagnostics.Tracing
             offset += srcLength;
         }
 
-        [RequiresUnsafe]
         internal static unsafe void WriteToBuffer<T>(byte* buffer, uint bufferLength, ref uint offset, T value) where T : unmanaged
         {
             Debug.Assert(bufferLength >= (offset + sizeof(T)));
@@ -254,7 +252,6 @@ namespace System.Diagnostics.Tracing
             TypeInfo = typeInfo;
         }
 
-        [RequiresUnsafe]
         internal unsafe bool GenerateMetadata(byte* pMetadataBlob, ref uint offset, uint blobSize)
         {
             TypeCode typeCode = GetTypeCodeExtended(ParameterType);
@@ -310,7 +307,6 @@ namespace System.Diagnostics.Tracing
             return true;
         }
 
-        [RequiresUnsafe]
         private static unsafe bool GenerateMetadataForProperty(PropertyAnalysis property, byte* pMetadataBlob, ref uint offset, uint blobSize)
         {
             Debug.Assert(property != null);
@@ -378,7 +374,6 @@ namespace System.Diagnostics.Tracing
             return true;
         }
 
-        [RequiresUnsafe]
         internal unsafe bool GenerateMetadataV2(byte* pMetadataBlob, ref uint offset, uint blobSize)
         {
             if (TypeInfo == null)
@@ -386,7 +381,6 @@ namespace System.Diagnostics.Tracing
             return GenerateMetadataForNamedTypeV2(ParameterName, TypeInfo, pMetadataBlob, ref offset, blobSize);
         }
 
-        [RequiresUnsafe]
         private static unsafe bool GenerateMetadataForNamedTypeV2(string name, TraceLoggingTypeInfo typeInfo, byte* pMetadataBlob, ref uint offset, uint blobSize)
         {
             Debug.Assert(pMetadataBlob != null);
@@ -407,7 +401,6 @@ namespace System.Diagnostics.Tracing
             return GenerateMetadataForTypeV2(typeInfo, pMetadataBlob, ref offset, blobSize);
         }
 
-        [RequiresUnsafe]
         private static unsafe bool GenerateMetadataForTypeV2(TraceLoggingTypeInfo? typeInfo, byte* pMetadataBlob, ref uint offset, uint blobSize)
         {
             Debug.Assert(typeInfo != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -237,7 +237,6 @@ namespace System.Diagnostics.Tracing
             s_returnCode = error;
         }
 
-        [RequiresUnsafe]
         private static unsafe object? EncodeObject(ref object? data, ref EventData* dataDescriptor, ref byte* dataBuffer, ref uint totalEventSize)
         /*++
 
@@ -463,7 +462,6 @@ namespace System.Diagnostics.Tracing
         /// <param name="eventPayload">
         /// Payload for the ETW event.
         /// </param>
-        [RequiresUnsafe]
         internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, IntPtr eventHandle, Guid* activityID, Guid* childActivityID, object?[] eventPayload)
         {
             WriteEventErrorCode status = WriteEventErrorCode.NoError;
@@ -674,7 +672,6 @@ namespace System.Diagnostics.Tracing
         /// <param name="data">
         /// pointer  do the event data
         /// </param>
-        [RequiresUnsafe]
         protected internal unsafe bool WriteEvent(ref EventDescriptor eventDescriptor, IntPtr eventHandle, Guid* activityID, Guid* childActivityID, int dataCount, IntPtr data)
         {
             if (childActivityID != null)
@@ -696,7 +693,6 @@ namespace System.Diagnostics.Tracing
             return true;
         }
 
-        [RequiresUnsafe]
         internal unsafe bool WriteEventRaw(
             ref EventDescriptor eventDescriptor,
             IntPtr eventHandle,
@@ -769,7 +765,6 @@ namespace System.Diagnostics.Tracing
             _liveSessions = null;
         }
 
-        [RequiresUnsafe]
         protected override unsafe void HandleEnableNotification(
                                     EventProvider target,
                                     byte *additionalData,
@@ -870,7 +865,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // Write an event.
-        [RequiresUnsafe]
         internal override unsafe EventProvider.WriteEventErrorCode EventWriteTransfer(
             in EventDescriptor eventDescriptor,
             IntPtr eventHandle,
@@ -904,7 +898,6 @@ namespace System.Diagnostics.Tracing
         }
 
         // Define an EventPipeEvent handle.
-        [RequiresUnsafe]
         internal override unsafe IntPtr DefineEventHandle(uint eventID, string eventName, long keywords, uint eventVersion,
             uint level, byte* pMetadata, uint metadataLength)
         {
@@ -1153,7 +1146,6 @@ namespace System.Diagnostics.Tracing
             set => _allKeywordMask = unchecked((long)value);
         }
 
-        [RequiresUnsafe]
         protected virtual unsafe void HandleEnableNotification(
                                     EventProvider target,
                                     byte *additionalData,
@@ -1234,7 +1226,6 @@ namespace System.Diagnostics.Tracing
         {
         }
 
-        [RequiresUnsafe]
         internal virtual unsafe EventProvider.WriteEventErrorCode EventWriteTransfer(
             in EventDescriptor eventDescriptor,
             IntPtr eventHandle,
@@ -1252,14 +1243,12 @@ namespace System.Diagnostics.Tracing
         }
 
         // Define an EventPipeEvent handle.
-        [RequiresUnsafe]
         internal virtual unsafe IntPtr DefineEventHandle(uint eventID, string eventName, long keywords, uint eventVersion,
             uint level, byte* pMetadata, uint metadataLength)
         {
             return IntPtr.Zero;
         }
 
-        [RequiresUnsafe]
         protected unsafe void ProviderCallback(
                         EventProvider target,
                         byte *additionalData,
@@ -1341,7 +1330,6 @@ namespace System.Diagnostics.Tracing
             return args;
         }
 
-        [RequiresUnsafe]
         protected unsafe bool MarshalFilterData(Interop.Advapi32.EVENT_FILTER_DESCRIPTOR* filterData, out ControllerCommand command, out byte[]? data)
         {
             Debug.Assert(filterData != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1272,7 +1272,6 @@ namespace System.Diagnostics.Tracing
             /// <param name="pointer">Pinned tracelogging-compatible metadata blob.</param>
             /// <param name="size">The size of the metadata blob.</param>
             /// <param name="reserved">Value for reserved: 2 for per-provider metadata, 1 for per-event metadata</param>
-            [RequiresUnsafe]
             internal unsafe void SetMetadata(byte* pointer, int size, int reserved)
             {
                 this.m_Ptr = (ulong)pointer;
@@ -1321,7 +1320,6 @@ namespace System.Diagnostics.Tracing
                                     "requires unreferenced code, but EnsureDescriptorsInitialized does not access this member and is safe to call.")]
         [RequiresUnreferencedCode(EventSourceRequiresUnreferenceMessage)]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         protected unsafe void WriteEventCore(int eventId, int eventDataCount, EventData* data)
         {
             WriteEventWithRelatedActivityIdCore(eventId, null, eventDataCount, data);
@@ -1357,7 +1355,6 @@ namespace System.Diagnostics.Tracing
                                     "requires unreferenced code, but EnsureDescriptorsInitialized does not access this member and is safe to call.")]
         [RequiresUnreferencedCode(EventSourceRequiresUnreferenceMessage)]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         protected unsafe void WriteEventWithRelatedActivityIdCore(int eventId, Guid* relatedActivityId, int eventDataCount, EventData* data)
         {
             if (IsEnabled())
@@ -1573,7 +1570,6 @@ namespace System.Diagnostics.Tracing
 
         #region private
 
-        [RequiresUnsafe]
         private unsafe void WriteEventRaw(
             string? eventName,
             ref EventDescriptor eventDescriptor,
@@ -1791,7 +1787,6 @@ namespace System.Diagnostics.Tracing
             return new Guid(bytes.Slice(0, 16));
         }
 
-        [RequiresUnsafe]
         private static unsafe void DecodeObjects(object?[] decodedObjects, Type[] parameterTypes, EventData* data)
         {
             for (int i = 0; i < decodedObjects.Length; i++, data++)
@@ -1960,7 +1955,6 @@ namespace System.Diagnostics.Tracing
         }
 
         [Conditional("DEBUG")]
-        [RequiresUnsafe]
         private static unsafe void AssertValidString(EventData* data)
         {
             Debug.Assert(data->Size >= 0 && data->Size % 2 == 0, "String size should be even");
@@ -1991,7 +1985,6 @@ namespace System.Diagnostics.Tracing
                     Justification = "EnsureDescriptorsInitialized's use of GetType preserves this method which " +
                                     "requires unreferenced code, but EnsureDescriptorsInitialized does not access this member and is safe to call.")]
         [RequiresUnreferencedCode(EventSourceRequiresUnreferenceMessage)]
-        [RequiresUnsafe]
         private unsafe void WriteEventVarargs(int eventId, Guid* childActivityID, object?[] args)
         {
             if (IsEnabled())
@@ -2155,7 +2148,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [RequiresUnsafe]
         private unsafe void WriteToAllListeners(EventWrittenEventArgs eventCallbackArgs, int eventDataCount, EventData* data)
         {
             Debug.Assert(m_eventData != null);
@@ -3926,7 +3918,6 @@ namespace System.Diagnostics.Tracing
 
 #if CORECLR
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InitializeDefaultEventSources(Exception* pException)
         {
             try
@@ -4330,7 +4321,6 @@ namespace System.Diagnostics.Tracing
             TimeStamp = DateTime.UtcNow;
         }
 
-        [RequiresUnsafe]
         internal unsafe EventWrittenEventArgs(EventSource eventSource, int eventId, Guid* pActivityID, Guid* pChildActivityID)
             : this(eventSource, eventId)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -224,7 +224,6 @@ namespace System.Diagnostics.Tracing
 
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         public unsafe void ThreadPoolIOEnqueue(NativeOverlapped* nativeOverlapped)
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
@@ -266,7 +265,6 @@ namespace System.Diagnostics.Tracing
 
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         public unsafe void ThreadPoolIODequeue(NativeOverlapped* nativeOverlapped)
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword | Keywords.ThreadTransferKeyword))
@@ -306,7 +304,6 @@ namespace System.Diagnostics.Tracing
 
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         public unsafe void ThreadPoolIOPack(NativeOverlapped* nativeOverlapped)
         {
             if (IsEnabled(EventLevel.Verbose, Keywords.ThreadingKeyword))

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
@@ -34,7 +34,6 @@ namespace System.Diagnostics.Tracing
         private int bufferNesting;          // We may merge many fields int a single blob.   If we are doing this we increment this.
         private bool writingScalars;
 
-        [RequiresUnsafe]
         internal void Enable(
             byte* scratch,
             int scratchSize,
@@ -66,14 +65,12 @@ namespace System.Diagnostics.Tracing
         /// A pointer to the next unused data descriptor, or datasEnd if they were
         /// all used. (Descriptors may be unused if a string or array was null.)
         /// </returns>
-        [RequiresUnsafe]
         internal EventSource.EventData* Finish()
         {
             this.ScalarsEnd();
             return this.datas;
         }
 
-        [RequiresUnsafe]
         internal void AddScalar(void* value, int size)
         {
             var pb = (byte*)value;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -325,7 +325,6 @@ namespace System.Diagnostics.Tracing
         /// the values must match the number and types of the fields described by the
         /// eventTypes parameter.
         /// </param>
-        [RequiresUnsafe]
         private unsafe void WriteMultiMerge(
             string? eventName,
             ref EventSourceOptions options,
@@ -386,7 +385,6 @@ namespace System.Diagnostics.Tracing
         /// the values must match the number and types of the fields described by the
         /// eventTypes parameter.
         /// </param>
-        [RequiresUnsafe]
         private unsafe void WriteMultiMergeInner(
             string? eventName,
             ref EventSourceOptions options,
@@ -506,7 +504,6 @@ namespace System.Diagnostics.Tracing
         /// The number and types of the values must match the number and types of the
         /// fields described by the eventTypes parameter.
         /// </param>
-        [RequiresUnsafe]
         internal unsafe void WriteMultiMerge(
             string? eventName,
             ref EventSourceOptions options,
@@ -577,7 +574,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [RequiresUnsafe]
         private unsafe void WriteImpl(
             string? eventName,
             ref EventSourceOptions options,
@@ -699,7 +695,6 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        [RequiresUnsafe]
         private unsafe void WriteToAllListeners(string? eventName, ref EventDescriptor eventDescriptor, EventTags tags, Guid* pActivityId, Guid* pChildActivityId, EventPayload? payload)
         {
             // Self described events do not have an id attached. We mark it internally with -1.
@@ -722,7 +717,6 @@ namespace System.Diagnostics.Tracing
         }
 
         [NonEvent]
-        [RequiresUnsafe]
         private static unsafe void WriteCleanup(GCHandle* pPins, int cPins)
         {
             DataCollector.ThreadInstance.Disable();

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/TraceLogging/XplatEventLogger.cs
@@ -22,7 +22,6 @@ namespace System.Diagnostics.Tracing
         private static unsafe string GetClrConfig(string configName) => new string(EventSource_GetClrConfig(configName));
 
         [LibraryImport(RuntimeHelpers.QCall, StringMarshalling = StringMarshalling.Utf16)]
-        [RequiresUnsafe]
         private static unsafe partial char* EventSource_GetClrConfig(string configName);
 
         private static bool initializedPersistentListener;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Icu.cs
@@ -427,7 +427,6 @@ namespace System.Globalization
             return result;
         }
 
-        [RequiresUnsafe]
         private static unsafe bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, IcuEnumCalendarsData* callbackContext)
         {
 #if TARGET_MACCATALYST || TARGET_IOS || TARGET_TVOS
@@ -439,7 +438,6 @@ namespace System.Globalization
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void EnumCalendarInfoCallback(char* calendarStringPtr, IntPtr context)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CalendarData.Nls.cs
@@ -60,7 +60,6 @@ namespace System.Globalization
 
         // EnumCalendarInfoExEx callback itself.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL EnumCalendarInfoCallback(char* lpCalendarInfoString, uint calendar, IntPtr pReserved, void* lParam)
         {
             EnumData* context = (EnumData*)lParam;
@@ -93,7 +92,6 @@ namespace System.Globalization
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL EnumCalendarsCallback(char* lpCalendarInfoString, uint calendar, IntPtr reserved, void* lParam)
         {
             NlsEnumCalendarsData* context = (NlsEnumCalendarsData*)lParam;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Icu.cs
@@ -64,7 +64,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe int IcuIndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr, bool fromBeginning)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -102,7 +101,6 @@ namespace System.Globalization
         /// as the JIT wouldn't be able to optimize the ignoreCase path away.
         /// </summary>
         /// <returns></returns>
-        [RequiresUnsafe]
         private unsafe int IndexOfOrdinalIgnoreCaseHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr, bool fromBeginning)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -218,7 +216,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe int IndexOfOrdinalHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr, bool fromBeginning)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -314,7 +311,6 @@ namespace System.Globalization
         }
 
         // this method sets '*matchLengthPtr' (if not nullptr) only on success
-        [RequiresUnsafe]
         private unsafe bool IcuStartsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -344,7 +340,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe bool StartsWithOrdinalIgnoreCaseHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -427,7 +422,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe bool StartsWithOrdinalHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -501,7 +495,6 @@ namespace System.Globalization
         }
 
         // this method sets '*matchLengthPtr' (if not nullptr) only on success
-        [RequiresUnsafe]
         private unsafe bool IcuEndsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -531,7 +524,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe bool EndsWithOrdinalIgnoreCaseHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -615,7 +607,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe bool EndsWithOrdinalHelper(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.Nls.cs
@@ -243,7 +243,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe int FindString(
                     uint dwFindNLSStringFlags,
                     ReadOnlySpan<char> lpStringSource,
@@ -295,7 +294,6 @@ namespace System.Globalization
             }
         }
 
-        [RequiresUnsafe]
         private unsafe int NlsIndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr, bool fromBeginning)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -307,7 +305,6 @@ namespace System.Globalization
             return FindString(positionFlag | (uint)GetNativeCompareFlags(options), source, target, matchLengthPtr);
         }
 
-        [RequiresUnsafe]
         private unsafe bool NlsStartsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -329,7 +326,6 @@ namespace System.Globalization
             return false;
         }
 
-        [RequiresUnsafe]
         private unsafe bool NlsEndsWith(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options, int* matchLengthPtr)
         {
             Debug.Assert(!GlobalizationMode.Invariant);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CompareInfo.cs
@@ -627,7 +627,6 @@ namespace System.Globalization
             return matched;
         }
 
-        [RequiresUnsafe]
         private unsafe bool StartsWithCore(ReadOnlySpan<char> source, ReadOnlySpan<char> prefix, CompareOptions options, int* matchLengthPtr) =>
             GlobalizationMode.UseNls ?
                 NlsStartsWith(source, prefix, options, matchLengthPtr) :
@@ -776,7 +775,6 @@ namespace System.Globalization
             return IsSuffix(source, suffix, CompareOptions.None);
         }
 
-        [RequiresUnsafe]
         private unsafe bool EndsWithCore(ReadOnlySpan<char> source, ReadOnlySpan<char> suffix, CompareOptions options, int* matchLengthPtr) =>
             GlobalizationMode.UseNls ?
                 NlsEndsWith(source, suffix, options, matchLengthPtr) :
@@ -1045,7 +1043,6 @@ namespace System.Globalization
         /// Caller needs to ensure <paramref name="matchLengthPtr"/> is non-null and points
         /// to a valid address. This method will validate <paramref name="options"/>.
         /// </summary>
-        [RequiresUnsafe]
         private unsafe int IndexOf(ReadOnlySpan<char> source, ReadOnlySpan<char> value, int* matchLengthPtr, CompareOptions options, bool fromBeginning)
         {
             Debug.Assert(matchLengthPtr != null);
@@ -1111,7 +1108,6 @@ namespace System.Globalization
             return retVal;
         }
 
-        [RequiresUnsafe]
         private unsafe int IndexOfCore(ReadOnlySpan<char> source, ReadOnlySpan<char> target, CompareOptions options, int* matchLengthPtr, bool fromBeginning) =>
             GlobalizationMode.UseNls ?
                 NlsIndexOfCore(source, target, options, matchLengthPtr, fromBeginning) :

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.Nls.cs
@@ -37,7 +37,6 @@ namespace System.Globalization
             return value;
         }
 
-        [RequiresUnsafe]
         internal static unsafe int GetLocaleInfoEx(string lpLocaleName, uint lcType, char* lpLCData, int cchData)
         {
             Debug.Assert(!GlobalizationMode.Invariant);
@@ -346,7 +345,6 @@ namespace System.Globalization
 
         // EnumSystemLocaleEx callback.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL EnumSystemLocalesProc(char* lpLocaleString, uint flags, void* contextHandle)
         {
             EnumLocaleData* context = (EnumLocaleData*)contextHandle;
@@ -370,7 +368,6 @@ namespace System.Globalization
 
         // EnumSystemLocaleEx callback.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL EnumAllSystemLocalesProc(char* lpLocaleString, uint flags, void* contextHandle)
         {
             try
@@ -392,7 +389,6 @@ namespace System.Globalization
 
         // EnumTimeFormatsEx callback itself.
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL EnumTimeCallback(char* lpTimeFormatString, void* lParam)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Icu.cs
@@ -17,7 +17,6 @@ namespace System.Globalization
             return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("\u0131", "I", CompareOptions.IgnoreCase) == 0;
         }
 
-        [RequiresUnsafe]
         internal unsafe void IcuChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper)
         {
             Debug.Assert(!GlobalizationMode.Invariant);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Nls.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Nls.cs
@@ -8,7 +8,6 @@ namespace System.Globalization
 {
     public partial class TextInfo
     {
-        [RequiresUnsafe]
         private unsafe void NlsChangeCase(char* pSource, int pSourceLen, char* pResult, int pResultLen, bool toUpper)
         {
             Debug.Assert(!GlobalizationMode.Invariant);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -768,7 +768,6 @@ namespace System.Globalization
             return inputIndex;
         }
 
-        [RequiresUnsafe]
         private unsafe void ChangeCaseCore(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper)
         {
             if (GlobalizationMode.UseNls)

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -1183,7 +1183,6 @@ namespace System
         public static bool operator !=(Guid a, Guid b) => !EqualsCore(a, b);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe int HexsToChars<TChar>(TChar* guidChars, int a, int b) where TChar : unmanaged, IUtfChar<TChar>
         {
             guidChars[0] = TChar.CastFrom(HexConverter.ToCharLower(a >> 4));

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Path.cs
@@ -791,7 +791,6 @@ namespace System.IO
 
         private static ReadOnlySpan<byte> Base32Char => "abcdefghijklmnopqrstuvwxyz012345"u8;
 
-        [RequiresUnsafe]
         internal static unsafe void Populate83FileNameFromRandomBytes(byte* bytes, int byteCount, Span<char> chars)
         {
             // This method requires bytes of length 8 and chars of length 12.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -128,7 +128,6 @@ namespace System.IO
         private readonly nuint _sharedDataTotalByteCount;
         private int _referenceCount = 1;
 
-        [RequiresUnsafe]
         public SharedMemoryProcessDataHeader(SharedMemoryId id, SafeFileHandle fileHandle, SharedMemorySharedDataHeader* sharedDataHeader, nuint sharedDataTotalByteCount)
         {
             _id = id;
@@ -708,7 +707,6 @@ namespace System.IO
             }
         }
 
-        [RequiresUnsafe]
         public void* Pointer => (void*)addr;
     }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryStream.cs
@@ -131,7 +131,6 @@ namespace System.IO
         /// Creates a stream over a byte*.
         /// </summary>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe UnmanagedMemoryStream(byte* pointer, long length)
         {
             Initialize(pointer, length, length, FileAccess.Read);
@@ -141,7 +140,6 @@ namespace System.IO
         /// Creates a stream over a byte*.
         /// </summary>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe UnmanagedMemoryStream(byte* pointer, long length, long capacity, FileAccess access)
         {
             Initialize(pointer, length, capacity, access);
@@ -151,7 +149,6 @@ namespace System.IO
         /// Subclasses must call this method (or the other overload) to properly initialize all instance fields.
         /// </summary>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         protected unsafe void Initialize(byte* pointer, long length, long capacity, FileAccess access)
         {
             ArgumentNullException.ThrowIfNull(pointer);
@@ -297,7 +294,6 @@ namespace System.IO
         /// Pointer to memory at the current Position in the stream.
         /// </summary>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe byte* PositionPointer
         {
             get

--- a/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs
@@ -1733,7 +1733,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe TChar* Int32ToHexChars<TChar>(TChar* buffer, uint value, int hexBase, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -1790,7 +1789,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe TChar* UInt32ToBinaryChars<TChar>(TChar* buffer, uint value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -1828,7 +1826,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe void WriteTwoDigits<TChar>(uint value, TChar* ptr) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -1845,7 +1842,6 @@ namespace System
         /// This method performs best when the starting index is a constant literal.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe void WriteFourDigits<TChar>(uint value, TChar* ptr) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -1867,7 +1863,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe void WriteDigits<TChar>(uint value, TChar* ptr, int count) where TChar : unmanaged, IUtfChar<TChar>
         {
             TChar* cur;
@@ -1884,7 +1879,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe TChar* UInt32ToDecChars<TChar>(TChar* bufferEnd, uint value) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -1914,7 +1908,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe TChar* UInt32ToDecChars<TChar>(TChar* bufferEnd, uint value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -2174,7 +2167,6 @@ namespace System
 
 #if TARGET_64BIT
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
 #endif
         private static unsafe TChar* Int64ToHexChars<TChar>(TChar* buffer, ulong value, int hexBase, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
@@ -2247,7 +2239,6 @@ namespace System
 
 #if TARGET_64BIT
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
 #endif
         private static unsafe TChar* UInt64ToBinaryChars<TChar>(TChar* buffer, ulong value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
@@ -2309,7 +2300,6 @@ namespace System
 
 #if TARGET_64BIT
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
 #endif
         internal static unsafe TChar* UInt64ToDecChars<TChar>(TChar* bufferEnd, ulong value) where TChar : unmanaged, IUtfChar<TChar>
         {
@@ -2349,7 +2339,6 @@ namespace System
 
 #if TARGET_64BIT
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
 #endif
         internal static unsafe TChar* UInt64ToDecChars<TChar>(TChar* bufferEnd, ulong value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
@@ -2611,7 +2600,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe TChar* Int128ToHexChars<TChar>(TChar* buffer, UInt128 value, int hexBase, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             ulong lower = value.Lower;
@@ -2675,7 +2663,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe TChar* UInt128ToBinaryChars<TChar>(TChar* buffer, UInt128 value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             ulong lower = value.Lower;
@@ -2724,7 +2711,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe TChar* UInt128ToDecChars<TChar>(TChar* bufferEnd, UInt128 value) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
@@ -2737,7 +2723,6 @@ namespace System
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe TChar* UInt128ToDecChars<TChar>(TChar* bufferEnd, UInt128 value, int digits) where TChar : unmanaged, IUtfChar<TChar>
         {
             Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));

--- a/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Number.NumberToFloatingPointBits.cs
@@ -891,7 +891,6 @@ namespace System
         }
 
         // get 32-bit integer from at most 9 digits
-        [RequiresUnsafe]
         private static uint DigitsToUInt32(byte* p, int count)
         {
             Debug.Assert((1 <= count) && (count <= 9));
@@ -916,7 +915,6 @@ namespace System
         }
 
         // get 64-bit integer from at most 19 digits
-        [RequiresUnsafe]
         private static ulong DigitsToUInt64(byte* p, int count)
         {
             Debug.Assert((1 <= count) && (count <= 19));
@@ -945,7 +943,6 @@ namespace System
         /// https://lemire.me/blog/2022/01/21/swar-explained-parsing-eight-digits/
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static uint ParseEightDigitsUnrolled(byte* chars)
         {
             // let's take the following value (byte*) 12345678 and read it unaligned :

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
@@ -1942,7 +1942,6 @@ namespace System.Numerics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector<T> Load<T>(T* source) => LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
@@ -1953,7 +1952,6 @@ namespace System.Numerics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector<T> LoadAligned<T>(T* source)
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
@@ -1974,7 +1972,6 @@ namespace System.Numerics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -2991,7 +2988,6 @@ namespace System.Numerics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void Store<T>(this Vector<T> source, T* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
@@ -3002,7 +2998,6 @@ namespace System.Numerics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void StoreAligned<T>(this Vector<T> source, T* destination)
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
@@ -3023,7 +3018,6 @@ namespace System.Numerics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.Extensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.Extensions.cs
@@ -50,7 +50,6 @@ namespace System.Numerics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Store(this Vector2 source, float* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given 8-byte aligned destination.</summary>
@@ -59,7 +58,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 8-byte aligned.</exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void StoreAligned(this Vector2 source, float* destination)
         {
             if (((nuint)destination % (uint)(Vector2.Alignment)) != 0)
@@ -76,7 +74,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 8-byte aligned.</exception>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void StoreAlignedNonTemporal(this Vector2 source, float* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -675,14 +675,12 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.Load(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector2 Load(float* source) => LoadUnsafe(in *source);
 
         /// <inheritdoc cref="Vector4.LoadAligned(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector2 LoadAligned(float* source)
         {
             if (((nuint)(source) % Alignment) != 0)
@@ -696,7 +694,6 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LoadAlignedNonTemporal(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector2 LoadAlignedNonTemporal(float* source) => LoadAligned(source);
 
         /// <inheritdoc cref="Vector128.LoadUnsafe{T}(ref readonly T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.Extensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.Extensions.cs
@@ -45,7 +45,6 @@ namespace System.Numerics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Store(this Vector3 source, float* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given 8-byte aligned destination.</summary>
@@ -54,7 +53,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 8-byte aligned.</exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void StoreAligned(this Vector3 source, float* destination)
         {
             if (((nuint)destination % (uint)(Vector3.Alignment)) != 0)
@@ -71,7 +69,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 8-byte aligned.</exception>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void StoreAlignedNonTemporal(this Vector3 source, float* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -705,14 +705,12 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.Load(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector3 Load(float* source) => LoadUnsafe(in *source);
 
         /// <inheritdoc cref="Vector4.LoadAligned(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector3 LoadAligned(float* source)
         {
             if (((nuint)(source) % Alignment) != 0)
@@ -726,7 +724,6 @@ namespace System.Numerics
         /// <inheritdoc cref="Vector4.LoadAlignedNonTemporal(float*)" />
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector3 LoadAlignedNonTemporal(float* source) => LoadAligned(source);
 
         /// <inheritdoc cref="Vector128.LoadUnsafe{T}(ref readonly T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.Extensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.Extensions.cs
@@ -43,7 +43,6 @@ namespace System.Numerics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Store(this Vector4 source, float* destination) => source.AsVector128().Store(destination);
 
         /// <summary>Stores a vector at the given 16-byte aligned destination.</summary>
@@ -52,7 +51,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 16-byte aligned.</exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void StoreAligned(this Vector4 source, float* destination) => source.AsVector128().StoreAligned(destination);
 
         /// <summary>Stores a vector at the given 16-byte aligned destination.</summary>
@@ -61,7 +59,6 @@ namespace System.Numerics
         /// <exception cref="AccessViolationException"><paramref name="destination" /> is not 16-byte aligned.</exception>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void StoreAlignedNonTemporal(this Vector4 source, float* destination) => source.AsVector128().StoreAlignedNonTemporal(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector4.cs
@@ -770,21 +770,18 @@ namespace System.Numerics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector4 Load(float* source) => Vector128.Load(source).AsVector4();
 
         /// <inheritdoc cref="Vector128.LoadAligned{T}(T*)" />
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector4 LoadAligned(float* source) => Vector128.LoadAligned(source).AsVector4();
 
         /// <inheritdoc cref="Vector128.LoadAlignedNonTemporal{T}(T*)" />
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector4 LoadAlignedNonTemporal(float* source) => Vector128.LoadAlignedNonTemporal(source).AsVector4();
 
         /// <inheritdoc cref="Vector128.LoadUnsafe{T}(ref readonly T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector_1.cs
@@ -1073,17 +1073,14 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector<T> ISimdVector<Vector<T>, T>.Load(T* source) => Vector.Load(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAligned(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector<T> ISimdVector<Vector<T>, T>.LoadAligned(T* source) => Vector.LoadAligned(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector<T> ISimdVector<Vector<T>, T>.LoadAlignedNonTemporal(T* source) => Vector.LoadAlignedNonTemporal(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
@@ -1184,17 +1181,14 @@ namespace System.Numerics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector<T>, T>.Store(Vector<T> source, T* destination) => source.Store(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAligned(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector<T>, T>.StoreAligned(Vector<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector<T>, T>.StoreAlignedNonTemporal(Vector<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -101,7 +101,6 @@ namespace System
         /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public unsafe ReadOnlySpan(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/QCallHandles.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/QCallHandles.cs
@@ -24,7 +24,6 @@ namespace System.Runtime.CompilerServices
     {
         private object* _ptr;
 
-        [RequiresUnsafe]
         private ObjectHandleOnStack(object* pObject)
         {
             _ptr = pObject;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -187,7 +187,6 @@ namespace System.Runtime.CompilerServices
         internal static void WriteBarrier(ref object? dst, object? obj) => dst = obj;
 
         [Intrinsic]
-        [RequiresUnsafe]
         internal static unsafe void SetNextCallGenericContext(void* value) => throw new UnreachableException(); // Unconditionally expanded intrinsic
 
         [Intrinsic]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -281,7 +281,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void Copy<T>(void* destination, ref readonly T source)
             where T : allows ref struct
         {
@@ -302,7 +301,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void Copy<T>(ref T destination, void* source)
             where T : allows ref struct
         {
@@ -323,7 +321,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void CopyBlock(void* destination, void* source, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -362,7 +359,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void CopyBlockUnaligned(void* destination, void* source, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -483,7 +479,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void InitBlock(void* startAddress, byte value, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -523,7 +518,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void InitBlockUnaligned(void* startAddress, byte value, uint byteCount)
         {
             throw new PlatformNotSupportedException();
@@ -572,7 +566,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static T ReadUnaligned<T>(void* source)
             where T : allows ref struct
         {
@@ -624,7 +617,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void WriteUnaligned<T>(void* destination, T value)
             where T : allows ref struct
         {
@@ -697,7 +689,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static T Read<T>(void* source)
             where T : allows ref struct
         {
@@ -711,7 +702,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static void Write<T>(void* destination, T value)
             where T : allows ref struct
         {
@@ -725,7 +715,6 @@ namespace System.Runtime.CompilerServices
         [NonVersionable]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static ref T AsRef<T>(void* source)
             where T : allows ref struct
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/GCFrameRegistration.cs
@@ -19,7 +19,6 @@ namespace System.Runtime
         private nuint _osStackLocation;
 #endif
 
-        [RequiresUnsafe]
         public GCFrameRegistration(void** allocation, uint elemCount, bool areByRefs = true)
         {
             _reserved1 = 0;
@@ -34,11 +33,9 @@ namespace System.Runtime
 
 #if CORECLR
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         internal static extern void RegisterForGCReporting(GCFrameRegistration* pRegistration);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
         internal static extern void UnregisterForGCReporting(GCFrameRegistration* pRegistration);
 #endif
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComAwareWeakReference.ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComAwareWeakReference.ComWrappers.cs
@@ -17,7 +17,6 @@ namespace System
         private static unsafe delegate*<object, bool> s_possiblyComObjectCallback;
         private static unsafe delegate*<object, out object?, IntPtr> s_objectToComWeakRefCallback;
 
-        [RequiresUnsafe]
         internal static unsafe void InitializeCallbacks(
             delegate*<IntPtr, object?, object?> comWeakRefToObject,
             delegate*<object, bool> possiblyComObject,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.PlatformNotSupported.cs
@@ -21,7 +21,6 @@ namespace System.Runtime.InteropServices
             public IntPtr Vtable;
         }
 
-        [RequiresUnsafe]
         protected abstract unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count);
 
         protected abstract object? CreateObject(IntPtr externalComObject, CreateObjectFlags flags);
@@ -49,7 +48,6 @@ namespace System.Runtime.InteropServices
         {
             public IntPtr Vtable;
 
-            [RequiresUnsafe]
             public static unsafe T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class
             {
                 throw new PlatformNotSupportedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -129,14 +129,12 @@ namespace System.Runtime.InteropServices
             /// <typeparam name="T">Desired type.</typeparam>
             /// <param name="dispatchPtr">Pointer supplied to Vtable function entry.</param>
             /// <returns>Instance of type associated with dispatched function call.</returns>
-            [RequiresUnsafe]
             public static unsafe T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class
             {
                 ManagedObjectWrapper* comInstance = ToManagedObjectWrapper(dispatchPtr);
                 return Unsafe.As<T>(comInstance->Holder!.WrappedObject);
             }
 
-            [RequiresUnsafe]
             internal static unsafe ManagedObjectWrapper* ToManagedObjectWrapper(ComInterfaceDispatch* dispatchPtr)
             {
                 InternalComInterfaceDispatch* dispatch = (InternalComInterfaceDispatch*)unchecked((nuint)dispatchPtr & (nuint)InternalComInterfaceDispatch.DispatchAlignmentMask);
@@ -488,7 +486,6 @@ namespace System.Runtime.InteropServices
 
             private readonly ManagedObjectWrapper* _wrapper;
 
-            [RequiresUnsafe]
             public ManagedObjectWrapperHolder(ManagedObjectWrapper* wrapper, object wrappedObject)
             {
                 _wrapper = wrapper;
@@ -505,7 +502,6 @@ namespace System.Runtime.InteropServices
 
             public bool IsActivated => _wrapper->Flags.HasFlag(CreateComInterfaceFlagsEx.IsComActivated);
 
-            [RequiresUnsafe]
             internal ManagedObjectWrapper* Wrapper => _wrapper;
         }
 
@@ -513,7 +509,6 @@ namespace System.Runtime.InteropServices
         {
             private ManagedObjectWrapper* _wrapper;
 
-            [RequiresUnsafe]
             public ManagedObjectWrapperReleaser(ManagedObjectWrapper* wrapper)
             {
                 _wrapper = wrapper;
@@ -831,7 +826,6 @@ namespace System.Runtime.InteropServices
             return (nuint)((value + alignMask) & ~alignMask);
         }
 
-        [RequiresUnsafe]
         private unsafe ManagedObjectWrapper* CreateManagedObjectWrapper(object instance, CreateComInterfaceFlags flags)
         {
             ComInterfaceEntry* userDefined = ComputeVtables(instance, flags, out int userDefinedCount);
@@ -991,7 +985,6 @@ namespace System.Runtime.InteropServices
             return obj;
         }
 
-        [RequiresUnsafe]
         private static unsafe ComInterfaceDispatch* TryGetComInterfaceDispatch(IntPtr comObject)
         {
             // If the first Vtable entry is part of a ManagedObjectWrapper impl,
@@ -1513,7 +1506,6 @@ namespace System.Runtime.InteropServices
         /// If the interface entries cannot be created and a negative <paramref name="count" /> or <code>null</code> and a non-zero <paramref name="count" /> are returned,
         /// the call to <see cref="GetOrCreateComInterfaceForObject(object, CreateComInterfaceFlags)"/> will throw a <see cref="ArgumentException"/>.
         /// </remarks>
-        [RequiresUnsafe]
         protected abstract unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandleExtensions.cs
@@ -25,7 +25,6 @@ namespace System.Runtime.InteropServices
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
         /// <typeparam name="T">The element type of the pinned array.</typeparam>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe T* GetAddressOfArrayData<T>(
 #nullable disable // Nullable oblivious because no covariance between PinnedGCHandle<T> and PinnedGCHandle<T?>
             this PinnedGCHandle<T[]> handle)
@@ -49,7 +48,6 @@ namespace System.Runtime.InteropServices
         /// </returns>
         /// <exception cref="NullReferenceException">If the handle is not initialized or already disposed.</exception>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe char* GetAddressOfStringData(
 #nullable disable // Nullable oblivious because no covariance between PinnedGCHandle<T> and PinnedGCHandle<T?>
             this PinnedGCHandle<string> handle)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Java/JavaMarshal.Unsupported.cs
@@ -38,7 +38,6 @@ namespace System.Runtime.InteropServices.Java
         /// runtime code when cross-reference marking is required.
         /// Additionally, this callback must be implemented in unmanaged code.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences)
         {
             throw new PlatformNotSupportedException();
@@ -58,7 +57,6 @@ namespace System.Runtime.InteropServices.Java
         /// <returns>A <see cref="GCHandle"/> that represents the allocated reference-tracking handle.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="obj"/> is null.</exception>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context)
         {
             throw new PlatformNotSupportedException();
@@ -76,7 +74,6 @@ namespace System.Runtime.InteropServices.Java
         /// The returned pointer is the exact value that was originally provided as
         /// the context parameter when the handle was created.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void* GetContext(GCHandle obj)
         {
             throw new PlatformNotSupportedException();
@@ -91,7 +88,6 @@ namespace System.Runtime.InteropServices.Java
         /// <param name="crossReferences">A pointer to the structure containing cross-reference information produced during marking.</param>
         /// <param name="unreachableObjectHandles">A span of <see cref="GCHandle"/> values that were determined to be unreachable from the native side.</param>
         /// <exception cref="PlatformNotSupportedException">The runtime or platform does not support Java cross-reference marshalling.</exception>
-        [RequiresUnsafe]
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             ReadOnlySpan<GCHandle> unreachableObjectHandles)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshal.Unix.cs
@@ -33,7 +33,6 @@ namespace System.Runtime.InteropServices
 
         private static bool IsNullOrWin32Atom(IntPtr ptr) => ptr == IntPtr.Zero;
 
-        [RequiresUnsafe]
         internal static unsafe int StringToAnsiString(string s, byte* buffer, int bufferLength, bool bestFit = false, bool throwOnUnmappableChar = false)
         {
             Debug.Assert(bufferLength >= (s.Length + 1) * SystemMaxDBCSCharSize, "Insufficient buffer length passed to StringToAnsiString");

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/AnsiStringMarshaller.cs
@@ -19,7 +19,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="managed">The managed string to convert.</param>
         /// <returns>An unmanaged string.</returns>
-        [RequiresUnsafe]
         public static byte* ConvertToUnmanaged(string? managed)
         {
             if (managed is null)
@@ -38,7 +37,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanaged">The unmanaged string to convert.</param>
         /// <returns>A managed string.</returns>
-        [RequiresUnsafe]
         public static string? ConvertToManaged(byte* unmanaged)
             => Marshal.PtrToStringAnsi((IntPtr)unmanaged);
 
@@ -46,7 +44,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees the memory for the unmanaged string.
         /// </summary>
         /// <param name="unmanaged">The memory allocated for the unmanaged string.</param>
-        [RequiresUnsafe]
         public static void Free(byte* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
@@ -101,7 +98,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Converts the current managed string to an unmanaged string.
             /// </summary>
             /// <returns>The converted unmanaged string.</returns>
-            [RequiresUnsafe]
             public byte* ToUnmanaged() => _unmanagedValue;
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ArrayMarshaller.cs
@@ -29,7 +29,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="managed">The managed array.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The unmanaged pointer to the allocated memory.</returns>
-        [RequiresUnsafe]
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements)
         {
             if (managed is null)
@@ -59,7 +58,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The unmanaged allocation.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The <see cref="Span{TUnmanagedElement}"/> of unmanaged elements.</returns>
-        [RequiresUnsafe]
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -96,7 +94,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanagedValue">The unmanaged array.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal.</returns>
-        [RequiresUnsafe]
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
         {
             if (unmanagedValue is null)
@@ -109,7 +106,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees memory for the unmanaged array.
         /// </summary>
         /// <param name="unmanaged">The unmanaged array.</param>
-        [RequiresUnsafe]
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
@@ -188,7 +184,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Returns the unmanaged value representing the array.
             /// </summary>
             /// <returns>A pointer to the beginning of the unmanaged value.</returns>
-            [RequiresUnsafe]
             public TUnmanagedElement* ToUnmanaged()
             {
                 // Unsafe.AsPointer is safe since buffer must be pinned

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/BStrStringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/BStrStringMarshaller.cs
@@ -29,7 +29,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanaged">An unmanaged string to convert.</param>
         /// <returns>The converted managed string.</returns>
-        [RequiresUnsafe]
         public static string? ConvertToManaged(ushort* unmanaged)
         {
             if (unmanaged is null)
@@ -42,7 +41,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees the memory for the unmanaged string.
         /// </summary>
         /// <param name="unmanaged">The memory allocated for the unmanaged string.</param>
-        [RequiresUnsafe]
         public static void Free(ushort* unmanaged)
             => Marshal.FreeBSTR((IntPtr)unmanaged);
 
@@ -108,7 +106,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Converts the current managed string to an unmanaged string.
             /// </summary>
             /// <returns>The converted unmanaged string.</returns>
-            [RequiresUnsafe]
             public ushort* ToUnmanaged() => _ptrToFirstChar;
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/PointerArrayMarshaller.cs
@@ -59,7 +59,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The unmanaged allocation to get a destination for.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The <see cref="Span{TUnmanagedElement}"/> of unmanaged elements.</returns>
-        [RequiresUnsafe]
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -74,7 +73,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The unmanaged array.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The managed array.</returns>
-        [RequiresUnsafe]
         public static T*[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -97,7 +95,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanagedValue">The unmanaged array to get a source for.</param>
         /// <param name="numElements">The unmanaged element count.</param>
         /// <returns>The <see cref="ReadOnlySpan{TUnmanagedElement}"/> containing the unmanaged elements to marshal.</returns>
-        [RequiresUnsafe]
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements)
         {
             if (unmanagedValue is null)
@@ -110,7 +107,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees memory for the unmanaged array.
         /// </summary>
         /// <param name="unmanaged">The unmanaged array.</param>
-        [RequiresUnsafe]
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
@@ -189,7 +185,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Returns the unmanaged value representing the array.
             /// </summary>
             /// <returns>A pointer to the beginning of the unmanaged value.</returns>
-            [RequiresUnsafe]
             public TUnmanagedElement* ToUnmanaged()
             {
                 // Unsafe.AsPointer is safe since buffer must be pinned

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/ReadOnlySpanMarshaller.cs
@@ -38,7 +38,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <param name="managed">The managed span.</param>
             /// <param name="numElements">The number of elements in the span.</param>
             /// <returns>A pointer to the block of memory for the unmanaged elements.</returns>
-            [RequiresUnsafe]
             public static TUnmanagedElement* AllocateContainerForUnmanagedElements(ReadOnlySpan<T> managed, out int numElements)
             {
                 // Emulate the pinning behavior:
@@ -70,7 +69,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <param name="unmanaged">The pointer to the block of memory for the unmanaged elements.</param>
             /// <param name="numElements">The number of elements that will be copied into the memory block.</param>
             /// <returns>A span over the unmanaged memory that can contain the specified number of elements.</returns>
-            [RequiresUnsafe]
             public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
             {
                 if (unmanaged == null)
@@ -151,7 +149,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Returns the unmanaged value representing the array.
             /// </summary>
-            [RequiresUnsafe]
             public TUnmanagedElement* ToUnmanaged()
             {
                 // Unsafe.AsPointer is safe since buffer must be pinned
@@ -189,7 +186,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Initializes the <see cref="ReadOnlySpanMarshaller{T, TUnmanagedElement}.ManagedToUnmanagedOut"/> marshaller.
             /// </summary>
             /// <param name="unmanaged">A pointer to the array to be unmarshalled from native to managed.</param>
-            [RequiresUnsafe]
             public void FromUnmanaged(TUnmanagedElement* unmanaged)
             {
                 _unmanagedArray = unmanaged;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/SpanMarshaller.cs
@@ -63,7 +63,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The pointer to the block of memory for the unmanaged elements.</param>
         /// <param name="numElements">The number of elements that will be copied into the memory block.</param>
         /// <returns>A span over the unmanaged memory that can contain the specified number of elements.</returns>
-        [RequiresUnsafe]
         public static Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged == null)
@@ -78,7 +77,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The unmanaged value.</param>
         /// <param name="numElements">The number of elements in the unmanaged collection.</param>
         /// <returns>A span over enough memory to contain <paramref name="numElements"/> elements.</returns>
-        [RequiresUnsafe]
         public static Span<T> AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged is null)
@@ -101,7 +99,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// <param name="unmanaged">The unmanaged value.</param>
         /// <param name="numElements">The number of elements in the unmanaged collection.</param>
         /// <returns>A span over the native collection elements.</returns>
-        [RequiresUnsafe]
         public static ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanaged, int numElements)
         {
             if (unmanaged == null)
@@ -114,7 +111,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees the allocated unmanaged memory.
         /// </summary>
         /// <param name="unmanaged">A pointer to the allocated unmanaged memory.</param>
-        [RequiresUnsafe]
         public static void Free(TUnmanagedElement* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
@@ -185,7 +181,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// <summary>
             /// Returns the unmanaged value representing the array.
             /// </summary>
-            [RequiresUnsafe]
             public TUnmanagedElement* ToUnmanaged()
             {
                 // Unsafe.AsPointer is safe since buffer must be pinned

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf16StringMarshaller.cs
@@ -26,7 +26,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanaged">The unmanaged string to convert.</param>
         /// <returns>A managed string.</returns>
-        [RequiresUnsafe]
         public static string? ConvertToManaged(ushort* unmanaged)
             => Marshal.PtrToStringUni((IntPtr)unmanaged);
 
@@ -34,7 +33,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Frees the memory for the unmanaged string.
         /// </summary>
         /// <param name="unmanaged">The memory allocated for the unmanaged string.</param>
-        [RequiresUnsafe]
         public static void Free(ushort* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/Marshalling/Utf8StringMarshaller.cs
@@ -20,7 +20,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="managed">The managed string to convert.</param>
         /// <returns>An unmanaged string.</returns>
-        [RequiresUnsafe]
         public static byte* ConvertToUnmanaged(string? managed)
         {
             if (managed is null)
@@ -40,7 +39,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// </summary>
         /// <param name="unmanaged">The unmanaged string to convert.</param>
         /// <returns>A managed string.</returns>
-        [RequiresUnsafe]
         public static string? ConvertToManaged(byte* unmanaged)
             => Marshal.PtrToStringUTF8((IntPtr)unmanaged);
 
@@ -48,7 +46,6 @@ namespace System.Runtime.InteropServices.Marshalling
         /// Free the memory for a specified unmanaged string.
         /// </summary>
         /// <param name="unmanaged">The memory allocated for the unmanaged string.</param>
-        [RequiresUnsafe]
         public static void Free(byte* unmanaged)
             => Marshal.FreeCoTaskMem((IntPtr)unmanaged);
 
@@ -106,7 +103,6 @@ namespace System.Runtime.InteropServices.Marshalling
             /// Converts the current managed string to an unmanaged string.
             /// </summary>
             /// <returns>An unmanaged string.</returns>
-            [RequiresUnsafe]
             public byte* ToUnmanaged() => _unmanagedValue;
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/MemoryMarshal.cs
@@ -251,7 +251,6 @@ namespace System.Runtime.InteropServices
         /// <remarks>The returned span does not include the null terminator.</remarks>
         /// <exception cref="ArgumentException">The string is longer than <see cref="int.MaxValue"/>.</exception>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe ReadOnlySpan<char> CreateReadOnlySpanFromNullTerminated(char* value) =>
             value != null ? new ReadOnlySpan<char>(value, string.wcslen(value)) :
             default;
@@ -262,7 +261,6 @@ namespace System.Runtime.InteropServices
         /// <remarks>The returned span does not include the null terminator, nor does it validate the well-formedness of the UTF-8 data.</remarks>
         /// <exception cref="ArgumentException">The string is longer than <see cref="int.MaxValue"/>.</exception>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe ReadOnlySpan<byte> CreateReadOnlySpanFromNullTerminated(byte* value) =>
             value != null ? new ReadOnlySpan<byte>(value, string.strlen(value)) :
             default;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.Unix.cs
@@ -61,7 +61,6 @@ namespace System.Runtime.InteropServices
         ///    <para>This method is a thin wrapper over the C <c>free</c> API or a platform dependent aligned free API such as <c>_aligned_free</c> on Win32.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void AlignedFree(void* ptr)
         {
             if (ptr != null)
@@ -84,7 +83,6 @@ namespace System.Runtime.InteropServices
         ///     <para>This method is not compatible with <see cref="Free" /> or <see cref="Realloc" />, instead <see cref="AlignedFree" /> or <see cref="AlignedRealloc" /> should be called.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void* AlignedRealloc(void* ptr, nuint byteCount, nuint alignment)
         {
             if (!BitOperations.IsPow2(alignment))
@@ -178,7 +176,6 @@ namespace System.Runtime.InteropServices
         ///    <para>This method is a thin wrapper over the C <c>free</c> API.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Free(void* ptr)
         {
             if (ptr != null)
@@ -198,7 +195,6 @@ namespace System.Runtime.InteropServices
         ///     <para>This method is a thin wrapper over the C <c>realloc</c> API.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void* Realloc(void* ptr, nuint byteCount)
         {
             // The C standard does not define what happens when size == 0, we want an "empty" allocation

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.Windows.cs
@@ -48,7 +48,6 @@ namespace System.Runtime.InteropServices
         ///    <para>This method is a thin wrapper over the C <c>free</c> API or a platform dependent aligned free API such as <c>_aligned_free</c> on Win32.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void AlignedFree(void* ptr)
         {
             if (ptr != null)
@@ -71,7 +70,6 @@ namespace System.Runtime.InteropServices
         ///     <para>This method is not compatible with <see cref="Free" /> or <see cref="Realloc" />, instead <see cref="AlignedFree" /> or <see cref="AlignedRealloc" /> should be called.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void* AlignedRealloc(void* ptr, nuint byteCount, nuint alignment)
         {
             if (!BitOperations.IsPow2(alignment))
@@ -143,7 +141,6 @@ namespace System.Runtime.InteropServices
         ///    <para>This method is a thin wrapper over the C <c>free</c> API.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Free(void* ptr)
         {
             if (ptr != null)
@@ -163,7 +160,6 @@ namespace System.Runtime.InteropServices
         ///     <para>This method is a thin wrapper over the C <c>realloc</c> API.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void* Realloc(void* ptr, nuint byteCount)
         {
             // The Windows implementation treats size == 0 as Free, we want an "empty" allocation

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NativeMemory.cs
@@ -47,7 +47,6 @@ namespace System.Runtime.InteropServices
         ///     <para>The behavior when <paramref name="ptr" /> is <see langword="null"/> and <paramref name="byteCount" /> is greater than <c>0</c> is undefined.</para>
         /// </remarks>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Clear(void* ptr, nuint byteCount)
         {
             SpanHelpers.ClearWithoutReferences(ref *(byte*)ptr, byteCount);
@@ -61,7 +60,6 @@ namespace System.Runtime.InteropServices
         /// <param name="destination">A pointer to the destination memory block where the data is to be copied.</param>
         /// <param name="byteCount">The size, in bytes, to be copied from the source location to the destination.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Copy(void* source, void* destination, nuint byteCount)
         {
             SpanHelpers.Memmove(ref *(byte*)destination, ref *(byte*)source, byteCount);
@@ -75,7 +73,6 @@ namespace System.Runtime.InteropServices
         /// <param name="byteCount">The number of bytes to be set to <paramref name="value"/>.</param>
         /// <param name="value">The value to be set.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Fill(void* ptr, nuint byteCount, byte value)
         {
             SpanHelpers.Fill(ref *(byte*)ptr, byteCount, value);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.PlatformNotSupported.cs
@@ -56,7 +56,6 @@ namespace System.Runtime.InteropServices.ObjectiveC
         /// The <paramref name="isReferencedCallback"/> should return 0 for not reference or 1 for
         /// referenced. Any other value has undefined behavior.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void Initialize(
             delegate* unmanaged<void> beginEndCallback,
             delegate* unmanaged<IntPtr, int> isReferencedCallback,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveC/ObjectiveCMarshal.cs
@@ -58,7 +58,6 @@ namespace System.Runtime.InteropServices.ObjectiveC
         /// The <paramref name="isReferencedCallback"/> should return 0 for not reference or 1 for
         /// referenced. Any other value has undefined behavior.
         /// </remarks>
-        [RequiresUnsafe]
         public static unsafe void Initialize(
             delegate* unmanaged<void> beginEndCallback,
             delegate* unmanaged<IntPtr, int> isReferencedCallback,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ReferenceTrackerHost.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ReferenceTrackerHost.cs
@@ -75,7 +75,6 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable IDE0060, CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        [RequiresUnsafe]
         internal static unsafe int IReferenceTrackerHost_GetTrackerTarget(IntPtr pThis, IntPtr punk, IntPtr* ppNewReference)
 #pragma warning restore IDE0060, CS3016
         {
@@ -135,7 +134,6 @@ namespace System.Runtime.InteropServices
 
 #pragma warning disable CS3016
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvMemberFunction)])]
-        [RequiresUnsafe]
         internal static unsafe int IReferenceTrackerHost_QueryInterface(IntPtr pThis, Guid* guid, IntPtr* ppObject)
 #pragma warning restore CS3016
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TypeMapLazyDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TypeMapLazyDictionary.cs
@@ -79,7 +79,6 @@ namespace System.Runtime.InteropServices
         }
 
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "TypeMapLazyDictionary_ProcessAttributes")]
-        [RequiresUnsafe]
         private static unsafe partial void ProcessAttributes(
             QCallAssembly assembly,
             QCallTypeHandle groupType,
@@ -134,7 +133,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL NewPrecachedExternalTypeMap(CallbackContext* context)
         {
             Debug.Assert(context != null);
@@ -153,7 +151,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL NewPrecachedProxyTypeMap(CallbackContext* context)
         {
             Debug.Assert(context != null);
@@ -172,7 +169,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL NewExternalTypeEntry(CallbackContext* context, ProcessAttributesCallbackArg* arg)
         {
             Debug.Assert(context != null);
@@ -200,7 +196,6 @@ namespace System.Runtime.InteropServices
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe Interop.BOOL NewProxyTypeEntry(CallbackContext* context, ProcessAttributesCallbackArg* arg)
         {
             Debug.Assert(context != null);
@@ -239,7 +234,6 @@ namespace System.Runtime.InteropServices
             return Interop.BOOL.TRUE; // Continue processing.
         }
 
-        [RequiresUnsafe]
         private static unsafe CallbackContext CreateMaps(
             RuntimeType groupType,
             delegate* unmanaged<CallbackContext*, ProcessAttributesCallbackArg*, Interop.BOOL> newExternalTypeEntry,
@@ -363,7 +357,6 @@ namespace System.Runtime.InteropServices
 
         private unsafe struct TypeNameUtf8
         {
-            [RequiresUnsafe]
             public required void* Utf8TypeName { get; init; }
             public required int Utf8TypeNameLen { get; init; }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.PlatformNotSupported.cs
@@ -1550,688 +1550,519 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<ulong> InsertSelectedScalar(Vector128<ulong> result, [ConstantExpected(Max = (byte)(1))] byte resultIndex, Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte valueIndex) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndInsertScalar((Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndInsertScalar((Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndInsertScalar((Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndInsertScalar((Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndInsertScalar((Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>float64x2_t vld1q_dup_f64 (float64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> LoadAndReplicateToVector128(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>int64x2_t vld1q_dup_s64 (int64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> LoadAndReplicateToVector128(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>uint64x2_t vld1q_dup_u64 (uint64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> LoadAndReplicateToVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadPairVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<double> Value1, Vector64<double> Value2) LoadPairVector64(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadPairVector64(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairVector64(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<long> Value1, Vector64<long> Value2) LoadPairVector64(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadPairVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairVector64(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadPairVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ulong> Value1, Vector64<ulong> Value2) LoadPairVector64(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairScalarVector64(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairScalarVector64(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairScalarVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadPairVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadPairVector128(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadPairVector128(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadPairVector128(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadPairVector128(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadPairVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadPairVector128(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadPairVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadPairVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadPairVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadPairVector64NonTemporal(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<double> Value1, Vector64<double> Value2) LoadPairVector64NonTemporal(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadPairVector64NonTemporal(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairVector64NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<long> Value1, Vector64<long> Value2) LoadPairVector64NonTemporal(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadPairVector64NonTemporal(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairVector64NonTemporal(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadPairVector64NonTemporal(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairVector64NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ulong> Value1, Vector64<ulong> Value2) LoadPairVector64NonTemporal(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairScalarVector64NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairScalarVector64NonTemporal(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairScalarVector64NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadPairVector128NonTemporal(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadPairVector128NonTemporal(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadPairVector128NonTemporal(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadPairVector128NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadPairVector128NonTemporal(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadPairVector128NonTemporal(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadPairVector128NonTemporal(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadPairVector128NonTemporal(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadPairVector128NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadPairVector128NonTemporal(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) Load2xVector128AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) Load2xVector128AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) Load2xVector128AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) Load2xVector128AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) Load2xVector128AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) Load2xVector128AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) Load2xVector128AndUnzip(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) Load2xVector128AndUnzip(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) Load2xVector128AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) Load2xVector128AndUnzip(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) Load3xVector128AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) Load3xVector128AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) Load3xVector128AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) Load3xVector128AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) Load3xVector128AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) Load3xVector128AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) Load3xVector128AndUnzip(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) Load3xVector128AndUnzip(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) Load3xVector128AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) Load3xVector128AndUnzip(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) Load4xVector128AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) Load4xVector128AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) Load4xVector128AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) Load4xVector128AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) Load4xVector128AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) Load4xVector128AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) Load4xVector128AndUnzip(long* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) Load4xVector128AndUnzip(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) Load4xVector128AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) Load4xVector128AndUnzip(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) Load2xVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) Load2xVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) Load2xVector128(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) Load2xVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) Load2xVector128(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) Load2xVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) Load2xVector128(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) Load2xVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) Load2xVector128(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) Load2xVector128(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) Load3xVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) Load3xVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) Load3xVector128(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) Load3xVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) Load3xVector128(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) Load3xVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) Load3xVector128(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) Load3xVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) Load3xVector128(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) Load3xVector128(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) Load4xVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) Load4xVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) Load4xVector128(short* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) Load4xVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) Load4xVector128(int* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) Load4xVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) Load4xVector128(long* address)  { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D}, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) Load4xVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) Load4xVector128(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) Load4xVector128(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -3386,610 +3217,474 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<float> Sqrt(Vector128<float> value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(byte* address, Vector64<byte> value1, Vector64<byte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(double* address, Vector64<double> value1, Vector64<double> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(short* address, Vector64<short> value1, Vector64<short> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(int* address, Vector64<int> value1, Vector64<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(long* address, Vector64<long> value1, Vector64<long> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(sbyte* address, Vector64<sbyte> value1, Vector64<sbyte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(float* address, Vector64<float> value1, Vector64<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ushort* address, Vector64<ushort> value1, Vector64<ushort> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(uint* address, Vector64<uint> value1, Vector64<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ulong* address, Vector64<ulong> value1, Vector64<ulong> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(byte* address, Vector128<byte> value1, Vector128<byte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(double* address, Vector128<double> value1, Vector128<double> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(short* address, Vector128<short> value1, Vector128<short> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(int* address, Vector128<int> value1, Vector128<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(long* address, Vector128<long> value1, Vector128<long> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(sbyte* address, Vector128<sbyte> value1, Vector128<sbyte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(float* address, Vector128<float> value1, Vector128<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ushort* address, Vector128<ushort> value1, Vector128<ushort> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(uint* address, Vector128<uint> value1, Vector128<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ulong* address, Vector128<ulong> value1, Vector128<ulong> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(byte* address, Vector64<byte> value1, Vector64<byte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(double* address, Vector64<double> value1, Vector64<double> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(short* address, Vector64<short> value1, Vector64<short> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(int* address, Vector64<int> value1, Vector64<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(long* address, Vector64<long> value1, Vector64<long> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(sbyte* address, Vector64<sbyte> value1, Vector64<sbyte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(float* address, Vector64<float> value1, Vector64<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ushort* address, Vector64<ushort> value1, Vector64<ushort> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(uint* address, Vector64<uint> value1, Vector64<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ulong* address, Vector64<ulong> value1, Vector64<ulong> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(byte* address, Vector128<byte> value1, Vector128<byte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(double* address, Vector128<double> value1, Vector128<double> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(short* address, Vector128<short> value1, Vector128<short> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(int* address, Vector128<int> value1, Vector128<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(long* address, Vector128<long> value1, Vector128<long> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(sbyte* address, Vector128<sbyte> value1, Vector128<sbyte> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(float* address, Vector128<float> value1, Vector128<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ushort* address, Vector128<ushort> value1, Vector128<ushort> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(uint* address, Vector128<uint> value1, Vector128<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ulong* address, Vector128<ulong> value1, Vector128<ulong> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(int* address, Vector64<int> value1, Vector64<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(float* address, Vector64<float> value1, Vector64<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(uint* address, Vector64<uint> value1, Vector64<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(int* address, Vector64<int> value1, Vector64<int> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(float* address, Vector64<float> value1, Vector64<float> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(uint* address, Vector64<uint> value1, Vector64<uint> value2) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s8 (int8_t * ptr, int8x16x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.16B, Vt+1.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s8 (int8_t * ptr, int8x16x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.16B, Vt+1.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s16 (int16_t * ptr, int16x8x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.8H, Vt+1.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s16 (int16_t * ptr, int16x8x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.8H, Vt+1.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s32 (int32_t * ptr, int32x4x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_s32 (int32_t * ptr, int32x4x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst2_lane_f32 (float32_t * ptr, float32x2x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s8 (int8_t * ptr, int8x16x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.16B, Vt+1.16B, Vt+2.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2, Vector128<byte> value3) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s8 (int8_t * ptr, int8x16x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.16B, Vt+1.16B, Vt+2.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2, Vector128<sbyte> value3) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s16 (int16_t * ptr, int16x8x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.8H, Vt+1.8H, Vt+2.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2, Vector128<short> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s16 (int16_t * ptr, int16x8x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.8H, Vt+1.8H, Vt+2.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2, Vector128<ushort> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s32 (int32_t * ptr, int32x4x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2, Vector128<int> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_s32 (int32_t * ptr, int32x4x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2, Vector128<uint> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2, Vector128<long> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2, Vector128<ulong> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst3_lane_f32 (float32_t * ptr, float32x2x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2, Vector128<float> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2, Vector128<double> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s8 (int8_t * ptr, int8x16x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.16B, Vt+1.16B, Vt+2.16B, Vt+3.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2, Vector128<byte> value3, Vector128<byte> value4) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s8 (int8_t * ptr, int8x16x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.16B, Vt+1.16B, Vt+2.16B, Vt+3.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2, Vector128<sbyte> value3, Vector128<sbyte> value4) value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s16 (int16_t * ptr, int16x8x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.8H, Vt+1.8H, Vt+2.8H, Vt+3.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2, Vector128<short> value3, Vector128<short> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s16 (int16_t * ptr, int16x8x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.8H, Vt+1.8H, Vt+2.8H, Vt+3.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2, Vector128<ushort> value3, Vector128<ushort> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s32 (int32_t * ptr, int32x4x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2, Vector128<int> value3, Vector128<int> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_s32 (int32_t * ptr, int32x4x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2, Vector128<uint> value3, Vector128<uint> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2, Vector128<long> value3, Vector128<long> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2, Vector128<ulong> value3, Vector128<ulong> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void vst4_lane_f32 (float32_t * ptr, float32x2x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2, Vector128<float> value3, Vector128<float> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2, Vector128<double> value3, Vector128<double> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) value) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -8790,7 +8485,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadAndInsertScalar(Vector64<byte> value, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8798,7 +8492,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadAndInsertScalar(Vector64<short> value, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8806,7 +8499,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadAndInsertScalar(Vector64<int> value, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8814,7 +8506,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadAndInsertScalar(Vector64<sbyte> value, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8822,7 +8513,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadAndInsertScalar(Vector64<float> value, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8830,7 +8520,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadAndInsertScalar(Vector64<ushort> value, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8838,7 +8527,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadAndInsertScalar(Vector64<uint> value, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8846,7 +8534,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAndInsertScalar(Vector128<byte> value, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8854,7 +8541,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAndInsertScalar(Vector128<double> value, [ConstantExpected(Max = (byte)(1))] byte index, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8862,7 +8548,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAndInsertScalar(Vector128<short> value, [ConstantExpected(Max = (byte)(7))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8870,7 +8555,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAndInsertScalar(Vector128<int> value, [ConstantExpected(Max = (byte)(3))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8878,7 +8562,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAndInsertScalar(Vector128<long> value, [ConstantExpected(Max = (byte)(1))] byte index, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8886,7 +8569,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAndInsertScalar(Vector128<sbyte> value, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8894,7 +8576,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAndInsertScalar(Vector128<float> value, [ConstantExpected(Max = (byte)(3))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8902,7 +8583,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAndInsertScalar(Vector128<ushort> value, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8910,7 +8590,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAndInsertScalar(Vector128<uint> value, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -8918,91 +8597,69 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAndInsertScalar(Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndInsertScalar((Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndInsertScalar((Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndInsertScalar((Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9010,7 +8667,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadAndReplicateToVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9018,7 +8674,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadAndReplicateToVector64(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9026,7 +8681,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadAndReplicateToVector64(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9034,7 +8688,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadAndReplicateToVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9042,7 +8695,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadAndReplicateToVector64(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9050,7 +8702,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadAndReplicateToVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9058,7 +8709,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadAndReplicateToVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9066,7 +8716,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAndReplicateToVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9074,7 +8723,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAndReplicateToVector128(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9082,7 +8730,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAndReplicateToVector128(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9090,7 +8737,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAndReplicateToVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9098,7 +8744,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAndReplicateToVector128(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9106,7 +8751,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAndReplicateToVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9114,91 +8758,69 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAndReplicateToVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9206,7 +8828,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9214,7 +8835,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<double> LoadVector64(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9222,7 +8842,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadVector64(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9230,7 +8849,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadVector64(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9238,7 +8856,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<long> LoadVector64(long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9246,7 +8863,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9254,7 +8870,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadVector64(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9262,7 +8877,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9270,7 +8884,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9278,7 +8891,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ulong> LoadVector64(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9286,7 +8898,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.16B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadVector128(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9294,7 +8905,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9302,7 +8912,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadVector128(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9310,7 +8919,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadVector128(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9318,7 +8926,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadVector128(long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9326,7 +8933,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.16B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9334,7 +8940,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadVector128(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9342,7 +8947,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9350,7 +8954,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadVector128(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9358,175 +8961,132 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) Load2xVector64AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) Load2xVector64AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) Load2xVector64AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) Load2xVector64AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) Load2xVector64AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) Load2xVector64AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) Load2xVector64AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) Load3xVector64AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) Load3xVector64AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) Load3xVector64AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) Load3xVector64AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) Load3xVector64AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) Load3xVector64AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) Load3xVector64AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) Load4xVector64AndUnzip(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) Load4xVector64AndUnzip(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) Load4xVector64AndUnzip(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) Load4xVector64AndUnzip(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) Load4xVector64AndUnzip(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) Load4xVector64AndUnzip(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) Load4xVector64AndUnzip(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) Load2xVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) Load2xVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) Load2xVector64(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) Load2xVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) Load2xVector64(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) Load2xVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) Load2xVector64(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) Load3xVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) Load3xVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) Load3xVector64(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) Load3xVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) Load3xVector64(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) Load3xVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) Load3xVector64(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) Load4xVector64(byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) Load4xVector64(sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) Load4xVector64(short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) Load4xVector64(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) Load4xVector64(int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) Load4xVector64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) Load4xVector64(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15391,7 +14951,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector64<byte> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15399,7 +14958,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector64<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15407,7 +14965,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 {Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector64<short> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15415,7 +14972,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector64<int> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15423,7 +14979,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector64<long> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15431,7 +14986,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector64<sbyte> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15439,7 +14993,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector64<float> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15447,7 +15000,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector64<ushort> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15455,7 +15007,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector64<uint> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15463,7 +15014,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector64<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15471,7 +15021,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15479,7 +15028,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15487,7 +15035,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector128<short> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15495,7 +15042,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector128<int> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15503,7 +15049,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector128<long> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15511,7 +15056,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15519,7 +15063,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15527,7 +15070,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15535,7 +15077,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15543,7 +15084,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15551,7 +15091,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, Vector64<byte> value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15559,7 +15098,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, Vector64<short> value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15567,7 +15105,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, Vector64<int> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15575,7 +15112,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, Vector64<sbyte> value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15583,7 +15119,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, Vector64<float> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15591,7 +15126,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector64<ushort> value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15599,7 +15133,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, Vector64<uint> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15607,7 +15140,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, Vector128<byte> value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15615,7 +15147,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(double* address, Vector128<double> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15623,7 +15154,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, Vector128<short> value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15631,7 +15161,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, Vector128<int> value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15639,7 +15168,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(long* address, Vector128<long> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15647,7 +15175,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, Vector128<sbyte> value, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15655,7 +15182,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, Vector128<float> value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15663,7 +15189,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector128<ushort> value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15671,7 +15196,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, Vector128<uint> value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -15679,259 +15203,195 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ulong* address, Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.8B, Vt+1.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.8B, Vt+1.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.4H, Vt+1.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.4H, Vt+1.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.8B, Vt+1.8B, Vt+2.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2, Vector64<byte> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.8B, Vt+1.8B, Vt+2.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2, Vector64<sbyte> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.4H, Vt+1.4H, Vt+2.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2, Vector64<short> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.4H, Vt+1.4H, Vt+2.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2,  Vector64<ushort> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2, Vector64<int> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2, Vector64<uint> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2, Vector64<float> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.8B, Vt+1.8B, Vt+2.8B, Vt+3.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2, Vector64<byte> value3, Vector64<byte> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.8B, Vt+1.8B, Vt+2.8B, Vt+3.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2, Vector64<sbyte> value3, Vector64<sbyte> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.4H, Vt+1.4H, Vt+2.4H, Vt+3.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2, Vector64<short> value3, Vector64<short> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.4H, Vt+1.4H, Vt+2.4H, Vt+3.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2, Vector64<ushort> value3, Vector64<ushort> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2, Vector64<int> value3, Vector64<int> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2, Vector64<uint> value3, Vector64<uint> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2, Vector64<float> value3, Vector64<float> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/AdvSimd.cs
@@ -1554,688 +1554,519 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<ulong> InsertSelectedScalar(Vector128<ulong> result, [ConstantExpected(Max = (byte)(1))] byte resultIndex, Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte valueIndex) => Insert(result, resultIndex, Extract(value, valueIndex));
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndInsertScalar((Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndInsertScalar((Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndInsertScalar((Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndInsertScalar((Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndInsertScalar((Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndInsertScalar((Vector128<byte>, Vector128<byte>, Vector128<byte>, Vector128<byte>) values, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndInsertScalar((Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>, Vector128<sbyte>) values, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndInsertScalar((Vector128<short>, Vector128<short>, Vector128<short>, Vector128<short>) values, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndInsertScalar((Vector128<ushort>, Vector128<ushort>, Vector128<ushort>, Vector128<ushort>) values, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndInsertScalar((Vector128<int>, Vector128<int>, Vector128<int>, Vector128<int>) values, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndInsertScalar((Vector128<uint>, Vector128<uint>, Vector128<uint>, Vector128<uint>) values, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndInsertScalar((Vector128<long>, Vector128<long>, Vector128<long>, Vector128<long>) values, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndInsertScalar((Vector128<ulong>, Vector128<ulong>, Vector128<ulong>, Vector128<ulong>) values, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndInsertScalar((Vector128<float>, Vector128<float>, Vector128<float>, Vector128<float>) values, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }[Vm], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndInsertScalar((Vector128<double>, Vector128<double>, Vector128<double>, Vector128<double>) values, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(values, index, address);
 
             /// <summary>
             ///   <para>float64x2_t vld1q_dup_f64 (float64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> LoadAndReplicateToVector128(double* address) => LoadAndReplicateToVector128(address);
 
             /// <summary>
             ///   <para>int64x2_t vld1q_dup_s64 (int64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> LoadAndReplicateToVector128(long* address) => LoadAndReplicateToVector128(address);
 
             /// <summary>
             ///   <para>uint64x2_t vld1q_dup_u64 (uint64_t const * ptr)</para>
             ///   <para>  A64: LD1R { Vt.2D }, [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> LoadAndReplicateToVector128(ulong* address) => LoadAndReplicateToVector128(address);
 
             /// <summary>  A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD2R { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) => LoadAndReplicateToVector128x2(address);
 
             /// <summary>  A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD3R { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) => LoadAndReplicateToVector128x3(address);
 
             /// <summary>  A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LD4R { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) => LoadAndReplicateToVector128x4(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadPairVector64(byte* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<double> Value1, Vector64<double> Value2) LoadPairVector64(double* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadPairVector64(short* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairVector64(int* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<long> Value1, Vector64<long> Value2) LoadPairVector64(long* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadPairVector64(sbyte* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairVector64(float* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadPairVector64(ushort* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairVector64(uint* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ulong> Value1, Vector64<ulong> Value2) LoadPairVector64(ulong* address) => LoadPairVector64(address);
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairScalarVector64(int* address) => LoadPairScalarVector64(address);
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairScalarVector64(float* address) => LoadPairScalarVector64(address);
 
             /// <summary>  A64: LDP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairScalarVector64(uint* address) => LoadPairScalarVector64(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadPairVector128(byte* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadPairVector128(double* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadPairVector128(short* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadPairVector128(int* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadPairVector128(long* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadPairVector128(sbyte* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadPairVector128(float* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadPairVector128(ushort* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadPairVector128(uint* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadPairVector128(ulong* address) => LoadPairVector128(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadPairVector64NonTemporal(byte* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<double> Value1, Vector64<double> Value2) LoadPairVector64NonTemporal(double* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadPairVector64NonTemporal(short* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairVector64NonTemporal(int* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<long> Value1, Vector64<long> Value2) LoadPairVector64NonTemporal(long* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadPairVector64NonTemporal(sbyte* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairVector64NonTemporal(float* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadPairVector64NonTemporal(ushort* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairVector64NonTemporal(uint* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<ulong> Value1, Vector64<ulong> Value2) LoadPairVector64NonTemporal(ulong* address) => LoadPairVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadPairScalarVector64NonTemporal(int* address) => LoadPairScalarVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadPairScalarVector64NonTemporal(float* address) => LoadPairScalarVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadPairScalarVector64NonTemporal(uint* address) => LoadPairScalarVector64NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) LoadPairVector128NonTemporal(byte* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) LoadPairVector128NonTemporal(double* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) LoadPairVector128NonTemporal(short* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) LoadPairVector128NonTemporal(int* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) LoadPairVector128NonTemporal(long* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) LoadPairVector128NonTemporal(sbyte* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) LoadPairVector128NonTemporal(float* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) LoadPairVector128NonTemporal(ushort* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) LoadPairVector128NonTemporal(uint* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LDNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) LoadPairVector128NonTemporal(ulong* address) => LoadPairVector128NonTemporal(address);
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) Load2xVector128AndUnzip(byte* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) Load2xVector128AndUnzip(sbyte* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) Load2xVector128AndUnzip(short* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) Load2xVector128AndUnzip(ushort* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) Load2xVector128AndUnzip(int* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) Load2xVector128AndUnzip(uint* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) Load2xVector128AndUnzip(long* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) Load2xVector128AndUnzip(ulong* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) Load2xVector128AndUnzip(float* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) Load2xVector128AndUnzip(double* address) => Load2xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) Load3xVector128AndUnzip(byte* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) Load3xVector128AndUnzip(sbyte* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) Load3xVector128AndUnzip(short* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) Load3xVector128AndUnzip(ushort* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) Load3xVector128AndUnzip(int* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) Load3xVector128AndUnzip(uint* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) Load3xVector128AndUnzip(long* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) Load3xVector128AndUnzip(ulong* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) Load3xVector128AndUnzip(float* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) Load3xVector128AndUnzip(double* address) => Load3xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) Load4xVector128AndUnzip(byte* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) Load4xVector128AndUnzip(sbyte* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) Load4xVector128AndUnzip(short* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) Load4xVector128AndUnzip(ushort* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) Load4xVector128AndUnzip(int* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) Load4xVector128AndUnzip(uint* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) Load4xVector128AndUnzip(long* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) Load4xVector128AndUnzip(ulong* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) Load4xVector128AndUnzip(float* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) Load4xVector128AndUnzip(double* address) => Load4xVector128AndUnzip(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2) Load2xVector128(byte* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2) Load2xVector128(sbyte* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2) Load2xVector128(short* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2) Load2xVector128(ushort* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2) Load2xVector128(int* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2) Load2xVector128(uint* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2) Load2xVector128(long* address)  => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2) Load2xVector128(ulong* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2) Load2xVector128(float* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2) Load2xVector128(double* address) => Load2xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) Load3xVector128(byte* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) Load3xVector128(sbyte* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) Load3xVector128(short* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) Load3xVector128(ushort* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) Load3xVector128(int* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) Load3xVector128(uint* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) Load3xVector128(long* address)  => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) Load3xVector128(ulong* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) Load3xVector128(float* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) Load3xVector128(double* address) => Load3xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) Load4xVector128(byte* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) Load4xVector128(sbyte* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) Load4xVector128(short* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) Load4xVector128(ushort* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) Load4xVector128(int* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) Load4xVector128(uint* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) Load4xVector128(long* address)  => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D}, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) Load4xVector128(ulong* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) Load4xVector128(float* address) => Load4xVector128(address);
 
             /// <summary>  A64: LD1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) Load4xVector128(double* address) => Load4xVector128(address);
 
             /// <summary>
@@ -3390,610 +3221,474 @@ namespace System.Runtime.Intrinsics.Arm
             public static Vector128<float> Sqrt(Vector128<float> value) => Sqrt(value);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(byte* address, Vector64<byte> value1, Vector64<byte> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(double* address, Vector64<double> value1, Vector64<double> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(short* address, Vector64<short> value1, Vector64<short> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(int* address, Vector64<int> value1, Vector64<int> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(long* address, Vector64<long> value1, Vector64<long> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(sbyte* address, Vector64<sbyte> value1, Vector64<sbyte> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(float* address, Vector64<float> value1, Vector64<float> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ushort* address, Vector64<ushort> value1, Vector64<ushort> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(uint* address, Vector64<uint> value1, Vector64<uint> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ulong* address, Vector64<ulong> value1, Vector64<ulong> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(byte* address, Vector128<byte> value1, Vector128<byte> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(double* address, Vector128<double> value1, Vector128<double> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(short* address, Vector128<short> value1, Vector128<short> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(int* address, Vector128<int> value1, Vector128<int> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(long* address, Vector128<long> value1, Vector128<long> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(sbyte* address, Vector128<sbyte> value1, Vector128<sbyte> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(float* address, Vector128<float> value1, Vector128<float> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ushort* address, Vector128<ushort> value1, Vector128<ushort> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(uint* address, Vector128<uint> value1, Vector128<uint> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePair(ulong* address, Vector128<ulong> value1, Vector128<ulong> value2) => StorePair(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(byte* address, Vector64<byte> value1, Vector64<byte> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(double* address, Vector64<double> value1, Vector64<double> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(short* address, Vector64<short> value1, Vector64<short> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(int* address, Vector64<int> value1, Vector64<int> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(long* address, Vector64<long> value1, Vector64<long> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(sbyte* address, Vector64<sbyte> value1, Vector64<sbyte> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(float* address, Vector64<float> value1, Vector64<float> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ushort* address, Vector64<ushort> value1, Vector64<ushort> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(uint* address, Vector64<uint> value1, Vector64<uint> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Dt1, Dt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ulong* address, Vector64<ulong> value1, Vector64<ulong> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(byte* address, Vector128<byte> value1, Vector128<byte> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(double* address, Vector128<double> value1, Vector128<double> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(short* address, Vector128<short> value1, Vector128<short> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(int* address, Vector128<int> value1, Vector128<int> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(long* address, Vector128<long> value1, Vector128<long> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(sbyte* address, Vector128<sbyte> value1, Vector128<sbyte> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(float* address, Vector128<float> value1, Vector128<float> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ushort* address, Vector128<ushort> value1, Vector128<ushort> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(uint* address, Vector128<uint> value1, Vector128<uint> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP Qt1, Qt2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairNonTemporal(ulong* address, Vector128<ulong> value1, Vector128<ulong> value2) => StorePairNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(int* address, Vector64<int> value1, Vector64<int> value2) => StorePairScalar(address, value1, value2);
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(float* address, Vector64<float> value1, Vector64<float> value2) => StorePairScalar(address, value1, value2);
 
             /// <summary>  A64: STP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalar(uint* address, Vector64<uint> value1, Vector64<uint> value2) => StorePairScalar(address, value1, value2);
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(int* address, Vector64<int> value1, Vector64<int> value2) => StorePairScalarNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(float* address, Vector64<float> value1, Vector64<float> value2) => StorePairScalarNonTemporal(address, value1, value2);
 
             /// <summary>  A64: STNP St1, St2, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StorePairScalarNonTemporal(uint* address, Vector64<uint> value1, Vector64<uint> value2) => StorePairScalarNonTemporal(address, value1, value2);
 
             /// <summary>
             ///   <para>void vst2_lane_s8 (int8_t * ptr, int8x16x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.16B, Vt+1.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_s8 (int8_t * ptr, int8x16x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.16B, Vt+1.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_s16 (int16_t * ptr, int16x8x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.8H, Vt+1.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_s16 (int16_t * ptr, int16x8x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.8H, Vt+1.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_s32 (int32_t * ptr, int32x4x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_s32 (int32_t * ptr, int32x4x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst2_lane_f32 (float32_t * ptr, float32x2x2_t val, const int lane)</para>
             ///   <para>  A64: ST2 { Vt.4S, Vt+1.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST2 { Vt.2D, Vt+1.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s8 (int8_t * ptr, int8x16x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.16B, Vt+1.16B, Vt+2.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2, Vector128<byte> value3) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s8 (int8_t * ptr, int8x16x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.16B, Vt+1.16B, Vt+2.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2, Vector128<sbyte> value3) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s16 (int16_t * ptr, int16x8x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.8H, Vt+1.8H, Vt+2.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2, Vector128<short> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s16 (int16_t * ptr, int16x8x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.8H, Vt+1.8H, Vt+2.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2, Vector128<ushort> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s32 (int32_t * ptr, int32x4x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2, Vector128<int> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_s32 (int32_t * ptr, int32x4x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2, Vector128<uint> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2, Vector128<long> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2, Vector128<ulong> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst3_lane_f32 (float32_t * ptr, float32x2x3_t val, const int lane)</para>
             ///   <para>  A64: ST3 { Vt.4S, Vt+1.4S, Vt+2.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2, Vector128<float> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST3 { Vt.2D, Vt+1.2D, Vt+2.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2, Vector128<double> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_s8 (int8_t * ptr, int8x16x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.16B, Vt+1.16B, Vt+2.16B, Vt+3.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(byte* address, (Vector128<byte> value1, Vector128<byte> value2, Vector128<byte> value3, Vector128<byte> value4) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_s8 (int8_t * ptr, int8x16x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.16B, Vt+1.16B, Vt+2.16B, Vt+3.16B }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(sbyte* address, (Vector128<sbyte> value1, Vector128<sbyte> value2, Vector128<sbyte> value3, Vector128<sbyte> value4) value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_s16 (int16_t * ptr, int16x8x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.8H, Vt+1.8H, Vt+2.8H, Vt+3.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(short* address, (Vector128<short> value1, Vector128<short> value2, Vector128<short> value3, Vector128<short> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
            /// <summary>
             ///   <para>void vst4_lane_s16 (int16_t * ptr, int16x8x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.8H, Vt+1.8H, Vt+2.8H, Vt+3.8H }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ushort* address, (Vector128<ushort> value1, Vector128<ushort> value2, Vector128<ushort> value3, Vector128<ushort> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_s32 (int32_t * ptr, int32x4x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(int* address, (Vector128<int> value1, Vector128<int> value2, Vector128<int> value3, Vector128<int> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_s32 (int32_t * ptr, int32x4x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(uint* address, (Vector128<uint> value1, Vector128<uint> value2, Vector128<uint> value3, Vector128<uint> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(long* address, (Vector128<long> value1, Vector128<long> value2, Vector128<long> value3, Vector128<long> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(ulong* address, (Vector128<ulong> value1, Vector128<ulong> value2, Vector128<ulong> value3, Vector128<ulong> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>
             ///   <para>void vst4_lane_f32 (float32_t * ptr, float32x2x4_t val, const int lane)</para>
             ///   <para>  A64: ST4 { Vt.4S, Vt+1.4S, Vt+2.4S, Vt+3.4S }[index], [Xn]</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(float* address, (Vector128<float> value1, Vector128<float> value2, Vector128<float> value3, Vector128<float> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST4 { Vt.2D, Vt+1.2D, Vt+2.2D, Vt+3.2D }[index], [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreSelectedScalar(double* address, (Vector128<double> value1, Vector128<double> value2, Vector128<double> value3, Vector128<double> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
             /// <summary>  A64: ST2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST2 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST3 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST4 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void StoreVectorAndZip(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) value) => StoreVectorAndZip(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(byte* address, (Vector128<byte> Value1, Vector128<byte> Value2, Vector128<byte> Value3, Vector128<byte> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.16B, Vn+1.16B, Vn+2.16B, Vn+3.16B }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(sbyte* address, (Vector128<sbyte> Value1, Vector128<sbyte> Value2, Vector128<sbyte> Value3, Vector128<sbyte> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(short* address, (Vector128<short> Value1, Vector128<short> Value2, Vector128<short> Value3, Vector128<short> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.8H, Vn+1.8H, Vn+2.8H, Vn+3.8H }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ushort* address, (Vector128<ushort> Value1, Vector128<ushort> Value2, Vector128<ushort> Value3, Vector128<ushort> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(int* address, (Vector128<int> Value1, Vector128<int> Value2, Vector128<int> Value3, Vector128<int> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(uint* address, (Vector128<uint> Value1, Vector128<uint> Value2, Vector128<uint> Value3, Vector128<uint> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(long* address, (Vector128<long> Value1, Vector128<long> Value2, Vector128<long> Value3, Vector128<long> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(ulong* address, (Vector128<ulong> Value1, Vector128<ulong> Value2, Vector128<ulong> Value3, Vector128<ulong> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.4S }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(float* address, (Vector128<float> Value1, Vector128<float> Value2, Vector128<float> Value3, Vector128<float> Value4) value) => Store(address, value);
 
             /// <summary>  A64: ST1 { Vn.2D, Vn+1.2D, Vn+2.2D, Vn+3.2D }, [Xn]</summary>
-            [RequiresUnsafe]
             public static unsafe void Store(double* address, (Vector128<double> Value1, Vector128<double> Value2, Vector128<double> Value3, Vector128<double> Value4) value) => Store(address, value);
 
             /// <summary>
@@ -8794,7 +8489,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadAndInsertScalar(Vector64<byte> value, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8802,7 +8496,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadAndInsertScalar(Vector64<short> value, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8810,7 +8503,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadAndInsertScalar(Vector64<int> value, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8818,7 +8510,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadAndInsertScalar(Vector64<sbyte> value, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8826,7 +8517,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadAndInsertScalar(Vector64<float> value, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8834,7 +8524,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadAndInsertScalar(Vector64<ushort> value, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8842,7 +8531,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadAndInsertScalar(Vector64<uint> value, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8850,7 +8538,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAndInsertScalar(Vector128<byte> value, [ConstantExpected(Max = (byte)(15))] byte index, byte* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8858,7 +8545,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAndInsertScalar(Vector128<double> value, [ConstantExpected(Max = (byte)(1))] byte index, double* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8866,7 +8552,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAndInsertScalar(Vector128<short> value, [ConstantExpected(Max = (byte)(7))] byte index, short* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8874,7 +8559,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAndInsertScalar(Vector128<int> value, [ConstantExpected(Max = (byte)(3))] byte index, int* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8882,7 +8566,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAndInsertScalar(Vector128<long> value, [ConstantExpected(Max = (byte)(1))] byte index, long* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8890,7 +8573,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAndInsertScalar(Vector128<sbyte> value, [ConstantExpected(Max = (byte)(15))] byte index, sbyte* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8898,7 +8580,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAndInsertScalar(Vector128<float> value, [ConstantExpected(Max = (byte)(3))] byte index, float* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8906,7 +8587,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAndInsertScalar(Vector128<ushort> value, [ConstantExpected(Max = (byte)(7))] byte index, ushort* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8914,7 +8594,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAndInsertScalar(Vector128<uint> value, [ConstantExpected(Max = (byte)(3))] byte index, uint* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>
@@ -8922,91 +8601,69 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLDR.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAndInsertScalar(Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte index, ulong* address) => LoadAndInsertScalar(value, index, address);
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndInsertScalar((Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndInsertScalar((Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndInsertScalar((Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndInsertScalar((Vector64<byte>, Vector64<byte>, Vector64<byte>, Vector64<byte>) values, [ConstantExpected(Max = (byte)(7))] byte index, byte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndInsertScalar((Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>, Vector64<sbyte>) values, [ConstantExpected(Max = (byte)(7))] byte index, sbyte* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndInsertScalar((Vector64<short>, Vector64<short>, Vector64<short>, Vector64<short>) values, [ConstantExpected(Max = (byte)(3))] byte index, short* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndInsertScalar((Vector64<ushort>, Vector64<ushort>, Vector64<ushort>, Vector64<ushort>) values, [ConstantExpected(Max = (byte)(3))] byte index, ushort* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndInsertScalar((Vector64<int>, Vector64<int>, Vector64<int>, Vector64<int>) values, [ConstantExpected(Max = (byte)(1))] byte index, int* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndInsertScalar((Vector64<uint>, Vector64<uint>, Vector64<uint>, Vector64<uint>) values, [ConstantExpected(Max = (byte)(1))] byte index, uint* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }[Vm], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndInsertScalar((Vector64<float>, Vector64<float>, Vector64<float>, Vector64<float>) values, [ConstantExpected(Max = (byte)(1))] byte index, float* address) => LoadAndInsertScalar(values, index, address);
 
         /// <summary>
@@ -9014,7 +8671,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadAndReplicateToVector64(byte* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9022,7 +8678,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadAndReplicateToVector64(short* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9030,7 +8685,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadAndReplicateToVector64(int* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9038,7 +8692,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadAndReplicateToVector64(sbyte* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9046,7 +8699,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadAndReplicateToVector64(float* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9054,7 +8706,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadAndReplicateToVector64(ushort* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9062,7 +8713,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadAndReplicateToVector64(uint* address) => LoadAndReplicateToVector64(address);
 
         /// <summary>
@@ -9070,7 +8720,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAndReplicateToVector128(byte* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9078,7 +8727,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAndReplicateToVector128(short* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9086,7 +8734,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAndReplicateToVector128(int* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9094,7 +8741,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAndReplicateToVector128(sbyte* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9102,7 +8748,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAndReplicateToVector128(float* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9110,7 +8755,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAndReplicateToVector128(ushort* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>
@@ -9118,91 +8762,69 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 { Dd[], Dd+1[] }, [Rn]</para>
         ///   <para>  A64: LD1R { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAndReplicateToVector128(uint* address) => LoadAndReplicateToVector128(address);
 
         /// <summary>  A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD2R { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) => LoadAndReplicateToVector64x2(address);
 
         /// <summary>  A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD3R { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) => LoadAndReplicateToVector64x3(address);
 
         /// <summary>  A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>  A64: LD4R { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) => LoadAndReplicateToVector64x4(address);
 
         /// <summary>
@@ -9210,7 +8832,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<byte> LoadVector64(byte* address) => LoadVector64(address);
 
         /// <summary>
@@ -9218,7 +8839,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<double> LoadVector64(double* address) => LoadVector64(address);
 
         /// <summary>
@@ -9226,7 +8846,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<short> LoadVector64(short* address) => LoadVector64(address);
 
         /// <summary>
@@ -9234,7 +8853,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<int> LoadVector64(int* address) => LoadVector64(address);
 
         /// <summary>
@@ -9242,7 +8860,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<long> LoadVector64(long* address) => LoadVector64(address);
 
         /// <summary>
@@ -9250,7 +8867,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<sbyte> LoadVector64(sbyte* address) => LoadVector64(address);
 
         /// <summary>
@@ -9258,7 +8874,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<float> LoadVector64(float* address) => LoadVector64(address);
 
         /// <summary>
@@ -9266,7 +8881,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ushort> LoadVector64(ushort* address) => LoadVector64(address);
 
         /// <summary>
@@ -9274,7 +8888,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<uint> LoadVector64(uint* address) => LoadVector64(address);
 
         /// <summary>
@@ -9282,7 +8895,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, [Rn]</para>
         ///   <para>  A64: LD1 Vt.1D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector64<ulong> LoadVector64(ulong* address) => LoadVector64(address);
 
         /// <summary>
@@ -9290,7 +8902,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.16B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadVector128(byte* address) => LoadVector128(address);
 
         /// <summary>
@@ -9298,7 +8909,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) => LoadVector128(address);
 
         /// <summary>
@@ -9306,7 +8916,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadVector128(short* address) => LoadVector128(address);
 
         /// <summary>
@@ -9314,7 +8923,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadVector128(int* address) => LoadVector128(address);
 
         /// <summary>
@@ -9322,7 +8930,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadVector128(long* address) => LoadVector128(address);
 
         /// <summary>
@@ -9330,7 +8937,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.8 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.16B, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) => LoadVector128(address);
 
         /// <summary>
@@ -9338,7 +8944,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadVector128(float* address) => LoadVector128(address);
 
         /// <summary>
@@ -9346,7 +8951,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.16 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.8H, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) => LoadVector128(address);
 
         /// <summary>
@@ -9354,7 +8958,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.32 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.4S, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadVector128(uint* address) => LoadVector128(address);
 
         /// <summary>
@@ -9362,175 +8965,132 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VLD1.64 Dd, Dd+1, [Rn]</para>
         ///   <para>  A64: LD1 Vt.2D, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) => LoadVector128(address);
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) Load2xVector64AndUnzip(byte* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) Load2xVector64AndUnzip(sbyte* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) Load2xVector64AndUnzip(short* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) Load2xVector64AndUnzip(ushort* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) Load2xVector64AndUnzip(int* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) Load2xVector64AndUnzip(uint* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) Load2xVector64AndUnzip(float* address) => Load2xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) Load3xVector64AndUnzip(byte* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) Load3xVector64AndUnzip(sbyte* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) Load3xVector64AndUnzip(short* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) Load3xVector64AndUnzip(ushort* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) Load3xVector64AndUnzip(int* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) Load3xVector64AndUnzip(uint* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) Load3xVector64AndUnzip(float* address) => Load3xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) Load4xVector64AndUnzip(byte* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) Load4xVector64AndUnzip(sbyte* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) Load4xVector64AndUnzip(short* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) Load4xVector64AndUnzip(ushort* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) Load4xVector64AndUnzip(int* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) Load4xVector64AndUnzip(uint* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD4 { Vn.4S, Vn+1.4S, Vn+2.4S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) Load4xVector64AndUnzip(float* address) => Load4xVector64AndUnzip(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2) Load2xVector64(byte* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2) Load2xVector64(sbyte* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2) Load2xVector64(short* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2) Load2xVector64(ushort* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2) Load2xVector64(int* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2) Load2xVector64(uint* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2) Load2xVector64(float* address) => Load2xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) Load3xVector64(byte* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) Load3xVector64(sbyte* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) Load3xVector64(short* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) Load3xVector64(ushort* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) Load3xVector64(int* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) Load3xVector64(uint* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) Load3xVector64(float* address) => Load3xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) Load4xVector64(byte* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) Load4xVector64(sbyte* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) Load4xVector64(short* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) Load4xVector64(ushort* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) Load4xVector64(int* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) Load4xVector64(uint* address) => Load4xVector64(address);
 
         /// <summary>  A64: LD1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) Load4xVector64(float* address) => Load4xVector64(address);
 
         /// <summary>
@@ -15395,7 +14955,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector64<byte> source) => Store(address, source);
 
         /// <summary>
@@ -15403,7 +14962,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector64<double> source) => Store(address, source);
 
         /// <summary>
@@ -15411,7 +14969,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 {Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector64<short> source) => Store(address, source);
 
         /// <summary>
@@ -15419,7 +14976,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector64<int> source) => Store(address, source);
 
         /// <summary>
@@ -15427,7 +14983,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector64<long> source) => Store(address, source);
 
         /// <summary>
@@ -15435,7 +14990,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector64<sbyte> source) => Store(address, source);
 
         /// <summary>
@@ -15443,7 +14997,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector64<float> source) => Store(address, source);
 
         /// <summary>
@@ -15451,7 +15004,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector64<ushort> source) => Store(address, source);
 
         /// <summary>
@@ -15459,7 +15011,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector64<uint> source) => Store(address, source);
 
         /// <summary>
@@ -15467,7 +15018,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.1D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector64<ulong> source) => Store(address, source);
 
         /// <summary>
@@ -15475,7 +15025,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector128<byte> source) => Store(address, source);
 
         /// <summary>
@@ -15483,7 +15032,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) => Store(address, source);
 
         /// <summary>
@@ -15491,7 +15039,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector128<short> source) => Store(address, source);
 
         /// <summary>
@@ -15499,7 +15046,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector128<int> source) => Store(address, source);
 
         /// <summary>
@@ -15507,7 +15053,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector128<long> source) => Store(address, source);
 
         /// <summary>
@@ -15515,7 +15060,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.16B }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector128<sbyte> source) => Store(address, source);
 
         /// <summary>
@@ -15523,7 +15067,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector128<float> source) => Store(address, source);
 
         /// <summary>
@@ -15531,7 +15074,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.8H }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) => Store(address, source);
 
         /// <summary>
@@ -15539,7 +15081,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.4S }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector128<uint> source) => Store(address, source);
 
         /// <summary>
@@ -15547,7 +15088,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.64 { Dd, Dd+1 }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.2D }, [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector128<ulong> source) => Store(address, source);
 
         /// <summary>
@@ -15555,7 +15095,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, Vector64<byte> value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15563,7 +15102,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, Vector64<short> value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15571,7 +15109,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, Vector64<int> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15579,7 +15116,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, Vector64<sbyte> value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15587,7 +15123,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, Vector64<float> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15595,7 +15130,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector64<ushort> value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15603,7 +15137,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, Vector64<uint> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15611,7 +15144,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, Vector128<byte> value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15619,7 +15151,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(double* address, Vector128<double> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15627,7 +15158,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, Vector128<short> value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15635,7 +15165,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, Vector128<int> value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15643,7 +15172,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(long* address, Vector128<long> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15651,7 +15179,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.8 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.B }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, Vector128<sbyte> value, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15659,7 +15186,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, Vector128<float> value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15667,7 +15193,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.16 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.H }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector128<ushort> value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15675,7 +15200,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VST1.32 { Dd[index] }, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.S }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, Vector128<uint> value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>
@@ -15683,259 +15207,195 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  A32: VSTR.64 Dd, [Rn]</para>
         ///   <para>  A64: ST1 { Vt.D }[index], [Xn]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ulong* address, Vector128<ulong> value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.8B, Vt+1.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.8B, Vt+1.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.4H, Vt+1.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.4H, Vt+1.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.8B, Vt+1.8B, Vt+2.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2, Vector64<byte> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.8B, Vt+1.8B, Vt+2.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2, Vector64<sbyte> value3) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.4H, Vt+1.4H, Vt+2.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2, Vector64<short> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.4H, Vt+1.4H, Vt+2.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2,  Vector64<ushort> value3) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2, Vector64<int> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST3 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2, Vector64<uint> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vt.2S, Vt+1.2S, Vt+2.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2, Vector64<float> value3) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.8B, Vt+1.8B, Vt+2.8B, Vt+3.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte* address, (Vector64<byte> value1, Vector64<byte> value2, Vector64<byte> value3, Vector64<byte> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.8B, Vt+1.8B, Vt+2.8B, Vt+3.8B }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte* address, (Vector64<sbyte> value1, Vector64<sbyte> value2, Vector64<sbyte> value3, Vector64<sbyte> value4) value, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.4H, Vt+1.4H, Vt+2.4H, Vt+3.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short* address, (Vector64<short> value1, Vector64<short> value2, Vector64<short> value3, Vector64<short> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.4H, Vt+1.4H, Vt+2.4H, Vt+3.4H }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, (Vector64<ushort> value1, Vector64<ushort> value2, Vector64<ushort> value3, Vector64<ushort> value4) value, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int* address, (Vector64<int> value1, Vector64<int> value2, Vector64<int> value3, Vector64<int> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint* address, (Vector64<uint> value1, Vector64<uint> value2, Vector64<uint> value3, Vector64<uint> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST4 { Vt.2S, Vt+1.2S, Vt+2.2S, Vt+3.2S }[index], [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float* address, (Vector64<float> value1, Vector64<float> value2, Vector64<float> value3, Vector64<float> value4) value, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, value, index);
 
         /// <summary>  A64: ST2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST2 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST3 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST4 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void StoreVectorAndZip(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) value) => StoreVectorAndZip(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, (Vector64<byte> Value1, Vector64<byte> Value2, Vector64<byte> Value3, Vector64<byte> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.8B, Vn+1.8B, Vn+2.8B, Vn+3.8B }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, (Vector64<sbyte> Value1, Vector64<sbyte> Value2, Vector64<sbyte> Value3, Vector64<sbyte> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, (Vector64<short> Value1, Vector64<short> Value2, Vector64<short> Value3, Vector64<short> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.4H, Vn+1.4H, Vn+2.4H, Vn+3.4H }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, (Vector64<ushort> Value1, Vector64<ushort> Value2, Vector64<ushort> Value3, Vector64<ushort> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, (Vector64<int> Value1, Vector64<int> Value2, Vector64<int> Value3, Vector64<int> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, (Vector64<uint> Value1, Vector64<uint> Value2, Vector64<uint> Value3, Vector64<uint> Value4) value) => Store(address, value);
 
         /// <summary>  A64: ST1 { Vn.2S, Vn+1.2S, Vn+2.2S, Vn+3.2S }, [Xn]</summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, (Vector64<float> Value1, Vector64<float> Value2, Vector64<float> Value3, Vector64<float> Value4) value) => Store(address, value);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.PlatformNotSupported.cs
@@ -3778,14 +3778,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfh_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -3799,7 +3797,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3812,21 +3809,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfh_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -3840,7 +3834,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3853,7 +3846,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -3863,14 +3855,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfw_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -3884,7 +3874,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3897,21 +3886,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfw_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -3925,7 +3911,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3938,7 +3923,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -3948,14 +3932,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, SXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfd_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -3969,7 +3951,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, UXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3982,21 +3963,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, SXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfd_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4010,7 +3988,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, UXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4023,7 +4000,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -4033,14 +4009,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfb_gather_[s64]offset(svbool_t pg, const void *base, svint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4054,7 +4028,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u32]offset(svbool_t pg, const void *base, svuint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4067,21 +4040,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u64]offset(svbool_t pg, const void *base, svuint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svprfb_gather_[s64]offset(svbool_t pg, const void *base, svint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4095,7 +4065,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u32]offset(svbool_t pg, const void *base, svuint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4108,7 +4077,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u64]offset(svbool_t pg, const void *base, svuint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -4118,7 +4086,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVector(Vector<double> mask, double* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4131,14 +4098,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[u64]index[_f64](svbool_t pg, const float64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVector(Vector<double> mask, double* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[s32]index[_s32](svbool_t pg, const int32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVector(Vector<int> mask, int* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4152,14 +4117,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1_gather_[u32]index[_s32](svbool_t pg, const int32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVector(Vector<int> mask, int* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[s64]index[_s64](svbool_t pg, const int64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVector(Vector<long> mask, long* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4172,14 +4135,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1_gather_[u64]index[_s64](svbool_t pg, const int64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVector(Vector<long> mask, long* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[s32]index[_f32](svbool_t pg, const float32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVector(Vector<float> mask, float* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4193,14 +4154,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat32_t svld1_gather_[u32]index[_f32](svbool_t pg, const float32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVector(Vector<float> mask, float* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[s32]index[_u32](svbool_t pg, const uint32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVector(Vector<uint> mask, uint* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4214,14 +4173,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1_gather_[u32]index[_u32](svbool_t pg, const uint32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVector(Vector<uint> mask, uint* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[s64]index[_u64](svbool_t pg, const uint64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVector(Vector<ulong> mask, ulong* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4234,7 +4191,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1_gather_[u64]index[_u64](svbool_t pg, const uint64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVector(Vector<ulong> mask, ulong* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4244,7 +4200,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtend(Vector<int> mask, byte* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4258,14 +4213,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_gather_[u32]offset_s32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtend(Vector<int> mask, byte* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1ub_gather_[s64]offset_s64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtend(Vector<long> mask, byte* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4278,14 +4231,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1ub_gather_[u64]offset_s64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtend(Vector<long> mask, byte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1ub_gather_[s32]offset_u32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtend(Vector<uint> mask, byte* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4299,14 +4250,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1ub_gather_[u32]offset_u32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtend(Vector<uint> mask, byte* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1ub_gather_[s64]offset_u64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4319,7 +4268,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1ub_gather_[u64]offset_u64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4329,7 +4277,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4343,14 +4290,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1ub_gather_[u32]offset_s32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1ub_gather_[s64]offset_s64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4363,14 +4308,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1ub_gather_[u64]offset_s64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1ub_gather_[s32]offset_u32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4384,14 +4327,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1ub_gather_[u32]offset_u32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1ub_gather_[s64]offset_u64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4404,7 +4345,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1ub_gather_[u64]offset_u64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -4414,7 +4354,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorFirstFaulting(Vector<double> mask, double* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4427,7 +4366,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[u64]index[_f64](svbool_t pg, const float64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorFirstFaulting(Vector<double> mask, double* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4441,14 +4379,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1_gather_[s32]index[_s32](svbool_t pg, const int32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorFirstFaulting(Vector<int> mask, int* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[u32]index[_s32](svbool_t pg, const int32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorFirstFaulting(Vector<int> mask, int* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4461,21 +4397,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1_gather_[s64]index[_s64](svbool_t pg, const int64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorFirstFaulting(Vector<long> mask, long* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[u64]index[_s64](svbool_t pg, const int64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorFirstFaulting(Vector<long> mask, long* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[s32]index[_f32](svbool_t pg, const float32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorFirstFaulting(Vector<float> mask, float* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4489,7 +4422,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat32_t svldff1_gather_[u32]index[_f32](svbool_t pg, const float32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorFirstFaulting(Vector<float> mask, float* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4503,14 +4435,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1_gather_[s32]index[_u32](svbool_t pg, const uint32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorFirstFaulting(Vector<uint> mask, uint* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[u32]index[_u32](svbool_t pg, const uint32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorFirstFaulting(Vector<uint> mask, uint* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4523,14 +4453,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1_gather_[s64]index[_u64](svbool_t pg, const uint64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorFirstFaulting(Vector<ulong> mask, ulong* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[u64]index[_u64](svbool_t pg, const uint64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorFirstFaulting(Vector<ulong> mask, ulong* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4540,7 +4468,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtend(Vector<int> mask, short* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4554,14 +4481,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[u32]index_s32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtend(Vector<int> mask, short* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[s64]index_s64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtend(Vector<long> mask, short* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4574,14 +4499,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sh_gather_[u64]index_s64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtend(Vector<long> mask, short* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[s32]index_u32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtend(Vector<uint> mask, short* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4595,14 +4518,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sh_gather_[u32]index_u32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtend(Vector<uint> mask, short* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[s64]index_u64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4615,7 +4536,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sh_gather_[u64]index_u64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4625,7 +4545,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4639,14 +4558,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[u32]index_s32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[s64]index_s64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4659,14 +4576,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sh_gather_[u64]index_s64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[s32]index_u32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4680,14 +4595,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1sh_gather_[u32]index_u32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[s64]index_u64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4700,7 +4613,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sh_gather_[u64]index_u64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4710,56 +4622,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(Vector<int> mask, short* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1sh_gather_[u32]offset_s32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(Vector<int> mask, short* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[s64]offset_s64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(Vector<long> mask, short* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[u64]offset_s64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(Vector<long> mask, short* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[s32]offset_u32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(Vector<uint> mask, short* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[u32]offset_u32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(Vector<uint> mask, short* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[s64]offset_u64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[u64]offset_u64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -4769,56 +4673,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<int> mask, short* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1sh_gather_[u32]offset_s32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<int> mask, short* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[s64]offset_s64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, short* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[u64]offset_s64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, short* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[s32]offset_u32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[u32]offset_u32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[s64]offset_u64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[u64]offset_u64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -4828,7 +4724,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtend(Vector<long> mask, int* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4841,14 +4736,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[u64]index_s64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtend(Vector<long> mask, int* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[s64]index_u64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4861,7 +4754,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sw_gather_[u64]index_u64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4871,7 +4763,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4884,14 +4775,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[u64]index_s64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[s64]index_u64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4904,7 +4793,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sw_gather_[u64]index_u64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -4914,28 +4802,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(Vector<long> mask, int* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1sw_gather_[u64]offset_s64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(Vector<long> mask, int* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[s64]offset_u64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[u64]offset_u64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -4945,28 +4829,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, int* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sw_gather_[u64]offset_s64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, int* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[s64]offset_u64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[u64]offset_u64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -4976,7 +4856,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtend(Vector<int> mask, sbyte* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -4990,14 +4869,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_gather_[u32]offset_s32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtend(Vector<int> mask, sbyte* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1sb_gather_[s64]offset_s64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtend(Vector<long> mask, sbyte* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5010,14 +4887,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sb_gather_[u64]offset_s64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtend(Vector<long> mask, sbyte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1sb_gather_[s32]offset_u32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtend(Vector<uint> mask, sbyte* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5031,14 +4906,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sb_gather_[u32]offset_u32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtend(Vector<uint> mask, sbyte* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1sb_gather_[s64]offset_u64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5051,7 +4924,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sb_gather_[u64]offset_u64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -5061,7 +4933,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5075,14 +4946,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sb_gather_[u32]offset_s32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sb_gather_[s64]offset_s64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5095,14 +4964,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sb_gather_[u64]offset_s64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sb_gather_[s32]offset_u32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5116,14 +4983,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1sb_gather_[u32]offset_u32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sb_gather_[s64]offset_u64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5136,7 +5001,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sb_gather_[u64]offset_u64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5146,56 +5010,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<int> mask, ushort* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1uh_gather_[u32]offset_s32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<int> mask, ushort* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[s64]offset_s64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<long> mask, ushort* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[u64]offset_s64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<long> mask, ushort* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[s32]offset_u32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<uint> mask, ushort* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[u32]offset_u32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<uint> mask, ushort* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[s64]offset_u64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[u64]offset_u64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5205,56 +5061,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1uh_gather_[u32]offset_s32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[s64]offset_s64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[u64]offset_s64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[s32]offset_u32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[u32]offset_u32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[s64]offset_u64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[u64]offset_u64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5264,7 +5112,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtend(Vector<int> mask, ushort* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5278,14 +5125,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[u32]index_s32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtend(Vector<int> mask, ushort* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[s64]index_s64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtend(Vector<long> mask, ushort* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5298,14 +5143,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uh_gather_[u64]index_s64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtend(Vector<long> mask, ushort* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[s32]index_u32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtend(Vector<uint> mask, ushort* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5319,14 +5162,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1uh_gather_[u32]index_u32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtend(Vector<uint> mask, ushort* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[s64]index_u64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5339,7 +5180,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uh_gather_[u64]index_u64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -5349,7 +5189,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5363,14 +5202,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[u32]index_s32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[s64]index_s64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5383,14 +5220,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uh_gather_[u64]index_s64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[s32]index_u32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<int> indices) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -5404,14 +5239,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1uh_gather_[u32]index_u32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<uint> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[s64]index_u64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5424,7 +5257,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1uh_gather_[u64]index_u64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -5434,28 +5266,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<long> mask, uint* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1uw_gather_[u64]offset_s64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<long> mask, uint* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[s64]offset_u64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[u64]offset_u64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5465,28 +5293,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1uw_gather_[u64]offset_s64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[s64]offset_u64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[u64]offset_u64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5496,7 +5320,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtend(Vector<long> mask, uint* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5509,14 +5332,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[u64]index_s64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtend(Vector<long> mask, uint* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[s64]index_u64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5529,7 +5350,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uw_gather_[u64]index_u64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -5539,7 +5359,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5552,14 +5371,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[u64]index_s64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[s64]index_u64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<long> indices) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5572,7 +5389,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1uw_gather_[u64]index_u64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<ulong> indices) { throw new PlatformNotSupportedException(); }
 
 
@@ -5582,84 +5398,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsetFirstFaulting(Vector<double> mask, double* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svldff1_gather_[u64]offset[_f64](svbool_t pg, const float64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsetFirstFaulting(Vector<double> mask, double* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[s32]offset[_s32](svbool_t pg, const int32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsetFirstFaulting(Vector<int> mask, int* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[u32]offset[_s32](svbool_t pg, const int32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsetFirstFaulting(Vector<int> mask, int* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[s64]offset[_s64](svbool_t pg, const int64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsetFirstFaulting(Vector<long> mask, long* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[u64]offset[_s64](svbool_t pg, const int64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsetFirstFaulting(Vector<long> mask, long* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[s32]offset[_f32](svbool_t pg, const float32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsetFirstFaulting(Vector<float> mask, float* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[u32]offset[_f32](svbool_t pg, const float32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsetFirstFaulting(Vector<float> mask, float* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[s32]offset[_u32](svbool_t pg, const uint32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsetFirstFaulting(Vector<uint> mask, uint* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[u32]offset[_u32](svbool_t pg, const uint32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsetFirstFaulting(Vector<uint> mask, uint* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[s64]offset[_u64](svbool_t pg, const uint64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(Vector<ulong> mask, ulong* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[u64]offset[_u64](svbool_t pg, const uint64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -5669,84 +5473,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsets(Vector<double> mask, double* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svld1_gather_[u64]offset[_f64](svbool_t pg, const float64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsets(Vector<double> mask, double* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[s32]offset[_s32](svbool_t pg, const int32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsets(Vector<int> mask, int* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[u32]offset[_s32](svbool_t pg, const int32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsets(Vector<int> mask, int* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[s64]offset[_s64](svbool_t pg, const int64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsets(Vector<long> mask, long* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[u64]offset[_s64](svbool_t pg, const int64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsets(Vector<long> mask, long* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[s32]offset[_f32](svbool_t pg, const float32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsets(Vector<float> mask, float* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[u32]offset[_f32](svbool_t pg, const float32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsets(Vector<float> mask, float* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[s32]offset[_u32](svbool_t pg, const uint32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsets(Vector<uint> mask, uint* address, Vector<int> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[u32]offset[_u32](svbool_t pg, const uint32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsets(Vector<uint> mask, uint* address, Vector<uint> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[s64]offset[_u64](svbool_t pg, const uint64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<long> offsets) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[u64]offset[_u64](svbool_t pg, const uint64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) { throw new PlatformNotSupportedException(); }
 
 
@@ -6058,7 +5850,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xarray, Xindex]</para>
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVector(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6066,7 +5857,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVector(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6074,7 +5864,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xarray, Xindex, LSL #1]</para>
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVector(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6082,7 +5871,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVector(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6090,7 +5878,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVector(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6098,7 +5885,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xarray, Xindex]</para>
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVector(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6106,7 +5892,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVector(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6114,7 +5899,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xarray, Xindex, LSL #1]</para>
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVector(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6122,7 +5906,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVector(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -6130,7 +5913,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVector(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6140,70 +5922,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svld1rq[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1RQB Zresult.B, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVector128AndReplicateToVector(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svld1rq[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVector128AndReplicateToVector(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16_t svld1rq[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1RQH Zresult.H, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVector128AndReplicateToVector(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svld1rq[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVector128AndReplicateToVector(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svld1rq[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVector128AndReplicateToVector(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8_t svld1rq[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1RQB Zresult.B, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVector128AndReplicateToVector(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svld1rq[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVector128AndReplicateToVector(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svld1rq[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1RQH Zresult.H, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVector128AndReplicateToVector(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svld1rq[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVector128AndReplicateToVector(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svld1rq[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVector128AndReplicateToVector(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6213,7 +5985,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldnf1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteNonFaultingZeroExtendToInt16(Vector<short> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6223,7 +5994,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteNonFaultingZeroExtendToInt32(Vector<int> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6233,7 +6003,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteNonFaultingZeroExtendToInt64(Vector<long> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6243,7 +6012,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svldnf1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteNonFaultingZeroExtendToUInt16(Vector<ushort> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6253,7 +6021,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteNonFaultingZeroExtendToUInt32(Vector<uint> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6263,7 +6030,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteNonFaultingZeroExtendToUInt64(Vector<ulong> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6271,42 +6037,36 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldff1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteZeroExtendFirstFaulting(Vector<short> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svldff1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendFirstFaulting(Vector<ushort> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6316,7 +6076,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svld1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteZeroExtendToInt16(Vector<short> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6326,7 +6085,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteZeroExtendToInt32(Vector<int> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6336,7 +6094,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteZeroExtendToInt64(Vector<long> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6346,7 +6103,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svld1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendToUInt16(Vector<ushort> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6356,7 +6112,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteZeroExtendToUInt32(Vector<uint> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6366,7 +6121,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendToUInt64(Vector<ulong> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6376,70 +6130,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldff1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.B, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorFirstFaulting(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svldff1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorFirstFaulting(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16_t svldff1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1H Zresult.H, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorFirstFaulting(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorFirstFaulting(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorFirstFaulting(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8_t svldff1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1B Zresult.B, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorFirstFaulting(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldff1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorFirstFaulting(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svldff1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.H, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorFirstFaulting(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorFirstFaulting(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorFirstFaulting(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6449,7 +6193,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16NonFaultingSignExtendToInt32(Vector<int> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6459,7 +6202,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16NonFaultingSignExtendToInt64(Vector<long> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6469,7 +6211,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16NonFaultingSignExtendToUInt32(Vector<uint> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6479,7 +6220,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16NonFaultingSignExtendToUInt64(Vector<ulong> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6489,28 +6229,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6520,7 +6256,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16SignExtendToInt32(Vector<int> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6530,7 +6265,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16SignExtendToInt64(Vector<long> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6540,7 +6274,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16SignExtendToUInt32(Vector<uint> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6550,7 +6283,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendToUInt64(Vector<ulong> mask, short* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6560,7 +6292,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32NonFaultingSignExtendToInt64(Vector<long> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6570,7 +6301,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32NonFaultingSignExtendToUInt64(Vector<ulong> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6580,14 +6310,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6597,7 +6325,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32SignExtendToInt64(Vector<long> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6607,7 +6334,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendToUInt64(Vector<ulong> mask, int* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6617,70 +6343,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldnf1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorNonFaulting(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svldnf1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorNonFaulting(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16_t svldnf1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorNonFaulting(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldnf1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorNonFaulting(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldnf1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorNonFaulting(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8_t svldnf1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorNonFaulting(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldnf1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorNonFaulting(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svldnf1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorNonFaulting(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldnf1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorNonFaulting(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldnf1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorNonFaulting(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6690,70 +6406,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldnt1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNT1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorNonTemporal(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64_t svldnt1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorNonTemporal(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16_t svldnt1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNT1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorNonTemporal(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldnt1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorNonTemporal(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldnt1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorNonTemporal(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8_t svldnt1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNT1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorNonTemporal(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32_t svldnt1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorNonTemporal(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svldnt1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNT1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorNonTemporal(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldnt1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorNonTemporal(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldnt1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorNonTemporal(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6763,7 +6469,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldnf1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteNonFaultingSignExtendToInt16(Vector<short> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6773,7 +6478,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteNonFaultingSignExtendToInt32(Vector<int> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6783,7 +6487,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteNonFaultingSignExtendToInt64(Vector<long> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6793,7 +6496,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svldnf1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteNonFaultingSignExtendToUInt16(Vector<ushort> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6803,7 +6505,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteNonFaultingSignExtendToUInt32(Vector<uint> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6813,7 +6514,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteNonFaultingSignExtendToUInt64(Vector<ulong> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6823,42 +6523,36 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldff1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteSignExtendFirstFaulting(Vector<short> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32_t svldff1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16_t svldff1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendFirstFaulting(Vector<ushort> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6868,7 +6562,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svld1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteSignExtendToInt16(Vector<short> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6878,7 +6571,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteSignExtendToInt32(Vector<int> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6888,7 +6580,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteSignExtendToInt64(Vector<long> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6898,7 +6589,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svld1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendToUInt16(Vector<ushort> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6908,7 +6598,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteSignExtendToUInt32(Vector<uint> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6918,7 +6607,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendToUInt64(Vector<ulong> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6928,7 +6616,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16NonFaultingZeroExtendToInt32(Vector<int> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6938,7 +6625,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16NonFaultingZeroExtendToInt64(Vector<long> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6948,7 +6634,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16NonFaultingZeroExtendToUInt32(Vector<uint> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6958,7 +6643,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16NonFaultingZeroExtendToUInt64(Vector<ulong> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6968,28 +6652,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -6999,7 +6679,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendToInt32(Vector<int> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7009,7 +6688,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendToInt64(Vector<long> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7019,7 +6697,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendToUInt32(Vector<uint> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7029,7 +6706,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendToUInt64(Vector<ulong> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7039,7 +6715,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32NonFaultingZeroExtendToInt64(Vector<long> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7049,7 +6724,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32NonFaultingZeroExtendToUInt64(Vector<ulong> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7059,14 +6733,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7076,7 +6748,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendToInt64(Vector<long> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7086,7 +6757,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32ZeroExtendToUInt64(Vector<ulong> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7096,70 +6766,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x2_t svld2[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD2B {Zresult0.B, Zresult1.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>) Load2xVectorAndUnzip(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64x2_t svld2[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>) Load2xVectorAndUnzip(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16x2_t svld2[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD2H {Zresult0.H, Zresult1.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>) Load2xVectorAndUnzip(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32x2_t svld2[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>) Load2xVectorAndUnzip(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64x2_t svld2[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>) Load2xVectorAndUnzip(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8x2_t svld2[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD2B {Zresult0.B, Zresult1.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>) Load2xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32x2_t svld2[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>) Load2xVectorAndUnzip(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16x2_t svld2[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD2H {Zresult0.H, Zresult1.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>) Load2xVectorAndUnzip(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32x2_t svld2[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>) Load2xVectorAndUnzip(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64x2_t svld2[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>) Load2xVectorAndUnzip(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7169,70 +6829,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x3_t svld3[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD3B {Zresult0.B - Zresult2.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>, Vector<byte>) Load3xVectorAndUnzip(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64x3_t svld3[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>, Vector<double>) Load3xVectorAndUnzip(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16x3_t svld3[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD3H {Zresult0.H - Zresult2.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>, Vector<short>) Load3xVectorAndUnzip(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32x3_t svld3[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>, Vector<int>) Load3xVectorAndUnzip(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64x3_t svld3[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>, Vector<long>) Load3xVectorAndUnzip(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8x3_t svld3[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD3B {Zresult0.B - Zresult2.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>, Vector<sbyte>) Load3xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32x3_t svld3[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>, Vector<float>) Load3xVectorAndUnzip(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16x3_t svld3[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD3H {Zresult0.H - Zresult2.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>, Vector<ushort>) Load3xVectorAndUnzip(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32x3_t svld3[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>, Vector<uint>) Load3xVectorAndUnzip(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64x3_t svld3[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>) Load3xVectorAndUnzip(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -7242,70 +6892,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x4_t svld4[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD4B {Zresult0.B - Zresult3.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>, Vector<byte>, Vector<byte>) Load4xVectorAndUnzip(Vector<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat64x4_t svld4[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>, Vector<double>, Vector<double>) Load4xVectorAndUnzip(Vector<double> mask, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint16x4_t svld4[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD4H {Zresult0.H - Zresult3.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>, Vector<short>, Vector<short>) Load4xVectorAndUnzip(Vector<short> mask, short* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint32x4_t svld4[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>, Vector<int>, Vector<int>) Load4xVectorAndUnzip(Vector<int> mask, int* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint64x4_t svld4[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>, Vector<long>, Vector<long>) Load4xVectorAndUnzip(Vector<long> mask, long* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svint8x4_t svld4[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD4B {Zresult0.B - Zresult3.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>, Vector<sbyte>, Vector<sbyte>) Load4xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svfloat32x4_t svld4[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>, Vector<float>, Vector<float>) Load4xVectorAndUnzip(Vector<float> mask, float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint16x4_t svld4[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD4H {Zresult0.H - Zresult3.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>, Vector<ushort>, Vector<ushort>) Load4xVectorAndUnzip(Vector<ushort> mask, ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint32x4_t svld4[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>, Vector<uint>, Vector<uint>) Load4xVectorAndUnzip(Vector<uint> mask, uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>svuint64x4_t svld4[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>, Vector<ulong>) Load4xVectorAndUnzip(Vector<ulong> mask, ulong* address) { throw new PlatformNotSupportedException(); }
 
 
@@ -8317,7 +7957,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch16Bit(Vector<ushort> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -8327,7 +7966,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch32Bit(Vector<uint> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -8337,7 +7975,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch64Bit(Vector<ulong> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -8347,7 +7984,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch8Bit(Vector<byte> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw new PlatformNotSupportedException(); }
 
 
@@ -9343,7 +8979,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<long> indicies, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9356,14 +8991,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<ulong> indicies, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<int> indicies, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -9377,14 +9010,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<uint> indicies, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<long> indicies, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9397,14 +9028,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<ulong> indicies, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<int> indicies, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -9418,14 +9047,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<uint> indicies, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<int> indicies, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         // <summary>
@@ -9439,14 +9066,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<uint> indicies, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<long> indicies, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -9459,7 +9084,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<ulong> indicies, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9495,56 +9119,48 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1h_scatter_[s32]index[_s32](svbool_t pg, int16_t *base, svint32_t indices, svint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, SXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<int> mask, short* address, Vector<int> indices, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[u32]index[_s32](svbool_t pg, int16_t *base, svuint32_t indices, svint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, UXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<int> mask, short* address, Vector<uint> indices, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[s64]index[_s64](svbool_t pg, int16_t *base, svint64_t indices, svint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, short* address, Vector<long> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[u64]index[_s64](svbool_t pg, int16_t *base, svuint64_t indices, svint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, short* address, Vector<ulong> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[s32]index[_u32](svbool_t pg, uint16_t *base, svint32_t indices, svuint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, SXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, ushort* address, Vector<int> indices, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[u32]index[_u32](svbool_t pg, uint16_t *base, svuint32_t indices, svuint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, UXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, ushort* address, Vector<uint> indices, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[s64]index[_u64](svbool_t pg, uint16_t *base, svint64_t indices, svuint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, ushort* address, Vector<long> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1h_scatter_[u64]index[_u64](svbool_t pg, uint16_t *base, svuint64_t indices, svuint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9554,56 +9170,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<int> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<int> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9625,28 +9233,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1w_scatter_[s64]index[_s64](svbool_t pg, int32_t *base, svint64_t indices, svint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, int* address, Vector<long> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1w_scatter_[u64]index[_s64](svbool_t pg, int32_t *base, svuint64_t indices, svint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, int* address, Vector<ulong> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1w_scatter_[s64]index[_u64](svbool_t pg, uint32_t *base, svint64_t indices, svuint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, uint* address, Vector<long> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1w_scatter_[u64]index[_u64](svbool_t pg, uint32_t *base, svuint64_t indices, svuint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9656,28 +9260,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9716,56 +9316,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<int> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<int> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -9775,84 +9367,72 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<double> mask, double* address, Vector<long> offsets, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<double> mask, double* address, Vector<ulong> offsets, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<int> mask, int* address, Vector<int> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<int> mask, int* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<long> mask, long* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<long> mask, long* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<float> mask, float* address, Vector<int> offsets, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<float> mask, float* address, Vector<uint> offsets, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<uint> mask, uint* address, Vector<int> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<uint> mask, uint* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -10374,280 +9954,240 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)</para>
         ///   <para>  ST1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, Vector<byte> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_u8](svbool_t pg, uint8_t *base, svuint8x2_t data)</para>
         ///   <para>  ST2B {Zdata0.B, Zdata1.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_u8](svbool_t pg, uint8_t *base, svuint8x3_t data)</para>
         ///   <para>  ST3B {Zdata0.B - Zdata2.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2, Vector<byte> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_u8](svbool_t pg, uint8_t *base, svuint8x4_t data)</para>
         ///   <para>  ST4B {Zdata0.B - Zdata3.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2, Vector<byte> Value3, Vector<byte> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_f64](svbool_t pg, float64_t *base, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_f64](svbool_t pg, float64_t *base, svfloat64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_f64](svbool_t pg, float64_t *base, svfloat64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2, Vector<double> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_f64](svbool_t pg, float64_t *base, svfloat64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2, Vector<double> Value3, Vector<double> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_s16](svbool_t pg, int16_t *base, svint16_t data)</para>
         ///   <para>  ST1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, Vector<short> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_s16](svbool_t pg, int16_t *base, svint16x2_t data)</para>
         ///   <para>  ST2H {Zdata0.H, Zdata1.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_s16](svbool_t pg, int16_t *base, svint16x3_t data)</para>
         ///   <para>  ST3H {Zdata0.H - Zdata2.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2, Vector<short> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_s16](svbool_t pg, int16_t *base, svint16x4_t data)</para>
         ///   <para>  ST4H {Zdata0.H - Zdata3.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2, Vector<short> Value3, Vector<short> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_s32](svbool_t pg, int32_t *base, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_s32](svbool_t pg, int32_t *base, svint32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_s32](svbool_t pg, int32_t *base, svint32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2, Vector<int> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_s32](svbool_t pg, int32_t *base, svint32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2, Vector<int> Value3, Vector<int> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_s64](svbool_t pg, int64_t *base, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_s64](svbool_t pg, int64_t *base, svint64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_s64](svbool_t pg, int64_t *base, svint64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2, Vector<long> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_s64](svbool_t pg, int64_t *base, svint64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2, Vector<long> Value3, Vector<long> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_s8](svbool_t pg, int8_t *base, svint8_t data)</para>
         ///   <para>  ST1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, Vector<sbyte> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_s8](svbool_t pg, int8_t *base, svint8x2_t data)</para>
         ///   <para>  ST2B {Zdata0.B, Zdata1.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_s8](svbool_t pg, int8_t *base, svint8x3_t data)</para>
         ///   <para>  ST3B {Zdata0.B - Zdata2.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2, Vector<sbyte> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_s8](svbool_t pg, int8_t *base, svint8x4_t data)</para>
         ///   <para>  ST4B {Zdata0.B - Zdata3.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2, Vector<sbyte> Value3, Vector<sbyte> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_f32](svbool_t pg, float32_t *base, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_f32](svbool_t pg, float32_t *base, svfloat32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_f32](svbool_t pg, float32_t *base, svfloat32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2, Vector<float> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_f32](svbool_t pg, float32_t *base, svfloat32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2, Vector<float> Value3, Vector<float> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_u16](svbool_t pg, uint16_t *base, svuint16_t data)</para>
         ///   <para>  ST1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, Vector<ushort> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_u16](svbool_t pg, uint16_t *base, svuint16x2_t data)</para>
         ///   <para>  ST2H {Zdata0.H, Zdata1.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_u16](svbool_t pg, uint16_t *base, svuint16x3_t data)</para>
         ///   <para>  ST3H {Zdata0.H - Zdata2.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2, Vector<ushort> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_u16](svbool_t pg, uint16_t *base, svuint16x4_t data)</para>
         ///   <para>  ST4H {Zdata0.H - Zdata3.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2, Vector<ushort> Value3, Vector<ushort> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_u32](svbool_t pg, uint32_t *base, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_u32](svbool_t pg, uint32_t *base, svuint32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_u32](svbool_t pg, uint32_t *base, svuint32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2, Vector<uint> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_u32](svbool_t pg, uint32_t *base, svuint32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2, Vector<uint> Value3, Vector<uint> Value4) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1[_u64](svbool_t pg, uint64_t *base, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst2[_u64](svbool_t pg, uint64_t *base, svuint64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst3[_u64](svbool_t pg, uint64_t *base, svuint64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3) data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst4[_u64](svbool_t pg, uint64_t *base, svuint64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3, Vector<ulong> Value4) data) { throw new PlatformNotSupportedException(); }
 
 
@@ -10657,84 +10197,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1b[_s16](svbool_t pg, int8_t *base, svint16_t data)</para>
         ///   <para>  ST1B Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<short> mask, sbyte* address, Vector<short> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b[_s32](svbool_t pg, int8_t *base, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<int> mask, sbyte* address, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h[_s32](svbool_t pg, int16_t *base, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<int> mask, short* address, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b[_s64](svbool_t pg, int8_t *base, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, sbyte* address, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h[_s64](svbool_t pg, int16_t *base, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, short* address, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1w[_s64](svbool_t pg, int32_t *base, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, int* address, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b[_u16](svbool_t pg, uint8_t *base, svuint16_t data)</para>
         ///   <para>  ST1B Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ushort> mask, byte* address, Vector<ushort> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b[_u32](svbool_t pg, uint8_t *base, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<uint> mask, byte* address, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h[_u32](svbool_t pg, uint16_t *base, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<uint> mask, ushort* address, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1b[_u64](svbool_t pg, uint8_t *base, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1h[_u64](svbool_t pg, uint16_t *base, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svst1w[_u64](svbool_t pg, uint32_t *base, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -10744,70 +10272,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svstnt1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)</para>
         ///   <para>  STNT1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<byte> mask, byte* address, Vector<byte> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_f64](svbool_t pg, float64_t *base, svfloat64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<double> mask, double* address, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_s16](svbool_t pg, int16_t *base, svint16_t data)</para>
         ///   <para>  STNT1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<short> mask, short* address, Vector<short> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_s32](svbool_t pg, int32_t *base, svint32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<int> mask, int* address, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_s64](svbool_t pg, int64_t *base, svint64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<long> mask, long* address, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_s8](svbool_t pg, int8_t *base, svint8_t data)</para>
         ///   <para>  STNT1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<sbyte> mask, sbyte* address, Vector<sbyte> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_f32](svbool_t pg, float32_t *base, svfloat32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<float> mask, float* address, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_u16](svbool_t pg, uint16_t *base, svuint16_t data)</para>
         ///   <para>  STNT1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<ushort> mask, ushort* address, Vector<ushort> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_u32](svbool_t pg, uint32_t *base, svuint32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<uint> mask, uint* address, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void svstnt1[_u64](svbool_t pg, uint64_t *base, svuint64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve.cs
@@ -3775,14 +3775,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfh_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -3796,7 +3794,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -3809,21 +3806,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<short> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfh_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfh_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -3837,7 +3831,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -3850,7 +3843,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch16Bit(Vector<ushort> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch16Bit(mask, address, indices, prefetchType);
 
 
@@ -3860,14 +3852,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfw_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -3881,7 +3871,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -3894,21 +3883,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<int> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfw_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfw_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -3922,7 +3908,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -3935,7 +3920,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch32Bit(Vector<uint> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch32Bit(mask, address, indices, prefetchType);
 
 
@@ -3945,14 +3929,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, SXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfd_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -3966,7 +3948,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, UXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -3979,21 +3960,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<long> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfd_gather_[s32]index(svbool_t pg, const void *base, svint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, SXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         /// <summary>
         ///   <para>void svprfd_gather_[s64]index(svbool_t pg, const void *base, svint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         // <summary>
@@ -4007,7 +3985,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u32]index(svbool_t pg, const void *base, svuint32_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.S, UXTW #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
         /// <summary>
@@ -4020,7 +3997,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd_gather_[u64]index(svbool_t pg, const void *base, svuint64_t indices, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch64Bit(Vector<ulong> mask, void* address, Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch64Bit(mask, address, indices, prefetchType);
 
 
@@ -4030,14 +4006,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         /// <summary>
         ///   <para>void svprfb_gather_[s64]offset(svbool_t pg, const void *base, svint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         // <summary>
@@ -4051,7 +4025,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u32]offset(svbool_t pg, const void *base, svuint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         /// <summary>
@@ -4064,21 +4037,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u64]offset(svbool_t pg, const void *base, svuint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<byte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         /// <summary>
         ///   <para>void svprfb_gather_[s32]offset(svbool_t pg, const void *base, svint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         /// <summary>
         ///   <para>void svprfb_gather_[s64]offset(svbool_t pg, const void *base, svint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         // <summary>
@@ -4092,7 +4062,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u32]offset(svbool_t pg, const void *base, svuint32_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
         /// <summary>
@@ -4105,7 +4074,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb_gather_[u64]offset(svbool_t pg, const void *base, svuint64_t offsets, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void GatherPrefetch8Bit(Vector<sbyte> mask, void* address, Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) => GatherPrefetch8Bit(mask, address, offsets, prefetchType);
 
 
@@ -4115,7 +4083,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVector(Vector<double> mask, double* address, Vector<long> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
@@ -4128,14 +4095,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[u64]index[_f64](svbool_t pg, const float64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVector(Vector<double> mask, double* address, Vector<ulong> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[s32]index[_s32](svbool_t pg, const int32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVector(Vector<int> mask, int* address, Vector<int> indices) => GatherVector(mask, address, indices);
 
         // <summary>
@@ -4149,14 +4114,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1_gather_[u32]index[_s32](svbool_t pg, const int32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVector(Vector<int> mask, int* address, Vector<uint> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[s64]index[_s64](svbool_t pg, const int64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVector(Vector<long> mask, long* address, Vector<long> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
@@ -4169,14 +4132,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1_gather_[u64]index[_s64](svbool_t pg, const int64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVector(Vector<long> mask, long* address, Vector<ulong> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[s32]index[_f32](svbool_t pg, const float32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVector(Vector<float> mask, float* address, Vector<int> indices) => GatherVector(mask, address, indices);
 
         // <summary>
@@ -4190,14 +4151,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat32_t svld1_gather_[u32]index[_f32](svbool_t pg, const float32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVector(Vector<float> mask, float* address, Vector<uint> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[s32]index[_u32](svbool_t pg, const uint32_t *base, svint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVector(Vector<uint> mask, uint* address, Vector<int> indices) => GatherVector(mask, address, indices);
 
         // <summary>
@@ -4211,14 +4170,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1_gather_[u32]index[_u32](svbool_t pg, const uint32_t *base, svuint32_t indices)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVector(Vector<uint> mask, uint* address, Vector<uint> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[s64]index[_u64](svbool_t pg, const uint64_t *base, svint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVector(Vector<ulong> mask, ulong* address, Vector<long> indices) => GatherVector(mask, address, indices);
 
         /// <summary>
@@ -4231,7 +4188,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1_gather_[u64]index[_u64](svbool_t pg, const uint64_t *base, svuint64_t indices)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVector(Vector<ulong> mask, ulong* address, Vector<ulong> indices) => GatherVector(mask, address, indices);
 
 
@@ -4241,7 +4197,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtend(Vector<int> mask, byte* address, Vector<int> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         // <summary>
@@ -4255,14 +4210,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_gather_[u32]offset_s32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtend(Vector<int> mask, byte* address, Vector<uint> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svld1ub_gather_[s64]offset_s64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtend(Vector<long> mask, byte* address, Vector<long> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -4275,14 +4228,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1ub_gather_[u64]offset_s64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtend(Vector<long> mask, byte* address, Vector<ulong> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svld1ub_gather_[s32]offset_u32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtend(Vector<uint> mask, byte* address, Vector<int> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         // <summary>
@@ -4296,14 +4247,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1ub_gather_[u32]offset_u32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtend(Vector<uint> mask, byte* address, Vector<uint> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1ub_gather_[s64]offset_u64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<long> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -4316,7 +4265,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1ub_gather_[u64]offset_u64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtend(Vector<ulong> mask, byte* address, Vector<ulong> indices) => GatherVectorByteZeroExtend(mask, address, indices);
 
 
@@ -4326,7 +4274,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1ub_gather_[s32]offset_s32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address, Vector<int> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         // <summary>
@@ -4340,14 +4287,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1ub_gather_[u32]offset_s32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address, Vector<uint> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1ub_gather_[s64]offset_s64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address, Vector<long> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
@@ -4360,14 +4305,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1ub_gather_[u64]offset_s64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address, Vector<ulong> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1ub_gather_[s32]offset_u32(svbool_t pg, const uint8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address, Vector<int> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         // <summary>
@@ -4381,14 +4324,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1ub_gather_[u32]offset_u32(svbool_t pg, const uint8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address, Vector<uint> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1ub_gather_[s64]offset_u64(svbool_t pg, const uint8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address, Vector<long> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
@@ -4401,7 +4342,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1ub_gather_[u64]offset_u64(svbool_t pg, const uint8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address, Vector<ulong> offsets) => GatherVectorByteZeroExtendFirstFaulting(mask, address, offsets);
 
 
@@ -4411,7 +4351,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[s64]index[_f64](svbool_t pg, const float64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorFirstFaulting(Vector<double> mask, double* address, Vector<long> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4424,7 +4363,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[u64]index[_f64](svbool_t pg, const float64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorFirstFaulting(Vector<double> mask, double* address, Vector<ulong> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -4438,14 +4376,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1_gather_[s32]index[_s32](svbool_t pg, const int32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorFirstFaulting(Vector<int> mask, int* address, Vector<int> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[u32]index[_s32](svbool_t pg, const int32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorFirstFaulting(Vector<int> mask, int* address, Vector<uint> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4458,21 +4394,18 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1_gather_[s64]index[_s64](svbool_t pg, const int64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorFirstFaulting(Vector<long> mask, long* address, Vector<long> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[u64]index[_s64](svbool_t pg, const int64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorFirstFaulting(Vector<long> mask, long* address, Vector<ulong> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[s32]index[_f32](svbool_t pg, const float32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorFirstFaulting(Vector<float> mask, float* address, Vector<int> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -4486,7 +4419,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat32_t svldff1_gather_[u32]index[_f32](svbool_t pg, const float32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorFirstFaulting(Vector<float> mask, float* address, Vector<uint> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -4500,14 +4432,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1_gather_[s32]index[_u32](svbool_t pg, const uint32_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorFirstFaulting(Vector<uint> mask, uint* address, Vector<int> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[u32]index[_u32](svbool_t pg, const uint32_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorFirstFaulting(Vector<uint> mask, uint* address, Vector<uint> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4520,14 +4450,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1_gather_[s64]index[_u64](svbool_t pg, const uint64_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorFirstFaulting(Vector<ulong> mask, ulong* address, Vector<long> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[u64]index[_u64](svbool_t pg, const uint64_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorFirstFaulting(Vector<ulong> mask, ulong* address, Vector<ulong> indices) => GatherVectorFirstFaulting(mask, address, indices);
 
 
@@ -4537,7 +4465,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtend(Vector<int> mask, short* address, Vector<int> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         // <summary>
@@ -4551,14 +4478,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[u32]index_s32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtend(Vector<int> mask, short* address, Vector<uint> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[s64]index_s64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtend(Vector<long> mask, short* address, Vector<long> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         /// <summary>
@@ -4571,14 +4496,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sh_gather_[u64]index_s64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtend(Vector<long> mask, short* address, Vector<ulong> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[s32]index_u32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtend(Vector<uint> mask, short* address, Vector<int> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         // <summary>
@@ -4592,14 +4515,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sh_gather_[u32]index_u32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtend(Vector<uint> mask, short* address, Vector<uint> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[s64]index_u64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<long> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
         /// <summary>
@@ -4612,7 +4533,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sh_gather_[u64]index_u64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtend(Vector<ulong> mask, short* address, Vector<ulong> indices) => GatherVectorInt16SignExtend(mask, address, indices);
 
 
@@ -4622,7 +4542,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[s32]index_s32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address, Vector<int> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -4636,14 +4555,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[u32]index_s32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address, Vector<uint> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[s64]index_s64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address, Vector<long> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4656,14 +4573,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sh_gather_[u64]index_s64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address, Vector<ulong> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[s32]index_u32(svbool_t pg, const int16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<int> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -4677,14 +4592,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1sh_gather_[u32]index_u32(svbool_t pg, const int16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<uint> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[s64]index_u64(svbool_t pg, const int16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<long> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4697,7 +4610,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sh_gather_[u64]index_u64(svbool_t pg, const int16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<ulong> indices) => GatherVectorInt16SignExtendFirstFaulting(mask, address, indices);
 
 
@@ -4707,56 +4619,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(Vector<int> mask, short* address, Vector<int> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svld1sh_gather_[u32]offset_s32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(Vector<int> mask, short* address, Vector<uint> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[s64]offset_s64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(Vector<long> mask, short* address, Vector<long> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1sh_gather_[u64]offset_s64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(Vector<long> mask, short* address, Vector<ulong> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[s32]offset_u32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(Vector<uint> mask, short* address, Vector<int> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1sh_gather_[u32]offset_u32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(Vector<uint> mask, short* address, Vector<uint> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[s64]offset_u64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<long> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1sh_gather_[u64]offset_u64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(Vector<ulong> mask, short* address, Vector<ulong> offsets) => GatherVectorInt16WithByteOffsetsSignExtend(mask, address, offsets);
 
 
@@ -4766,56 +4670,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_gather_[s32]offset_s32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<int> mask, short* address, Vector<int> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svldff1sh_gather_[u32]offset_s32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<int> mask, short* address, Vector<uint> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[s64]offset_s64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, short* address, Vector<long> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_gather_[u64]offset_s64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, short* address, Vector<ulong> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[s32]offset_u32(svbool_t pg, const int16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<int> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_gather_[u32]offset_u32(svbool_t pg, const int16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<uint> mask, short* address, Vector<uint> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[s64]offset_u64(svbool_t pg, const int16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<long> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_gather_[u64]offset_u64(svbool_t pg, const int16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, short* address, Vector<ulong> offsets) => GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
 
@@ -4825,7 +4721,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtend(Vector<long> mask, int* address, Vector<long> indices) => GatherVectorInt32SignExtend(mask, address, indices);
 
         /// <summary>
@@ -4838,14 +4733,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[u64]index_s64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtend(Vector<long> mask, int* address, Vector<ulong> indices) => GatherVectorInt32SignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[s64]index_u64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<long> indices) => GatherVectorInt32SignExtend(mask, address, indices);
 
         /// <summary>
@@ -4858,7 +4751,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sw_gather_[u64]index_u64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtend(Vector<ulong> mask, int* address, Vector<ulong> indices) => GatherVectorInt32SignExtend(mask, address, indices);
 
 
@@ -4868,7 +4760,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[s64]index_s64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address, Vector<long> indices) => GatherVectorInt32SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4881,14 +4772,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[u64]index_s64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address, Vector<ulong> indices) => GatherVectorInt32SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[s64]index_u64(svbool_t pg, const int32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<long> indices) => GatherVectorInt32SignExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -4901,7 +4790,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sw_gather_[u64]index_u64(svbool_t pg, const int32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<ulong> indices) => GatherVectorInt32SignExtendFirstFaulting(mask, address, indices);
 
 
@@ -4911,28 +4799,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(Vector<long> mask, int* address, Vector<long> offsets) => GatherVectorInt32WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1sw_gather_[u64]offset_s64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(Vector<long> mask, int* address, Vector<ulong> offsets) => GatherVectorInt32WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[s64]offset_u64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<long> offsets) => GatherVectorInt32WithByteOffsetsSignExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1sw_gather_[u64]offset_u64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(Vector<ulong> mask, int* address, Vector<ulong> offsets) => GatherVectorInt32WithByteOffsetsSignExtend(mask, address, offsets);
 
 
@@ -4942,28 +4826,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_gather_[s64]offset_s64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, int* address, Vector<long> offsets) => GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1sw_gather_[u64]offset_s64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<long> mask, int* address, Vector<ulong> offsets) => GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[s64]offset_u64(svbool_t pg, const int32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<long> offsets) => GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_gather_[u64]offset_u64(svbool_t pg, const int32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(Vector<ulong> mask, int* address, Vector<ulong> offsets) => GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(mask, address, offsets);
 
 
@@ -4973,7 +4853,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtend(Vector<int> mask, sbyte* address, Vector<int> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         // <summary>
@@ -4987,14 +4866,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_gather_[u32]offset_s32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtend(Vector<int> mask, sbyte* address, Vector<uint> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svld1sb_gather_[s64]offset_s64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtend(Vector<long> mask, sbyte* address, Vector<long> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         /// <summary>
@@ -5007,14 +4884,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sb_gather_[u64]offset_s64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtend(Vector<long> mask, sbyte* address, Vector<ulong> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svld1sb_gather_[s32]offset_u32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtend(Vector<uint> mask, sbyte* address, Vector<int> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         // <summary>
@@ -5028,14 +4903,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sb_gather_[u32]offset_u32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtend(Vector<uint> mask, sbyte* address, Vector<uint> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1sb_gather_[s64]offset_u64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<long> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
         /// <summary>
@@ -5048,7 +4921,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sb_gather_[u64]offset_u64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtend(Vector<ulong> mask, sbyte* address, Vector<ulong> indices) => GatherVectorSByteSignExtend(mask, address, indices);
 
 
@@ -5058,7 +4930,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sb_gather_[s32]offset_s32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address, Vector<int> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         // <summary>
@@ -5072,14 +4943,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sb_gather_[u32]offset_s32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address, Vector<uint> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1sb_gather_[s64]offset_s64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address, Vector<long> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
@@ -5092,14 +4961,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sb_gather_[u64]offset_s64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address, Vector<ulong> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sb_gather_[s32]offset_u32(svbool_t pg, const int8_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address, Vector<int> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         // <summary>
@@ -5113,14 +4980,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1sb_gather_[u32]offset_u32(svbool_t pg, const int8_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address, Vector<uint> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sb_gather_[s64]offset_u64(svbool_t pg, const int8_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address, Vector<long> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
@@ -5133,7 +4998,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1sb_gather_[u64]offset_u64(svbool_t pg, const int8_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address, Vector<ulong> offsets) => GatherVectorSByteSignExtendFirstFaulting(mask, address, offsets);
 
 
@@ -5143,56 +5007,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<int> mask, ushort* address, Vector<int> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svld1uh_gather_[u32]offset_s32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<int> mask, ushort* address, Vector<uint> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[s64]offset_s64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<long> mask, ushort* address, Vector<long> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[u64]offset_s64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<long> mask, ushort* address, Vector<ulong> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[s32]offset_u32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<uint> mask, ushort* address, Vector<int> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[u32]offset_u32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<uint> mask, ushort* address, Vector<uint> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[s64]offset_u64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<long> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[u64]offset_u64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtend(mask, address, offsets);
 
 
@@ -5202,56 +5058,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[s32]offset_s32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<int> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svldff1uh_gather_[u32]offset_s32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<uint> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[s64]offset_s64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<long> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[u64]offset_s64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<ulong> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[s32]offset_u32(svbool_t pg, const uint16_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<int> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[u32]offset_u32(svbool_t pg, const uint16_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<uint> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[s64]offset_u64(svbool_t pg, const uint16_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<long> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[u64]offset_u64(svbool_t pg, const uint16_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<ulong> offsets) => GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
 
@@ -5261,7 +5109,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtend(Vector<int> mask, ushort* address, Vector<int> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         // <summary>
@@ -5275,14 +5122,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_gather_[u32]index_s32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtend(Vector<int> mask, ushort* address, Vector<uint> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svld1uh_gather_[s64]index_s64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtend(Vector<long> mask, ushort* address, Vector<long> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -5295,14 +5140,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uh_gather_[u64]index_s64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtend(Vector<long> mask, ushort* address, Vector<ulong> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svld1uh_gather_[s32]index_u32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtend(Vector<uint> mask, ushort* address, Vector<int> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         // <summary>
@@ -5316,14 +5159,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1uh_gather_[u32]index_u32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtend(Vector<uint> mask, ushort* address, Vector<uint> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1uh_gather_[s64]index_u64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<long> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -5336,7 +5177,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uh_gather_[u64]index_u64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtend(Vector<ulong> mask, ushort* address, Vector<ulong> indices) => GatherVectorUInt16ZeroExtend(mask, address, indices);
 
 
@@ -5346,7 +5186,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[s32]index_s32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<int> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -5360,14 +5199,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_gather_[u32]index_s32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address, Vector<uint> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_gather_[s64]index_s64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<long> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -5380,14 +5217,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uh_gather_[u64]index_s64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address, Vector<ulong> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_gather_[s32]index_u32(svbool_t pg, const uint16_t *base, svint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, SXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<int> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         // <summary>
@@ -5401,14 +5236,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldff1uh_gather_[u32]index_u32(svbool_t pg, const uint16_t *base, svuint32_t indices)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, Zindices.S, UXTW #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address, Vector<uint> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_gather_[s64]index_u64(svbool_t pg, const uint16_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<long> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -5421,7 +5254,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1uh_gather_[u64]index_u64(svbool_t pg, const uint16_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address, Vector<ulong> indices) => GatherVectorUInt16ZeroExtendFirstFaulting(mask, address, indices);
 
 
@@ -5431,28 +5263,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<long> mask, uint* address, Vector<long> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1uw_gather_[u64]offset_s64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<long> mask, uint* address, Vector<ulong> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[s64]offset_u64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<long> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtend(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[u64]offset_u64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtend(mask, address, offsets);
 
 
@@ -5462,28 +5290,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[s64]offset_s64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<long> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1uw_gather_[u64]offset_s64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<ulong> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[s64]offset_u64(svbool_t pg, const uint32_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<long> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[u64]offset_u64(svbool_t pg, const uint32_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<ulong> offsets) => GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(mask, address, offsets);
 
 
@@ -5493,7 +5317,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtend(Vector<long> mask, uint* address, Vector<long> indices) => GatherVectorUInt32ZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -5506,14 +5329,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_gather_[u64]index_s64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtend(Vector<long> mask, uint* address, Vector<ulong> indices) => GatherVectorUInt32ZeroExtend(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svld1uw_gather_[s64]index_u64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<long> indices) => GatherVectorUInt32ZeroExtend(mask, address, indices);
 
         /// <summary>
@@ -5526,7 +5347,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uw_gather_[u64]index_u64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtend(Vector<ulong> mask, uint* address, Vector<ulong> indices) => GatherVectorUInt32ZeroExtend(mask, address, indices);
 
 
@@ -5536,7 +5356,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[s64]index_s64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<long> indices) => GatherVectorUInt32ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -5549,14 +5368,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_gather_[u64]index_s64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address, Vector<ulong> indices) => GatherVectorUInt32ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_gather_[s64]index_u64(svbool_t pg, const uint32_t *base, svint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<long> indices) => GatherVectorUInt32ZeroExtendFirstFaulting(mask, address, indices);
 
         /// <summary>
@@ -5569,7 +5386,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldff1uw_gather_[u64]index_u64(svbool_t pg, const uint32_t *base, svuint64_t indices)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, Zindices.D, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address, Vector<ulong> indices) => GatherVectorUInt32ZeroExtendFirstFaulting(mask, address, indices);
 
 
@@ -5579,84 +5395,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svldff1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsetFirstFaulting(Vector<double> mask, double* address, Vector<long> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat64_t svldff1_gather_[u64]offset[_f64](svbool_t pg, const float64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsetFirstFaulting(Vector<double> mask, double* address, Vector<ulong> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[s32]offset[_s32](svbool_t pg, const int32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsetFirstFaulting(Vector<int> mask, int* address, Vector<int> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svldff1_gather_[u32]offset[_s32](svbool_t pg, const int32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsetFirstFaulting(Vector<int> mask, int* address, Vector<uint> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[s64]offset[_s64](svbool_t pg, const int64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsetFirstFaulting(Vector<long> mask, long* address, Vector<long> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svldff1_gather_[u64]offset[_s64](svbool_t pg, const int64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsetFirstFaulting(Vector<long> mask, long* address, Vector<ulong> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[s32]offset[_f32](svbool_t pg, const float32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsetFirstFaulting(Vector<float> mask, float* address, Vector<int> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat32_t svldff1_gather_[u32]offset[_f32](svbool_t pg, const float32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsetFirstFaulting(Vector<float> mask, float* address, Vector<uint> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[s32]offset[_u32](svbool_t pg, const uint32_t *base, svint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsetFirstFaulting(Vector<uint> mask, uint* address, Vector<int> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svldff1_gather_[u32]offset[_u32](svbool_t pg, const uint32_t *base, svuint32_t offsets)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsetFirstFaulting(Vector<uint> mask, uint* address, Vector<uint> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[s64]offset[_u64](svbool_t pg, const uint64_t *base, svint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(Vector<ulong> mask, ulong* address, Vector<long> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svldff1_gather_[u64]offset[_u64](svbool_t pg, const uint64_t *base, svuint64_t offsets)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) => GatherVectorWithByteOffsetFirstFaulting(mask, address, offsets);
 
 
@@ -5666,84 +5470,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svfloat64_t svld1_gather_[s64]offset[_f64](svbool_t pg, const float64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsets(Vector<double> mask, double* address, Vector<long> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat64_t svld1_gather_[u64]offset[_f64](svbool_t pg, const float64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> GatherVectorWithByteOffsets(Vector<double> mask, double* address, Vector<ulong> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[s32]offset[_s32](svbool_t pg, const int32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsets(Vector<int> mask, int* address, Vector<int> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint32_t svld1_gather_[u32]offset[_s32](svbool_t pg, const int32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> GatherVectorWithByteOffsets(Vector<int> mask, int* address, Vector<uint> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[s64]offset[_s64](svbool_t pg, const int64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsets(Vector<long> mask, long* address, Vector<long> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svint64_t svld1_gather_[u64]offset[_s64](svbool_t pg, const int64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> GatherVectorWithByteOffsets(Vector<long> mask, long* address, Vector<ulong> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[s32]offset[_f32](svbool_t pg, const float32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsets(Vector<float> mask, float* address, Vector<int> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svfloat32_t svld1_gather_[u32]offset[_f32](svbool_t pg, const float32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> GatherVectorWithByteOffsets(Vector<float> mask, float* address, Vector<uint> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[s32]offset[_u32](svbool_t pg, const uint32_t *base, svint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsets(Vector<uint> mask, uint* address, Vector<int> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint32_t svld1_gather_[u32]offset[_u32](svbool_t pg, const uint32_t *base, svuint32_t offsets)</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> GatherVectorWithByteOffsets(Vector<uint> mask, uint* address, Vector<uint> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[s64]offset[_u64](svbool_t pg, const uint64_t *base, svint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<long> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
         /// <summary>
         ///   <para>svuint64_t svld1_gather_[u64]offset[_u64](svbool_t pg, const uint64_t *base, svuint64_t offsets)</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> GatherVectorWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets) => GatherVectorWithByteOffsets(mask, address, offsets);
 
 
@@ -6055,7 +5847,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xarray, Xindex]</para>
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVector(Vector<byte> mask, byte* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6063,7 +5854,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVector(Vector<double> mask, double* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6071,7 +5861,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xarray, Xindex, LSL #1]</para>
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVector(Vector<short> mask, short* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6079,7 +5868,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVector(Vector<int> mask, int* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6087,7 +5875,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVector(Vector<long> mask, long* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6095,7 +5882,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xarray, Xindex]</para>
         ///   <para>  LD1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVector(Vector<sbyte> mask, sbyte* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6103,7 +5889,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVector(Vector<float> mask, float* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6111,7 +5896,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xarray, Xindex, LSL #1]</para>
         ///   <para>  LD1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVector(Vector<ushort> mask, ushort* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6119,7 +5903,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xarray, Xindex, LSL #2]</para>
         ///   <para>  LD1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVector(Vector<uint> mask, uint* address) => LoadVector(mask, address);
 
         /// <summary>
@@ -6127,7 +5910,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xarray, Xindex, LSL #3]</para>
         ///   <para>  LD1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVector(Vector<ulong> mask, ulong* address) => LoadVector(mask, address);
 
 
@@ -6137,70 +5919,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svld1rq[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1RQB Zresult.B, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVector128AndReplicateToVector(Vector<byte> mask, byte* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svfloat64_t svld1rq[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVector128AndReplicateToVector(Vector<double> mask, double* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svint16_t svld1rq[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1RQH Zresult.H, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVector128AndReplicateToVector(Vector<short> mask, short* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svld1rq[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVector128AndReplicateToVector(Vector<int> mask, int* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svld1rq[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVector128AndReplicateToVector(Vector<long> mask, long* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svint8_t svld1rq[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1RQB Zresult.B, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVector128AndReplicateToVector(Vector<sbyte> mask, sbyte* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svfloat32_t svld1rq[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVector128AndReplicateToVector(Vector<float> mask, float* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svld1rq[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1RQH Zresult.H, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVector128AndReplicateToVector(Vector<ushort> mask, ushort* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svld1rq[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1RQW Zresult.S, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVector128AndReplicateToVector(Vector<uint> mask, uint* address) => LoadVector128AndReplicateToVector(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svld1rq[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD1RQD Zresult.D, Pg/Z, [Xbase, #0]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVector128AndReplicateToVector(Vector<ulong> mask, ulong* address) => LoadVector128AndReplicateToVector(mask, address);
 
 
@@ -6210,7 +5982,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldnf1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteNonFaultingZeroExtendToInt16(Vector<short> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToInt16(mask, address);
 
 
@@ -6220,7 +5991,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteNonFaultingZeroExtendToInt32(Vector<int> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToInt32(mask, address);
 
 
@@ -6230,7 +6000,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteNonFaultingZeroExtendToInt64(Vector<long> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToInt64(mask, address);
 
 
@@ -6240,7 +6009,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svldnf1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteNonFaultingZeroExtendToUInt16(Vector<ushort> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToUInt16(mask, address);
 
 
@@ -6250,7 +6018,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteNonFaultingZeroExtendToUInt32(Vector<uint> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToUInt32(mask, address);
 
 
@@ -6260,7 +6027,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteNonFaultingZeroExtendToUInt64(Vector<ulong> mask, byte* address) => LoadVectorByteNonFaultingZeroExtendToUInt64(mask, address);
 
 
@@ -6268,42 +6034,36 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldff1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteZeroExtendFirstFaulting(Vector<short> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svldff1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteZeroExtendFirstFaulting(Vector<int> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldff1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteZeroExtendFirstFaulting(Vector<long> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svldff1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendFirstFaulting(Vector<ushort> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldff1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteZeroExtendFirstFaulting(Vector<uint> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendFirstFaulting(Vector<ulong> mask, byte* address) => LoadVectorByteZeroExtendFirstFaulting(mask, address);
 
 
@@ -6313,7 +6073,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svld1ub_s16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorByteZeroExtendToInt16(Vector<short> mask, byte* address) => LoadVectorByteZeroExtendToInt16(mask, address);
 
 
@@ -6323,7 +6082,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1ub_s32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorByteZeroExtendToInt32(Vector<int> mask, byte* address) => LoadVectorByteZeroExtendToInt32(mask, address);
 
 
@@ -6333,7 +6091,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1ub_s64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorByteZeroExtendToInt64(Vector<long> mask, byte* address) => LoadVectorByteZeroExtendToInt64(mask, address);
 
 
@@ -6343,7 +6100,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svld1ub_u16(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorByteZeroExtendToUInt16(Vector<ushort> mask, byte* address) => LoadVectorByteZeroExtendToUInt16(mask, address);
 
 
@@ -6353,7 +6109,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1ub_u32(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorByteZeroExtendToUInt32(Vector<uint> mask, byte* address) => LoadVectorByteZeroExtendToUInt32(mask, address);
 
 
@@ -6363,7 +6118,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1ub_u64(svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD1B Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorByteZeroExtendToUInt64(Vector<ulong> mask, byte* address) => LoadVectorByteZeroExtendToUInt64(mask, address);
 
 
@@ -6373,70 +6127,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldff1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDFF1B Zresult.B, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorFirstFaulting(Vector<byte> mask, byte* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svfloat64_t svldff1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorFirstFaulting(Vector<double> mask, double* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint16_t svldff1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1H Zresult.H, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorFirstFaulting(Vector<short> mask, short* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svldff1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorFirstFaulting(Vector<int> mask, int* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldff1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorFirstFaulting(Vector<long> mask, long* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint8_t svldff1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1B Zresult.B, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorFirstFaulting(Vector<sbyte> mask, sbyte* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svfloat32_t svldff1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorFirstFaulting(Vector<float> mask, float* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svldff1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.H, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorFirstFaulting(Vector<ushort> mask, ushort* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldff1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.S, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorFirstFaulting(Vector<uint> mask, uint* address) => LoadVectorFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDFF1D Zresult.D, Pg/Z, [Xbase, XZR, LSL #3]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorFirstFaulting(Vector<ulong> mask, ulong* address) => LoadVectorFirstFaulting(mask, address);
         // Load 16-bit data and sign-extend, non-faulting
 
@@ -6444,7 +6188,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16NonFaultingSignExtendToInt32(Vector<int> mask, short* address) => LoadVectorInt16NonFaultingSignExtendToInt32(mask, address);
 
 
@@ -6454,7 +6197,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16NonFaultingSignExtendToInt64(Vector<long> mask, short* address) => LoadVectorInt16NonFaultingSignExtendToInt64(mask, address);
 
 
@@ -6464,7 +6206,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16NonFaultingSignExtendToUInt32(Vector<uint> mask, short* address) => LoadVectorInt16NonFaultingSignExtendToUInt32(mask, address);
 
 
@@ -6474,7 +6215,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16NonFaultingSignExtendToUInt64(Vector<ulong> mask, short* address) => LoadVectorInt16NonFaultingSignExtendToUInt64(mask, address);
 
 
@@ -6484,28 +6224,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16SignExtendFirstFaulting(Vector<int> mask, short* address) => LoadVectorInt16SignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldff1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16SignExtendFirstFaulting(Vector<long> mask, short* address) => LoadVectorInt16SignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16SignExtendFirstFaulting(Vector<uint> mask, short* address) => LoadVectorInt16SignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDFF1SH Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendFirstFaulting(Vector<ulong> mask, short* address) => LoadVectorInt16SignExtendFirstFaulting(mask, address);
 
 
@@ -6515,7 +6251,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sh_s32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorInt16SignExtendToInt32(Vector<int> mask, short* address) => LoadVectorInt16SignExtendToInt32(mask, address);
 
 
@@ -6525,7 +6260,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sh_s64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt16SignExtendToInt64(Vector<long> mask, short* address) => LoadVectorInt16SignExtendToInt64(mask, address);
 
 
@@ -6535,7 +6269,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sh_u32(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorInt16SignExtendToUInt32(Vector<uint> mask, short* address) => LoadVectorInt16SignExtendToUInt32(mask, address);
 
 
@@ -6545,7 +6278,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sh_u64(svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD1SH Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt16SignExtendToUInt64(Vector<ulong> mask, short* address) => LoadVectorInt16SignExtendToUInt64(mask, address);
 
 
@@ -6555,7 +6287,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32NonFaultingSignExtendToInt64(Vector<long> mask, int* address) => LoadVectorInt32NonFaultingSignExtendToInt64(mask, address);
 
 
@@ -6565,7 +6296,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32NonFaultingSignExtendToUInt64(Vector<ulong> mask, int* address) => LoadVectorInt32NonFaultingSignExtendToUInt64(mask, address);
 
 
@@ -6575,14 +6305,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32SignExtendFirstFaulting(Vector<long> mask, int* address) => LoadVectorInt32SignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDFF1SW Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendFirstFaulting(Vector<ulong> mask, int* address) => LoadVectorInt32SignExtendFirstFaulting(mask, address);
 
 
@@ -6592,7 +6320,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sw_s64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorInt32SignExtendToInt64(Vector<long> mask, int* address) => LoadVectorInt32SignExtendToInt64(mask, address);
 
 
@@ -6602,7 +6329,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sw_u64(svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD1SW Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorInt32SignExtendToUInt64(Vector<ulong> mask, int* address) => LoadVectorInt32SignExtendToUInt64(mask, address);
 
 
@@ -6612,70 +6338,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldnf1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorNonFaulting(Vector<byte> mask, byte* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svfloat64_t svldnf1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorNonFaulting(Vector<double> mask, double* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint16_t svldnf1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorNonFaulting(Vector<short> mask, short* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svldnf1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorNonFaulting(Vector<int> mask, int* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldnf1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorNonFaulting(Vector<long> mask, long* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint8_t svldnf1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorNonFaulting(Vector<sbyte> mask, sbyte* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svfloat32_t svldnf1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorNonFaulting(Vector<float> mask, float* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svldnf1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorNonFaulting(Vector<ushort> mask, ushort* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldnf1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorNonFaulting(Vector<uint> mask, uint* address) => LoadVectorNonFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldnf1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDNF1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorNonFaulting(Vector<ulong> mask, ulong* address) => LoadVectorNonFaulting(mask, address);
 
 
@@ -6685,70 +6401,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8_t svldnt1[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LDNT1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<byte> LoadVectorNonTemporal(Vector<byte> mask, byte* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svfloat64_t svldnt1[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<double> LoadVectorNonTemporal(Vector<double> mask, double* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svint16_t svldnt1[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LDNT1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorNonTemporal(Vector<short> mask, short* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svldnt1[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorNonTemporal(Vector<int> mask, int* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldnt1[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorNonTemporal(Vector<long> mask, long* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svint8_t svldnt1[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNT1B Zresult.B, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<sbyte> LoadVectorNonTemporal(Vector<sbyte> mask, sbyte* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svfloat32_t svldnt1[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<float> LoadVectorNonTemporal(Vector<float> mask, float* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svldnt1[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNT1H Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorNonTemporal(Vector<ushort> mask, ushort* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldnt1[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNT1W Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorNonTemporal(Vector<uint> mask, uint* address) => LoadVectorNonTemporal(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldnt1[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LDNT1D Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorNonTemporal(Vector<ulong> mask, ulong* address) => LoadVectorNonTemporal(mask, address);
 
 
@@ -6758,7 +6464,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldnf1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteNonFaultingSignExtendToInt16(Vector<short> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt16(mask, address);
 
 
@@ -6768,7 +6473,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteNonFaultingSignExtendToInt32(Vector<int> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt32(mask, address);
 
 
@@ -6778,7 +6482,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteNonFaultingSignExtendToInt64(Vector<long> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToInt64(mask, address);
 
 
@@ -6788,7 +6491,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svldnf1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteNonFaultingSignExtendToUInt16(Vector<ushort> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt16(mask, address);
 
 
@@ -6798,7 +6500,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteNonFaultingSignExtendToUInt32(Vector<uint> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt32(mask, address);
 
 
@@ -6808,7 +6509,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDNF1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteNonFaultingSignExtendToUInt64(Vector<ulong> mask, sbyte* address) => LoadVectorSByteNonFaultingSignExtendToUInt64(mask, address);
 
 
@@ -6818,42 +6518,36 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svldff1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteSignExtendFirstFaulting(Vector<short> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint32_t svldff1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteSignExtendFirstFaulting(Vector<int> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldff1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteSignExtendFirstFaulting(Vector<long> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint16_t svldff1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.H, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendFirstFaulting(Vector<ushort> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldff1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.S, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteSignExtendFirstFaulting(Vector<uint> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LDFF1SB Zresult.D, Pg/Z, [Xbase, XZR]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendFirstFaulting(Vector<ulong> mask, sbyte* address) => LoadVectorSByteSignExtendFirstFaulting(mask, address);
 
 
@@ -6863,7 +6557,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint16_t svld1sb_s16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<short> LoadVectorSByteSignExtendToInt16(Vector<short> mask, sbyte* address) => LoadVectorSByteSignExtendToInt16(mask, address);
 
 
@@ -6873,7 +6566,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1sb_s32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorSByteSignExtendToInt32(Vector<int> mask, sbyte* address) => LoadVectorSByteSignExtendToInt32(mask, address);
 
 
@@ -6883,7 +6575,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1sb_s64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorSByteSignExtendToInt64(Vector<long> mask, sbyte* address) => LoadVectorSByteSignExtendToInt64(mask, address);
 
 
@@ -6893,7 +6584,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint16_t svld1sb_u16(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.H, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ushort> LoadVectorSByteSignExtendToUInt16(Vector<ushort> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt16(mask, address);
 
 
@@ -6903,7 +6593,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1sb_u32(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorSByteSignExtendToUInt32(Vector<uint> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt32(mask, address);
 
 
@@ -6913,7 +6602,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1sb_u64(svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD1SB Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorSByteSignExtendToUInt64(Vector<ulong> mask, sbyte* address) => LoadVectorSByteSignExtendToUInt64(mask, address);
 
 
@@ -6923,7 +6611,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldnf1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16NonFaultingZeroExtendToInt32(Vector<int> mask, ushort* address) => LoadVectorUInt16NonFaultingZeroExtendToInt32(mask, address);
 
 
@@ -6933,7 +6620,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16NonFaultingZeroExtendToInt64(Vector<long> mask, ushort* address) => LoadVectorUInt16NonFaultingZeroExtendToInt64(mask, address);
 
 
@@ -6943,7 +6629,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svldnf1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16NonFaultingZeroExtendToUInt32(Vector<uint> mask, ushort* address) => LoadVectorUInt16NonFaultingZeroExtendToUInt32(mask, address);
 
 
@@ -6953,7 +6638,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDNF1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16NonFaultingZeroExtendToUInt64(Vector<ulong> mask, ushort* address) => LoadVectorUInt16NonFaultingZeroExtendToUInt64(mask, address);
 
 
@@ -6961,28 +6645,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svldff1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<int> mask, ushort* address) => LoadVectorUInt16ZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svint64_t svldff1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<long> mask, ushort* address) => LoadVectorUInt16ZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint32_t svldff1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.S, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<uint> mask, ushort* address) => LoadVectorUInt16ZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LDFF1H Zresult.D, Pg/Z, [Xbase, XZR, LSL #1]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendFirstFaulting(Vector<ulong> mask, ushort* address) => LoadVectorUInt16ZeroExtendFirstFaulting(mask, address);
 
 
@@ -6992,7 +6672,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint32_t svld1uh_s32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<int> LoadVectorUInt16ZeroExtendToInt32(Vector<int> mask, ushort* address) => LoadVectorUInt16ZeroExtendToInt32(mask, address);
 
 
@@ -7002,7 +6681,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uh_s64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt16ZeroExtendToInt64(Vector<long> mask, ushort* address) => LoadVectorUInt16ZeroExtendToInt64(mask, address);
 
 
@@ -7012,7 +6690,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint32_t svld1uh_u32(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.S, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<uint> LoadVectorUInt16ZeroExtendToUInt32(Vector<uint> mask, ushort* address) => LoadVectorUInt16ZeroExtendToUInt32(mask, address);
 
 
@@ -7022,7 +6699,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uh_u64(svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD1H Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt16ZeroExtendToUInt64(Vector<ulong> mask, ushort* address) => LoadVectorUInt16ZeroExtendToUInt64(mask, address);
 
 
@@ -7032,7 +6708,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldnf1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32NonFaultingZeroExtendToInt64(Vector<long> mask, uint* address) => LoadVectorUInt32NonFaultingZeroExtendToInt64(mask, address);
 
 
@@ -7042,7 +6717,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svldnf1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDNF1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32NonFaultingZeroExtendToUInt64(Vector<ulong> mask, uint* address) => LoadVectorUInt32NonFaultingZeroExtendToUInt64(mask, address);
 
 
@@ -7050,14 +6724,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svldff1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendFirstFaulting(Vector<long> mask, uint* address) => LoadVectorUInt32ZeroExtendFirstFaulting(mask, address);
 
         /// <summary>
         ///   <para>svuint64_t svldff1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LDFF1W Zresult.D, Pg/Z, [Xbase, XZR, LSL #2]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32ZeroExtendFirstFaulting(Vector<ulong> mask, uint* address) => LoadVectorUInt32ZeroExtendFirstFaulting(mask, address);
 
 
@@ -7067,7 +6739,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svint64_t svld1uw_s64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<long> LoadVectorUInt32ZeroExtendToInt64(Vector<long> mask, uint* address) => LoadVectorUInt32ZeroExtendToInt64(mask, address);
 
 
@@ -7077,7 +6748,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint64_t svld1uw_u64(svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD1W Zresult.D, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector<ulong> LoadVectorUInt32ZeroExtendToUInt64(Vector<ulong> mask, uint* address) => LoadVectorUInt32ZeroExtendToUInt64(mask, address);
 
 
@@ -7087,70 +6757,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x2_t svld2[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD2B {Zresult0.B, Zresult1.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>) Load2xVectorAndUnzip(Vector<byte> mask, byte* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat64x2_t svld2[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>) Load2xVectorAndUnzip(Vector<double> mask, double* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint16x2_t svld2[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD2H {Zresult0.H, Zresult1.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>) Load2xVectorAndUnzip(Vector<short> mask, short* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint32x2_t svld2[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>) Load2xVectorAndUnzip(Vector<int> mask, int* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint64x2_t svld2[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>) Load2xVectorAndUnzip(Vector<long> mask, long* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint8x2_t svld2[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD2B {Zresult0.B, Zresult1.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>) Load2xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat32x2_t svld2[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>) Load2xVectorAndUnzip(Vector<float> mask, float* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint16x2_t svld2[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD2H {Zresult0.H, Zresult1.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>) Load2xVectorAndUnzip(Vector<ushort> mask, ushort* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint32x2_t svld2[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD2W {Zresult0.S, Zresult1.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>) Load2xVectorAndUnzip(Vector<uint> mask, uint* address) => Load2xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint64x2_t svld2[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD2D {Zresult0.D, Zresult1.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>) Load2xVectorAndUnzip(Vector<ulong> mask, ulong* address) => Load2xVectorAndUnzip(mask, address);
 
 
@@ -7160,70 +6820,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x3_t svld3[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD3B {Zresult0.B - Zresult2.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>, Vector<byte>) Load3xVectorAndUnzip(Vector<byte> mask, byte* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat64x3_t svld3[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>, Vector<double>) Load3xVectorAndUnzip(Vector<double> mask, double* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint16x3_t svld3[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD3H {Zresult0.H - Zresult2.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>, Vector<short>) Load3xVectorAndUnzip(Vector<short> mask, short* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint32x3_t svld3[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>, Vector<int>) Load3xVectorAndUnzip(Vector<int> mask, int* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint64x3_t svld3[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>, Vector<long>) Load3xVectorAndUnzip(Vector<long> mask, long* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint8x3_t svld3[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD3B {Zresult0.B - Zresult2.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>, Vector<sbyte>) Load3xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat32x3_t svld3[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>, Vector<float>) Load3xVectorAndUnzip(Vector<float> mask, float* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint16x3_t svld3[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD3H {Zresult0.H - Zresult2.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>, Vector<ushort>) Load3xVectorAndUnzip(Vector<ushort> mask, ushort* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint32x3_t svld3[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD3W {Zresult0.S - Zresult2.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>, Vector<uint>) Load3xVectorAndUnzip(Vector<uint> mask, uint* address) => Load3xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint64x3_t svld3[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD3D {Zresult0.D - Zresult2.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>) Load3xVectorAndUnzip(Vector<ulong> mask, ulong* address) => Load3xVectorAndUnzip(mask, address);
 
 
@@ -7233,70 +6883,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>svuint8x4_t svld4[_u8](svbool_t pg, const uint8_t *base)</para>
         ///   <para>  LD4B {Zresult0.B - Zresult3.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<byte>, Vector<byte>, Vector<byte>, Vector<byte>) Load4xVectorAndUnzip(Vector<byte> mask, byte* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat64x4_t svld4[_f64](svbool_t pg, const float64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<double>, Vector<double>, Vector<double>, Vector<double>) Load4xVectorAndUnzip(Vector<double> mask, double* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint16x4_t svld4[_s16](svbool_t pg, const int16_t *base)</para>
         ///   <para>  LD4H {Zresult0.H - Zresult3.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<short>, Vector<short>, Vector<short>, Vector<short>) Load4xVectorAndUnzip(Vector<short> mask, short* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint32x4_t svld4[_s32](svbool_t pg, const int32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<int>, Vector<int>, Vector<int>, Vector<int>) Load4xVectorAndUnzip(Vector<int> mask, int* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint64x4_t svld4[_s64](svbool_t pg, const int64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<long>, Vector<long>, Vector<long>, Vector<long>) Load4xVectorAndUnzip(Vector<long> mask, long* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svint8x4_t svld4[_s8](svbool_t pg, const int8_t *base)</para>
         ///   <para>  LD4B {Zresult0.B - Zresult3.B}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<sbyte>, Vector<sbyte>, Vector<sbyte>, Vector<sbyte>) Load4xVectorAndUnzip(Vector<sbyte> mask, sbyte* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svfloat32x4_t svld4[_f32](svbool_t pg, const float32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<float>, Vector<float>, Vector<float>, Vector<float>) Load4xVectorAndUnzip(Vector<float> mask, float* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint16x4_t svld4[_u16](svbool_t pg, const uint16_t *base)</para>
         ///   <para>  LD4H {Zresult0.H - Zresult3.H}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ushort>, Vector<ushort>, Vector<ushort>, Vector<ushort>) Load4xVectorAndUnzip(Vector<ushort> mask, ushort* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint32x4_t svld4[_u32](svbool_t pg, const uint32_t *base)</para>
         ///   <para>  LD4W {Zresult0.S - Zresult3.S}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<uint>, Vector<uint>, Vector<uint>, Vector<uint>) Load4xVectorAndUnzip(Vector<uint> mask, uint* address) => Load4xVectorAndUnzip(mask, address);
 
         /// <summary>
         ///   <para>svuint64x4_t svld4[_u64](svbool_t pg, const uint64_t *base)</para>
         ///   <para>  LD4D {Zresult0.D - Zresult3.D}, Pg/Z, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe (Vector<ulong>, Vector<ulong>, Vector<ulong>, Vector<ulong>) Load4xVectorAndUnzip(Vector<ulong> mask, ulong* address) => Load4xVectorAndUnzip(mask, address);
 
 
@@ -8308,7 +7948,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfh(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFH op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch16Bit(Vector<ushort> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) => Prefetch16Bit(mask, address, prefetchType);
 
 
@@ -8318,7 +7957,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfw(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFW op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch32Bit(Vector<uint> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) => Prefetch32Bit(mask, address, prefetchType);
 
 
@@ -8328,7 +7966,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfd(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFD op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch64Bit(Vector<ulong> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) => Prefetch64Bit(mask, address, prefetchType);
 
 
@@ -8338,7 +7975,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svprfb(svbool_t pg, const void *base, enum svprfop op)</para>
         ///   <para>  PRFB op, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch8Bit(Vector<byte> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) => Prefetch8Bit(mask, address, prefetchType);
 
 
@@ -9334,7 +8970,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<long> indicies, Vector<double> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
@@ -9347,14 +8982,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<double> mask, double* address, Vector<ulong> indicies, Vector<double> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<int> indicies, Vector<int> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -9368,14 +9001,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<int> mask, int* address, Vector<uint> indicies, Vector<int> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
         ///   <para>void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<long> indicies, Vector<long> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
@@ -9388,14 +9019,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<long> mask, long* address, Vector<ulong> indicies, Vector<long> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<int> indicies, Vector<float> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -9409,14 +9038,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<float> mask, float* address, Vector<uint> indicies, Vector<float> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
         ///   <para>void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<int> indicies, Vector<uint> data) => Scatter(mask, address, indicies, data);
 
         // <summary>
@@ -9430,14 +9057,12 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<uint> mask, uint* address, Vector<uint> indicies, Vector<uint> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
         ///   <para>void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<long> indicies, Vector<ulong> data) => Scatter(mask, address, indicies, data);
 
         /// <summary>
@@ -9450,7 +9075,6 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter(Vector<ulong> mask, ulong* address, Vector<ulong> indicies, Vector<ulong> data) => Scatter(mask, address, indicies, data);
 
 
@@ -9486,56 +9110,48 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1h_scatter_[s32]index[_s32](svbool_t pg, int16_t *base, svint32_t indices, svint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, SXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<int> mask, short* address, Vector<int> indices, Vector<int> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[u32]index[_s32](svbool_t pg, int16_t *base, svuint32_t indices, svint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, UXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<int> mask, short* address, Vector<uint> indices, Vector<int> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[s64]index[_s64](svbool_t pg, int16_t *base, svint64_t indices, svint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, short* address, Vector<long> indices, Vector<long> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[u64]index[_s64](svbool_t pg, int16_t *base, svuint64_t indices, svint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<long> mask, short* address, Vector<ulong> indices, Vector<long> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[s32]index[_u32](svbool_t pg, uint16_t *base, svint32_t indices, svuint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, SXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, ushort* address, Vector<int> indices, Vector<uint> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[u32]index[_u32](svbool_t pg, uint16_t *base, svuint32_t indices, svuint32_t data)
         ///   ST1H Zdata.S, Pg, [Xbase, Zindices.S, UXTW #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<uint> mask, ushort* address, Vector<uint> indices, Vector<uint> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[s64]index[_u64](svbool_t pg, uint16_t *base, svint64_t indices, svuint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, ushort* address, Vector<long> indices, Vector<ulong> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1h_scatter_[u64]index[_u64](svbool_t pg, uint16_t *base, svuint64_t indices, svuint64_t data)
         ///   ST1H Zdata.D, Pg, [Xbase, Zindices.D, LSL #1]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> indices, Vector<ulong> data) => Scatter16BitNarrowing(mask, address, indices, data);
 
 
@@ -9545,56 +9161,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1h_scatter_[s32]offset[_s32](svbool_t pg, int16_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<int> offsets, Vector<int> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s32]offset[_u32](svbool_t pg, uint16_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<int> offsets, Vector<uint> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
@@ -9616,28 +9224,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1w_scatter_[s64]index[_s64](svbool_t pg, int32_t *base, svint64_t indices, svint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, int* address, Vector<long> indices, Vector<long> data) => Scatter32BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1w_scatter_[u64]index[_s64](svbool_t pg, int32_t *base, svuint64_t indices, svint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<long> mask, int* address, Vector<ulong> indices, Vector<long> data) => Scatter32BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1w_scatter_[s64]index[_u64](svbool_t pg, uint32_t *base, svint64_t indices, svuint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, uint* address, Vector<long> indices, Vector<ulong> data) => Scatter32BitNarrowing(mask, address, indices, data);
 
         /// <summary>
         /// void svst1w_scatter_[u64]index[_u64](svbool_t pg, uint32_t *base, svuint64_t indices, svuint64_t data)
         ///   ST1W Zdata.D, Pg, [Xbase, Zindices.D, LSL #2]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> indices, Vector<ulong> data) => Scatter32BitNarrowing(mask, address, indices, data);
 
 
@@ -9647,28 +9251,24 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
@@ -9707,56 +9307,48 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1b_scatter_[s32]offset[_s32](svbool_t pg, int8_t *base, svint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<int> offsets, Vector<int> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s32]offset[_u32](svbool_t pg, uint8_t *base, svint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<int> offsets, Vector<uint> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
         /// <summary>
         ///   <para>void svst1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, Zoffsets.D]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowing(mask, address, offsets, data);
 
 
@@ -9766,84 +9358,72 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svst1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<double> mask, double* address, Vector<long> offsets, Vector<double> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<double> mask, double* address, Vector<ulong> offsets, Vector<double> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_s32](svbool_t pg, int32_t *base, svint32_t offsets, svint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<int> mask, int* address, Vector<int> offsets, Vector<int> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<int> mask, int* address, Vector<uint> offsets, Vector<int> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<long> mask, long* address, Vector<long> offsets, Vector<long> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<long> mask, long* address, Vector<ulong> offsets, Vector<long> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_f32](svbool_t pg, float32_t *base, svint32_t offsets, svfloat32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<float> mask, float* address, Vector<int> offsets, Vector<float> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<float> mask, float* address, Vector<uint> offsets, Vector<float> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[s32]offset[_u32](svbool_t pg, uint32_t *base, svint32_t offsets, svuint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, SXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<uint> mask, uint* address, Vector<int> offsets, Vector<uint> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
         ///   ST1W Zdata.S, Pg, [Xbase, Zoffsets.S, UXTW]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<uint> mask, uint* address, Vector<uint> offsets, Vector<uint> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<long> offsets, Vector<ulong> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
         /// <summary>
         /// void svst1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
         ///   ST1D Zdata.D, Pg, [Xbase, Zoffsets.D]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsets(Vector<ulong> mask, ulong* address, Vector<ulong> offsets, Vector<ulong> data) => ScatterWithByteOffsets(mask, address, offsets, data);
 
 
@@ -10365,280 +9945,240 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)</para>
         ///   <para>  ST1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, Vector<byte> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_u8](svbool_t pg, uint8_t *base, svuint8x2_t data)</para>
         ///   <para>  ST2B {Zdata0.B, Zdata1.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_u8](svbool_t pg, uint8_t *base, svuint8x3_t data)</para>
         ///   <para>  ST3B {Zdata0.B - Zdata2.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2, Vector<byte> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_u8](svbool_t pg, uint8_t *base, svuint8x4_t data)</para>
         ///   <para>  ST4B {Zdata0.B - Zdata3.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<byte> mask, byte* address, (Vector<byte> Value1, Vector<byte> Value2, Vector<byte> Value3, Vector<byte> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_f64](svbool_t pg, float64_t *base, svfloat64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, Vector<double> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_f64](svbool_t pg, float64_t *base, svfloat64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_f64](svbool_t pg, float64_t *base, svfloat64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2, Vector<double> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_f64](svbool_t pg, float64_t *base, svfloat64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<double> mask, double* address, (Vector<double> Value1, Vector<double> Value2, Vector<double> Value3, Vector<double> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_s16](svbool_t pg, int16_t *base, svint16_t data)</para>
         ///   <para>  ST1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, Vector<short> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_s16](svbool_t pg, int16_t *base, svint16x2_t data)</para>
         ///   <para>  ST2H {Zdata0.H, Zdata1.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_s16](svbool_t pg, int16_t *base, svint16x3_t data)</para>
         ///   <para>  ST3H {Zdata0.H - Zdata2.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2, Vector<short> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_s16](svbool_t pg, int16_t *base, svint16x4_t data)</para>
         ///   <para>  ST4H {Zdata0.H - Zdata3.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<short> mask, short* address, (Vector<short> Value1, Vector<short> Value2, Vector<short> Value3, Vector<short> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_s32](svbool_t pg, int32_t *base, svint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, Vector<int> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_s32](svbool_t pg, int32_t *base, svint32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_s32](svbool_t pg, int32_t *base, svint32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2, Vector<int> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_s32](svbool_t pg, int32_t *base, svint32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<int> mask, int* address, (Vector<int> Value1, Vector<int> Value2, Vector<int> Value3, Vector<int> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_s64](svbool_t pg, int64_t *base, svint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, Vector<long> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_s64](svbool_t pg, int64_t *base, svint64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_s64](svbool_t pg, int64_t *base, svint64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2, Vector<long> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_s64](svbool_t pg, int64_t *base, svint64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<long> mask, long* address, (Vector<long> Value1, Vector<long> Value2, Vector<long> Value3, Vector<long> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_s8](svbool_t pg, int8_t *base, svint8_t data)</para>
         ///   <para>  ST1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, Vector<sbyte> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_s8](svbool_t pg, int8_t *base, svint8x2_t data)</para>
         ///   <para>  ST2B {Zdata0.B, Zdata1.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_s8](svbool_t pg, int8_t *base, svint8x3_t data)</para>
         ///   <para>  ST3B {Zdata0.B - Zdata2.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2, Vector<sbyte> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_s8](svbool_t pg, int8_t *base, svint8x4_t data)</para>
         ///   <para>  ST4B {Zdata0.B - Zdata3.B}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<sbyte> mask, sbyte* address, (Vector<sbyte> Value1, Vector<sbyte> Value2, Vector<sbyte> Value3, Vector<sbyte> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_f32](svbool_t pg, float32_t *base, svfloat32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, Vector<float> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_f32](svbool_t pg, float32_t *base, svfloat32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_f32](svbool_t pg, float32_t *base, svfloat32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2, Vector<float> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_f32](svbool_t pg, float32_t *base, svfloat32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<float> mask, float* address, (Vector<float> Value1, Vector<float> Value2, Vector<float> Value3, Vector<float> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_u16](svbool_t pg, uint16_t *base, svuint16_t data)</para>
         ///   <para>  ST1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, Vector<ushort> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_u16](svbool_t pg, uint16_t *base, svuint16x2_t data)</para>
         ///   <para>  ST2H {Zdata0.H, Zdata1.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_u16](svbool_t pg, uint16_t *base, svuint16x3_t data)</para>
         ///   <para>  ST3H {Zdata0.H - Zdata2.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2, Vector<ushort> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_u16](svbool_t pg, uint16_t *base, svuint16x4_t data)</para>
         ///   <para>  ST4H {Zdata0.H - Zdata3.H}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ushort> mask, ushort* address, (Vector<ushort> Value1, Vector<ushort> Value2, Vector<ushort> Value3, Vector<ushort> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_u32](svbool_t pg, uint32_t *base, svuint32_t data)</para>
         ///   <para>  ST1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, Vector<uint> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_u32](svbool_t pg, uint32_t *base, svuint32x2_t data)</para>
         ///   <para>  ST2W {Zdata0.S, Zdata1.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_u32](svbool_t pg, uint32_t *base, svuint32x3_t data)</para>
         ///   <para>  ST3W {Zdata0.S - Zdata2.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2, Vector<uint> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_u32](svbool_t pg, uint32_t *base, svuint32x4_t data)</para>
         ///   <para>  ST4W {Zdata0.S - Zdata3.S}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<uint> mask, uint* address, (Vector<uint> Value1, Vector<uint> Value2, Vector<uint> Value3, Vector<uint> Value4) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1[_u64](svbool_t pg, uint64_t *base, svuint64_t data)</para>
         ///   <para>  ST1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, Vector<ulong> data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst2[_u64](svbool_t pg, uint64_t *base, svuint64x2_t data)</para>
         ///   <para>  ST2D {Zdata0.D, Zdata1.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst3[_u64](svbool_t pg, uint64_t *base, svuint64x3_t data)</para>
         ///   <para>  ST3D {Zdata0.D - Zdata2.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3) data) => StoreAndZip(mask, address, data);
 
         /// <summary>
         ///   <para>void svst4[_u64](svbool_t pg, uint64_t *base, svuint64x4_t data)</para>
         ///   <para>  ST4D {Zdata0.D - Zdata3.D}, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAndZip(Vector<ulong> mask, ulong* address, (Vector<ulong> Value1, Vector<ulong> Value2, Vector<ulong> Value3, Vector<ulong> Value4) data) => StoreAndZip(mask, address, data);
 
 
@@ -10648,84 +10188,72 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svst1b[_s16](svbool_t pg, int8_t *base, svint16_t data)</para>
         ///   <para>  ST1B Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<short> mask, sbyte* address, Vector<short> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1b[_s32](svbool_t pg, int8_t *base, svint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<int> mask, sbyte* address, Vector<int> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1h[_s32](svbool_t pg, int16_t *base, svint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<int> mask, short* address, Vector<int> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1b[_s64](svbool_t pg, int8_t *base, svint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, sbyte* address, Vector<long> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1h[_s64](svbool_t pg, int16_t *base, svint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, short* address, Vector<long> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1w[_s64](svbool_t pg, int32_t *base, svint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<long> mask, int* address, Vector<long> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1b[_u16](svbool_t pg, uint8_t *base, svuint16_t data)</para>
         ///   <para>  ST1B Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ushort> mask, byte* address, Vector<ushort> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1b[_u32](svbool_t pg, uint8_t *base, svuint32_t data)</para>
         ///   <para>  ST1B Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<uint> mask, byte* address, Vector<uint> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1h[_u32](svbool_t pg, uint16_t *base, svuint32_t data)</para>
         ///   <para>  ST1H Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<uint> mask, ushort* address, Vector<uint> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1b[_u64](svbool_t pg, uint8_t *base, svuint64_t data)</para>
         ///   <para>  ST1B Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, byte* address, Vector<ulong> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1h[_u64](svbool_t pg, uint16_t *base, svuint64_t data)</para>
         ///   <para>  ST1H Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, ushort* address, Vector<ulong> data) => StoreNarrowing(mask, address, data);
 
         /// <summary>
         ///   <para>void svst1w[_u64](svbool_t pg, uint32_t *base, svuint64_t data)</para>
         ///   <para>  ST1W Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNarrowing(Vector<ulong> mask, uint* address, Vector<ulong> data) => StoreNarrowing(mask, address, data);
 
 
@@ -10735,70 +10263,60 @@ namespace System.Runtime.Intrinsics.Arm
         ///   <para>void svstnt1[_u8](svbool_t pg, uint8_t *base, svuint8_t data)</para>
         ///   <para>  STNT1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<byte> mask, byte* address, Vector<byte> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_f64](svbool_t pg, float64_t *base, svfloat64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<double> mask, double* address, Vector<double> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_s16](svbool_t pg, int16_t *base, svint16_t data)</para>
         ///   <para>  STNT1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<short> mask, short* address, Vector<short> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_s32](svbool_t pg, int32_t *base, svint32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<int> mask, int* address, Vector<int> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_s64](svbool_t pg, int64_t *base, svint64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<long> mask, long* address, Vector<long> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_s8](svbool_t pg, int8_t *base, svint8_t data)</para>
         ///   <para>  STNT1B Zdata.B, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<sbyte> mask, sbyte* address, Vector<sbyte> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_f32](svbool_t pg, float32_t *base, svfloat32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<float> mask, float* address, Vector<float> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_u16](svbool_t pg, uint16_t *base, svuint16_t data)</para>
         ///   <para>  STNT1H Zdata.H, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<ushort> mask, ushort* address, Vector<ushort> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_u32](svbool_t pg, uint32_t *base, svuint32_t data)</para>
         ///   <para>  STNT1W Zdata.S, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<uint> mask, uint* address, Vector<uint> data) => StoreNonTemporal(mask, address, data);
 
         /// <summary>
         ///   <para>void svstnt1[_u64](svbool_t pg, uint64_t *base, svuint64_t data)</para>
         ///   <para>  STNT1D Zdata.D, Pg, [Xbase, #0, MUL VL]</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> data) => StoreNonTemporal(mask, address, data);
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
@@ -3601,28 +3601,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1h_scatter_[s64]index[_s64](svbool_t pg, int16_t *base, svint64_t indices, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<long> mask, short* address, Vector<long> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]index[_s64](svbool_t pg, int16_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<long> mask, short* address, Vector<ulong> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]index[_u64](svbool_t pg, uint16_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<long> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]index[_u64](svbool_t pg, uint16_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<ulong> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3632,42 +3628,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1H Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1H Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3689,28 +3679,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1w_scatter_[s64]index[_s64](svbool_t pg, int32_t *base, svint64_t indices, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<long> mask, int* address, Vector<long> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]index[_s64](svbool_t pg, int32_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<long> mask, int* address, Vector<ulong> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[s64]index[_u64](svbool_t pg, uint32_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<long> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]index[_u64](svbool_t pg, uint32_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<ulong> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3720,28 +3706,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3780,42 +3762,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1B Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1B Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3864,42 +3840,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1_scatter_[s64]index[_f64](svbool_t pg, float64_t *base, svint64_t indices, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<double> mask, double* address, Vector<long> indices, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_f64](svbool_t pg, float64_t *base, svuint64_t indices, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<double> mask, double* address, Vector<ulong> indices, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[s64]index[_s64](svbool_t pg, int64_t *base, svint64_t indices, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<long> mask, long* address, Vector<long> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_s64](svbool_t pg, int64_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<long> mask, long* address, Vector<ulong> indices, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[s64]index[_u64](svbool_t pg, uint64_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<ulong> mask, ulong* address, Vector<long> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_u64](svbool_t pg, uint64_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> indices, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 
@@ -3909,63 +3879,54 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<double> mask, double* address, Vector<long> offsets, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<double> mask, double* address, Vector<ulong> offsets, Vector<double> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<int> mask, int* address, Vector<uint> offsets, Vector<int> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<long> mask, long* address, Vector<long> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<long> mask, long* address, Vector<ulong> offsets, Vector<long> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<float> mask, float* address, Vector<uint> offsets, Vector<float> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<uint> mask, uint* address, Vector<uint> offsets, Vector<uint> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<ulong> mask, ulong* address, Vector<long> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> offsets, Vector<ulong> data) { throw new PlatformNotSupportedException(); }
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
@@ -3603,28 +3603,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1h_scatter_[s64]index[_s64](svbool_t pg, int16_t *base, svint64_t indices, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<long> mask, short* address, Vector<long> indices, Vector<long> data) => Scatter16BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]index[_s64](svbool_t pg, int16_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<long> mask, short* address, Vector<ulong> indices, Vector<long> data) => Scatter16BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]index[_u64](svbool_t pg, uint16_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<long> indices, Vector<ulong> data) => Scatter16BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]index[_u64](svbool_t pg, uint16_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<ulong> indices, Vector<ulong> data) => Scatter16BitNarrowingNonTemporal(mask, address, indices, data);
 
 
@@ -3634,42 +3630,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1h_scatter_[u32]offset[_s32](svbool_t pg, int16_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1H Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<int> mask, short* address, Vector<uint> offsets, Vector<int> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]offset[_s64](svbool_t pg, int16_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, short* address, Vector<long> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]offset[_s64](svbool_t pg, int16_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, short* address, Vector<ulong> offsets, Vector<long> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[u32]offset[_u32](svbool_t pg, uint16_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1H Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<uint> mask, ushort* address, Vector<uint> offsets, Vector<uint> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[s64]offset[_u64](svbool_t pg, uint16_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<long> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1h_scatter_[u64]offset[_u64](svbool_t pg, uint16_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1H Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, ushort* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter16BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
 
@@ -3691,28 +3681,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1w_scatter_[s64]index[_s64](svbool_t pg, int32_t *base, svint64_t indices, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<long> mask, int* address, Vector<long> indices, Vector<long> data) => Scatter32BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]index[_s64](svbool_t pg, int32_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<long> mask, int* address, Vector<ulong> indices, Vector<long> data) => Scatter32BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[s64]index[_u64](svbool_t pg, uint32_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<long> indices, Vector<ulong> data) => Scatter32BitNarrowingNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]index[_u64](svbool_t pg, uint32_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<ulong> indices, Vector<ulong> data) => Scatter32BitNarrowingNonTemporal(mask, address, indices, data);
 
 
@@ -3722,28 +3708,24 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1w_scatter_[s64]offset[_s64](svbool_t pg, int32_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, int* address, Vector<long> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]offset[_s64](svbool_t pg, int32_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, int* address, Vector<ulong> offsets, Vector<long> data) => Scatter32BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[s64]offset[_u64](svbool_t pg, uint32_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<long> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1w_scatter_[u64]offset[_u64](svbool_t pg, uint32_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1W Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, uint* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter32BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
 
@@ -3782,42 +3764,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1b_scatter_[u32]offset[_s32](svbool_t pg, int8_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1B Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<int> mask, sbyte* address, Vector<uint> offsets, Vector<int> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1b_scatter_[s64]offset[_s64](svbool_t pg, int8_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, sbyte* address, Vector<long> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1b_scatter_[u64]offset[_s64](svbool_t pg, int8_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<long> mask, sbyte* address, Vector<ulong> offsets, Vector<long> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1b_scatter_[u32]offset[_u32](svbool_t pg, uint8_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1B Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<uint> mask, byte* address, Vector<uint> offsets, Vector<uint> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1b_scatter_[s64]offset[_u64](svbool_t pg, uint8_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, byte* address, Vector<long> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1b_scatter_[u64]offset[_u64](svbool_t pg, uint8_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1B Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(Vector<ulong> mask, byte* address, Vector<ulong> offsets, Vector<ulong> data) => Scatter8BitWithByteOffsetsNarrowingNonTemporal(mask, address, offsets, data);
 
 
@@ -3866,42 +3842,36 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1_scatter_[s64]index[_f64](svbool_t pg, float64_t *base, svint64_t indices, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<double> mask, double* address, Vector<long> indices, Vector<double> data) => ScatterNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_f64](svbool_t pg, float64_t *base, svuint64_t indices, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<double> mask, double* address, Vector<ulong> indices, Vector<double> data) => ScatterNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1_scatter_[s64]index[_s64](svbool_t pg, int64_t *base, svint64_t indices, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<long> mask, long* address, Vector<long> indices, Vector<long> data) => ScatterNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_s64](svbool_t pg, int64_t *base, svuint64_t indices, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<long> mask, long* address, Vector<ulong> indices, Vector<long> data) => ScatterNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1_scatter_[s64]index[_u64](svbool_t pg, uint64_t *base, svint64_t indices, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<ulong> mask, ulong* address, Vector<long> indices, Vector<ulong> data) => ScatterNonTemporal(mask, address, indices, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]index[_u64](svbool_t pg, uint64_t *base, svuint64_t indices, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> indices, Vector<ulong> data) => ScatterNonTemporal(mask, address, indices, data);
 
 
@@ -3911,63 +3881,54 @@ namespace System.Runtime.Intrinsics.Arm
         /// void svstnt1_scatter_[s64]offset[_f64](svbool_t pg, float64_t *base, svint64_t offsets, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<double> mask, double* address, Vector<long> offsets, Vector<double> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_f64](svbool_t pg, float64_t *base, svuint64_t offsets, svfloat64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<double> mask, double* address, Vector<ulong> offsets, Vector<double> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_s32](svbool_t pg, int32_t *base, svuint32_t offsets, svint32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<int> mask, int* address, Vector<uint> offsets, Vector<int> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[s64]offset[_s64](svbool_t pg, int64_t *base, svint64_t offsets, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<long> mask, long* address, Vector<long> offsets, Vector<long> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_s64](svbool_t pg, int64_t *base, svuint64_t offsets, svint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<long> mask, long* address, Vector<ulong> offsets, Vector<long> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_f32](svbool_t pg, float32_t *base, svuint32_t offsets, svfloat32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<float> mask, float* address, Vector<uint> offsets, Vector<float> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u32]offset[_u32](svbool_t pg, uint32_t *base, svuint32_t offsets, svuint32_t data)
         ///   STNT1W Zdata.S, Pg, [Zoffsets.S, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<uint> mask, uint* address, Vector<uint> offsets, Vector<uint> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[s64]offset[_u64](svbool_t pg, uint64_t *base, svint64_t offsets, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<ulong> mask, ulong* address, Vector<long> offsets, Vector<ulong> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
         /// <summary>
         /// void svstnt1_scatter_[u64]offset[_u64](svbool_t pg, uint64_t *base, svuint64_t offsets, svuint64_t data)
         ///   STNT1D Zdata.D, Pg, [Zoffsets.D, Xbase]
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(Vector<ulong> mask, ulong* address, Vector<ulong> offsets, Vector<ulong> data) => ScatterWithByteOffsetsNonTemporal(mask, address, offsets, data);
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/ISimdVector_2.cs
@@ -523,14 +523,12 @@ namespace System.Runtime.Intrinsics
         /// <param name="source">The source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual TSelf Load(T* source) => TSelf.LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
         /// <param name="source">The aligned source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual TSelf LoadAligned(T* source)
         {
             if (((nuint)(source) % (uint)(TSelf.Alignment)) != 0)
@@ -545,7 +543,6 @@ namespace System.Runtime.Intrinsics
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual TSelf LoadAlignedNonTemporal(T* source) => TSelf.LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -722,14 +719,12 @@ namespace System.Runtime.Intrinsics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual void Store(TSelf source, T* destination) => TSelf.StoreUnsafe(source, ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The aligned destination at which <paramref name="source" /> will be stored.</param>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual void StoreAligned(TSelf source, T* destination)
         {
             if (((nuint)(destination) % (uint)(TSelf.Alignment)) != 0)
@@ -744,7 +739,6 @@ namespace System.Runtime.Intrinsics
         /// <param name="destination">The aligned destination at which <paramref name="source" /> will be stored.</param>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         static virtual void StoreAlignedNonTemporal(TSelf source, T* destination) => TSelf.StoreAligned(source, destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/SimdVectorExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/SimdVectorExtensions.cs
@@ -73,7 +73,6 @@ namespace System.Runtime.Intrinsics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The destination at which <paramref name="source" /> will be stored.</param>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         public static void Store<TVector, T>(this TVector source, T* destination)
             where TVector : ISimdVector<TVector, T>
         {
@@ -86,7 +85,6 @@ namespace System.Runtime.Intrinsics
         /// <param name="source">The vector that will be stored.</param>
         /// <param name="destination">The aligned destination at which <paramref name="source" /> will be stored.</param>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         public static void StoreAligned<TVector, T>(this TVector source, T* destination)
             where TVector : ISimdVector<TVector, T>
         {
@@ -100,7 +98,6 @@ namespace System.Runtime.Intrinsics
         /// <param name="destination">The aligned destination at which <paramref name="source" /> will be stored.</param>
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
-        [RequiresUnsafe]
         public static void StoreAlignedNonTemporal<TVector, T>(this TVector source, T* destination)
             where TVector : ISimdVector<TVector, T>
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -2361,7 +2361,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector128<T> Load<T>(T* source) => LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
@@ -2372,7 +2371,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector128<T> LoadAligned<T>(T* source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
@@ -2393,7 +2391,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector128<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -3941,7 +3938,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void Store<T>(this Vector128<T> source, T* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
@@ -3952,7 +3948,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void StoreAligned<T>(this Vector128<T> source, T* destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
@@ -3973,7 +3968,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector128<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128_1.cs
@@ -725,17 +725,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector128<T> ISimdVector<Vector128<T>, T>.Load(T* source) => Vector128.Load(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAligned(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector128<T> ISimdVector<Vector128<T>, T>.LoadAligned(T* source) => Vector128.LoadAligned(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector128<T> ISimdVector<Vector128<T>, T>.LoadAlignedNonTemporal(T* source) => Vector128.LoadAlignedNonTemporal(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
@@ -836,17 +833,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector128<T>, T>.Store(Vector128<T> source, T* destination) => source.Store(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAligned(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector128<T>, T>.StoreAligned(Vector128<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector128<T>, T>.StoreAlignedNonTemporal(Vector128<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -2439,7 +2439,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector256<T> Load<T>(T* source) => LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
@@ -2450,7 +2449,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector256<T> LoadAligned<T>(T* source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
@@ -2471,7 +2469,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector256<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -3919,7 +3916,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> and <paramref name="destination" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void Store<T>(this Vector256<T> source, T* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
@@ -3930,7 +3926,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void StoreAligned<T>(this Vector256<T> source, T* destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
@@ -3951,7 +3946,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector256<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256_1.cs
@@ -713,17 +713,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector256<T> ISimdVector<Vector256<T>, T>.Load(T* source) => Vector256.Load(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAligned(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector256<T> ISimdVector<Vector256<T>, T>.LoadAligned(T* source) => Vector256.LoadAligned(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector256<T> ISimdVector<Vector256<T>, T>.LoadAlignedNonTemporal(T* source) => Vector256.LoadAlignedNonTemporal(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
@@ -824,17 +821,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector256<T>, T>.Store(Vector256<T> source, T* destination) => source.Store(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAligned(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector256<T>, T>.StoreAligned(Vector256<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector256<T>, T>.StoreAlignedNonTemporal(Vector256<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -2458,7 +2458,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector512<T> Load<T>(T* source) => LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
@@ -2469,7 +2468,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector512<T> LoadAligned<T>(T* source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
@@ -2490,7 +2488,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector512<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -3923,7 +3920,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> and <paramref name="destination" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void Store<T>(this Vector512<T> source, T* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
@@ -3934,7 +3930,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void StoreAligned<T>(this Vector512<T> source, T* destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
@@ -3955,7 +3950,6 @@ namespace System.Runtime.Intrinsics
         /// <remarks>This method may bypass the cache on certain platforms.</remarks>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector512<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512_1.cs
@@ -713,17 +713,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector512<T> ISimdVector<Vector512<T>, T>.Load(T* source) => Vector512.Load(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAligned(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector512<T> ISimdVector<Vector512<T>, T>.LoadAligned(T* source) => Vector512.LoadAligned(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector512<T> ISimdVector<Vector512<T>, T>.LoadAlignedNonTemporal(T* source) => Vector512.LoadAlignedNonTemporal(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
@@ -824,17 +821,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector512<T>, T>.Store(Vector512<T> source, T* destination) => source.Store(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAligned(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector512<T>, T>.StoreAligned(Vector512<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector512<T>, T>.StoreAlignedNonTemporal(Vector512<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -2339,7 +2339,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector64<T> Load<T>(T* source) => LoadUnsafe(ref *source);
 
         /// <summary>Loads a vector from the given aligned source.</summary>
@@ -2350,7 +2349,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe Vector64<T> LoadAligned<T>(T* source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
@@ -2371,7 +2369,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe Vector64<T> LoadAlignedNonTemporal<T>(T* source) => LoadAligned(source);
 
         /// <summary>Loads a vector from the given source.</summary>
@@ -3845,7 +3842,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void Store<T>(this Vector64<T> source, T* destination) => source.StoreUnsafe(ref *destination);
 
         /// <summary>Stores a vector at the given aligned destination.</summary>
@@ -3856,7 +3852,6 @@ namespace System.Runtime.Intrinsics
         [Intrinsic]
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe void StoreAligned<T>(this Vector64<T> source, T* destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
@@ -3877,7 +3872,6 @@ namespace System.Runtime.Intrinsics
         /// <exception cref="NotSupportedException">The type of <paramref name="source" /> (<typeparamref name="T" />) is not supported.</exception>
         [Intrinsic]
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal<T>(this Vector64<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <summary>Stores a vector at the given destination.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64_1.cs
@@ -782,17 +782,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Load(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector64<T> ISimdVector<Vector64<T>, T>.Load(T* source) => Vector64.Load(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAligned(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector64<T> ISimdVector<Vector64<T>, T>.LoadAligned(T* source) => Vector64.LoadAligned(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadAlignedNonTemporal(T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static Vector64<T> ISimdVector<Vector64<T>, T>.LoadAlignedNonTemporal(T* source) => Vector64.LoadAlignedNonTemporal(source);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.LoadUnsafe(ref readonly T)" />
@@ -893,17 +890,14 @@ namespace System.Runtime.Intrinsics
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.Store(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector64<T>, T>.Store(Vector64<T> source, T* destination) => source.Store(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAligned(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector64<T>, T>.StoreAligned(Vector64<T> source, T* destination) => source.StoreAligned(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreAlignedNonTemporal(TSelf, T*)" />
         [Intrinsic]
-        [RequiresUnsafe]
         static void ISimdVector<Vector64<T>, T>.StoreAlignedNonTemporal(Vector64<T> source, T* destination) => source.StoreAlignedNonTemporal(destination);
 
         /// <inheritdoc cref="ISimdVector{TSelf, T}.StoreUnsafe(TSelf, ref T)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/PackedSimd.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/PackedSimd.PlatformNotSupported.cs
@@ -395,228 +395,154 @@ namespace System.Runtime.Intrinsics.Wasm
 
         // Load
 
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadVector128(sbyte*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadVector128(byte*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadVector128(short*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadVector128(int*    address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadVector128(uint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadVector128(long*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadVector128(ulong*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadVector128(float*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadVector128(nint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadVector128(nuint*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarVector128(int*    address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarVector128(uint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarVector128(long*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarVector128(ulong*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarVector128(float*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarVector128(double* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarVector128(nint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarVector128(nuint*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadScalarAndSplatVector128(sbyte*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadScalarAndSplatVector128(byte*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadScalarAndSplatVector128(short*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadScalarAndSplatVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarAndSplatVector128(int*    address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarAndSplatVector128(uint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarAndSplatVector128(long*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarAndSplatVector128(ulong*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarAndSplatVector128(float*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarAndSplatVector128(double* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarAndSplatVector128(nint*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarAndSplatVector128(nuint*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadScalarAndInsert(sbyte*  address, Vector128<sbyte>  vector, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadScalarAndInsert(byte*   address, Vector128<byte>   vector, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadScalarAndInsert(short*  address, Vector128<short>  vector, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadScalarAndInsert(ushort* address, Vector128<ushort> vector, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarAndInsert(int*    address, Vector128<int>    vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarAndInsert(uint*   address, Vector128<uint>   vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarAndInsert(long*   address, Vector128<long>   vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarAndInsert(ulong*  address, Vector128<ulong>  vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarAndInsert(float*  address, Vector128<float>  vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarAndInsert(double* address, Vector128<double> vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarAndInsert(nint*   address, Vector128<nint>   vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarAndInsert(nuint*  address, Vector128<nuint>  vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadWideningVector128(sbyte*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadWideningVector128(byte*   address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadWideningVector128(short*  address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadWideningVector128(ushort* address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadWideningVector128(int*    address) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadWideningVector128(uint*   address) { throw new PlatformNotSupportedException(); }
 
         // Store
 
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte*  address, Vector128<sbyte>  source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(byte*   address, Vector128<byte>   source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(short*  address, Vector128<short>  source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(int*    address, Vector128<int>    source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(uint*   address, Vector128<uint>   source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(long*   address, Vector128<long>   source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(ulong*  address, Vector128<ulong>  source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(float*  address, Vector128<float>  source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(nint*   address, Vector128<nint>   source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void Store(nuint*  address, Vector128<nuint>  source) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte*  address, Vector128<sbyte>  source, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx16
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte*   address, Vector128<byte>   source, [ConstantExpected(Max = (byte)(15))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx16
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short*  address, Vector128<short>  source, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx8
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector128<ushort> source, [ConstantExpected(Max = (byte)(7))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx8
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int*    address, Vector128<int>    source, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx4
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint*   address, Vector128<uint>   source, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx4
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(long*   address, Vector128<long>   source, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx2
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ulong*  address, Vector128<ulong>  source, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx2
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float*  address, Vector128<float>  source, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx4
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(double* address, Vector128<double> source, [ConstantExpected(Max = (byte)(1))] byte index) { throw new PlatformNotSupportedException(); } // takes ImmLaneIdx2
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(nint*   address, Vector128<nint>   source, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(nuint*  address, Vector128<nuint>  source, [ConstantExpected(Max = (byte)(3))] byte index) { throw new PlatformNotSupportedException(); }
 
         // Floating-point sign bit operations

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/PackedSimd.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Wasm/PackedSimd.cs
@@ -1044,307 +1044,233 @@ namespace System.Runtime.Intrinsics.Wasm
 
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadVector128(sbyte*  address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadVector128(byte*   address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadVector128(short*  address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadVector128(int*    address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadVector128(uint*   address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadVector128(long*   address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadVector128(ulong*  address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadVector128(float*  address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadVector128(nint*   address) => LoadVector128(address);
         /// <summary>  v128.load</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadVector128(nuint*  address) => LoadVector128(address);
 
         /// <summary>  v128.load32.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarVector128(int*    address) => LoadScalarVector128(address);
         /// <summary>  v128.load32.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarVector128(uint*   address) => LoadScalarVector128(address);
         /// <summary>  v128.load64.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarVector128(long*   address) => LoadScalarVector128(address);
         /// <summary>  v128.load64.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarVector128(ulong*  address) => LoadScalarVector128(address);
         /// <summary>  v128.load32.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarVector128(float*  address) => LoadScalarVector128(address);
         /// <summary>  v128.load64.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarVector128(double* address) => LoadScalarVector128(address);
         /// <summary>  v128.load32.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarVector128(nint*   address) => LoadScalarVector128(address);
         /// <summary>  v128.load32.zero</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarVector128(nuint*  address) => LoadScalarVector128(address);
 
         /// <summary>  v128.load8_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadScalarAndSplatVector128(sbyte*  address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load8_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadScalarAndSplatVector128(byte*   address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load16_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadScalarAndSplatVector128(short*  address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load16_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadScalarAndSplatVector128(ushort* address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load32_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarAndSplatVector128(int*    address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load32_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarAndSplatVector128(uint*   address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarAndSplatVector128(long*   address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarAndSplatVector128(ulong*  address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarAndSplatVector128(float*  address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarAndSplatVector128(double* address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarAndSplatVector128(nint*   address) => LoadScalarAndSplatVector128(address);
         /// <summary>  v128.load64_splat</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarAndSplatVector128(nuint*  address) => LoadScalarAndSplatVector128(address);
 
         /// <summary>  v128.load8_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte>  LoadScalarAndInsert(sbyte*  address, Vector128<sbyte>  vector, [ConstantExpected(Max = (byte)(15))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx16
         /// <summary>  v128.load8_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<byte>   LoadScalarAndInsert(byte*   address, Vector128<byte>   vector, [ConstantExpected(Max = (byte)(15))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx16
         /// <summary>  v128.load16_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadScalarAndInsert(short*  address, Vector128<short>  vector, [ConstantExpected(Max = (byte)(7))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx8
         /// <summary>  v128.load16_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadScalarAndInsert(ushort* address, Vector128<ushort> vector, [ConstantExpected(Max = (byte)(7))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx8
         /// <summary>  v128.load32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadScalarAndInsert(int*    address, Vector128<int>    vector, [ConstantExpected(Max = (byte)(3))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx4
         /// <summary>  v128.load32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadScalarAndInsert(uint*   address, Vector128<uint>   vector, [ConstantExpected(Max = (byte)(3))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx4
         /// <summary>  v128.load64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadScalarAndInsert(long*   address, Vector128<long>   vector, [ConstantExpected(Max = (byte)(1))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx2
         /// <summary>  v128.load64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadScalarAndInsert(ulong*  address, Vector128<ulong>  vector, [ConstantExpected(Max = (byte)(1))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx2
         /// <summary>  v128.load32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<float>  LoadScalarAndInsert(float*  address, Vector128<float>  vector, [ConstantExpected(Max = (byte)(3))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx4
         /// <summary>  v128.load64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarAndInsert(double* address, Vector128<double> vector, [ConstantExpected(Max = (byte)(1))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx2
         /// <summary>  v128.load32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nint>   LoadScalarAndInsert(nint*   address, Vector128<nint>   vector, [ConstantExpected(Max = (byte)(3))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx4
         /// <summary>  v128.load32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<nuint>  LoadScalarAndInsert(nuint*  address, Vector128<nuint>  vector, [ConstantExpected(Max = (byte)(3))] byte index) => LoadScalarAndInsert(address, vector, index); // takes ImmLaneIdx4
 
         // Store
 
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte*  address, Vector128<sbyte>  source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(byte*   address, Vector128<byte>   source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(short*  address, Vector128<short>  source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(int*    address, Vector128<int>    source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(uint*   address, Vector128<uint>   source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(long*   address, Vector128<long>   source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(ulong*  address, Vector128<ulong>  source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(float*  address, Vector128<float>  source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(nint*   address, Vector128<nint>   source) => Store(address, source);
         /// <summary>  v128.store</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void Store(nuint*  address, Vector128<nuint>  source) => Store(address, source);
 
         /// <summary>  v128.store8_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(sbyte*  address, Vector128<sbyte>  source, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx16
         /// <summary>  v128.store8_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(byte*   address, Vector128<byte>   source, [ConstantExpected(Max = (byte)(15))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx16
         /// <summary>  v128.store16_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(short*  address, Vector128<short>  source, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx8
         /// <summary>  v128.store16_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector128<ushort> source, [ConstantExpected(Max = (byte)(7))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx8
         /// <summary>  v128.store32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(int*    address, Vector128<int>    source, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx4
         /// <summary>  v128.store32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(uint*   address, Vector128<uint>   source, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx4
         /// <summary>  v128.store64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(long*   address, Vector128<long>   source, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx2
         /// <summary>  v128.store64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(ulong*  address, Vector128<ulong>  source, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx2
         /// <summary>  v128.store32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(float*  address, Vector128<float>  source, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx4
         /// <summary>  v128.store64_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(double* address, Vector128<double> source, [ConstantExpected(Max = (byte)(1))] byte index) => StoreSelectedScalar(address, source, index); // takes ImmLaneIdx2
         /// <summary>  v128.store32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(nint*   address, Vector128<nint>   source, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, source, index);
         /// <summary>  v128.store32_lane</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe void StoreSelectedScalar(nuint*  address, Vector128<nuint>  source, [ConstantExpected(Max = (byte)(3))] byte index) => StoreSelectedScalar(address, source, index);
 
         /// <summary>  v128.load8x8_s</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<short>  LoadWideningVector128(sbyte*  address) => LoadWideningVector128(address);
         /// <summary>  v128.load8x8_u</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadWideningVector128(byte*   address) => LoadWideningVector128(address);
         /// <summary>  v128.load16x4_s</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<int>    LoadWideningVector128(short*  address) => LoadWideningVector128(address);
         /// <summary>  v128.load16x4_u</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<uint>   LoadWideningVector128(ushort* address) => LoadWideningVector128(address);
         /// <summary>  v128.load32x2_s</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<long>   LoadWideningVector128(int*    address) => LoadWideningVector128(address);
         /// <summary>  v128.load32x2_u</summary>
         [Intrinsic]
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong>  LoadWideningVector128(uint*   address) => LoadWideningVector128(address);
 
         // Floating-point sign bit operations

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.PlatformNotSupported.cs
@@ -107,7 +107,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTSS xmm1,         m32</para>
         ///   <para>  VBROADCASTSS xmm1 {k1}{z}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> BroadcastScalarToVector128(float* source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -115,14 +114,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTSS ymm1,         m32</para>
         ///   <para>  VBROADCASTSS ymm1 {k1}{z}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> BroadcastScalarToVector256(float* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_broadcast_sd (double const * mem_addr)</para>
         ///   <para>  VBROADCASTSD ymm1,         m64</para>
         ///   <para>  VBROADCASTSD ymm1 {k1}{z}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> BroadcastScalarToVector256(double* source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -130,14 +127,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTF128  ymm1,         m128</para>
         ///   <para>  VBROADCASTF32x4 ymm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> BroadcastVector128ToVector256(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_broadcast_pd (__m128d const * mem_addr)</para>
         ///   <para>  VBROADCASTF128  ymm1,         m128</para>
         ///   <para>  VBROADCASTF64x2 ymm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> BroadcastVector128ToVector256(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -578,119 +573,101 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadAlignedVector256(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadAlignedVector256(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadAlignedVector256(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadAlignedVector256(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadAlignedVector256(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadAlignedVector256(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadAlignedVector256(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_load_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadAlignedVector256(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_load_ps (float const * mem_addr)</para>
         ///   <para>  VMOVAPS ymm1,         m256</para>
         ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> LoadAlignedVector256(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_load_pd (double const * mem_addr)</para>
         ///   <para>  VMOVAPD ymm1,         m256</para>
         ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> LoadAlignedVector256(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadDquVector256(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadDquVector256(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadDquVector256(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadDquVector256(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadDquVector256(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadDquVector256(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadDquVector256(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadDquVector256(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -698,120 +675,102 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  ymm1,         m256</para>
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadVector256(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU  ymm1,         m256</para>
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadVector256(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU16 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadVector256(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU16 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadVector256(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadVector256(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadVector256(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadVector256(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_loadu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadVector256(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_loadu_ps (float const * mem_addr)</para>
         ///   <para>  VMOVUPS ymm1,         m256</para>
         ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> LoadVector256(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_loadu_pd (double const * mem_addr)</para>
         ///   <para>  VMOVUPD ymm1,         m256</para>
         ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> LoadVector256(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m128 _mm_maskload_ps (float const * mem_addr, __m128i mask)</para>
         ///   <para>  VMASKMOVPS xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_maskload_pd (double const * mem_addr, __m128i mask)</para>
         ///   <para>  VMASKMOVPD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_maskload_ps (float const * mem_addr, __m256i mask)</para>
         ///   <para>  VMASKMOVPS ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_maskload_pd (double const * mem_addr, __m256i mask)</para>
         ///   <para>  VMASKMOVPD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm_maskstore_ps (float * mem_addr, __m128i mask, __m128 a)</para>
         ///   <para>  VMASKMOVPS m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_maskstore_pd (double * mem_addr, __m128i mask, __m128d a)</para>
         ///   <para>  VMASKMOVPD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_ps (float * mem_addr, __m256i mask, __m256 a)</para>
         ///   <para>  VMASKMOVPS m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_pd (double * mem_addr, __m256i mask, __m256d a)</para>
         ///   <para>  VMASKMOVPD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1087,70 +1046,60 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m256,         ymm1</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU  m256,         ymm1</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector256<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_ps (float * mem_addr, __m256 a)</para>
         ///   <para>  VMOVUPS m256,         ymm1</para>
         ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_storeu_pd (double * mem_addr, __m256d a)</para>
         ///   <para>  VMOVUPD m256,         ymm1</para>
         ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector256<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1158,131 +1107,111 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector256<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_ps (float * mem_addr, __m256 a)</para>
         ///   <para>  VMOVAPS m256,         ymm1</para>
         ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_store_pd (double * mem_addr, __m256d a)</para>
         ///   <para>  VMOVAPD m256,         ymm1</para>
         ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector256<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector256<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_ps (float * mem_addr, __m256 a)</para>
         ///   <para>  VMOVNTPS m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_stream_pd (double * mem_addr, __m256d a)</para>
         ///   <para>  VMOVNTPD m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector256<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx.cs
@@ -108,7 +108,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTSS xmm1,         m32</para>
         ///   <para>  VBROADCASTSS xmm1 {k1}{z}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> BroadcastScalarToVector128(float* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -116,7 +115,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTSS ymm1,         m32</para>
         ///   <para>  VBROADCASTSS ymm1 {k1}{z}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> BroadcastScalarToVector256(float* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -124,7 +122,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTSD ymm1,         m64</para>
         ///   <para>  VBROADCASTSD ymm1 {k1}{z}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> BroadcastScalarToVector256(double* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -132,7 +129,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTF128  ymm1,         m128</para>
         ///   <para>  VBROADCASTF32x4 ymm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> BroadcastVector128ToVector256(float* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -140,7 +136,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTF128  ymm1,         m128</para>
         ///   <para>  VBROADCASTF64x2 ymm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> BroadcastVector128ToVector256(double* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -581,7 +576,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadAlignedVector256(sbyte* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -589,7 +583,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadAlignedVector256(byte* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -597,7 +590,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadAlignedVector256(short* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -605,7 +597,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadAlignedVector256(ushort* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -613,7 +604,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadAlignedVector256(int* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -621,7 +611,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadAlignedVector256(uint* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -629,7 +618,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadAlignedVector256(long* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -637,7 +625,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   ymm1,         m256</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadAlignedVector256(ulong* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -645,7 +632,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS ymm1,         m256</para>
         ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> LoadAlignedVector256(float* address) => LoadAlignedVector256(address);
 
         /// <summary>
@@ -653,63 +639,54 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD ymm1,         m256</para>
         ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> LoadAlignedVector256(double* address) => LoadAlignedVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadDquVector256(sbyte* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadDquVector256(byte* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadDquVector256(short* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadDquVector256(ushort* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadDquVector256(int* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadDquVector256(uint* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadDquVector256(long* address) => LoadDquVector256(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_lddqu_si256 (__m256i const * mem_addr)</para>
         ///   <para>  VLDDQU ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadDquVector256(ulong* address) => LoadDquVector256(address);
 
         /// <summary>
@@ -717,7 +694,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  ymm1,         m256</para>
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadVector256(sbyte* address) => LoadVector256(address);
 
         /// <summary>
@@ -725,7 +701,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  ymm1,         m256</para>
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadVector256(byte* address) => LoadVector256(address);
 
         /// <summary>
@@ -733,7 +708,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU16 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadVector256(short* address) => LoadVector256(address);
 
         /// <summary>
@@ -741,7 +715,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU16 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadVector256(ushort* address) => LoadVector256(address);
 
         /// <summary>
@@ -749,7 +722,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadVector256(int* address) => LoadVector256(address);
 
         /// <summary>
@@ -757,7 +729,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadVector256(uint* address) => LoadVector256(address);
 
         /// <summary>
@@ -765,7 +736,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadVector256(long* address) => LoadVector256(address);
 
         /// <summary>
@@ -773,7 +743,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   ymm1,         m256</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadVector256(ulong* address) => LoadVector256(address);
 
         /// <summary>
@@ -781,7 +750,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS ymm1,         m256</para>
         ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> LoadVector256(float* address) => LoadVector256(address);
 
         /// <summary>
@@ -789,63 +757,54 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD ymm1,         m256</para>
         ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> LoadVector256(double* address) => LoadVector256(address);
 
         /// <summary>
         ///   <para>__m128 _mm_maskload_ps (float const * mem_addr, __m128i mask)</para>
         ///   <para>  VMASKMOVPS xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m128d _mm_maskload_pd (double const * mem_addr, __m128i mask)</para>
         ///   <para>  VMASKMOVPD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256 _mm256_maskload_ps (float const * mem_addr, __m256i mask)</para>
         ///   <para>  VMASKMOVPS ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256d _mm256_maskload_pd (double const * mem_addr, __m256i mask)</para>
         ///   <para>  VMASKMOVPD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>void _mm_maskstore_ps (float * mem_addr, __m128i mask, __m128 a)</para>
         ///   <para>  VMASKMOVPS m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_maskstore_pd (double * mem_addr, __m128i mask, __m128d a)</para>
         ///   <para>  VMASKMOVPD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_ps (float * mem_addr, __m256i mask, __m256 a)</para>
         ///   <para>  VMASKMOVPS m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_pd (double * mem_addr, __m256i mask, __m256d a)</para>
         ///   <para>  VMASKMOVPD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) => MaskStore(address, mask, source);
 
         /// <summary>
@@ -1120,7 +1079,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m256,         ymm1</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector256<sbyte> source) => Store(address, source);
 
         /// <summary>
@@ -1128,7 +1086,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m256,         ymm1</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector256<byte> source) => Store(address, source);
 
         /// <summary>
@@ -1136,7 +1093,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector256<short> source) => Store(address, source);
 
         /// <summary>
@@ -1144,7 +1100,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector256<ushort> source) => Store(address, source);
 
         /// <summary>
@@ -1152,7 +1107,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector256<int> source) => Store(address, source);
 
         /// <summary>
@@ -1160,7 +1114,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector256<uint> source) => Store(address, source);
 
         /// <summary>
@@ -1168,7 +1121,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector256<long> source) => Store(address, source);
 
         /// <summary>
@@ -1176,7 +1128,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m256,         ymm1</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector256<ulong> source) => Store(address, source);
 
         /// <summary>
@@ -1184,7 +1135,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS m256,         ymm1</para>
         ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector256<float> source) => Store(address, source);
 
         /// <summary>
@@ -1192,7 +1142,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD m256,         ymm1</para>
         ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector256<double> source) => Store(address, source);
 
         /// <summary>
@@ -1200,7 +1149,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector256<sbyte> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1208,7 +1156,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector256<byte> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1216,7 +1163,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector256<short> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1224,7 +1170,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector256<ushort> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1232,7 +1177,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector256<int> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1240,7 +1184,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector256<uint> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1248,7 +1191,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector256<long> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1256,7 +1198,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m256,         ymm1</para>
         ///   <para>  VMOVDQA64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector256<ulong> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1264,7 +1205,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS m256,         ymm1</para>
         ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector256<float> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1272,77 +1212,66 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD m256,         ymm1</para>
         ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector256<double> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector256<sbyte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector256<byte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector256<short> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector256<ushort> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector256<int> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector256<uint> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector256<long> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_si256 (__m256i * mem_addr, __m256i a)</para>
         ///   <para>  VMOVNTDQ m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector256<ulong> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_ps (float * mem_addr, __m256 a)</para>
         ///   <para>  VMOVNTPS m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector256<float> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm256_stream_pd (double * mem_addr, __m256d a)</para>
         ///   <para>  VMOVNTPD m256, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector256<double> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v1.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v1.PlatformNotSupported.cs
@@ -1180,122 +1180,102 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector128<byte> mask, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_mask_compressstoreu_pd (void * a, __mmask8 k, __m128d a)</para>
         ///   <para>  VCOMPRESSPD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector128<short> mask, Vector128<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_compressstoreu_ps (void * a, __mmask8 k, __m128 a)</para>
         ///   <para>  VCOMPRESSPS m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector256<byte> mask, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_mask_compressstoreu_pd (void * a, __mmask8 k, __m256d a)</para>
         ///   <para>  VCOMPRESSPD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector256<short> mask, Vector256<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_mask_compressstoreu_ps (void * a, __mmask8 k, __m256 a)</para>
         ///   <para>  VCOMPRESSPS m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2095,70 +2075,60 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> ExpandLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_mask_expandloadu_pd (__m128d s, __mmask8 k, void const * a)</para>
         ///   <para>  VEXPANDPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> ExpandLoad(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi16 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ExpandLoad(short* address, Vector128<short> mask, Vector128<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi32 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ExpandLoad(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi64 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ExpandLoad(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi8 (__m128i s, __mmask16 k, void const * a)</para>
         ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> ExpandLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_expandloadu_ps (__m128 s, __mmask8 k, void const * a)</para>
         ///   <para>  VEXPANDPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> ExpandLoad(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi16 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> ExpandLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi32 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> ExpandLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_expandloadu_epi64 (__m128i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> ExpandLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2166,70 +2136,60 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> ExpandLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_address_expandloadu_pd (__m256d s, __mmask8 k, void const * a)</para>
         ///   <para>  VEXPANDPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> ExpandLoad(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_expandloadu_epi16 (__m256i s, __mmask16 k, void const * a)</para>
         ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ExpandLoad(short* address, Vector256<short> mask, Vector256<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_address_expandloadu_epi32 (__m256i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ExpandLoad(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_address_expandloadu_epi64 (__m256i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ExpandLoad(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_expandloadu_epi8 (__m256i s, __mmask32 k, void const * a)</para>
         ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> ExpandLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_address_expandloadu_ps (__m256 s, __mmask8 k, void const * a)</para>
         ///   <para>  VEXPANDPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> ExpandLoad(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_expandloadu_epi16 (__m256i s, __mmask16 k, void const * a)</para>
         ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> ExpandLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_address_expandloadu_epi32 (__m256i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> ExpandLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_address_expandloadu_epi64 (__m256i s, __mmask8 k, void const * a)</para>
         ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> ExpandLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2444,70 +2404,60 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> MaskLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_mask_loadu_pd (__m128d s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi16 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> MaskLoad(short* address, Vector128<short> mask, Vector128<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi8 (__m128i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> MaskLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_loadu_ps (__m128 s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi16 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> MaskLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_loadu_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2515,69 +2465,59 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> MaskLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_mask_loadu_pd (__m256d s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi16 (__m256i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> MaskLoad(short* address, Vector256<short> mask, Vector256<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi8 (__m256i s, __mmask32 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> MaskLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_mask_loadu_ps (__m256 s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi16 (__m256i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> MaskLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2585,42 +2525,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoadAligned(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_load_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoadAligned(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_load_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoadAligned(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_load_ps (__m128 s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoadAligned(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_load_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoadAligned(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_load_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoadAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2628,238 +2562,200 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoadAligned(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_load_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoadAligned(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_load_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoadAligned(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_mask_load_ps (__m256 s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoadAligned(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_load_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoadAligned(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_load_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoadAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector128<byte> mask, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
         ///   <para>  VMOVUPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector128<short> mask, Vector128<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
         ///   <para>  VMOVUPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector256<byte> mask, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
         ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector256<short> mask, Vector256<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
         ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm_mask_store_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
         ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_store_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
         ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm256_mask_store_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
         ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_store_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
         ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4105,38 +4001,32 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
             ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<long> BroadcastVector128ToVector512(long* address) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
             ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<ulong> BroadcastVector128ToVector512(ulong* address) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512d _mm512_broadcast_f64x2 (__m128d const * mem_addr)</para>
             ///   <para>  VBROADCASTF64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<double> BroadcastVector128ToVector512(double* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
             ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<int> BroadcastVector256ToVector512(int* address) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
             ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<uint> BroadcastVector256ToVector512(uint* address) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512 _mm512_broadcast_f32x8 (__m256 const * mem_addr)</para>
             ///   <para>  VBROADCASTF32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<float> BroadcastVector256ToVector512(float* address) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -4175,25 +4065,21 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector512<byte> mask, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector512<short> mask, Vector512<short> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -4349,28 +4235,24 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<byte> ExpandLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_expandloadu_epi16 (__m512i s, __mmask32 k, void * const a)</para>
             ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<short> ExpandLoad(short* address, Vector512<short> mask, Vector512<short> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_expandloadu_epi8 (__m512i s, __mmask64 k, void * const a)</para>
             ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<sbyte> ExpandLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m512i _mm512_mask_expandloadu_epi16 (__m512i s, __mmask32 k, void * const a)</para>
             ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<ushort> ExpandLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v1.cs
@@ -1179,140 +1179,120 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector128<byte> mask, Vector128<byte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128d _mm_mask_compressstoreu_pd (void * a, __mmask8 k, __m128d a)</para>
         ///   <para>  VCOMPRESSPD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector128<double> mask, Vector128<double> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector128<short> mask, Vector128<short> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector128<int> mask, Vector128<int> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector128<long> mask, Vector128<long> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128 _mm_mask_compressstoreu_ps (void * a, __mmask8 k, __m128 a)</para>
         ///   <para>  VCOMPRESSPS m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector128<float> mask, Vector128<float> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector128<uint> mask, Vector128<uint> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
         ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector256<byte> mask, Vector256<byte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m256d _mm256_mask_compressstoreu_pd (void * a, __mmask8 k, __m256d a)</para>
         ///   <para>  VCOMPRESSPD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector256<double> mask, Vector256<double> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector256<short> mask, Vector256<short> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector256<int> mask, Vector256<int> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector256<long> mask, Vector256<long> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m256 _mm256_mask_compressstoreu_ps (void * a, __mmask8 k, __m256 a)</para>
         ///   <para>  VCOMPRESSPS m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector256<float> mask, Vector256<float> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector256<uint> mask, Vector256<uint> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
         ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => CompressStore(address, mask, source);
 
         /// <summary>
@@ -2112,7 +2092,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> ExpandLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2120,7 +2099,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> ExpandLoad(double* address, Vector128<double> mask, Vector128<double> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2128,7 +2106,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ExpandLoad(short* address, Vector128<short> mask, Vector128<short> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2136,7 +2113,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ExpandLoad(int* address, Vector128<int> mask, Vector128<int> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2144,7 +2120,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ExpandLoad(long* address, Vector128<long> mask, Vector128<long> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2152,7 +2127,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> ExpandLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2160,7 +2134,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> ExpandLoad(float* address, Vector128<float> mask, Vector128<float> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2168,7 +2141,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> ExpandLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2176,7 +2148,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> ExpandLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2184,7 +2155,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> ExpandLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2192,7 +2162,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> ExpandLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2200,7 +2169,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> ExpandLoad(double* address, Vector256<double> mask, Vector256<double> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2208,7 +2176,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ExpandLoad(short* address, Vector256<short> mask, Vector256<short> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2216,7 +2183,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ExpandLoad(int* address, Vector256<int> mask, Vector256<int> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2224,7 +2190,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ExpandLoad(long* address, Vector256<long> mask, Vector256<long> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2232,7 +2197,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> ExpandLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2240,7 +2204,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> ExpandLoad(float* address, Vector256<float> mask, Vector256<float> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2248,7 +2211,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> ExpandLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2256,7 +2218,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> ExpandLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2264,7 +2225,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> ExpandLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -2479,7 +2439,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> MaskLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2487,7 +2446,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask, Vector128<double> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2495,7 +2453,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> MaskLoad(short* address, Vector128<short> mask, Vector128<short> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2503,7 +2460,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask, Vector128<int> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2511,7 +2467,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask, Vector128<long> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2519,7 +2474,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> MaskLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2527,7 +2481,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask, Vector128<float> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2535,7 +2488,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> MaskLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2543,7 +2495,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2551,7 +2502,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2559,7 +2509,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> MaskLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2567,7 +2516,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask, Vector256<double> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2575,14 +2523,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> MaskLoad(short* address, Vector256<short> mask, Vector256<short> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
         ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask, Vector256<int> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2590,7 +2536,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask, Vector256<long> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2598,7 +2543,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> MaskLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2606,7 +2550,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask, Vector256<float> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2614,7 +2557,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> MaskLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2622,7 +2564,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2630,7 +2571,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -2638,7 +2578,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> MaskLoadAligned(double* address, Vector128<double> mask, Vector128<double> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2646,7 +2585,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoadAligned(int* address, Vector128<int> mask, Vector128<int> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2654,7 +2592,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoadAligned(long* address, Vector128<long> mask, Vector128<long> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2662,7 +2599,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> MaskLoadAligned(float* address, Vector128<float> mask, Vector128<float> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2670,7 +2606,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoadAligned(uint* address, Vector128<uint> mask, Vector128<uint> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2678,7 +2613,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoadAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2686,7 +2620,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> MaskLoadAligned(double* address, Vector256<double> mask, Vector256<double> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2694,7 +2627,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoadAligned(int* address, Vector256<int> mask, Vector256<int> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2702,7 +2634,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoadAligned(long* address, Vector256<long> mask, Vector256<long> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2710,7 +2641,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> MaskLoadAligned(float* address, Vector256<float> mask, Vector256<float> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2718,7 +2648,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoadAligned(uint* address, Vector256<uint> mask, Vector256<uint> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -2726,231 +2655,198 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoadAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector128<byte> mask, Vector128<byte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
         ///   <para>  VMOVUPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector128<short> mask, Vector128<short> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
         ///   <para>  VMOVUPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector256<byte> mask, Vector256<byte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
         ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector256<short> mask, Vector256<short> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
         ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
         ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
         ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
         ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector128<double> mask, Vector128<double> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector128<int> mask, Vector128<int> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector128<long> mask, Vector128<long> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
         ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector128<float> mask, Vector128<float> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector128<uint> mask, Vector128<uint> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
         ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector256<double> mask, Vector256<double> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector256<int> mask, Vector256<int> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector256<long> mask, Vector256<long> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
         ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector256<float> mask, Vector256<float> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector256<uint> mask, Vector256<uint> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
         ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
@@ -4197,42 +4093,36 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
             ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<long> BroadcastVector128ToVector512(long* address) => BroadcastVector128ToVector512(address);
 
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
             ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<ulong> BroadcastVector128ToVector512(ulong* address) => BroadcastVector128ToVector512(address);
 
             /// <summary>
             ///   <para>__m512d _mm512_broadcast_f64x2 (__m128d const * mem_addr)</para>
             ///   <para>  VBROADCASTF64x2 zmm1 {k1}{z}, m128</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<double> BroadcastVector128ToVector512(double* address) => BroadcastVector128ToVector512(address);
 
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
             ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<int> BroadcastVector256ToVector512(int* address) => BroadcastVector256ToVector512(address);
 
             /// <summary>
             ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
             ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<uint> BroadcastVector256ToVector512(uint* address) => BroadcastVector256ToVector512(address);
 
             /// <summary>
             ///   <para>__m512 _mm512_broadcast_f32x8 (__m256 const * mem_addr)</para>
             ///   <para>  VBROADCASTF32x8 zmm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector512<float> BroadcastVector256ToVector512(float* address) => BroadcastVector256ToVector512(address);
 
             /// <summary>
@@ -4271,28 +4161,24 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector512<byte> mask, Vector512<byte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector512<short> mask, Vector512<short> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
             ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) => CompressStore(address, mask, source);
 
             /// <summary>
@@ -4448,7 +4334,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<byte> ExpandLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -4456,7 +4341,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<short> ExpandLoad(short* address, Vector512<short> mask, Vector512<short> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -4464,7 +4348,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<sbyte> ExpandLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -4472,7 +4355,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector512<ushort> ExpandLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v2.PlatformNotSupported.cs
@@ -112,13 +112,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         ///   <para>  VMOVW xmm1/m16, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(short* address, Vector128<short> source)  { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>  VMOVW xmm1/m16, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(ushort* address, Vector128<ushort> source)  { throw new PlatformNotSupportedException(); }
 
         /// <summary>Provides access to the x86 AVX10.2 hardware instructions, that are only available to 64-bit processes, via intrinsics.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx10v2.cs
@@ -111,13 +111,11 @@ namespace System.Runtime.Intrinsics.X86
         /// <summary>
         ///   <para>  VMOVW xmm1/m16, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(short* address, Vector128<short> source) => StoreScalar(address, source);
 
         /// <summary>
         ///   <para>  VMOVW xmm1/m16, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(ushort* address, Vector128<ushort> source) => StoreScalar(address, source);
 
         /// <summary>Provides access to the x86 AVX10.2 hardware instructions, that are only available to 64-bit processes, via intrinsics.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.PlatformNotSupported.cs
@@ -425,7 +425,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB xmm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> BroadcastScalarToVector128(byte* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastb_epi8 (__m128i a)</para>
@@ -433,7 +432,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB xmm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> BroadcastScalarToVector128(sbyte* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastw_epi16 (__m128i a)</para>
@@ -441,7 +439,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW xmm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> BroadcastScalarToVector128(short* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastw_epi16 (__m128i a)</para>
@@ -449,7 +446,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW xmm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> BroadcastScalarToVector128(ushort* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastd_epi32 (__m128i a)</para>
@@ -457,7 +453,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD xmm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> BroadcastScalarToVector128(int* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastd_epi32 (__m128i a)</para>
@@ -465,7 +460,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD xmm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> BroadcastScalarToVector128(uint* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastq_epi64 (__m128i a)</para>
@@ -473,7 +467,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ xmm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> BroadcastScalarToVector128(long* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_broadcastq_epi64 (__m128i a)</para>
@@ -481,7 +474,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ xmm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> BroadcastScalarToVector128(ulong* source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -551,7 +543,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB ymm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> BroadcastScalarToVector256(byte* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastb_epi8 (__m128i a)</para>
@@ -559,7 +550,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB ymm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastw_epi16 (__m128i a)</para>
@@ -567,7 +557,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW ymm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> BroadcastScalarToVector256(short* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastw_epi16 (__m128i a)</para>
@@ -575,7 +564,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW ymm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> BroadcastScalarToVector256(ushort* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastd_epi32 (__m128i a)</para>
@@ -583,7 +571,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD ymm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> BroadcastScalarToVector256(int* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastd_epi32 (__m128i a)</para>
@@ -591,7 +578,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD ymm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> BroadcastScalarToVector256(uint* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastq_epi64 (__m128i a)</para>
@@ -599,7 +585,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ ymm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> BroadcastScalarToVector256(long* source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastq_epi64 (__m128i a)</para>
@@ -607,7 +592,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ ymm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> BroadcastScalarToVector256(ulong* source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -616,7 +600,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -624,7 +607,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> BroadcastVector128ToVector256(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -632,7 +614,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> BroadcastVector128ToVector256(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -640,7 +621,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> BroadcastVector128ToVector256(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -648,7 +628,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> BroadcastVector128ToVector256(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -656,7 +635,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> BroadcastVector128ToVector256(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -664,7 +642,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI64x2 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> BroadcastVector128ToVector256(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_broadcastsi128_si256 (__m128i a)</para>
@@ -672,7 +649,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI64x2 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> BroadcastVector128ToVector256(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -826,84 +802,72 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBW ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ConvertToVector256Int16(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXBW ymm1,         m128</para>
         ///   <para>  VPMOVZXBW ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ConvertToVector256Int16(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVSXBD ymm1,         m64</para>
         ///   <para>  VPMOVSXBD ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXBD ymm1,         m64</para>
         ///   <para>  VPMOVZXBD ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVSXWD ymm1,         m128</para>
         ///   <para>  VPMOVSXWD ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXWD ymm1,         m128</para>
         ///   <para>  VPMOVZXWD ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVSXBQ ymm1,         m32</para>
         ///   <para>  VPMOVSXBQ ymm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXBQ ymm1,         m32</para>
         ///   <para>  VPMOVZXBQ ymm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVSXWQ ymm1,         m64</para>
         ///   <para>  VPMOVSXWQ ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXWQ ymm1,         m64</para>
         ///   <para>  VPMOVZXWQ ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVSXDQ ymm1,         m128</para>
         ///   <para>  VPMOVSXDQ ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>  VPMOVZXDQ ymm1,         m128</para>
         ///   <para>  VPMOVZXDQ ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -960,168 +924,144 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i32gather_epi32 (int const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i32gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i32gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_i32gather_ps (float const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VGATHERDPS xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_i32gather_pd (double const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VGATHERDPD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i64gather_epi32 (int const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i64gather_epi32 (int const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i64gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_i64gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_i64gather_ps (float const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VGATHERQPS xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_i64gather_pd (double const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VGATHERQPD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i32gather_epi32 (int const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> GatherVector256(int* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i32gather_epi32 (int const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> GatherVector256(uint* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i32gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i32gather_epi64 (__int64 const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_i32gather_ps (float const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VGATHERDPS ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> GatherVector256(float* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_i32gather_pd (double const* base_addr, __m128i vindex, const int scale)</para>
         ///   <para>  VGATHERDPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm256_i64gather_epi32 (int const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm256_i64gather_epi32 (int const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i64gather_epi64 (__int64 const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERQQ ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_i64gather_epi64 (__int64 const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VPGATHERQQ ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm256_i64gather_ps (float const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VGATHERQPS xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_i64gather_pd (double const* base_addr, __m256i vindex, const int scale)</para>
         ///   <para>  VGATHERQPD ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1129,168 +1069,144 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<int> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i32gather_epi32 (__m128i src, int const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<int> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i32gather_epi64 (__m128i src, __int64 const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<int> index, Vector128<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i32gather_epi64 (__m128i src, __int64 const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<int> index, Vector128<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_i32gather_ps (__m128 src, float const* base_addr, __m128i vindex, __m128 mask, const int scale)</para>
         ///   <para>  VGATHERDPS xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<int> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_mask_i32gather_pd (__m128d src, double const* base_addr, __m128i vindex, __m128d mask, const int scale)</para>
         ///   <para>  VGATHERDPD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<int> index, Vector128<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i64gather_epi32 (__m128i src, int const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<long> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i64gather_epi32 (__m128i src, int const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<long> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i64gather_epi64 (__m128i src, __int64 const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<long> index, Vector128<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_mask_i64gather_epi64 (__m128i src, __int64 const* base_addr, __m128i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<long> index, Vector128<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_mask_i64gather_ps (__m128 src, float const* base_addr, __m128i vindex, __m128 mask, const int scale)</para>
         ///   <para>  VGATHERQPS xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<long> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_mask_i64gather_pd (__m128d src, double const* base_addr, __m128i vindex, __m128d mask, const int scale)</para>
         ///   <para>  VGATHERQPD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<long> index, Vector128<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i32gather_epi32 (__m256i src, int const* base_addr, __m256i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> GatherMaskVector256(Vector256<int> source, int* baseAddress, Vector256<int> index, Vector256<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i32gather_epi32 (__m256i src, int const* base_addr, __m256i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> GatherMaskVector256(Vector256<uint> source, uint* baseAddress, Vector256<int> index, Vector256<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i32gather_epi64 (__m256i src, __int64 const* base_addr, __m128i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector128<int> index, Vector256<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i32gather_epi64 (__m256i src, __int64 const* base_addr, __m128i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector128<int> index, Vector256<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256 _mm256_mask_i32gather_ps (__m256 src, float const* base_addr, __m256i vindex, __m256 mask, const int scale)</para>
         ///   <para>  VPGATHERDPS ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> GatherMaskVector256(Vector256<float> source, float* baseAddress, Vector256<int> index, Vector256<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_mask_i32gather_pd (__m256d src, double const* base_addr, __m128i vindex, __m256d mask, const int scale)</para>
         ///   <para>  VPGATHERDPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector128<int> index, Vector256<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm256_mask_i64gather_epi32 (__m128i src, int const* base_addr, __m256i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector256<long> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm256_mask_i64gather_epi32 (__m128i src, int const* base_addr, __m256i vindex, __m128i mask, const int scale)</para>
         ///   <para>  VPGATHERQD xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector256<long> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i64gather_epi64 (__m256i src, __int64 const* base_addr, __m256i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERQQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector256<long> index, Vector256<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_mask_i64gather_epi64 (__m256i src, __int64 const* base_addr, __m256i vindex, __m256i mask, const int scale)</para>
         ///   <para>  VPGATHERQQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector256<long> index, Vector256<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm256_mask_i64gather_ps (__m128 src, float const* base_addr, __m256i vindex, __m128 mask, const int scale)</para>
         ///   <para>  VGATHERQPS xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector256<long> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256d _mm256_mask_i64gather_pd (__m256d src, double const* base_addr, __m256i vindex, __m256d mask, const int scale)</para>
         ///   <para>  VGATHERQPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector256<long> index, Vector256<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1380,147 +1296,123 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadAlignedVector256NonTemporal(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadAlignedVector256NonTemporal(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadAlignedVector256NonTemporal(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadAlignedVector256NonTemporal(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadAlignedVector256NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadAlignedVector256NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadAlignedVector256NonTemporal(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadAlignedVector256NonTemporal(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi32 (int const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi32 (int const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi64 (__int64 const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVQ xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi64 (__int64 const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVQ xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi32 (int const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi32 (int const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi64 (__int64 const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVQ ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi64 (__int64 const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVQ ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm_maskstore_epi32 (int* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_maskstore_epi32 (int* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_maskstore_epi64 (__int64* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVQ m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_maskstore_epi64 (__int64* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVQ m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_epi32 (int* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_epi32 (int* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_epi64 (__int64* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVQ m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm256_maskstore_epi64 (__int64* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVQ m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx2.cs
@@ -425,7 +425,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB xmm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> BroadcastScalarToVector128(byte* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -434,7 +433,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB xmm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> BroadcastScalarToVector128(sbyte* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -443,7 +441,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW xmm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> BroadcastScalarToVector128(short* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -452,7 +449,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW xmm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> BroadcastScalarToVector128(ushort* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -461,7 +457,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD xmm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> BroadcastScalarToVector128(int* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -470,7 +465,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD xmm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> BroadcastScalarToVector128(uint* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -479,7 +473,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ xmm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> BroadcastScalarToVector128(long* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -488,7 +481,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ xmm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> BroadcastScalarToVector128(ulong* source) => BroadcastScalarToVector128(source);
 
         /// <summary>
@@ -558,7 +550,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB ymm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> BroadcastScalarToVector256(byte* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -567,7 +558,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTB ymm1 {k1}{z}, m8</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -576,7 +566,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW ymm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> BroadcastScalarToVector256(short* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -585,7 +574,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTW ymm1 {k1}{z}, m16</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> BroadcastScalarToVector256(ushort* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -594,7 +582,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD ymm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> BroadcastScalarToVector256(int* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -603,7 +590,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTD ymm1 {k1}{z}, m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> BroadcastScalarToVector256(uint* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -612,7 +598,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ ymm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> BroadcastScalarToVector256(long* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -621,7 +606,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPBROADCASTQ ymm1 {k1}{z}, m64</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> BroadcastScalarToVector256(ulong* source) => BroadcastScalarToVector256(source);
 
         /// <summary>
@@ -630,7 +614,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -639,7 +622,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> BroadcastVector128ToVector256(byte* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -648,7 +630,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> BroadcastVector128ToVector256(short* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -657,7 +638,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> BroadcastVector128ToVector256(ushort* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -666,7 +646,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> BroadcastVector128ToVector256(int* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -675,7 +654,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI32x4 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> BroadcastVector128ToVector256(uint* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -684,7 +662,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI64x2 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> BroadcastVector128ToVector256(long* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -693,7 +670,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VBROADCASTI64x2 ymm1 {k1}{z}, m128</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> BroadcastVector128ToVector256(ulong* address) => BroadcastVector128ToVector256(address);
 
         /// <summary>
@@ -847,7 +823,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBW ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ConvertToVector256Int16(sbyte* address) => ConvertToVector256Int16(address);
 
         /// <summary>
@@ -855,7 +830,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBW ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> ConvertToVector256Int16(byte* address) => ConvertToVector256Int16(address);
 
         /// <summary>
@@ -863,7 +837,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBD ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(sbyte* address) => ConvertToVector256Int32(address);
 
         /// <summary>
@@ -871,7 +844,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBD ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(byte* address) => ConvertToVector256Int32(address);
 
         /// <summary>
@@ -879,7 +851,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWD ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(short* address) => ConvertToVector256Int32(address);
 
         /// <summary>
@@ -887,7 +858,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWD ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> ConvertToVector256Int32(ushort* address) => ConvertToVector256Int32(address);
 
         /// <summary>
@@ -895,7 +865,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBQ ymm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(sbyte* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -903,7 +872,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBQ ymm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(byte* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -911,7 +879,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWQ ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(short* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -919,7 +886,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWQ ymm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(ushort* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -927,7 +893,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXDQ ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(int* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -935,7 +900,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXDQ ymm1 {k1}{z}, m128</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> ConvertToVector256Int64(uint* address) => ConvertToVector256Int64(address);
 
         /// <summary>
@@ -992,7 +956,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1010,7 +973,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1028,7 +990,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1046,7 +1007,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1064,7 +1024,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPS xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1082,7 +1041,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1100,7 +1058,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1118,7 +1075,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1136,7 +1092,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherVector128(long* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1154,7 +1109,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherVector128(ulong* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1172,7 +1126,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPS xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1190,7 +1143,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherVector128(double* baseAddress, Vector128<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1208,7 +1160,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> GatherVector256(int* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1226,7 +1177,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> GatherVector256(uint* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1244,7 +1194,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1262,7 +1211,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1280,7 +1228,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPS ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> GatherVector256(float* baseAddress, Vector256<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1298,7 +1245,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector128<int> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1316,7 +1262,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherVector128(int* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1334,7 +1279,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherVector128(uint* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1352,7 +1296,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherVector256(long* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1370,7 +1313,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherVector256(ulong* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1388,7 +1330,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPS xmm1, vm64y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherVector128(float* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1406,7 +1347,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPD ymm1, vm64y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherVector256(double* baseAddress, Vector256<long> index, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1424,7 +1364,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<int> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1442,7 +1381,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<int> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1460,7 +1398,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<int> index, Vector128<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1478,7 +1415,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<int> index, Vector128<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1496,7 +1432,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPS xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<int> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1514,7 +1449,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERDPD xmm1, vm32x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<int> index, Vector128<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1532,7 +1466,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector128<long> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1550,7 +1483,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector128<long> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1568,7 +1500,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> GatherMaskVector128(Vector128<long> source, long* baseAddress, Vector128<long> index, Vector128<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1586,7 +1517,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> GatherMaskVector128(Vector128<ulong> source, ulong* baseAddress, Vector128<long> index, Vector128<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1604,7 +1534,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPS xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector128<long> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1622,7 +1551,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPD xmm1, vm64x, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> GatherMaskVector128(Vector128<double> source, double* baseAddress, Vector128<long> index, Vector128<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1640,7 +1568,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> GatherMaskVector256(Vector256<int> source, int* baseAddress, Vector256<int> index, Vector256<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1658,7 +1585,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> GatherMaskVector256(Vector256<uint> source, uint* baseAddress, Vector256<int> index, Vector256<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1676,7 +1602,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector128<int> index, Vector256<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1694,7 +1619,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector128<int> index, Vector256<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1712,7 +1636,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDPS ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<float> GatherMaskVector256(Vector256<float> source, float* baseAddress, Vector256<int> index, Vector256<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1730,7 +1653,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERDPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector128<int> index, Vector256<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1748,7 +1670,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> GatherMaskVector128(Vector128<int> source, int* baseAddress, Vector256<long> index, Vector128<int> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1766,7 +1687,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQD xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> GatherMaskVector128(Vector128<uint> source, uint* baseAddress, Vector256<long> index, Vector128<uint> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1784,7 +1704,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> GatherMaskVector256(Vector256<long> source, long* baseAddress, Vector256<long> index, Vector256<long> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1802,7 +1721,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPGATHERQQ ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> GatherMaskVector256(Vector256<ulong> source, ulong* baseAddress, Vector256<long> index, Vector256<ulong> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1820,7 +1738,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPS xmm1, vm32y, xmm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> GatherMaskVector128(Vector128<float> source, float* baseAddress, Vector256<long> index, Vector128<float> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1838,7 +1755,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VGATHERQPD ymm1, vm32y, ymm2</para>
         ///   <para>The scale parameter should be 1, 2, 4 or 8, otherwise, ArgumentOutOfRangeException will be thrown.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<double> GatherMaskVector256(Vector256<double> source, double* baseAddress, Vector256<long> index, Vector256<double> mask, [ConstantExpected(Min = (byte)(1), Max = (byte)(8))] byte scale)
         {
             return scale switch
@@ -1938,168 +1854,144 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<sbyte> LoadAlignedVector256NonTemporal(sbyte* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<byte> LoadAlignedVector256NonTemporal(byte* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<short> LoadAlignedVector256NonTemporal(short* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ushort> LoadAlignedVector256NonTemporal(ushort* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> LoadAlignedVector256NonTemporal(int* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> LoadAlignedVector256NonTemporal(uint* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> LoadAlignedVector256NonTemporal(long* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m256i _mm256_stream_load_si256 (__m256i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA ymm1, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> LoadAlignedVector256NonTemporal(ulong* address) => LoadAlignedVector256NonTemporal(address);
 
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi32 (int const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi32 (int const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVD xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi64 (__int64 const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVQ xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m128i _mm_maskload_epi64 (__int64 const* mem_addr, __m128i mask)</para>
         ///   <para>  VPMASKMOVQ xmm1, xmm2, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi32 (int const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi32 (int const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVD ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi64 (__int64 const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVQ ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>__m256i _mm256_maskload_epi64 (__int64 const* mem_addr, __m256i mask)</para>
         ///   <para>  VPMASKMOVQ ymm1, ymm2, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask) => MaskLoad(address, mask);
 
         /// <summary>
         ///   <para>void _mm_maskstore_epi32 (int* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_maskstore_epi32 (int* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVD m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_maskstore_epi64 (__int64* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVQ m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm_maskstore_epi64 (__int64* mem_addr, __m128i mask, __m128i a)</para>
         ///   <para>  VPMASKMOVQ m128, xmm1, xmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_epi32 (int* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_epi32 (int* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVD m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_epi64 (__int64* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVQ m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm256_maskstore_epi64 (__int64* mem_addr, __m256i mask, __m256i a)</para>
         ///   <para>  VPMASKMOVQ m256, ymm1, ymm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => MaskStore(address, mask, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.PlatformNotSupported.cs
@@ -394,28 +394,24 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<byte> MaskLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi16 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<short> MaskLoad(short* address, Vector128<short> mask, Vector128<short> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi8 (__m128i s, __mmask16 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<sbyte> MaskLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi16 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ushort> MaskLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -423,78 +419,66 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<byte> MaskLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi16 (__m256i s, __mmask16 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<short> MaskLoad(short* address, Vector256<short> mask, Vector256<short> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi8 (__m256i s, __mmask32 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<sbyte> MaskLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi16 (__m256i s, __mmask16 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ushort> MaskLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
             ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(byte* address, Vector128<byte> mask, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(short* address, Vector128<short> mask, Vector128<short> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
             ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
             ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(byte* address, Vector256<byte> mask, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
             ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(short* address, Vector256<short> mask, Vector256<short> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
             ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
             ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -927,25 +911,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_loadu_epi8 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<sbyte> LoadVector512(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi8 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<byte> LoadVector512(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi16 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU16 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<short> LoadVector512(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi16 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU16 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<ushort> LoadVector512(ushort* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -953,53 +933,45 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> MaskLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi16 (__m512i s, __mmask32 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> MaskLoad(short* address, Vector512<short> mask, Vector512<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi8 (__m512i s, __mmask64 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> MaskLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi16 (__m512i s, __mmask32 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> MaskLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask64 k, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector512<byte> mask, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask32 k, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector512<short> mask, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask64 k, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask32 k, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1306,25 +1278,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm512_storeu_epi8 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(sbyte* address, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi8 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(byte* address, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi16 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(short* address, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi16 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(ushort* address, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512BW.cs
@@ -394,7 +394,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<byte> MaskLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -402,7 +401,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<short> MaskLoad(short* address, Vector128<short> mask, Vector128<short> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -410,7 +408,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<sbyte> MaskLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -418,7 +415,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ushort> MaskLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -426,7 +422,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<byte> MaskLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -434,7 +429,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<short> MaskLoad(short* address, Vector256<short> mask, Vector256<short> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -442,7 +436,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU8 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<sbyte> MaskLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -450,63 +443,54 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ushort> MaskLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
             ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(byte* address, Vector128<byte> mask, Vector128<byte> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(short* address, Vector128<short> mask, Vector128<short> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask16 k, __m128i a)</para>
             ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_si128 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
             ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(byte* address, Vector256<byte> mask, Vector256<byte> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
             ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(short* address, Vector256<short> mask, Vector256<short> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask32 k, __m256i a)</para>
             ///   <para>  VMOVDQU8 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_si256 (void * mem_addr, __mmask16 k, __m256i a)</para>
             ///   <para>  VMOVDQU16 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) => MaskStore(address, mask, source);
 
             /// <summary>
@@ -940,28 +924,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_loadu_epi8 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<sbyte> LoadVector512(sbyte* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi8 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU8 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<byte> LoadVector512(byte* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi16 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU16 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<short> LoadVector512(short* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi16 (void const * mem_addr)</para>
         ///   <para>  VMOVDQU16 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe Vector512<ushort> LoadVector512(ushort* address) => LoadVector512(address);
 
         /// <summary>
@@ -969,7 +949,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> MaskLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -977,7 +956,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> MaskLoad(short* address, Vector512<short> mask, Vector512<short> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -985,7 +963,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU8 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> MaskLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -993,35 +970,30 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> MaskLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask64 k, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(byte* address, Vector512<byte> mask, Vector512<byte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask32 k, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(short* address, Vector512<short> mask, Vector512<short> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask64 k, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_si512 (void * mem_addr, __mmask32 k, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) => MaskStore(address, mask, source);
 
         /// <summary>
@@ -1328,28 +1300,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm512_storeu_epi8 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(sbyte* address, Vector512<sbyte> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi8 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU8 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(byte* address, Vector512<byte> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi16 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(short* address, Vector512<short> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi16 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU16 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static new unsafe void Store(ushort* address, Vector512<ushort> source) => Store(address, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.PlatformNotSupported.cs
@@ -316,38 +316,32 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> BroadcastVector128ToVector512(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> BroadcastVector128ToVector512(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512d _mm512_broadcast_f64x2 (__m128d const * mem_addr)</para>
         ///   <para>  VBROADCASTF64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> BroadcastVector128ToVector512(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> BroadcastVector256ToVector512(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> BroadcastVector256ToVector512(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_broadcast_f32x8 (__m256 const * mem_addr)</para>
         ///   <para>  VBROADCASTF32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> BroadcastVector256ToVector512(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512DQ.cs
@@ -317,42 +317,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> BroadcastVector128ToVector512(long* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x2 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> BroadcastVector128ToVector512(ulong* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512d _mm512_broadcast_f64x2 (__m128d const * mem_addr)</para>
         ///   <para>  VBROADCASTF64x2 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> BroadcastVector128ToVector512(double* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> BroadcastVector256ToVector512(int* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x8 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> BroadcastVector256ToVector512(uint* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>
         ///   <para>__m512 _mm512_broadcast_f32x8 (__m256 const * mem_addr)</para>
         ///   <para>  VBROADCASTF32x8 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> BroadcastVector256ToVector512(float* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.PlatformNotSupported.cs
@@ -782,74 +782,62 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m128d _mm_mask_compressstoreu_pd (void * a, __mmask8 k, __m128d a)</para>
             ///   <para>  VCOMPRESSPD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128 _mm_mask_compressstoreu_ps (void * a, __mmask8 k, __m128 a)</para>
             ///   <para>  VCOMPRESSPS m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>__m256d _mm256_mask_compressstoreu_pd (void * a, __mmask8 k, __m256d a)</para>
             ///   <para>  VCOMPRESSPD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256 _mm256_mask_compressstoreu_ps (void * a, __mmask8 k, __m256 a)</para>
             ///   <para>  VCOMPRESSPS m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1288,42 +1276,36 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> ExpandLoad(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi32 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> ExpandLoad(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi64 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> ExpandLoad(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128 _mm_mask_expandloadu_ps (__m128 s, __mmask8 k, void const * a)</para>
             ///   <para>  VEXPANDPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> ExpandLoad(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi32 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> ExpandLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi64 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> ExpandLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1331,42 +1313,36 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> ExpandLoad(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_address_expandloadu_epi32 (__m256i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> ExpandLoad(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_address_expandloadu_epi64 (__m256i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> ExpandLoad(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256 _mm256_address_expandloadu_ps (__m256 s, __mmask8 k, void const * a)</para>
             ///   <para>  VEXPANDPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> ExpandLoad(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_address_expandloadu_epi32 (__m256i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> ExpandLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_address_expandloadu_epi64 (__m256i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> ExpandLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1437,42 +1413,36 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128 _mm_mask_loadu_ps (__m128 s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_loadu_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1480,41 +1450,35 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256 _mm256_mask_loadu_ps (__m256 s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1522,42 +1486,36 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> MaskLoadAligned(double* address, Vector128<double> mask, Vector128<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_load_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> MaskLoadAligned(int* address, Vector128<int> mask, Vector128<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_load_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> MaskLoadAligned(long* address, Vector128<long> mask, Vector128<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128 _mm_mask_load_ps (__m128 s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> MaskLoadAligned(float* address, Vector128<float> mask, Vector128<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_load_epi32 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> MaskLoadAligned(uint* address, Vector128<uint> mask, Vector128<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_load_epi64 (__m128i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> MaskLoadAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -1565,190 +1523,160 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> MaskLoadAligned(double* address, Vector256<double> mask, Vector256<double> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_load_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> MaskLoadAligned(int* address, Vector256<int> mask, Vector256<int> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_load_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> MaskLoadAligned(long* address, Vector256<long> mask, Vector256<long> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256 _mm256_mask_load_ps (__m256 s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> MaskLoadAligned(float* address, Vector256<float> mask, Vector256<float> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_load_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> MaskLoadAligned(uint* address, Vector256<uint> mask, Vector256<uint> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_load_epi64 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> MaskLoadAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
             ///   <para>  VMOVUPD m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
             ///   <para>  VMOVUPS m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
             ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
             ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm_mask_store_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
             ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(double* address, Vector128<double> mask, Vector128<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(int* address, Vector128<int> mask, Vector128<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(long* address, Vector128<long> mask, Vector128<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_store_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
             ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(float* address, Vector128<float> mask, Vector128<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(uint* address, Vector128<uint> mask, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm256_mask_store_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
             ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(double* address, Vector256<double> mask, Vector256<double> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(int* address, Vector256<int> mask, Vector256<int> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(long* address, Vector256<long> mask, Vector256<long> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_store_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
             ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(float* address, Vector256<float> mask, Vector256<float> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(uint* address, Vector256<uint> mask, Vector256<uint> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -2642,38 +2570,32 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_broadcast_i32x4 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> BroadcastVector128ToVector512(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x4 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> BroadcastVector128ToVector512(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_broadcast_f32x4 (__m128 const * mem_addr)</para>
         ///   <para>  VBROADCASTF32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> BroadcastVector128ToVector512(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x4 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> BroadcastVector256ToVector512(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x4 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> BroadcastVector256ToVector512(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512d _mm512_broadcast_f64x4 (__m256d const * mem_addr)</para>
         ///   <para>  VBROADCASTF64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> BroadcastVector256ToVector512(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -2991,37 +2913,31 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512d _mm512_mask_compressstoreu_pd (void * s, __mmask8 k, __m512d a)</para>
         ///   <para>  VCOMPRESSPD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector512<double> mask, Vector512<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi32 (void * s, __mmask16 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector512<int> mask, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi64 (void * s, __mmask8 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSQ m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector512<long> mask, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_mask_compressstoreu_ps (void * s, __mmask16 k, __m512 a)</para>
         ///   <para>  VCOMPRESSPS m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector512<float> mask, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi32 (void * s, __mmask16 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector512<uint> mask, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi64 (void * s, __mmask8 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSQ m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -3537,42 +3453,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> ExpandLoad(double* address, Vector512<double> mask, Vector512<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi32 (__m512i s, __mmask16 k, void * const a)</para>
         ///   <para>  VPEXPANDD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> ExpandLoad(int* address, Vector512<int> mask, Vector512<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi64 (__m512i s, __mmask8 k, void * const a)</para>
         ///   <para>  VPEXPANDQ zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> ExpandLoad(long* address, Vector512<long> mask, Vector512<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_mask_expandloadu_ps (__m512 s, __mmask16 k, void * const a)</para>
         ///   <para>  VEXPANDPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> ExpandLoad(float* address, Vector512<float> mask, Vector512<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi32 (__m512i s, __mmask16 k, void * const a)</para>
         ///   <para>  VPEXPANDD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> ExpandLoad(uint* address, Vector512<uint> mask, Vector512<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi64 (__m512i s, __mmask8 k, void * const a)</para>
         ///   <para>  VPEXPANDQ zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> ExpandLoad(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4037,171 +3947,143 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadAlignedVector512(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadAlignedVector512(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadAlignedVector512(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadAlignedVector512(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadAlignedVector512(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadAlignedVector512(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadAlignedVector512(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_load_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadAlignedVector512(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_load_ps (float const * mem_addr)</para>
         ///   <para>  VMOVAPS zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> LoadAlignedVector512(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512d _mm512_load_pd (double const * mem_addr)</para>
         ///   <para>  VMOVAPD zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> LoadAlignedVector512(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadAlignedVector512NonTemporal(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadAlignedVector512NonTemporal(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadAlignedVector512NonTemporal(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadAlignedVector512NonTemporal(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadAlignedVector512NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadAlignedVector512NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadAlignedVector512NonTemporal(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadAlignedVector512NonTemporal(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadVector512(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadVector512(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadVector512(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadVector512(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadVector512(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadVector512(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadVector512(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1 , m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadVector512(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_loadu_ps (float const * mem_addr)</para>
         ///   <para>  VMOVUPS zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> LoadVector512(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512d _mm512_loadu_pd (double const * mem_addr)</para>
         ///   <para>  VMOVUPD zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> LoadVector512(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4209,42 +4091,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> MaskLoad(double* address, Vector512<double> mask, Vector512<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi32 (__m512i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> MaskLoad(int* address, Vector512<int> mask, Vector512<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi64 (__m512i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> MaskLoad(long* address, Vector512<long> mask, Vector512<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_mask_loadu_ps (__m512 s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVUPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> MaskLoad(float* address, Vector512<float> mask, Vector512<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi32 (__m512i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> MaskLoad(uint* address, Vector512<uint> mask, Vector512<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_loadu_epi64 (__m512i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> MaskLoad(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -4252,116 +4128,98 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> MaskLoadAligned(double* address, Vector512<double> mask, Vector512<double> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_load_epi32 (__m512i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> MaskLoadAligned(int* address, Vector512<int> mask, Vector512<int> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_load_epi64 (__m512i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> MaskLoadAligned(long* address, Vector512<long> mask, Vector512<long> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512 _mm512_mask_load_ps (__m512 s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVAPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> MaskLoadAligned(float* address, Vector512<float> mask, Vector512<float> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_load_epi32 (__m512i s, __mmask16 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> MaskLoadAligned(uint* address, Vector512<uint> mask, Vector512<uint> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_load_epi64 (__m512i s, __mmask8 k, void const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> MaskLoadAligned(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_pd (void * mem_addr, __mmask8 k, __m512d a)</para>
         ///   <para>  VMOVUPD m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector512<double> mask, Vector512<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector512<int> mask, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector512<long> mask, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_ps (void * mem_addr, __mmask16 k, __m512 a)</para>
         ///   <para>  VMOVUPS m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector512<float> mask, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector512<uint> mask, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm512_mask_store_pd (void * mem_addr, __mmask8 k, __m512d a)</para>
         ///   <para>  VMOVAPD m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector512<double> mask, Vector512<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_store_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector512<int> mask, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_store_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector512<long> mask, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_store_ps (void * mem_addr, __mmask16 k, __m512 a)</para>
         ///   <para>  VMOVAPS m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector512<float> mask, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_store_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector512<uint> mask, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_mask_store_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -5145,183 +5003,153 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVUPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_storeu_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVUPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector512<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVAPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_store_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVAPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector512<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector512<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector512<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector512<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector512<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVNTPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector512<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm512_stream_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVNTPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector512<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512F.cs
@@ -782,84 +782,72 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m128d _mm_mask_compressstoreu_pd (void * a, __mmask8 k, __m128d a)</para>
             ///   <para>  VCOMPRESSPD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(double* address, Vector128<double> mask, Vector128<double> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(int* address, Vector128<int> mask, Vector128<int> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(long* address, Vector128<long> mask, Vector128<long> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128 _mm_mask_compressstoreu_ps (void * a, __mmask8 k, __m128 a)</para>
             ///   <para>  VCOMPRESSPS m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(float* address, Vector128<float> mask, Vector128<float> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi32 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSD m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(uint* address, Vector128<uint> mask, Vector128<uint> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi64 (void * a, __mask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSQ m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m256d _mm256_mask_compressstoreu_pd (void * a, __mmask8 k, __m256d a)</para>
             ///   <para>  VCOMPRESSPD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(double* address, Vector256<double> mask, Vector256<double> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(int* address, Vector256<int> mask, Vector256<int> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(long* address, Vector256<long> mask, Vector256<long> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m256 _mm256_mask_compressstoreu_ps (void * a, __mmask8 k, __m256 a)</para>
             ///   <para>  VCOMPRESSPS m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(float* address, Vector256<float> mask, Vector256<float> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi32 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSD m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(uint* address, Vector256<uint> mask, Vector256<uint> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi64 (void * a, __mmask8 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSQ m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => CompressStore(address, mask, source);
 
             /// <summary>
@@ -1298,7 +1286,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> ExpandLoad(double* address, Vector128<double> mask, Vector128<double> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1306,7 +1293,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> ExpandLoad(int* address, Vector128<int> mask, Vector128<int> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1314,7 +1300,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> ExpandLoad(long* address, Vector128<long> mask, Vector128<long> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1322,7 +1307,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> ExpandLoad(float* address, Vector128<float> mask, Vector128<float> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1330,7 +1314,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> ExpandLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1338,7 +1321,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDQ xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> ExpandLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1346,7 +1328,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> ExpandLoad(double* address, Vector256<double> mask, Vector256<double> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1354,7 +1335,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> ExpandLoad(int* address, Vector256<int> mask, Vector256<int> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1362,7 +1342,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> ExpandLoad(long* address, Vector256<long> mask, Vector256<long> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1370,7 +1349,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VEXPANDPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> ExpandLoad(float* address, Vector256<float> mask, Vector256<float> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1378,7 +1356,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> ExpandLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1386,7 +1363,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDQ ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> ExpandLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -1457,7 +1433,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> MaskLoad(double* address, Vector128<double> mask, Vector128<double> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1465,7 +1440,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> MaskLoad(int* address, Vector128<int> mask, Vector128<int> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1473,7 +1447,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> MaskLoad(long* address, Vector128<long> mask, Vector128<long> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1481,7 +1454,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> MaskLoad(float* address, Vector128<float> mask, Vector128<float> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1489,7 +1461,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> MaskLoad(uint* address, Vector128<uint> mask, Vector128<uint> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1497,7 +1468,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> MaskLoad(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1505,14 +1475,12 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> MaskLoad(double* address, Vector256<double> mask, Vector256<double> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
             ///   <para>__m256i _mm256_mask_loadu_epi32 (__m256i s, __mmask8 k, void const * mem_addr)</para>
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> MaskLoad(int* address, Vector256<int> mask, Vector256<int> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1520,7 +1488,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> MaskLoad(long* address, Vector256<long> mask, Vector256<long> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1528,7 +1495,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVUPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> MaskLoad(float* address, Vector256<float> mask, Vector256<float> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1536,7 +1502,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> MaskLoad(uint* address, Vector256<uint> mask, Vector256<uint> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1544,7 +1509,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQU64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> MaskLoad(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => MaskLoad(address, mask, merge);
 
             /// <summary>
@@ -1552,7 +1516,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<double> MaskLoadAligned(double* address, Vector128<double> mask, Vector128<double> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1560,7 +1523,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<int> MaskLoadAligned(int* address, Vector128<int> mask, Vector128<int> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1568,7 +1530,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<long> MaskLoadAligned(long* address, Vector128<long> mask, Vector128<long> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1576,7 +1537,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<float> MaskLoadAligned(float* address, Vector128<float> mask, Vector128<float> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1584,7 +1544,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<uint> MaskLoadAligned(uint* address, Vector128<uint> mask, Vector128<uint> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1592,7 +1551,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ulong> MaskLoadAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1600,7 +1558,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPD ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<double> MaskLoadAligned(double* address, Vector256<double> mask, Vector256<double> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1608,7 +1565,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<int> MaskLoadAligned(int* address, Vector256<int> mask, Vector256<int> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1616,7 +1572,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<long> MaskLoadAligned(long* address, Vector256<long> mask, Vector256<long> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1624,7 +1579,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVAPS ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<float> MaskLoadAligned(float* address, Vector256<float> mask, Vector256<float> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1632,7 +1586,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA32 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<uint> MaskLoadAligned(uint* address, Vector256<uint> mask, Vector256<uint> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
@@ -1640,175 +1593,150 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VMOVDQA64 ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ulong> MaskLoadAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> merge) => MaskLoadAligned(address, mask, merge);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
             ///   <para>  VMOVUPD m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(double* address, Vector128<double> mask, Vector128<double> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(int* address, Vector128<int> mask, Vector128<int> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(long* address, Vector128<long> mask, Vector128<long> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
             ///   <para>  VMOVUPS m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(float* address, Vector128<float> mask, Vector128<float> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(uint* address, Vector128<uint> mask, Vector128<uint> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
             ///   <para>  VMOVUPD m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(double* address, Vector256<double> mask, Vector256<double> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(int* address, Vector256<int> mask, Vector256<int> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(long* address, Vector256<long> mask, Vector256<long> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
             ///   <para>  VMOVUPS m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(float* address, Vector256<float> mask, Vector256<float> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(uint* address, Vector256<uint> mask, Vector256<uint> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQU64 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStore(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => MaskStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_pd (void * mem_addr, __mmask8 k, __m128d a)</para>
             ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(double* address, Vector128<double> mask, Vector128<double> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(int* address, Vector128<int> mask, Vector128<int> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(long* address, Vector128<long> mask, Vector128<long> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_ps (void * mem_addr, __mmask8 k, __m128 a)</para>
             ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(float* address, Vector128<float> mask, Vector128<float> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_epi32 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(uint* address, Vector128<uint> mask, Vector128<uint> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm_mask_store_epi64 (void * mem_addr, __mmask8 k, __m128i a)</para>
             ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(ulong* address, Vector128<ulong> mask, Vector128<ulong> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_pd (void * mem_addr, __mmask8 k, __m256d a)</para>
             ///   <para>  VMOVAPD m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(double* address, Vector256<double> mask, Vector256<double> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(int* address, Vector256<int> mask, Vector256<int> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(long* address, Vector256<long> mask, Vector256<long> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_ps (void * mem_addr, __mmask8 k, __m256 a)</para>
             ///   <para>  VMOVAPS m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(float* address, Vector256<float> mask, Vector256<float> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_epi32 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(uint* address, Vector256<uint> mask, Vector256<uint> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_store_epi64 (void * mem_addr, __mmask8 k, __m256i a)</para>
             ///   <para>  VMOVDQA32 m256 {k1}{z}, ymm1</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void MaskStoreAligned(ulong* address, Vector256<ulong> mask, Vector256<ulong> source) => MaskStoreAligned(address, mask, source);
 
             /// <summary>
@@ -2704,42 +2632,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_broadcast_i32x4 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> BroadcastVector128ToVector512(int* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i32x4 (__m128i const * mem_addr)</para>
         ///   <para>  VBROADCASTI32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> BroadcastVector128ToVector512(uint* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512 _mm512_broadcast_f32x4 (__m128 const * mem_addr)</para>
         ///   <para>  VBROADCASTF32x4 zmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> BroadcastVector128ToVector512(float* address) => BroadcastVector128ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x4 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> BroadcastVector256ToVector512(long* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_broadcast_i64x4 (__m256i const * mem_addr)</para>
         ///   <para>  VBROADCASTI64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> BroadcastVector256ToVector512(ulong* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>
         ///   <para>__m512d _mm512_broadcast_f64x4 (__m256d const * mem_addr)</para>
         ///   <para>  VBROADCASTF64x4 zmm1 {k1}{z}, m256</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> BroadcastVector256ToVector512(double* address) => BroadcastVector256ToVector512(address);
 
         /// <summary>
@@ -3057,42 +2979,36 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512d _mm512_mask_compressstoreu_pd (void * s, __mmask8 k, __m512d a)</para>
         ///   <para>  VCOMPRESSPD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(double* address, Vector512<double> mask, Vector512<double> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi32 (void * s, __mmask16 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(int* address, Vector512<int> mask, Vector512<int> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi64 (void * s, __mmask8 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSQ m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(long* address, Vector512<long> mask, Vector512<long> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m512 _mm512_mask_compressstoreu_ps (void * s, __mmask16 k, __m512 a)</para>
         ///   <para>  VCOMPRESSPS m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(float* address, Vector512<float> mask, Vector512<float> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi32 (void * s, __mmask16 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSD m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(uint* address, Vector512<uint> mask, Vector512<uint> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_compressstoreu_epi64 (void * s, __mmask8 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSQ m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) => CompressStore(address, mask, source);
 
         /// <summary>
@@ -3610,7 +3526,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> ExpandLoad(double* address, Vector512<double> mask, Vector512<double> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -3618,7 +3533,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> ExpandLoad(int* address, Vector512<int> mask, Vector512<int> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -3626,7 +3540,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> ExpandLoad(long* address, Vector512<long> mask, Vector512<long> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -3634,7 +3547,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VEXPANDPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> ExpandLoad(float* address, Vector512<float> mask, Vector512<float> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -3642,7 +3554,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> ExpandLoad(uint* address, Vector512<uint> mask, Vector512<uint> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -3650,7 +3561,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDQ zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> ExpandLoad(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -4117,196 +4027,168 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadAlignedVector512(byte* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadAlignedVector512(sbyte* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadAlignedVector512(short* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadAlignedVector512(ushort* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadAlignedVector512(int* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadAlignedVector512(uint* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadAlignedVector512(long* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_load_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQA64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadAlignedVector512(ulong* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512 _mm512_load_ps (float const * mem_addr)</para>
         ///   <para>  VMOVAPS zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> LoadAlignedVector512(float* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512d _mm512_load_pd (double const * mem_addr)</para>
         ///   <para>  VMOVAPD zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> LoadAlignedVector512(double* address) => LoadAlignedVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadAlignedVector512NonTemporal(sbyte* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadAlignedVector512NonTemporal(byte* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadAlignedVector512NonTemporal(short* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadAlignedVector512NonTemporal(ushort* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadAlignedVector512NonTemporal(int* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadAlignedVector512NonTemporal(uint* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadAlignedVector512NonTemporal(long* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_stream_load_si512 (__m512i const* mem_addr)</para>
         ///   <para>  VMOVNTDQA zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadAlignedVector512NonTemporal(ulong* address) => LoadAlignedVector512NonTemporal(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> LoadVector512(sbyte* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> LoadVector512(byte* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> LoadVector512(short* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_si512 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> LoadVector512(ushort* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> LoadVector512(int* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi32 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU32 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> LoadVector512(uint* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> LoadVector512(long* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512i _mm512_loadu_epi64 (__m512i const * mem_addr)</para>
         ///   <para>  VMOVDQU64 zmm1 , m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> LoadVector512(ulong* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512 _mm512_loadu_ps (float const * mem_addr)</para>
         ///   <para>  VMOVUPS zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> LoadVector512(float* address) => LoadVector512(address);
 
         /// <summary>
         ///   <para>__m512d _mm512_loadu_pd (double const * mem_addr)</para>
         ///   <para>  VMOVUPD zmm1, m512</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> LoadVector512(double* address) => LoadVector512(address);
 
         /// <summary>
@@ -4314,7 +4196,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> MaskLoad(double* address, Vector512<double> mask, Vector512<double> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4322,7 +4203,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> MaskLoad(int* address, Vector512<int> mask, Vector512<int> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4330,7 +4210,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> MaskLoad(long* address, Vector512<long> mask, Vector512<long> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4338,7 +4217,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> MaskLoad(float* address, Vector512<float> mask, Vector512<float> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4346,7 +4224,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> MaskLoad(uint* address, Vector512<uint> mask, Vector512<uint> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4354,7 +4231,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> MaskLoad(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) => MaskLoad(address, mask, merge);
 
         /// <summary>
@@ -4362,7 +4238,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<double> MaskLoadAligned(double* address, Vector512<double> mask, Vector512<double> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -4370,7 +4245,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<int> MaskLoadAligned(int* address, Vector512<int> mask, Vector512<int> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -4378,7 +4252,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<long> MaskLoadAligned(long* address, Vector512<long> mask, Vector512<long> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -4386,7 +4259,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<float> MaskLoadAligned(float* address, Vector512<float> mask, Vector512<float> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -4394,7 +4266,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA32 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<uint> MaskLoadAligned(uint* address, Vector512<uint> mask, Vector512<uint> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
@@ -4402,91 +4273,78 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA64 zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ulong> MaskLoadAligned(ulong* address, Vector512<ulong> mask, Vector512<ulong> merge) => MaskLoadAligned(address, mask, merge);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_pd (void * mem_addr, __mmask8 k, __m512d a)</para>
         ///   <para>  VMOVUPD m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(double* address, Vector512<double> mask, Vector512<double> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(int* address, Vector512<int> mask, Vector512<int> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(long* address, Vector512<long> mask, Vector512<long> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_ps (void * mem_addr, __mmask16 k, __m512 a)</para>
         ///   <para>  VMOVUPS m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(float* address, Vector512<float> mask, Vector512<float> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(uint* address, Vector512<uint> mask, Vector512<uint> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_storeu_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStore(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) => MaskStore(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_pd (void * mem_addr, __mmask8 k, __m512d a)</para>
         ///   <para>  VMOVAPD m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(double* address, Vector512<double> mask, Vector512<double> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(int* address, Vector512<int> mask, Vector512<int> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(long* address, Vector512<long> mask, Vector512<long> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_ps (void * mem_addr, __mmask16 k, __m512 a)</para>
         ///   <para>  VMOVAPS m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(float* address, Vector512<float> mask, Vector512<float> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_epi32 (void * mem_addr, __mmask16 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(uint* address, Vector512<uint> mask, Vector512<uint> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
         ///   <para>void _mm512_mask_store_epi64 (void * mem_addr, __mmask8 k, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512 {k1}{z}, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskStoreAligned(ulong* address, Vector512<ulong> mask, Vector512<ulong> source) => MaskStoreAligned(address, mask, source);
 
         /// <summary>
@@ -5271,210 +5129,180 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector512<sbyte> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector512<byte> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector512<short> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector512<ushort> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector512<int> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector512<uint> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector512<long> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQU64 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector512<ulong> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVUPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector512<float> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_storeu_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVUPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector512<double> source) => Store(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector512<byte> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector512<sbyte> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector512<short> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector512<ushort> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector512<int> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_epi32 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector512<uint> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector512<long> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_epi64 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVDQA32 m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector512<ulong> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVAPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector512<float> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_store_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVAPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector512<double> source) => StoreAligned(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector512<sbyte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector512<byte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector512<short> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector512<ushort> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector512<int> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector512<uint> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector512<long> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_si512 (void * mem_addr, __m512i a)</para>
         ///   <para>  VMOVNTDQ m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector512<ulong> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_ps (float * mem_addr, __m512 a)</para>
         ///   <para>  VMOVNTPS m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector512<float> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
         ///   <para>void _mm512_stream_pd (double * mem_addr, __m512d a)</para>
         ///   <para>  VMOVNTPD m512, zmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector512<double> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi2.PlatformNotSupported.cs
@@ -75,50 +75,42 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector128<byte> mask, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector128<short> mask, Vector128<short> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector256<byte> mask, Vector256<byte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector256<short> mask, Vector256<short> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -168,28 +160,24 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<byte> ExpandLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi16 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<short> ExpandLoad(short* address, Vector128<short> mask, Vector128<short> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi8 (__m128i s, __mmask16 k, void const * a)</para>
             ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<sbyte> ExpandLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m128i _mm_mask_expandloadu_epi16 (__m128i s, __mmask8 k, void const * a)</para>
             ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ushort> ExpandLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -197,28 +185,24 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<byte> ExpandLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_expandloadu_epi16 (__m256i s, __mmask16 k, void const * a)</para>
             ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<short> ExpandLoad(short* address, Vector256<short> mask, Vector256<short> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_expandloadu_epi8 (__m256i s, __mmask32 k, void const * a)</para>
             ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<sbyte> ExpandLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>__m256i _mm256_mask_expandloadu_epi16 (__m256i s, __mmask16 k, void const * a)</para>
             ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ushort> ExpandLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) { throw new PlatformNotSupportedException(); }
         }
 
@@ -258,25 +242,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector512<byte> mask, Vector512<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector512<short> mask, Vector512<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -305,28 +285,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> ExpandLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi16 (__m512i s, __mmask32 k, void * const a)</para>
         ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> ExpandLoad(short* address, Vector512<short> mask, Vector512<short> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi8 (__m512i s, __mmask64 k, void * const a)</para>
         ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> ExpandLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m512i _mm512_mask_expandloadu_epi16 (__m512i s, __mmask32 k, void * const a)</para>
         ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> ExpandLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) { throw new PlatformNotSupportedException(); }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Avx512Vbmi2.cs
@@ -77,56 +77,48 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector128<byte> mask, Vector128<byte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector128<short> mask, Vector128<short> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi8 (void * s, __mmask16 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSB m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>__m128i _mm_mask_compressstoreu_epi16 (void * s, __mmask8 k, __m128i a)</para>
             ///   <para>  VPCOMPRESSW m128 {k1}{z}, xmm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector128<ushort> mask, Vector128<ushort> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(byte* address, Vector256<byte> mask, Vector256<byte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(short* address, Vector256<short> mask, Vector256<short> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi8 (void * s, __mmask32 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSB m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> source) => CompressStore(address, mask, source);
 
             /// <summary>
             ///   <para>void _mm256_mask_compressstoreu_epi16 (void * s, __mmask16 k, __m256i a)</para>
             ///   <para>  VPCOMPRESSW m256 {k1}{z}, ymm2</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void CompressStore(ushort* address, Vector256<ushort> mask, Vector256<ushort> source) => CompressStore(address, mask, source);
 
             /// <summary>
@@ -176,7 +168,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<byte> ExpandLoad(byte* address, Vector128<byte> mask, Vector128<byte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -184,7 +175,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<short> ExpandLoad(short* address, Vector128<short> mask, Vector128<short> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -192,7 +182,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<sbyte> ExpandLoad(sbyte* address, Vector128<sbyte> mask, Vector128<sbyte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -200,7 +189,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW xmm1 {k1}{z}, m128</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector128<ushort> ExpandLoad(ushort* address, Vector128<ushort> mask, Vector128<ushort> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -208,7 +196,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<byte> ExpandLoad(byte* address, Vector256<byte> mask, Vector256<byte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -216,7 +203,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<short> ExpandLoad(short* address, Vector256<short> mask, Vector256<short> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -224,7 +210,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDB ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<sbyte> ExpandLoad(sbyte* address, Vector256<sbyte> mask, Vector256<sbyte> merge) => ExpandLoad(address, mask, merge);
 
             /// <summary>
@@ -232,7 +217,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  VPEXPANDW ymm1 {k1}{z}, m256</para>
             /// </summary>
             /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-            [RequiresUnsafe]
             public static unsafe Vector256<ushort> ExpandLoad(ushort* address, Vector256<ushort> mask, Vector256<ushort> merge) => ExpandLoad(address, mask, merge);
         }
 
@@ -273,28 +257,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(byte* address, Vector512<byte> mask, Vector512<byte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(short* address, Vector512<short> mask, Vector512<short> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi8 (void * s, __mmask64 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSB m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> source) => CompressStore(address, mask, source);
 
         /// <summary>
         ///   <para>__m512i _mm512_mask_compresstoreu_epi16 (void * s, __mmask32 k, __m512i a)</para>
         ///   <para>  VPCOMPRESSW m512 {k1}{z}, zmm2</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void CompressStore(ushort* address, Vector512<ushort> mask, Vector512<ushort> source) => CompressStore(address, mask, source);
 
         /// <summary>
@@ -323,7 +303,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<byte> ExpandLoad(byte* address, Vector512<byte> mask, Vector512<byte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -331,7 +310,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<short> ExpandLoad(short* address, Vector512<short> mask, Vector512<short> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -339,7 +317,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDB zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<sbyte> ExpandLoad(sbyte* address, Vector512<sbyte> mask, Vector512<sbyte> merge) => ExpandLoad(address, mask, merge);
 
         /// <summary>
@@ -347,7 +324,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPEXPANDW zmm1 {k1}{z}, m512</para>
         /// </summary>
         /// <remarks>The native and managed intrinsics have different order of parameters.</remarks>
-        [RequiresUnsafe]
         public static unsafe Vector512<ushort> ExpandLoad(ushort* address, Vector512<ushort> mask, Vector512<ushort> merge) => ExpandLoad(address, mask, merge);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Bmi2.PlatformNotSupported.cs
@@ -50,7 +50,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>The above native signature does not directly correspond to the managed signature.</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* low) { throw new PlatformNotSupportedException(); }
 
             /// <summary>
@@ -86,7 +85,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  MULX r32a, r32b, r/m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe uint MultiplyNoFlags(uint left, uint right, uint* low) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Bmi2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Bmi2.cs
@@ -50,7 +50,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>The above native signature does not directly correspond to the managed signature.</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* low) => MultiplyNoFlags(left, right, low);
 
             /// <summary>
@@ -86,7 +85,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  MULX r32a, r32b, r/m32</para>
         ///   <para>The above native signature does not directly correspond to the managed signature.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe uint MultiplyNoFlags(uint left, uint right, uint* low) => MultiplyNoFlags(left, right, low);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.PlatformNotSupported.cs
@@ -359,21 +359,18 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS xmm1,         m128</para>
         ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAlignedVector128(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_loadh_pi (__m128 a, __m64 const* mem_addr)</para>
         ///   <para>   MOVHPS xmm1,       m64</para>
         ///   <para>  VMOVHPS xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadHigh(Vector128<float> lower, float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_loadl_pi (__m128 a, __m64 const* mem_addr)</para>
         ///   <para>   MOVLPS xmm1,       m64</para>
         ///   <para>  VMOVLPS xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadLow(Vector128<float> upper, float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_load_ss (float const* mem_address)</para>
@@ -381,7 +378,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSS xmm1,      m32</para>
         ///   <para>  VMOVSS xmm1 {k1}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadScalarVector128(float* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128 _mm_loadu_ps (float const* mem_address)</para>
@@ -389,7 +385,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS xmm1,         m128</para>
         ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadVector128(float* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -475,25 +470,21 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT0 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch0(void* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT1 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch1(void* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT2 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch2(void* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHNTA m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void PrefetchNonTemporal(void* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -576,7 +567,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS m128,         xmm1</para>
         ///   <para>  VMOVUPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_ps (float* mem_addr, __m128 a)</para>
@@ -584,14 +574,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS m128,         xmm1</para>
         ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_ps (float* mem_addr, __m128 a)</para>
         ///   <para>   MOVNTPS m128, xmm1</para>
         ///   <para>  VMOVNTPS m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_sfence(void)</para>
@@ -603,14 +591,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPS m64, xmm1</para>
         ///   <para>  VMOVHPS m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreHigh(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storel_pi (__m64* mem_addr, __m128 a)</para>
         ///   <para>   MOVLPS m64, xmm1</para>
         ///   <para>  VMOVLPS m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreLow(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_ss (float* mem_addr, __m128 a)</para>
@@ -618,7 +604,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSS m32,      xmm1</para>
         ///   <para>  VMOVSS m32 {k1}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(float* address, Vector128<float> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse.cs
@@ -359,7 +359,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS xmm1,         m128</para>
         ///   <para>  VMOVAPS xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadAlignedVector128(float* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -367,7 +366,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPS xmm1,       m64</para>
         ///   <para>  VMOVHPS xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadHigh(Vector128<float> lower, float* address) => LoadHigh(lower, address);
 
         /// <summary>
@@ -375,7 +373,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVLPS xmm1,       m64</para>
         ///   <para>  VMOVLPS xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadLow(Vector128<float> upper, float* address) => LoadLow(upper, address);
 
         /// <summary>
@@ -384,7 +381,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSS xmm1,      m32</para>
         ///   <para>  VMOVSS xmm1 {k1}, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadScalarVector128(float* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -393,7 +389,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPS xmm1,         m128</para>
         ///   <para>  VMOVUPS xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<float> LoadVector128(float* address) => LoadVector128(address);
 
         /// <summary>
@@ -479,28 +474,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT0 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch0(void* address) => Prefetch0(address);
 
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT1 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch1(void* address) => Prefetch1(address);
 
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHT2 m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Prefetch2(void* address) => Prefetch2(address);
 
         /// <summary>
         ///   <para>void _mm_prefetch(char* p, int i)</para>
         ///   <para>  PREFETCHNTA m8</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void PrefetchNonTemporal(void* address) => PrefetchNonTemporal(address);
 
         /// <summary>
@@ -583,7 +574,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS m128,         xmm1</para>
         ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(float* address, Vector128<float> source) => Store(address, source);
 
         /// <summary>
@@ -592,7 +582,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPS m128,         xmm1</para>
         ///   <para>  VMOVAPS m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(float* address, Vector128<float> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -600,7 +589,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTPS m128, xmm1</para>
         ///   <para>  VMOVNTPS m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(float* address, Vector128<float> source) => StoreAlignedNonTemporal(address, source);
         /// <summary>
         ///   <para>void _mm_sfence(void)</para>
@@ -613,7 +601,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPS m64, xmm1</para>
         ///   <para>  VMOVHPS m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreHigh(float* address, Vector128<float> source) => StoreHigh(address, source);
 
         /// <summary>
@@ -621,7 +608,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVLPS m64, xmm1</para>
         ///   <para>  VMOVLPS m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreLow(float* address, Vector128<float> source) => StoreLow(address, source);
 
         /// <summary>
@@ -630,7 +616,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSS m32,      xmm1</para>
         ///   <para>  VMOVSS m32 {k1}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(float* address, Vector128<float> source) => StoreScalar(address, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.PlatformNotSupported.cs
@@ -85,14 +85,12 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  MOVNTI m64, r64</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreNonTemporal(long* address, long value) { throw new PlatformNotSupportedException(); }
             /// <summary>
             ///   <para>void _mm_stream_si64(__int64 *p, __int64 a)</para>
             ///   <para>  MOVNTI m64, r64</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreNonTemporal(ulong* address, ulong value) { throw new PlatformNotSupportedException(); }
         }
 
@@ -795,7 +793,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAlignedVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -803,13 +800,11 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAlignedVector128(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
         ///   <para>  MOVDQA xmm, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAlignedVector128(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -817,7 +812,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAlignedVector128(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -825,7 +819,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAlignedVector128(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -833,7 +826,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAlignedVector128(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -841,7 +833,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAlignedVector128(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_load_si128 (__m128i const* mem_address)</para>
@@ -849,7 +840,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAlignedVector128(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_load_pd (double const* mem_address)</para>
@@ -857,7 +847,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD xmm1,         m128</para>
         ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAlignedVector128(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -870,14 +859,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPD xmm1,       m64</para>
         ///   <para>  VMOVHPD xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadHigh(Vector128<double> lower, double* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_loadl_pd (__m128d a, double const* mem_addr)</para>
         ///   <para>   MOVLPD xmm1,       m64</para>
         ///   <para>  VMOVLPD xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadLow(Vector128<double> upper, double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -885,28 +872,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD xmm1, m32</para>
         ///   <para>  VMOVD xmm1, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadScalarVector128(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si32 (void const* mem_addr)</para>
         ///   <para>   MOVD xmm1, m32</para>
         ///   <para>  VMOVD xmm1, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadScalarVector128(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadl_epi64 (__m128i const* mem_addr)</para>
         ///   <para>   MOVQ xmm1, m64</para>
         ///   <para>  VMOVQ xmm1, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadScalarVector128(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadl_epi64 (__m128i const* mem_addr)</para>
         ///   <para>   MOVQ xmm1, m64</para>
         ///   <para>  VMOVQ xmm1, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadScalarVector128(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_load_sd (double const* mem_address)</para>
@@ -914,7 +897,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSD xmm1,      m64</para>
         ///   <para>  VMOVSD xmm1 {k1}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarVector128(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -923,7 +905,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  xmm1,         m128</para>
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -931,7 +912,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  xmm1,         m128</para>
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadVector128(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -939,7 +919,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU16 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadVector128(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -947,7 +926,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU16 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -955,7 +933,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadVector128(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -963,7 +940,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadVector128(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -971,7 +947,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadVector128(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_loadu_si128 (__m128i const* mem_address)</para>
@@ -979,7 +954,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128d _mm_loadu_pd (double const* mem_address)</para>
@@ -987,7 +961,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD xmm1,         m128</para>
         ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -995,14 +968,12 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         ///   <para>  VMASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskMove(Vector128<sbyte> source, Vector128<sbyte> mask, sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_maskmoveu_si128 (__m128i a,  __m128i mask, char* mem_address)</para>
         ///   <para>   MASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         ///   <para>  VMASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskMove(Vector128<byte> source, Vector128<byte> mask, byte* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1645,7 +1616,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m128,         xmm1</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1653,7 +1623,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m128,         xmm1</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1661,7 +1630,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector128<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1669,7 +1637,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1677,7 +1644,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1685,7 +1651,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1693,7 +1658,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1701,7 +1665,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_pd (double* mem_addr, __m128d a)</para>
@@ -1709,7 +1672,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD m128,         xmm1</para>
         ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1718,7 +1680,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1726,7 +1687,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1734,7 +1694,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector128<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1742,7 +1701,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1750,7 +1708,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1758,7 +1715,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1766,7 +1722,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_si128 (__m128i* mem_addr, __m128i a)</para>
@@ -1774,7 +1729,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_pd (double* mem_addr, __m128d a)</para>
@@ -1782,7 +1736,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD m128,         xmm1</para>
         ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1790,63 +1743,54 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector128<sbyte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector128<byte> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector128<short> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector128<ushort> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si128 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_pd (double* mem_addr, __m128d a)</para>
         ///   <para>   MOVNTPD m128, xmm1</para>
         ///   <para>  VMOVNTPD m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1854,27 +1798,23 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPD m64, xmm1</para>
         ///   <para>  VMOVHPD m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreHigh(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storel_pd (double* mem_addr, __m128d a)</para>
         ///   <para>   MOVLPD m64, xmm1</para>
         ///   <para>  VMOVLPD m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreLow(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         ///   <para>void _mm_stream_si32(int *p, int a)</para>
         ///   <para>  MOVNTI m32, r32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(int* address, int value) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_stream_si32(int *p, int a)</para>
         ///   <para>  MOVNTI m32, r32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(uint* address, uint value) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -1882,28 +1822,24 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD m32, xmm1</para>
         ///   <para>  VMOVD m32, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(int* address, Vector128<int> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storeu_si32 (void* mem_addr, __m128i a)</para>
         ///   <para>   MOVD m32, xmm1</para>
         ///   <para>  VMOVD m32, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(uint* address, Vector128<uint> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storel_epi64 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVQ m64, xmm1</para>
         ///   <para>  VMOVQ m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(long* address, Vector128<long> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_storel_epi64 (__m128i* mem_addr, __m128i a)</para>
         ///   <para>   MOVQ m64, xmm1</para>
         ///   <para>  VMOVQ m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(ulong* address, Vector128<ulong> source) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>void _mm_store_sd (double* mem_addr, __m128d a)</para>
@@ -1911,7 +1847,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSD m64,      xmm1</para>
         ///   <para>  VMOVSD m64 {k1}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(double* address, Vector128<double> source) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse2.cs
@@ -85,7 +85,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  MOVNTI m64, r64</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreNonTemporal(long* address, long value) => StoreNonTemporal(address, value);
 
             /// <summary>
@@ -93,7 +92,6 @@ namespace System.Runtime.Intrinsics.X86
             ///   <para>  MOVNTI m64, r64</para>
             ///   <para>This intrinsic is only available on 64-bit processes</para>
             /// </summary>
-            [RequiresUnsafe]
             public static unsafe void StoreNonTemporal(ulong* address, ulong value) => StoreNonTemporal(address, value);
         }
 
@@ -796,7 +794,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAlignedVector128(sbyte* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -805,7 +802,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAlignedVector128(byte* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -814,7 +810,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAlignedVector128(short* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -823,7 +818,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAlignedVector128(ushort* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -832,7 +826,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAlignedVector128(int* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -841,7 +834,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAlignedVector128(uint* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -850,7 +842,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAlignedVector128(long* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -859,7 +850,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   xmm1,         m128</para>
         ///   <para>  VMOVDQA64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAlignedVector128(ulong* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -868,7 +858,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD xmm1,         m128</para>
         ///   <para>  VMOVAPD xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAlignedVector128(double* address) => LoadAlignedVector128(address);
 
         /// <summary>
@@ -882,7 +871,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPD xmm1,       m64</para>
         ///   <para>  VMOVHPD xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadHigh(Vector128<double> lower, double* address) => LoadHigh(lower, address);
 
         /// <summary>
@@ -890,7 +878,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVLPD xmm1,       m64</para>
         ///   <para>  VMOVLPD xmm1, xmm2, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadLow(Vector128<double> upper, double* address) => LoadLow(upper, address);
 
         /// <summary>
@@ -898,7 +885,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD xmm1, m32</para>
         ///   <para>  VMOVD xmm1, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadScalarVector128(int* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -906,7 +892,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD xmm1, m32</para>
         ///   <para>  VMOVD xmm1, m32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadScalarVector128(uint* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -914,7 +899,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVQ xmm1, m64</para>
         ///   <para>  VMOVQ xmm1, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadScalarVector128(long* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -922,7 +906,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVQ xmm1, m64</para>
         ///   <para>  VMOVQ xmm1, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadScalarVector128(ulong* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -931,7 +914,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSD xmm1,      m64</para>
         ///   <para>  VMOVSD xmm1 {k1}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadScalarVector128(double* address) => LoadScalarVector128(address);
 
         /// <summary>
@@ -940,7 +922,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  xmm1,         m128</para>
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) => LoadVector128(address);
 
         /// <summary>
@@ -949,7 +930,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  xmm1,         m128</para>
         ///   <para>  VMOVDQU8 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadVector128(byte* address) => LoadVector128(address);
 
         /// <summary>
@@ -958,7 +938,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU16 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadVector128(short* address) => LoadVector128(address);
 
         /// <summary>
@@ -967,7 +946,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU16 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) => LoadVector128(address);
 
         /// <summary>
@@ -976,7 +954,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadVector128(int* address) => LoadVector128(address);
 
         /// <summary>
@@ -985,7 +962,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU32 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadVector128(uint* address) => LoadVector128(address);
 
         /// <summary>
@@ -994,7 +970,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadVector128(long* address) => LoadVector128(address);
 
         /// <summary>
@@ -1003,7 +978,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   xmm1,         m128</para>
         ///   <para>  VMOVDQU64 xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) => LoadVector128(address);
 
         /// <summary>
@@ -1012,7 +986,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD xmm1,         m128</para>
         ///   <para>  VMOVUPD xmm1 {k1}{z}, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadVector128(double* address) => LoadVector128(address);
 
         /// <summary>
@@ -1020,7 +993,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         ///   <para>  VMASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskMove(Vector128<sbyte> source, Vector128<sbyte> mask, sbyte* address) => MaskMove(source, mask, address);
 
         /// <summary>
@@ -1028,7 +1000,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         ///   <para>  VMASKMOVDQU xmm1, xmm2    ; Address: EDI/RDI</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void MaskMove(Vector128<byte> source, Vector128<byte> mask, byte* address) => MaskMove(source, mask, address);
 
         /// <summary>
@@ -1671,7 +1642,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m128,         xmm1</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(sbyte* address, Vector128<sbyte> source) => Store(address, source);
 
         /// <summary>
@@ -1680,7 +1650,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU  m128,         xmm1</para>
         ///   <para>  VMOVDQU8 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(byte* address, Vector128<byte> source) => Store(address, source);
 
         /// <summary>
@@ -1689,7 +1658,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(short* address, Vector128<short> source) => Store(address, source);
 
         /// <summary>
@@ -1698,7 +1666,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU16 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) => Store(address, source);
 
         /// <summary>
@@ -1707,7 +1674,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(int* address, Vector128<int> source) => Store(address, source);
 
         /// <summary>
@@ -1716,7 +1682,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(uint* address, Vector128<uint> source) => Store(address, source);
 
         /// <summary>
@@ -1725,7 +1690,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(long* address, Vector128<long> source) => Store(address, source);
 
         /// <summary>
@@ -1734,7 +1698,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQU   m128,         xmm1</para>
         ///   <para>  VMOVDQU64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(ulong* address, Vector128<ulong> source) => Store(address, source);
 
         /// <summary>
@@ -1743,7 +1706,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVUPD m128,         xmm1</para>
         ///   <para>  VMOVUPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void Store(double* address, Vector128<double> source) => Store(address, source);
 
         /// <summary>
@@ -1752,7 +1714,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(sbyte* address, Vector128<sbyte> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1761,7 +1722,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(byte* address, Vector128<byte> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1770,7 +1730,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(short* address, Vector128<short> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1779,7 +1738,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ushort* address, Vector128<ushort> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1788,7 +1746,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(int* address, Vector128<int> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1797,7 +1754,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA32 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(uint* address, Vector128<uint> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1806,7 +1762,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(long* address, Vector128<long> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1815,7 +1770,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDQA   m128,         xmm1</para>
         ///   <para>  VMOVDQA64 m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(ulong* address, Vector128<ulong> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1824,7 +1778,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVAPD m128,         xmm1</para>
         ///   <para>  VMOVAPD m128 {k1}{z}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAligned(double* address, Vector128<double> source) => StoreAligned(address, source);
 
         /// <summary>
@@ -1832,7 +1785,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, Vector128<sbyte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1840,7 +1792,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(byte* address, Vector128<byte> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1848,7 +1799,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(short* address, Vector128<short> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1856,7 +1806,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, Vector128<ushort> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1864,7 +1813,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(int* address, Vector128<int> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1872,7 +1820,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(uint* address, Vector128<uint> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1880,7 +1827,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(long* address, Vector128<long> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1888,7 +1834,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQ m128, xmm1</para>
         ///   <para>  VMOVNTDQ m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, Vector128<ulong> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1896,7 +1841,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTPD m128, xmm1</para>
         ///   <para>  VMOVNTPD m128, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreAlignedNonTemporal(double* address, Vector128<double> source) => StoreAlignedNonTemporal(address, source);
 
         /// <summary>
@@ -1904,7 +1848,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVHPD m64, xmm1</para>
         ///   <para>  VMOVHPD m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreHigh(double* address, Vector128<double> source) => StoreHigh(address, source);
 
         /// <summary>
@@ -1912,21 +1855,18 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVLPD m64, xmm1</para>
         ///   <para>  VMOVLPD m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreLow(double* address, Vector128<double> source) => StoreLow(address, source);
 
         /// <summary>
         ///   <para>void _mm_stream_si32(int *p, int a)</para>
         ///   <para>  MOVNTI m32, r32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(int* address, int value) => StoreNonTemporal(address, value);
 
         /// <summary>
         ///   <para>void _mm_stream_si32(int *p, int a)</para>
         ///   <para>  MOVNTI m32, r32</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreNonTemporal(uint* address, uint value) => StoreNonTemporal(address, value);
 
         /// <summary>
@@ -1934,7 +1874,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD m32, xmm1</para>
         ///   <para>  VMOVD m32, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(int* address, Vector128<int> source) => StoreScalar(address, source);
 
         /// <summary>
@@ -1942,7 +1881,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVD m32, xmm1</para>
         ///   <para>  VMOVD m32, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(uint* address, Vector128<uint> source) => StoreScalar(address, source);
 
         /// <summary>
@@ -1950,7 +1888,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVQ m64, xmm1</para>
         ///   <para>  VMOVQ m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(long* address, Vector128<long> source) => StoreScalar(address, source);
 
         /// <summary>
@@ -1958,7 +1895,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVQ m64, xmm1</para>
         ///   <para>  VMOVQ m64, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(ulong* address, Vector128<ulong> source) => StoreScalar(address, source);
 
         /// <summary>
@@ -1967,7 +1903,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVSD m64,      xmm1</para>
         ///   <para>  VMOVSD m64 {k1}, xmm1</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void StoreScalar(double* address, Vector128<double> source) => StoreScalar(address, source);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse3.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse3.PlatformNotSupported.cs
@@ -75,7 +75,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDDUP xmm1,         m64</para>
         ///   <para>  VMOVDDUP xmm1 {k1}{z}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAndDuplicateToVector128(double* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -83,56 +82,48 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadDquVector128(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadDquVector128(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadDquVector128(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadDquVector128(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadDquVector128(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadDquVector128(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadDquVector128(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_lddqu_si128 (__m128i const* mem_addr)</para>
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadDquVector128(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse3.cs
@@ -75,7 +75,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VMOVDDUP xmm1,         m64</para>
         ///   <para>  VMOVDDUP xmm1 {k1}{z}, m64</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<double> LoadAndDuplicateToVector128(double* address) => LoadAndDuplicateToVector128(address);
 
         /// <summary>
@@ -83,7 +82,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadDquVector128(sbyte* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -91,7 +89,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadDquVector128(byte* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -99,7 +96,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadDquVector128(short* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -107,7 +103,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadDquVector128(ushort* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -115,7 +110,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadDquVector128(int* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -123,7 +117,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadDquVector128(uint* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -131,7 +124,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadDquVector128(long* address) => LoadDquVector128(address);
 
         /// <summary>
@@ -139,7 +131,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   LDDQU xmm1, m128</para>
         ///   <para>  VLDDQU xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadDquVector128(ulong* address) => LoadDquVector128(address);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse41.PlatformNotSupported.cs
@@ -296,7 +296,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBW xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ConvertToVector128Int16(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXBW xmm1,         m64</para>
@@ -304,7 +303,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBW xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ConvertToVector128Int16(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVSXBD xmm1,         m32</para>
@@ -312,7 +310,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBD xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXBD xmm1,         m32</para>
@@ -320,7 +317,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBD xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVSXWD xmm1,         m64</para>
@@ -328,7 +324,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWD xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXWD xmm1,         m64</para>
@@ -336,7 +331,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWD xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVSXBQ xmm1,         m16</para>
@@ -344,7 +338,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBQ xmm1 {k1}{z}, m16</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXBQ xmm1,         m16</para>
@@ -352,7 +345,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBQ xmm1 {k1}{z}, m16</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVSXWQ xmm1,         m32</para>
@@ -360,7 +352,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWQ xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXWQ xmm1,         m32</para>
@@ -368,7 +359,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWQ xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVSXDQ xmm1,         m64</para>
@@ -376,7 +366,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXDQ xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>   PMOVZXDQ xmm1,         m64</para>
@@ -384,7 +373,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXDQ xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(uint* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
@@ -501,56 +489,48 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAlignedVector128NonTemporal(sbyte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAlignedVector128NonTemporal(byte* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAlignedVector128NonTemporal(short* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAlignedVector128NonTemporal(ushort* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAlignedVector128NonTemporal(int* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAlignedVector128NonTemporal(uint* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAlignedVector128NonTemporal(long* address) { throw new PlatformNotSupportedException(); }
         /// <summary>
         ///   <para>__m128i _mm_stream_load_si128 (const __m128i* mem_addr)</para>
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAlignedVector128NonTemporal(ulong* address) { throw new PlatformNotSupportedException(); }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse41.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/Sse41.cs
@@ -296,7 +296,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBW xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ConvertToVector128Int16(sbyte* address) => ConvertToVector128Int16(address);
 
         /// <summary>
@@ -305,7 +304,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBW xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> ConvertToVector128Int16(byte* address) => ConvertToVector128Int16(address);
 
         /// <summary>
@@ -314,7 +312,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBD xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(sbyte* address) => ConvertToVector128Int32(address);
 
         /// <summary>
@@ -323,7 +320,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBD xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(byte* address) => ConvertToVector128Int32(address);
 
         /// <summary>
@@ -332,7 +328,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWD xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(short* address) => ConvertToVector128Int32(address);
 
         /// <summary>
@@ -341,7 +336,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWD xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> ConvertToVector128Int32(ushort* address) => ConvertToVector128Int32(address);
 
         /// <summary>
@@ -350,7 +344,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXBQ xmm1 {k1}{z}, m16</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(sbyte* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -359,7 +352,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXBQ xmm1 {k1}{z}, m16</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(byte* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -368,7 +360,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXWQ xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(short* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -377,7 +368,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXWQ xmm1 {k1}{z}, m32</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(ushort* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -386,7 +376,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVSXDQ xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(int* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -395,7 +384,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>  VPMOVZXDQ xmm1 {k1}{z}, m64</para>
         ///   <para>The native signature does not exist. We provide this additional overload for completeness.</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> ConvertToVector128Int64(uint* address) => ConvertToVector128Int64(address);
 
         /// <summary>
@@ -512,7 +500,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<sbyte> LoadAlignedVector128NonTemporal(sbyte* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -520,7 +507,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<byte> LoadAlignedVector128NonTemporal(byte* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -528,7 +514,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<short> LoadAlignedVector128NonTemporal(short* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -536,7 +521,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ushort> LoadAlignedVector128NonTemporal(ushort* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -544,7 +528,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<int> LoadAlignedVector128NonTemporal(int* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -552,7 +535,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<uint> LoadAlignedVector128NonTemporal(uint* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -560,7 +542,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<long> LoadAlignedVector128NonTemporal(long* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>
@@ -568,7 +549,6 @@ namespace System.Runtime.Intrinsics.X86
         ///   <para>   MOVNTDQA xmm1, m128</para>
         ///   <para>  VMOVNTDQA xmm1, m128</para>
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe Vector128<ulong> LoadAlignedVector128NonTemporal(ulong* address) => LoadAlignedVector128NonTemporal(address);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/X86/X86Base.cs
@@ -106,7 +106,6 @@ namespace System.Runtime.Intrinsics.X86
         private static extern unsafe void CpuId(int* cpuInfo, int functionId, int subFunctionId);
 #else
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "X86Base_CpuId")]
-        [RequiresUnsafe]
         private static unsafe partial void CpuId(int* cpuInfo, int functionId, int subFunctionId);
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -740,7 +740,6 @@ namespace System.Runtime.Loader
         // These methods provide efficient reverse P/Invoke entry points for the VM.
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnAssemblyLoad(RuntimeAssembly* pAssembly, Exception* pException)
         {
             try
@@ -754,7 +753,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnTypeResolve(RuntimeAssembly* pAssembly, byte* typeName, RuntimeAssembly* ppResult, Exception* pException)
         {
             try
@@ -769,7 +767,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnResourceResolve(RuntimeAssembly* pAssembly, byte* resourceName, RuntimeAssembly* ppResult, Exception* pException)
         {
             try
@@ -784,7 +781,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void OnAssemblyResolve(RuntimeAssembly* pAssembly, char* assemblyFullName, RuntimeAssembly* ppResult, Exception* pException)
         {
             try
@@ -798,7 +794,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void Resolve(IntPtr gchAssemblyLoadContext, AssemblyName* pAssemblyName, Assembly* ppResult, Exception* pException)
         {
             try
@@ -813,7 +808,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ResolveSatelliteAssembly(IntPtr gchAssemblyLoadContext, AssemblyName* pAssemblyName, Assembly* ppResult, Exception* pException)
         {
             try
@@ -828,7 +822,6 @@ namespace System.Runtime.Loader
         }
 
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void ResolveUsingEvent(IntPtr gchAssemblyLoadContext, AssemblyName* pAssemblyName, Assembly* ppResult, Exception* pException)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -34,7 +34,6 @@ namespace System.Buffers
         internal static bool IsVectorizationSupported => Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe void SetBitmapBit(byte* bitmap, int value)
         {
             Debug.Assert((uint)value <= 127);
@@ -171,7 +170,6 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe bool TryComputeBitmap(ReadOnlySpan<char> values, byte* bitmap, out bool needleContainsZero)
         {
             byte* bitmapLocal = bitmap; // https://github.com/dotnet/runtime/issues/9040

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMapState.cs
@@ -52,7 +52,6 @@ namespace System.Buffers
         }
 
         // valuesPtr must remain valid for as long as this ProbabilisticMapState is used.
-        [RequiresUnsafe]
         public ProbabilisticMapState(ReadOnlySpan<char>* valuesPtr)
         {
             Debug.Assert((IntPtr)valuesPtr != IntPtr.Zero);

--- a/src/libraries/System.Private.CoreLib/src/System/Security/SecureString.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Security/SecureString.cs
@@ -23,7 +23,6 @@ namespace System.Security
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe SecureString(char* value, int length)
         {
             ArgumentNullException.ThrowIfNull(value);

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -106,7 +106,6 @@ namespace System
         /// </exception>
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public unsafe Span(void* pointer, int length)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Byte.cs
@@ -450,7 +450,6 @@ namespace System
 
         // IndexOfNullByte processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
         // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-        [RequiresUnsafe]
         internal static unsafe int IndexOfNullByte(byte* searchSpace)
         {
             const int Length = int.MaxValue;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.ByteMemOps.cs
@@ -262,7 +262,6 @@ namespace System
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "memmove")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        [RequiresUnsafe]
         private static unsafe partial void* memmove(void* dest, void* src, nuint len);
 #pragma warning restore CS3016
 #endif
@@ -486,7 +485,6 @@ namespace System
 #pragma warning disable CS3016 // Arrays as attribute arguments is not CLS-compliant
         [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "memset")]
         [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
-        [RequiresUnsafe]
         private static unsafe partial void* memset(void* dest, int value, nuint len);
 #pragma warning restore CS3016
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -529,7 +529,6 @@ namespace System
 
         // IndexOfNullCharacter processes memory in aligned chunks, and thus it won't crash even if it accesses memory beyond the null terminator.
         // This behavior is an implementation detail of the runtime and callers outside System.Private.CoreLib must not depend on it.
-        [RequiresUnsafe]
         public static unsafe int IndexOfNullCharacter(char* searchSpace)
         {
             const char value = '\0';

--- a/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/StartupHookProvider.cs
@@ -71,7 +71,6 @@ namespace System
         // and call the hook.
         [UnconditionalSuppressMessageAttribute("ReflectionAnalysis", "IL2026:RequiresUnreferencedCode",
             Justification = "An ILLink warning when trimming an app with System.StartupHookProvider.IsSupported=true already exists for ProcessStartupHooks.")]
-        [RequiresUnsafe]
         private static unsafe void CallStartupHook(char* pStartupHookPart)
         {
             if (!IsSupported)
@@ -88,7 +87,6 @@ namespace System
 
 #if CORECLR
         [UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void CallStartupHook(char* pStartupHookPart, Exception* pException)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2662,7 +2662,6 @@ namespace System
             return CreateTrimmedString(start, end);
         }
 
-        [RequiresUnsafe]
         private unsafe string TrimHelper(char* trimChars, int trimCharsLength, TrimType trimType)
         {
             Debug.Assert(trimChars != null);

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -116,13 +116,11 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
 #if MONO
         [DynamicDependency("Ctor(System.Char*)")]
 #endif
         public extern unsafe String(char* value);
 
-        [RequiresUnsafe]
         private static unsafe string Ctor(char* ptr)
         {
             if (ptr == null)
@@ -144,13 +142,11 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
 #if MONO
         [DynamicDependency("Ctor(System.Char*,System.Int32,System.Int32)")]
 #endif
         public extern unsafe String(char* value, int startIndex, int length);
 
-        [RequiresUnsafe]
         private static unsafe string Ctor(char* ptr, int startIndex, int length)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(length);
@@ -180,13 +176,11 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
 #if MONO
         [DynamicDependency("Ctor(System.SByte*)")]
 #endif
         public extern unsafe String(sbyte* value);
 
-        [RequiresUnsafe]
         private static unsafe string Ctor(sbyte* value)
         {
             byte* pb = (byte*)value;
@@ -200,13 +194,11 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
 #if MONO
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32)")]
 #endif
         public extern unsafe String(sbyte* value, int startIndex, int length);
 
-        [RequiresUnsafe]
         private static unsafe string Ctor(sbyte* value, int startIndex, int length)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
@@ -230,7 +222,6 @@ namespace System
         }
 
         // Encoder for String..ctor(sbyte*) and String..ctor(sbyte*, int, int)
-        [RequiresUnsafe]
         private static unsafe string CreateStringForSByteConstructor(byte* pb, int numBytes)
         {
             Debug.Assert(numBytes >= 0);
@@ -259,13 +250,11 @@ namespace System
 
         [CLSCompliant(false)]
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [RequiresUnsafe]
 #if MONO
         [DynamicDependency("Ctor(System.SByte*,System.Int32,System.Int32,System.Text.Encoding)")]
 #endif
         public extern unsafe String(sbyte* value, int startIndex, int length, Encoding enc);
 
-        [RequiresUnsafe]
         private static unsafe string Ctor(sbyte* value, int startIndex, int length, Encoding? enc)
         {
             if (enc == null)
@@ -541,7 +530,6 @@ namespace System
 
         // Helper for encodings so they can talk to our buffer directly
         // stringLength must be the exact size we'll expect
-        [RequiresUnsafe]
         internal static unsafe string CreateStringFromEncoding(
             byte* bytes, int byteLength, Encoding encoding)
         {
@@ -624,10 +612,8 @@ namespace System
             return new StringRuneEnumerator(this);
         }
 
-        [RequiresUnsafe]
         internal static unsafe int wcslen(char* ptr) => SpanHelpers.IndexOfNullCharacter(ptr);
 
-        [RequiresUnsafe]
         internal static unsafe int strlen(byte* ptr) => SpanHelpers.IndexOfNullByte(ptr);
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -123,7 +123,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             if (chars is null)
@@ -150,7 +149,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetByteCountCommon(char* pChars, int charCount)
         {
             // Common helper method for all non-EncoderNLS entry points to GetByteCount.
@@ -180,7 +178,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetByteCountCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetByteCountFast(char* pChars, int charsLength, EncoderFallback? fallback, out int charsConsumed)
         {
             // First: Can we short-circuit the entire calculation?
@@ -296,7 +293,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             if (chars is null || bytes is null)
@@ -346,7 +342,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount, bool throwForDestinationOverflow = true)
         {
             // Common helper method for all non-EncoderNLS entry points to GetBytes.
@@ -376,7 +371,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetBytesCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetBytesFast(char* pChars, int charsLength, byte* pBytes, int bytesLength, out int charsConsumed)
         {
             int bytesWritten = (int)Ascii.NarrowUtf16ToAscii(pChars, pBytes, (uint)Math.Min(charsLength, bytesLength));
@@ -471,7 +465,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             if (bytes is null)
@@ -498,7 +491,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetCharCountCommon(byte* pBytes, int byteCount)
         {
             // Common helper method for all non-DecoderNLS entry points to GetCharCount.
@@ -528,7 +520,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharCountCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetCharCountFast(byte* pBytes, int bytesLength, DecoderFallback? fallback, out int bytesConsumed)
         {
             // First: Can we short-circuit the entire calculation?
@@ -593,7 +584,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             if (bytes is null || chars is null)
@@ -643,7 +633,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount, bool throwForDestinationOverflow = true)
         {
             // Common helper method for all non-DecoderNLS entry points to GetChars.
@@ -673,7 +662,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharsCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetCharsFast(byte* pBytes, int bytesLength, char* pChars, int charsLength, out int bytesConsumed)
         {
             bytesConsumed = (int)Ascii.WidenAsciiToUtf16(pBytes, pChars, (uint)Math.Min(charsLength, bytesLength));

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.CaseConversion.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.CaseConversion.cs
@@ -204,7 +204,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         private static unsafe nuint ChangeCase<TFrom, TTo, TCasing>(TFrom* pSrc, TTo* pDest, nuint elementCount)
             where TFrom : unmanaged, IBinaryInteger<TFrom>
             where TTo : unmanaged, IBinaryInteger<TTo>
@@ -466,7 +465,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe void ChangeWidthAndWriteTo<TFrom, TTo>(Vector128<TFrom> vector, TTo* pDest, nuint elementOffset)
             where TFrom : unmanaged
             where TTo : unmanaged

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -105,7 +105,6 @@ namespace System.Text
         /// </summary>
         /// <returns>An ASCII byte is defined as 0x00 - 0x7F, inclusive.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe nuint GetIndexOfFirstNonAsciiByte(byte* pBuffer, nuint bufferLength)
         {
             // If 256/512-bit aren't supported but SSE2 is supported, use those specific intrinsics instead of
@@ -128,7 +127,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonAsciiByte_Vector(byte* pBuffer, nuint bufferLength)
         {
             // Squirrel away the original buffer reference. This method works by determining the exact
@@ -365,7 +363,6 @@ namespace System.Text
             return advSimdIndex < 16;
         }
 
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonAsciiByte_Intrinsified(byte* pBuffer, nuint bufferLength)
         {
             // JIT turns the below into constants
@@ -731,7 +728,6 @@ namespace System.Text
         /// </summary>
         /// <returns>An ASCII char is defined as 0x0000 - 0x007F, inclusive.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         internal static unsafe nuint GetIndexOfFirstNonAsciiChar(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // If 256/512-bit aren't supported but SSE2/ASIMD is supported, use those specific intrinsics instead of
@@ -754,7 +750,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonAsciiChar_Vector(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // Squirrel away the original buffer reference.This method works by determining the exact
@@ -960,7 +955,6 @@ namespace System.Text
         }
 
 #if NET
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonAsciiChar_Intrinsified(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // This method contains logic optimized using vector instructions for both x64 and Arm64.
@@ -1349,7 +1343,6 @@ namespace System.Text
         /// or once <paramref name="elementCount"/> elements have been converted. Returns the total number
         /// of elements that were able to be converted.
         /// </summary>
-        [RequiresUnsafe]
         internal static unsafe nuint NarrowUtf16ToAscii(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
         {
             nuint currentOffset = 0;
@@ -1716,7 +1709,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe nuint NarrowUtf16ToAscii_Intrinsified(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
         {
             // This method contains logic optimized using vector instructions for both x64 and Arm64.
@@ -1836,7 +1828,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe nuint NarrowUtf16ToAscii_Intrinsified_256(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
         {
             // This method contains logic optimized using vector instructions for x64 only.
@@ -1954,7 +1945,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe nuint NarrowUtf16ToAscii_Intrinsified_512(char* pUtf16Buffer, byte* pAsciiBuffer, nuint elementCount)
         {
             // This method contains logic optimized using vector instructions for x64 only.
@@ -2079,7 +2069,6 @@ namespace System.Text
         /// or once <paramref name="elementCount"/> elements have been converted. Returns the total number
         /// of elements that were able to be converted.
         /// </summary>
-        [RequiresUnsafe]
         internal static unsafe nuint WidenAsciiToUtf16(byte* pAsciiBuffer, char* pUtf16Buffer, nuint elementCount)
         {
             // Intrinsified in mono interpreter
@@ -2203,7 +2192,6 @@ namespace System.Text
 
 #if NET
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private static unsafe void WidenAsciiToUtf1_Vector<TVectorByte, TVectorUInt16>(byte* pAsciiBuffer, char* pUtf16Buffer, ref nuint currentOffset, nuint elementCount)
             where TVectorByte : unmanaged, ISimdVector<TVectorByte, byte>
             where TVectorUInt16 : unmanaged, ISimdVector<TVectorUInt16, ushort>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Decoder.cs
@@ -95,7 +95,6 @@ namespace System.Text
         // We expect this to be the workhorse for NLS Encodings, but for existing
         // ones we need a working (if slow) default implementation)
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetCharCount(byte* bytes, int count, bool flush)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -157,7 +156,6 @@ namespace System.Text
         // could easily overflow our output buffer.  Therefore we do an extra test
         // when we copy the buffer so that we don't overflow charCount either.
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetChars(byte* bytes, int byteCount,
                                            char* chars, int charCount, bool flush)
         {
@@ -269,7 +267,6 @@ namespace System.Text
         // that its likely that we didn't consume as many bytes as we could have.  For some
         // applications this could be slow.  (Like trying to exactly fill an output buffer from a bigger stream)
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe void Convert(byte* bytes, int byteCount,
                                            char* chars, int charCount, bool flush,
                                            out int bytesUsed, out int charsUsed, out bool completed)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderFallback.cs
@@ -74,7 +74,6 @@ namespace System.Text
 
         // Set the above values
         // This can't be part of the constructor because DecoderFallbacks would have to know how to implement these.
-        [RequiresUnsafe]
         internal unsafe void InternalInitialize(byte* byteStart, char* charEnd)
         {
             this.byteStart = byteStart;
@@ -105,7 +104,6 @@ namespace System.Text
         // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
         // array, and we might need the index, hence the byte*
         // Don't touch ref chars unless we succeed
-        [RequiresUnsafe]
         internal unsafe bool InternalFallback(byte[] bytes, byte* pBytes, ref char* chars)
         {
             Debug.Assert(byteStart != null, "[DecoderFallback.InternalFallback]Used InternalFallback without calling InternalInitialize");
@@ -159,7 +157,6 @@ namespace System.Text
         }
 
         // This version just counts the fallback and doesn't actually copy anything.
-        [RequiresUnsafe]
         internal virtual unsafe int InternalFallback(byte[] bytes, byte* pBytes)
         // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
         // array, and we might need the index, hence the byte*

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
@@ -63,7 +63,6 @@ namespace System.Text
                 return GetCharCount(pBytes + index, count, flush);
         }
 
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count, bool flush)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -114,7 +113,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount,
                                             char* chars, int charCount, bool flush)
         {
@@ -167,7 +165,6 @@ namespace System.Text
 
         // This is the version that used pointers.  We call the base encoding worker function
         // after setting our appropriate internal variables.  This is getting chars
-        [RequiresUnsafe]
         public override unsafe void Convert(byte* bytes, int byteCount,
                                               char* chars, int charCount, bool flush,
                                               out int bytesUsed, out int charsUsed, out bool completed)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderReplacementFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderReplacementFallback.cs
@@ -163,7 +163,6 @@ namespace System.Text
         }
 
         // This version just counts the fallback and doesn't actually copy anything.
-        [RequiresUnsafe]
         internal override unsafe int InternalFallback(byte[] bytes, byte* pBytes) =>
             // Right now this has both bytes and bytes[], since we might have extra bytes,
             // hence the array, and we might need the index, hence the byte*.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoder.cs
@@ -92,7 +92,6 @@ namespace System.Text
         // unfortunately for existing overrides, it has to call the [] version,
         // which is really slow, so avoid this method if you might be calling external encodings.
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetByteCount(char* chars, int count, bool flush)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -154,7 +153,6 @@ namespace System.Text
         // could easily overflow our output buffer.  Therefore we do an extra test
         // when we copy the buffer so that we don't overflow byteCount either.
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetBytes(char* chars, int charCount,
                                            byte* bytes, int byteCount, bool flush)
         {
@@ -268,7 +266,6 @@ namespace System.Text
         // that its likely that we didn't consume as many chars as we could have.  For some
         // applications this could be slow.  (Like trying to exactly fill an output buffer from a bigger stream)
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe void Convert(char* chars, int charCount,
                                            byte* bytes, int byteCount, bool flush,
                                            out int charsUsed, out int bytesUsed, out bool completed)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncoderFallback.cs
@@ -293,7 +293,6 @@ namespace System.Text
         // Note that this could also change the contents of this.encoder, which is the same
         // object that the caller is using, so the caller could mess up the encoder for us
         // if they aren't careful.
-        [RequiresUnsafe]
         internal unsafe bool InternalFallback(char ch, ref char* chars)
         {
             // Shouldn't have null charStart

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
@@ -62,7 +62,6 @@ namespace System.Text
             return result;
         }
 
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count, bool flush)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -104,7 +103,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount, bool flush)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -153,7 +151,6 @@ namespace System.Text
 
         // This is the version that uses pointers.  We call the base encoding worker function
         // after setting our appropriate internal variables.  This is getting bytes
-        [RequiresUnsafe]
         public override unsafe void Convert(char* chars, int charCount,
                                             byte* bytes, int byteCount, bool flush,
                                             out int charsUsed, out int bytesUsed, out bool completed)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs
@@ -119,7 +119,6 @@ namespace System.Text
         /// <summary>
         /// Entry point from <see cref="EncoderNLS.GetByteCount"/>.
         /// </summary>
-        [RequiresUnsafe]
         internal virtual unsafe int GetByteCount(char* pChars, int charCount, EncoderNLS? encoder)
         {
             Debug.Assert(encoder != null, "This code path should only be called from EncoderNLS.");
@@ -173,7 +172,6 @@ namespace System.Text
         /// The implementation should not attempt to perform any sort of fallback behavior.
         /// If custom fallback behavior is necessary, override <see cref="GetByteCountWithFallback"/>.
         /// </remarks>
-        [RequiresUnsafe]
         private protected virtual unsafe int GetByteCountFast(char* pChars, int charsLength, EncoderFallback? fallback, out int charsConsumed)
         {
             // Any production-quality type would override this method and provide a real
@@ -225,7 +223,6 @@ namespace System.Text
         /// (Implementation should call <see cref="ThrowConversionOverflow"/>.)
         /// </exception>
         [MethodImpl(MethodImplOptions.NoInlining)] // don't stack spill spans into our caller
-        [RequiresUnsafe]
         private protected unsafe int GetByteCountWithFallback(char* pCharsOriginal, int originalCharCount, int charsConsumedSoFar)
         {
             // This is a stub method that's marked "no-inlining" so that it we don't stack-spill spans
@@ -256,7 +253,6 @@ namespace System.Text
         /// If the return value would exceed <see cref="int.MaxValue"/>.
         /// (The implementation should call <see cref="ThrowConversionOverflow"/>.)
         /// </exception>
-        [RequiresUnsafe]
         private unsafe int GetByteCountWithFallback(char* pOriginalChars, int originalCharCount, int charsConsumedSoFar, EncoderNLS encoder)
         {
             Debug.Assert(encoder != null, "This code path should only be called from EncoderNLS.");
@@ -400,7 +396,6 @@ namespace System.Text
         /// <summary>
         /// Entry point from <see cref="EncoderNLS.GetBytes"/> and <see cref="EncoderNLS.Convert"/>.
         /// </summary>
-        [RequiresUnsafe]
         internal virtual unsafe int GetBytes(char* pChars, int charCount, byte* pBytes, int byteCount, EncoderNLS? encoder)
         {
             Debug.Assert(encoder != null, "This code path should only be called from EncoderNLS.");
@@ -445,7 +440,6 @@ namespace System.Text
         /// The implementation should not attempt to perform any sort of fallback behavior.
         /// If custom fallback behavior is necessary, override <see cref="GetBytesWithFallback"/>.
         /// </remarks>
-        [RequiresUnsafe]
         private protected virtual unsafe int GetBytesFast(char* pChars, int charsLength, byte* pBytes, int bytesLength, out int charsConsumed)
         {
             // Any production-quality type would override this method and provide a real
@@ -492,7 +486,6 @@ namespace System.Text
         /// If the destination buffer is not large enough to hold the entirety of the transcoded data.
         /// </exception>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private protected unsafe int GetBytesWithFallback(char* pOriginalChars, int originalCharCount, byte* pOriginalBytes, int originalByteCount, int charsConsumedSoFar, int bytesWrittenSoFar, bool throwForDestinationOverflow = true)
         {
             // This is a stub method that's marked "no-inlining" so that it we don't stack-spill spans
@@ -527,7 +520,6 @@ namespace System.Text
         /// too small to contain the entirety of the transcoded data and the <see cref="EncoderNLS"/> instance disallows
         /// partial transcoding.
         /// </exception>
-        [RequiresUnsafe]
         private unsafe int GetBytesWithFallback(char* pOriginalChars, int originalCharCount, byte* pOriginalBytes, int originalByteCount, int charsConsumedSoFar, int bytesWrittenSoFar, EncoderNLS encoder)
         {
             Debug.Assert(encoder != null, "This code path should only be called from EncoderNLS.");
@@ -720,7 +712,6 @@ namespace System.Text
         /// <summary>
         /// Entry point from <see cref="DecoderNLS.GetCharCount"/>.
         /// </summary>
-        [RequiresUnsafe]
         internal virtual unsafe int GetCharCount(byte* pBytes, int byteCount, DecoderNLS? decoder)
         {
             Debug.Assert(decoder != null, "This code path should only be called from DecoderNLS.");
@@ -776,7 +767,6 @@ namespace System.Text
         /// The implementation should not attempt to perform any sort of fallback behavior.
         /// If custom fallback behavior is necessary, override <see cref="GetCharCountWithFallback"/>.
         /// </remarks>
-        [RequiresUnsafe]
         private protected virtual unsafe int GetCharCountFast(byte* pBytes, int bytesLength, DecoderFallback? fallback, out int bytesConsumed)
         {
             // Any production-quality type would override this method and provide a real
@@ -827,7 +817,6 @@ namespace System.Text
         /// (Implementation should call <see cref="ThrowConversionOverflow"/>.)
         /// </exception>
         [MethodImpl(MethodImplOptions.NoInlining)] // don't stack spill spans into our caller
-        [RequiresUnsafe]
         private protected unsafe int GetCharCountWithFallback(byte* pBytesOriginal, int originalByteCount, int bytesConsumedSoFar)
         {
             // This is a stub method that's marked "no-inlining" so that it we don't stack-spill spans
@@ -858,7 +847,6 @@ namespace System.Text
         /// If the return value would exceed <see cref="int.MaxValue"/>.
         /// (The implementation should call <see cref="ThrowConversionOverflow"/>.)
         /// </exception>
-        [RequiresUnsafe]
         private unsafe int GetCharCountWithFallback(byte* pOriginalBytes, int originalByteCount, int bytesConsumedSoFar, DecoderNLS decoder)
         {
             Debug.Assert(decoder != null, "This code path should only be called from DecoderNLS.");
@@ -1004,7 +992,6 @@ namespace System.Text
         /// <summary>
         /// Entry point from <see cref="DecoderNLS.GetChars"/> and <see cref="DecoderNLS.Convert"/>.
         /// </summary>
-        [RequiresUnsafe]
         internal virtual unsafe int GetChars(byte* pBytes, int byteCount, char* pChars, int charCount, DecoderNLS? decoder)
         {
             Debug.Assert(decoder != null, "This code path should only be called from DecoderNLS.");
@@ -1049,7 +1036,6 @@ namespace System.Text
         /// The implementation should not attempt to perform any sort of fallback behavior.
         /// If custom fallback behavior is necessary, override <see cref="GetCharsWithFallback"/>.
         /// </remarks>
-        [RequiresUnsafe]
         private protected virtual unsafe int GetCharsFast(byte* pBytes, int bytesLength, char* pChars, int charsLength, out int bytesConsumed)
         {
             // Any production-quality type would override this method and provide a real
@@ -1096,7 +1082,6 @@ namespace System.Text
         /// If the destination buffer is not large enough to hold the entirety of the transcoded data.
         /// </exception>
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [RequiresUnsafe]
         private protected unsafe int GetCharsWithFallback(byte* pOriginalBytes, int originalByteCount, char* pOriginalChars, int originalCharCount, int bytesConsumedSoFar, int charsWrittenSoFar, bool throwForDestinationOverflow = true)
         {
             // This is a stub method that's marked "no-inlining" so that it we don't stack-spill spans
@@ -1131,7 +1116,6 @@ namespace System.Text
         /// too small to contain the entirety of the transcoded data and the <see cref="DecoderNLS"/> instance disallows
         /// partial transcoding.
         /// </exception>
-        [RequiresUnsafe]
         private protected unsafe int GetCharsWithFallback(byte* pOriginalBytes, int originalByteCount, char* pOriginalChars, int originalCharCount, int bytesConsumedSoFar, int charsWrittenSoFar, DecoderNLS decoder)
         {
             Debug.Assert(decoder != null, "This code path should only be called from DecoderNLS.");

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -568,7 +568,6 @@ namespace System.Text
         // which is really slow, so this method should be avoided if you're calling
         // a 3rd party encoding.
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetByteCount(char* chars, int count)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -691,7 +690,6 @@ namespace System.Text
         // when we copy the buffer so that we don't overflow byteCount either.
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetBytes(char* chars, int charCount,
                                               byte* bytes, int byteCount)
         {
@@ -771,7 +769,6 @@ namespace System.Text
         // We expect this to be the workhorse for NLS Encodings, but for existing
         // ones we need a working (if slow) default implementation)
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetCharCount(byte* bytes, int count)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -842,7 +839,6 @@ namespace System.Text
         // when we copy the buffer so that we don't overflow charCount either.
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public virtual unsafe int GetChars(byte* bytes, int byteCount,
                                               char* chars, int charCount)
         {
@@ -905,7 +901,6 @@ namespace System.Text
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe string GetString(byte* bytes, int byteCount)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -1167,7 +1162,6 @@ namespace System.Text
             public override int GetByteCount(char[] chars, int index, int count, bool flush) =>
                 _encoding.GetByteCount(chars, index, count);
 
-            [RequiresUnsafe]
             public override unsafe int GetByteCount(char* chars, int count, bool flush) =>
                 _encoding.GetByteCount(chars, count);
 
@@ -1195,7 +1189,6 @@ namespace System.Text
                                          byte[] bytes, int byteIndex, bool flush) =>
                 _encoding.GetBytes(chars, charIndex, charCount, bytes, byteIndex);
 
-            [RequiresUnsafe]
             public override unsafe int GetBytes(char* chars, int charCount,
                                                 byte* bytes, int byteCount, bool flush) =>
                 _encoding.GetBytes(chars, charCount, bytes, byteCount);
@@ -1223,7 +1216,6 @@ namespace System.Text
             public override int GetCharCount(byte[] bytes, int index, int count, bool flush) =>
                 _encoding.GetCharCount(bytes, index, count);
 
-            [RequiresUnsafe]
             public override unsafe int GetCharCount(byte* bytes, int count, bool flush) =>
                 // By default just call the encoding version, no flush by default
                 _encoding.GetCharCount(bytes, count);
@@ -1253,7 +1245,6 @@ namespace System.Text
                                          char[] chars, int charIndex, bool flush) =>
                 _encoding.GetChars(bytes, byteIndex, byteCount, chars, charIndex);
 
-            [RequiresUnsafe]
             public override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, bool flush) =>
                 // By default just call the encoding's version
@@ -1273,7 +1264,6 @@ namespace System.Text
             private unsafe byte* _bytes;
             private readonly DecoderFallbackBuffer _fallbackBuffer;
 
-            [RequiresUnsafe]
             internal unsafe EncodingCharBuffer(Encoding enc, DecoderNLS? decoder, char* charStart, int charCount,
                                                     byte* byteStart, int byteCount)
             {
@@ -1421,7 +1411,6 @@ namespace System.Text
             private readonly EncoderNLS? _encoder;
             internal EncoderFallbackBuffer fallbackBuffer;
 
-            [RequiresUnsafe]
             internal unsafe EncodingByteBuffer(Encoding inEncoding, EncoderNLS? inEncoder,
                         byte* inByteStart, int inByteCount, char* inCharStart, int inCharCount)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
@@ -39,7 +39,6 @@ namespace System.Text
          * but fallback mechanism must be consulted for non-Latin-1 chars.
          */
 
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             if (chars is null)
@@ -102,7 +101,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetByteCountCommon(char* pChars, int charCount)
         {
             // Common helper method for all non-EncoderNLS entry points to GetByteCount.
@@ -133,7 +131,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetByteCountCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetByteCountFast(char* pChars, int charsLength, EncoderFallback? fallback, out int charsConsumed)
         {
             // Can we short-circuit the entire calculation? If so, the output byte count
@@ -175,7 +172,6 @@ namespace System.Text
          * but fallback mechanism must be consulted for non-Latin-1 chars.
          */
 
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             if (chars is null || bytes is null)
@@ -292,7 +288,6 @@ namespace System.Text
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount, bool throwForDestinationOverflow = true)
         {
             // Common helper method for all non-EncoderNLS entry points to GetBytes.
@@ -322,7 +317,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetBytesCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetBytesFast(char* pChars, int charsLength, byte* pBytes, int bytesLength, out int charsConsumed)
         {
             int bytesWritten = (int)Latin1Utility.NarrowUtf16ToLatin1(pChars, pBytes, (uint)Math.Min(charsLength, bytesLength));
@@ -337,7 +331,6 @@ namespace System.Text
          * We never consult the fallback mechanism during decoding.
          */
 
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             if (bytes is null)
@@ -388,7 +381,6 @@ namespace System.Text
             return bytes.Length;
         }
 
-        [RequiresUnsafe]
         private protected override unsafe int GetCharCountFast(byte* pBytes, int bytesLength, DecoderFallback? fallback, out int bytesConsumed)
         {
             // We never consult the fallback mechanism during GetChars.
@@ -416,7 +408,6 @@ namespace System.Text
          * We never consult the fallback mechanism during decoding.
          */
 
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             if (bytes is null || chars is null)
@@ -603,7 +594,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount)
         {
             // Common helper method for all non-DecoderNLS entry points to GetChars.
@@ -627,7 +617,6 @@ namespace System.Text
         }
 
         // called by the fallback mechanism
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetCharsFast(byte* pBytes, int bytesLength, char* pChars, int charsLength, out int bytesConsumed)
         {
             int charsWritten = Math.Min(bytesLength, charsLength);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Utility.cs
@@ -18,7 +18,6 @@ namespace System.Text
         /// </summary>
         /// <returns>A Latin-1 char is defined as 0x0000 - 0x00FF, inclusive.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         public static unsafe nuint GetIndexOfFirstNonLatin1Char(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // If SSE2 is supported, use those specific intrinsics instead of the generic vectorized
@@ -31,7 +30,6 @@ namespace System.Text
                 : GetIndexOfFirstNonLatin1Char_Default(pBuffer, bufferLength);
         }
 
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonLatin1Char_Default(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // Squirrel away the original buffer reference.This method works by determining the exact
@@ -167,7 +165,6 @@ namespace System.Text
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
-        [RequiresUnsafe]
         private static unsafe nuint GetIndexOfFirstNonLatin1Char_Sse2(char* pBuffer, nuint bufferLength /* in chars */)
         {
             // This method contains logic optimized for both SSE2 and SSE41. Much of the logic in this method
@@ -537,7 +534,6 @@ namespace System.Text
         /// or once <paramref name="elementCount"/> elements have been converted. Returns the total number
         /// of elements that were able to be converted.
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe nuint NarrowUtf16ToLatin1(char* pUtf16Buffer, byte* pLatin1Buffer, nuint elementCount)
         {
             nuint currentOffset = 0;
@@ -767,7 +763,6 @@ namespace System.Text
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
-        [RequiresUnsafe]
         private static unsafe nuint NarrowUtf16ToLatin1_Sse2(char* pUtf16Buffer, byte* pLatin1Buffer, nuint elementCount)
         {
             // This method contains logic optimized for both SSE2 and SSE41. Much of the logic in this method
@@ -949,7 +944,6 @@ namespace System.Text
         /// buffer <paramref name="pUtf16Buffer"/>, widening data while copying. <paramref name="elementCount"/>
         /// specifies the element count of both the source and destination buffers.
         /// </summary>
-        [RequiresUnsafe]
         public static unsafe void WidenLatin1ToUtf16(byte* pLatin1Buffer, char* pUtf16Buffer, nuint elementCount)
         {
             // If SSE2 is supported, use those specific intrinsics instead of the generic vectorized
@@ -968,7 +962,6 @@ namespace System.Text
         }
 
         [CompExactlyDependsOn(typeof(Sse2))]
-        [RequiresUnsafe]
         private static unsafe void WidenLatin1ToUtf16_Sse2(byte* pLatin1Buffer, char* pUtf16Buffer, nuint elementCount)
         {
             // JIT turns the below into constants
@@ -1074,7 +1067,6 @@ namespace System.Text
             }
         }
 
-        [RequiresUnsafe]
         private static unsafe void WidenLatin1ToUtf16_Fallback(byte* pLatin1Buffer, char* pUtf16Buffer, nuint elementCount)
         {
             Debug.Assert(!Sse2.IsSupported);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/StringBuilder.cs
@@ -2323,7 +2323,6 @@ namespace System.Text
         /// <param name="value">The pointer to the start of the buffer.</param>
         /// <param name="valueCount">The number of characters in the buffer.</param>
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe StringBuilder Append(char* value, int valueCount)
         {
             // We don't check null value as this case will throw null reference exception anyway

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
@@ -130,7 +130,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -219,7 +218,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -263,7 +261,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -313,7 +310,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -354,7 +350,6 @@ namespace System.Text
         //
         // End of standard methods copied from EncodingNLS.cs
         //
-        [RequiresUnsafe]
         internal override unsafe int GetByteCount(char* chars, int count, EncoderNLS? encoder)
         {
             Debug.Assert(chars is not null, "[UTF32Encoding.GetByteCount]chars!=null");
@@ -486,7 +481,6 @@ namespace System.Text
             return byteCount;
         }
 
-        [RequiresUnsafe]
         internal override unsafe int GetBytes(char* chars, int charCount,
                                                  byte* bytes, int byteCount, EncoderNLS? encoder)
         {
@@ -689,7 +683,6 @@ namespace System.Text
             return (int)(bytes - byteStart);
         }
 
-        [RequiresUnsafe]
         internal override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS? baseDecoder)
         {
             Debug.Assert(bytes is not null, "[UTF32Encoding.GetCharCount]bytes!=null");
@@ -832,7 +825,6 @@ namespace System.Text
             return charCount;
         }
 
-        [RequiresUnsafe]
         internal override unsafe int GetChars(byte* bytes, int byteCount,
                                                 char* chars, int charCount, DecoderNLS? baseDecoder)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
@@ -166,7 +166,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -255,7 +254,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -299,7 +297,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -349,7 +346,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -390,7 +386,6 @@ namespace System.Text
         //
         // End of standard methods copied from EncodingNLS.cs
         //
-        [RequiresUnsafe]
         internal sealed override unsafe int GetByteCount(char* chars, int count, EncoderNLS? baseEncoder)
         {
             Debug.Assert(chars is not null, "[UTF7Encoding.GetByteCount]chars!=null");
@@ -400,7 +395,6 @@ namespace System.Text
             return GetBytes(chars, count, null, 0, baseEncoder);
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetBytes(
             char* chars, int charCount, byte* bytes, int byteCount, EncoderNLS? baseEncoder)
         {
@@ -541,7 +535,6 @@ namespace System.Text
             return buffer.Count;
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS? baseDecoder)
         {
             Debug.Assert(count >= 0, "[UTF7Encoding.GetCharCount]count >=0");
@@ -551,7 +544,6 @@ namespace System.Text
             return GetChars(bytes, count, null, 0, baseDecoder);
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetChars(
             byte* bytes, int byteCount, char* chars, int charCount, DecoderNLS? baseDecoder)
         {
@@ -902,7 +894,6 @@ namespace System.Text
             }
 
             // This version just counts the fallback and doesn't actually copy anything.
-            [RequiresUnsafe]
             internal override unsafe int InternalFallback(byte[] bytes, byte* pBytes)
             // Right now this has both bytes and bytes[], since we might have extra bytes, hence the
             // array, and we might need the index, hence the byte*

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -172,7 +172,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             if (chars is null)
@@ -199,7 +198,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetByteCountCommon(char* pChars, int charCount)
         {
             // Common helper method for all non-EncoderNLS entry points to GetByteCount.
@@ -230,7 +228,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharCountCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetByteCountFast(char* pChars, int charsLength, EncoderFallback? fallback, out int charsConsumed)
         {
             // The number of UTF-8 code units may exceed the number of UTF-16 code units,
@@ -342,7 +339,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             if (chars is null || bytes is null)
@@ -392,7 +388,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetBytesCommon(char* pChars, int charCount, byte* pBytes, int byteCount, bool throwForDestinationOverflow = true)
         {
             // Common helper method for all non-EncoderNLS entry points to GetBytes.
@@ -422,7 +417,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetBytesCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetBytesFast(char* pChars, int charsLength, byte* pBytes, int bytesLength, out int charsConsumed)
         {
             // We don't care about the exact OperationStatus value returned by the workhorse routine; we only
@@ -471,7 +465,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             if (bytes is null)
@@ -541,7 +534,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             if (bytes is null || chars is null)
@@ -598,7 +590,6 @@ namespace System.Text
         // Note:  We throw exceptions on individually encoded surrogates and other non-shortest forms.
         //        If exceptions aren't turned on, then we drop all non-shortest &individual surrogates.
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetCharsCommon(byte* pBytes, int byteCount, char* pChars, int charCount, bool throwForDestinationOverflow = true)
         {
             // Common helper method for all non-DecoderNLS entry points to GetChars.
@@ -628,7 +619,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharsCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetCharsFast(byte* pBytes, int bytesLength, char* pChars, int charsLength, out int bytesConsumed)
         {
             // We don't care about the exact OperationStatus value returned by the workhorse routine; we only
@@ -718,7 +708,6 @@ namespace System.Text
         //
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [RequiresUnsafe]
         private unsafe int GetCharCountCommon(byte* pBytes, int byteCount)
         {
             // Common helper method for all non-DecoderNLS entry points to GetCharCount.
@@ -749,7 +738,6 @@ namespace System.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)] // called directly by GetCharCountCommon
-        [RequiresUnsafe]
         private protected sealed override unsafe int GetCharCountFast(byte* pBytes, int bytesLength, DecoderFallback? fallback, out int bytesConsumed)
         {
             // The number of UTF-16 code units will never exceed the number of UTF-8 code units,

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf16Utility.Validation.cs
@@ -70,7 +70,6 @@ namespace System.Text.Unicode
         /// <remarks>
         /// Returns a pointer to the end of <paramref name="pInputBuffer"/> if the buffer is well-formed.
         /// </remarks>
-        [RequiresUnsafe]
         public static char* GetPointerToFirstInvalidChar(char* pInputBuffer, int inputLength, out long utf8CodeUnitCountAdjustment, out int scalarCountAdjustment)
         {
             Debug.Assert(inputLength >= 0, "Input length must not be negative.");

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Transcoding.cs
@@ -20,7 +20,6 @@ namespace System.Text.Unicode
         // On method return, pInputBufferRemaining and pOutputBufferRemaining will both point to where
         // the next byte would have been consumed from / the next char would have been written to.
         // inputLength in bytes, outputCharsRemaining in chars.
-        [RequiresUnsafe]
         public static OperationStatus TranscodeToUtf16(byte* pInputBuffer, int inputLength, char* pOutputBuffer, int outputCharsRemaining, out byte* pInputBufferRemaining, out char* pOutputBufferRemaining)
         {
             Debug.Assert(inputLength >= 0, "Input length must not be negative.");
@@ -839,7 +838,6 @@ namespace System.Text.Unicode
         // On method return, pInputBufferRemaining and pOutputBufferRemaining will both point to where
         // the next char would have been consumed from / the next byte would have been written to.
         // inputLength in chars, outputBytesRemaining in bytes.
-        [RequiresUnsafe]
         public static OperationStatus TranscodeToUtf8(char* pInputBuffer, int inputLength, byte* pOutputBuffer, int outputBytesRemaining, out char* pInputBufferRemaining, out byte* pOutputBufferRemaining)
         {
             const int CharsPerDWord = sizeof(uint) / sizeof(char);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Unicode/Utf8Utility.Validation.cs
@@ -24,7 +24,6 @@ namespace System.Text.Unicode
         /// <remarks>
         /// Returns a pointer to the end of <paramref name="pInputBuffer"/> if the buffer is well-formed.
         /// </remarks>
-        [RequiresUnsafe]
         public static byte* GetPointerToFirstInvalidByte(byte* pInputBuffer, int inputLength, out int utf16CodeUnitCountAdjustment, out int scalarCountAdjustment)
         {
             Debug.Assert(inputLength >= 0, "Input length must not be negative.");

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -122,7 +122,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetByteCount(char* chars, int count)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -211,7 +210,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
             ArgumentNullException.ThrowIfNull(chars);
@@ -255,7 +253,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -305,7 +302,6 @@ namespace System.Text
         // EncodingNLS, UTF7Encoding, UTF8Encoding, UTF32Encoding, ASCIIEncoding, UnicodeEncoding
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
             ArgumentNullException.ThrowIfNull(bytes);
@@ -346,7 +342,6 @@ namespace System.Text
         //
         // End of standard methods copied from EncodingNLS.cs
         //
-        [RequiresUnsafe]
         internal sealed override unsafe int GetByteCount(char* chars, int count, EncoderNLS? encoder)
         {
             Debug.Assert(chars is not null, "[UnicodeEncoding.GetByteCount]chars!=null");
@@ -635,7 +630,6 @@ namespace System.Text
             return byteCount;
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetBytes(
             char* chars, int charCount, byte* bytes, int byteCount, EncoderNLS? encoder)
         {
@@ -988,7 +982,6 @@ namespace System.Text
             return (int)(bytes - byteStart);
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetCharCount(byte* bytes, int count, DecoderNLS? baseDecoder)
         {
             Debug.Assert(bytes is not null, "[UnicodeEncoding.GetCharCount]bytes!=null");
@@ -1303,7 +1296,6 @@ namespace System.Text
             return charCount;
         }
 
-        [RequiresUnsafe]
         internal sealed override unsafe int GetChars(
             byte* bytes, int byteCount, char* chars, int charCount, DecoderNLS? baseDecoder)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/AutoreleasePool.cs
@@ -54,7 +54,6 @@ namespace System.Threading
 
 #if CORECLR
         [System.Runtime.InteropServices.UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void CreateAutoreleasePool(Exception* pException)
         {
             try
@@ -68,7 +67,6 @@ namespace System.Threading
         }
 
         [System.Runtime.InteropServices.UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void DrainAutoreleasePool(Exception* pException)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/IOCompletionCallbackHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/IOCompletionCallbackHelper.cs
@@ -30,7 +30,6 @@ namespace System.Threading
             helper._ioCompletionCallback(helper._errorCode, helper._numBytes, helper._pNativeOverlapped);
         }
 
-        [RequiresUnsafe]
         public static void PerformSingleIOCompletionCallback(uint errorCode, uint numBytes, NativeOverlapped* pNativeOverlapped)
         {
             Debug.Assert(pNativeOverlapped != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -879,7 +879,6 @@ namespace System.Threading
 
 #if CORECLR
         [System.Runtime.InteropServices.UnmanagedCallersOnly]
-        [RequiresUnsafe]
         private static unsafe void InitializeForMonitor(Lock* pLock, int managedThreadId, uint recursionCount, Exception* pException)
         {
             try

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/NamedMutex.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/NamedMutex.Unix.cs
@@ -262,7 +262,6 @@ namespace System.Threading
             }
         }
 
-        [RequiresUnsafe]
         private static unsafe void InitializeSharedData(void* v)
         {
             if (UsePThreadMutexes)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Overlapped.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Overlapped.cs
@@ -112,7 +112,6 @@ namespace System.Threading
         *  Unpins the native Overlapped struct
         ====================================================================*/
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static Overlapped Unpack(NativeOverlapped* nativeOverlappedPtr)
         {
             ArgumentNullException.ThrowIfNull(nativeOverlappedPtr);
@@ -121,7 +120,6 @@ namespace System.Threading
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static void Free(NativeOverlapped* nativeOverlappedPtr)
         {
             ArgumentNullException.ThrowIfNull(nativeOverlappedPtr);
@@ -205,7 +203,6 @@ namespace System.Threading
             }
         }
 
-        [RequiresUnsafe]
         internal static void FreeNativeOverlapped(NativeOverlapped* pNativeOverlapped)
         {
             nuint handleCount = GCHandleCountRef(pNativeOverlapped);
@@ -219,15 +216,12 @@ namespace System.Threading
         //
         // The NativeOverlapped structure is followed by GC handle count and inline array of GC handles
         //
-        [RequiresUnsafe]
         private static ref nuint GCHandleCountRef(NativeOverlapped* pNativeOverlapped)
             => ref *(nuint*)(pNativeOverlapped + 1);
 
-        [RequiresUnsafe]
         private static ref GCHandle GCHandleRef(NativeOverlapped* pNativeOverlapped, nuint index)
             => ref *((GCHandle*)((nuint*)(pNativeOverlapped + 1) + 1) + index);
 
-        [RequiresUnsafe]
         internal static Overlapped GetOverlappedFromNative(NativeOverlapped* pNativeOverlapped)
         {
             object? target = GCHandleRef(pNativeOverlapped, 0).Target;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -48,7 +48,6 @@ namespace System.Threading
         // Points to the next-most-recent blocking info for the thread
         private ThreadBlockingInfo* _next; // may be used by debuggers
 
-        [RequiresUnsafe]
         private void Push(void* objectPtr, ObjectKind objectKind, int timeoutMs)
         {
             Debug.Assert(objectPtr != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.cs
@@ -151,7 +151,6 @@ namespace System.Threading
 
         [CLSCompliant(false)]
         [SupportedOSPlatform("windows")]
-        [RequiresUnsafe]
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped)
         {
             if (overlapped == null)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
@@ -96,7 +96,6 @@ namespace System.Threading
 
         [CLSCompliant(false)]
         [SupportedOSPlatform("windows")]
-        [RequiresUnsafe]
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped) =>
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_OverlappedIO);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Wasi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Wasi.cs
@@ -111,7 +111,6 @@ namespace System.Threading
 
         [CLSCompliant(false)]
         [SupportedOSPlatform("windows")]
-        [RequiresUnsafe]
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped)
         {
             throw new PlatformNotSupportedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -46,7 +46,6 @@ namespace System.Threading
 
         [CLSCompliant(false)]
         [SupportedOSPlatform("windows")]
-        [RequiresUnsafe]
         public static unsafe bool UnsafeQueueNativeOverlapped(NativeOverlapped* overlapped) =>
             ThreadPool.UseWindowsThreadPool ?
             WindowsThreadPool.UnsafeQueueNativeOverlapped(overlapped) :

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandle.Portable.cs
@@ -57,7 +57,6 @@ namespace System.Threading
             }
         }
 
-        [RequiresUnsafe]
         private unsafe void FreeNativeOverlappedPortableCore(NativeOverlapped* overlapped)
         {
             ArgumentNullException.ThrowIfNull(overlapped);
@@ -75,7 +74,6 @@ namespace System.Threading
                 Overlapped.Free(overlapped);
         }
 
-        [RequiresUnsafe]
         private static unsafe object? GetNativeOverlappedStatePortableCore(NativeOverlapped* overlapped)
         {
             ArgumentNullException.ThrowIfNull(overlapped);
@@ -85,7 +83,6 @@ namespace System.Threading
             return wrapper._userState;
         }
 
-        [RequiresUnsafe]
         private static unsafe ThreadPoolBoundHandleOverlapped GetOverlappedWrapper(NativeOverlapped* overlapped)
         {
             ThreadPoolBoundHandleOverlapped wrapper;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandleOverlapped.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolBoundHandleOverlapped.cs
@@ -33,7 +33,6 @@ namespace System.Threading
             _nativeOverlapped->OffsetHigh = 0;
         }
 
-        [RequiresUnsafe]
         private static void CompletionCallback(uint errorCode, uint numBytes, NativeOverlapped* nativeOverlapped)
         {
             ThreadPoolBoundHandleOverlapped overlapped = (ThreadPoolBoundHandleOverlapped)Unpack(nativeOverlapped);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Win32ThreadPoolNativeOverlapped.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Win32ThreadPoolNativeOverlapped.cs
@@ -29,7 +29,6 @@ namespace System.Threading
             get { return s_dataArray![_dataIndex]; }
         }
 
-        [RequiresUnsafe]
         internal static unsafe Win32ThreadPoolNativeOverlapped* Allocate(IOCompletionCallback callback, object? state, object? pinData, PreAllocatedOverlapped? preAllocated, bool flowExecutionControl)
         {
             Win32ThreadPoolNativeOverlapped* overlapped = AllocateNew();
@@ -45,7 +44,6 @@ namespace System.Threading
             return overlapped;
         }
 
-        [RequiresUnsafe]
         private static unsafe Win32ThreadPoolNativeOverlapped* AllocateNew()
         {
             IntPtr freePtr;
@@ -157,7 +155,6 @@ namespace System.Threading
             }
         }
 
-        [RequiresUnsafe]
         internal static unsafe void Free(Win32ThreadPoolNativeOverlapped* overlapped)
         {
             // Reset all data.
@@ -185,7 +182,6 @@ namespace System.Threading
             return (Win32ThreadPoolNativeOverlapped*)overlapped;
         }
 
-        [RequiresUnsafe]
         internal static unsafe void CompleteWithCallback(uint errorCode, uint bytesWritten, Win32ThreadPoolNativeOverlapped* overlapped)
         {
             OverlappedData data = overlapped->Data;

--- a/src/libraries/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
+++ b/src/libraries/System.Reflection.Emit.Lightweight/ref/System.Reflection.Emit.Lightweight.cs
@@ -19,15 +19,12 @@ namespace System.Reflection.Emit
         public int GetTokenFor(System.RuntimeTypeHandle type) { throw null; }
         public int GetTokenFor(string literal) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe void SetCode(byte* code, int codeSize, int maxStackSize) { }
         public void SetCode(byte[]? code, int maxStackSize) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe void SetExceptions(byte* exceptions, int exceptionsSize) { }
         public void SetExceptions(byte[]? exceptions) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe void SetLocalSignature(byte* localSignature, int signatureSize) { }
         public void SetLocalSignature(byte[]? localSignature) { }
     }

--- a/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
+++ b/src/libraries/System.Runtime.InteropServices/ref/System.Runtime.InteropServices.cs
@@ -489,7 +489,6 @@ namespace System.Runtime.InteropServices.Marshalling
         public StrategyBasedComWrappers() { }
         public static System.Runtime.InteropServices.Marshalling.IIUnknownInterfaceDetailsStrategy DefaultIUnknownInterfaceDetailsStrategy { get { throw null; } }
         public static System.Runtime.InteropServices.Marshalling.IIUnknownStrategy DefaultIUnknownStrategy { get { throw null; } }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         protected unsafe sealed override System.Runtime.InteropServices.ComWrappers.ComInterfaceEntry* ComputeVtables(object obj, System.Runtime.InteropServices.CreateComInterfaceFlags flags, out int count) { throw null; }
         protected virtual System.Runtime.InteropServices.Marshalling.IIUnknownCacheStrategy CreateCacheStrategy() { throw null; }
         protected static System.Runtime.InteropServices.Marshalling.IIUnknownCacheStrategy CreateDefaultCacheStrategy() { throw null; }
@@ -768,11 +767,9 @@ namespace System.Runtime.InteropServices
         public struct ComInterfaceDispatch
         {
             public System.IntPtr Vtable;
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static T GetInstance<T>(ComInterfaceDispatch* dispatchPtr) where T : class { throw null; }
         }
         public System.IntPtr GetOrCreateComInterfaceForObject(object instance, System.Runtime.InteropServices.CreateComInterfaceFlags flags) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         protected unsafe abstract ComInterfaceEntry* ComputeVtables(object obj, System.Runtime.InteropServices.CreateComInterfaceFlags flags, out int count);
         public object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags) { throw null; }
         public object GetOrCreateObjectForComInstance(System.IntPtr externalComObject, System.Runtime.InteropServices.CreateObjectFlags flags, object? userState) { throw null; }
@@ -1300,10 +1297,8 @@ namespace System.Runtime.InteropServices
         [System.CLSCompliantAttribute(false)]
         public static void* AlignedAlloc(nuint byteCount, nuint alignment) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void AlignedFree(void* ptr) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void* AlignedRealloc(void* ptr, nuint byteCount, nuint alignment) { throw null; }
         [System.CLSCompliantAttribute(false)]
         public static void* Alloc(nuint byteCount) { throw null; }
@@ -1314,19 +1309,14 @@ namespace System.Runtime.InteropServices
         [System.CLSCompliantAttribute(false)]
         public static void* AllocZeroed(nuint elementCount, nuint elementSize) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(void* ptr) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void* Realloc(void* ptr, nuint byteCount) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Clear(void* ptr, nuint byteCount) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Copy(void* source, void* destination, nuint byteCount) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Fill(void* ptr, nuint byteCount, byte value) { throw null; }
     }
     public readonly partial struct NFloat : System.IComparable, System.IComparable<System.Runtime.InteropServices.NFloat>, System.IEquatable<System.Runtime.InteropServices.NFloat>, System.IFormattable, System.IParsable<System.Runtime.InteropServices.NFloat>, System.ISpanFormattable, System.ISpanParsable<System.Runtime.InteropServices.NFloat>, System.Numerics.IAdditionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IAdditiveIdentity<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IBinaryFloatingPointIeee754<System.Runtime.InteropServices.NFloat>, System.Numerics.IBinaryNumber<System.Runtime.InteropServices.NFloat>, System.Numerics.IBitwiseOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IComparisonOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, bool>, System.Numerics.IDecrementOperators<System.Runtime.InteropServices.NFloat>, System.Numerics.IDivisionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IEqualityOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, bool>, System.Numerics.IExponentialFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.IFloatingPoint<System.Runtime.InteropServices.NFloat>, System.Numerics.IFloatingPointConstants<System.Runtime.InteropServices.NFloat>, System.Numerics.IFloatingPointIeee754<System.Runtime.InteropServices.NFloat>, System.Numerics.IHyperbolicFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.IIncrementOperators<System.Runtime.InteropServices.NFloat>, System.Numerics.ILogarithmicFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.IMinMaxValue<System.Runtime.InteropServices.NFloat>, System.Numerics.IModulusOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IMultiplicativeIdentity<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IMultiplyOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.INumber<System.Runtime.InteropServices.NFloat>, System.Numerics.INumberBase<System.Runtime.InteropServices.NFloat>, System.Numerics.IPowerFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.IRootFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.ISignedNumber<System.Runtime.InteropServices.NFloat>, System.Numerics.ISubtractionOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.ITrigonometricFunctions<System.Runtime.InteropServices.NFloat>, System.Numerics.IUnaryNegationOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.Numerics.IUnaryPlusOperators<System.Runtime.InteropServices.NFloat, System.Runtime.InteropServices.NFloat>, System.IUtf8SpanFormattable
@@ -2408,13 +2398,9 @@ namespace System.Runtime.InteropServices.Java
     [System.CLSCompliantAttribute(false)]
     public static class JavaMarshal
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Initialize(delegate* unmanaged<MarkCrossReferencesArgs*, void> markCrossReferences) => throw null;
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe GCHandle CreateReferenceTrackingHandle(object obj, void* context) => throw null;
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void* GetContext(GCHandle obj) => throw null;
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void FinishCrossReferenceProcessing(
             MarkCrossReferencesArgs* crossReferences,
             System.ReadOnlySpan<GCHandle> unreachableObjectHandles) => throw null;
@@ -2454,7 +2440,6 @@ namespace System.Runtime.InteropServices.ObjectiveC
             System.Exception exception,
             System.RuntimeMethodHandle lastMethod,
             out System.IntPtr context);
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Initialize(
             delegate* unmanaged<void> beginEndCallback,
             delegate* unmanaged<System.IntPtr, int> isReferencedCallback,
@@ -2486,18 +2471,14 @@ namespace System.Runtime.InteropServices.Marshalling
         typeof(System.Runtime.InteropServices.Marshalling.AnsiStringMarshaller.ManagedToUnmanagedIn))]
     public static unsafe class AnsiStringMarshaller
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static byte* ConvertToUnmanaged(string? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static string? ConvertToManaged(byte* unmanaged) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(byte* unmanaged) { throw null; }
 
         public ref struct ManagedToUnmanagedIn
         {
             public static int BufferSize { get { throw null; } }
             public void FromManaged(string? managed, System.Span<byte> buffer) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public byte* ToUnmanaged()  { throw null; }
             public void Free() { throw null; }
         }
@@ -2514,16 +2495,12 @@ namespace System.Runtime.InteropServices.Marshalling
     public static unsafe class ArrayMarshaller<T, TUnmanagedElement>
         where TUnmanagedElement : unmanaged
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T[]? managed, out int numElements) { throw null; }
         public static System.ReadOnlySpan<T> GetManagedValuesSource(T[]? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         public static T[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         public static System.Span<T> GetManagedValuesDestination(T[]? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(TUnmanagedElement* unmanaged) { }
 
         public unsafe ref struct ManagedToUnmanagedIn
@@ -2536,7 +2513,6 @@ namespace System.Runtime.InteropServices.Marshalling
             public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() { throw null; }
             public ref TUnmanagedElement GetPinnableReference() { throw null; }
             public static ref T GetPinnableReference(T[]? array) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public TUnmanagedElement* ToUnmanaged() { throw null; }
             public void Free() { }
         }
@@ -2551,16 +2527,13 @@ namespace System.Runtime.InteropServices.Marshalling
     public static unsafe class BStrStringMarshaller
     {
         public static ushort* ConvertToUnmanaged(string? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static string? ConvertToManaged(ushort* unmanaged) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(ushort* unmanaged) { throw null; }
 
         public ref struct ManagedToUnmanagedIn
         {
             public static int BufferSize { get { throw null; } }
             public void FromManaged(string? managed, System.Span<byte> buffer) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public ushort* ToUnmanaged()  { throw null; }
             public void Free() { throw null; }
         }
@@ -2590,14 +2563,10 @@ namespace System.Runtime.InteropServices.Marshalling
     {
         public static TUnmanagedElement* AllocateContainerForUnmanagedElements(T*[]? managed, out int numElements) { throw null; }
         public static System.ReadOnlySpan<IntPtr> GetManagedValuesSource(T*[]? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static T*[]? AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         public static System.Span<IntPtr> GetManagedValuesDestination(T*[]? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanagedValue, int numElements) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(TUnmanagedElement* unmanaged) { }
 
         public unsafe ref struct ManagedToUnmanagedIn
@@ -2610,7 +2579,6 @@ namespace System.Runtime.InteropServices.Marshalling
             public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() { throw null; }
             public ref TUnmanagedElement GetPinnableReference() { throw null; }
             public static ref byte GetPinnableReference(T*[]? array) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public TUnmanagedElement* ToUnmanaged() { throw null; }
             public void Free() { }
         }
@@ -2624,18 +2592,14 @@ namespace System.Runtime.InteropServices.Marshalling
         typeof(System.Runtime.InteropServices.Marshalling.Utf8StringMarshaller.ManagedToUnmanagedIn))]
     public static unsafe class Utf8StringMarshaller
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static byte* ConvertToUnmanaged(string? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static string? ConvertToManaged(byte* unmanaged) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(byte* unmanaged) { throw null; }
 
         public ref struct ManagedToUnmanagedIn
         {
             public static int BufferSize { get { throw null; } }
             public void FromManaged(string? managed, System.Span<byte> buffer) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public byte* ToUnmanaged()  { throw null; }
             public void Free() { throw null; }
         }
@@ -2647,9 +2611,7 @@ namespace System.Runtime.InteropServices.Marshalling
     public static unsafe class Utf16StringMarshaller
     {
         public static ushort* ConvertToUnmanaged(string? managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static string? ConvertToManaged(ushort* unmanaged) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static void Free(ushort* unmanaged) { throw null; }
         public static ref readonly char GetPinnableReference(string? str) { throw null; }
     }
@@ -2673,7 +2635,6 @@ namespace System.Security
     {
         public SecureString() { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe SecureString(char* value, int length) { }
         public int Length { get { throw null; } }
         public void AppendChar(char c) { }

--- a/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
+++ b/src/libraries/System.Runtime.InteropServices/src/System/Runtime/InteropServices/Marshalling/StrategyBasedComWrappers.cs
@@ -79,7 +79,6 @@ namespace System.Runtime.InteropServices.Marshalling
         protected virtual IIUnknownCacheStrategy CreateCacheStrategy() => CreateDefaultCacheStrategy();
 
         /// <inheritdoc cref="ComWrappers.ComputeVtables" />
-        [RequiresUnsafe]
         protected sealed override unsafe ComInterfaceEntry* ComputeVtables(object obj, CreateComInterfaceFlags flags, out int count)
         {
             if (GetOrCreateInterfaceDetailsStrategy().GetComExposedTypeDetails(obj.GetType().TypeHandle) is { } details)

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -230,13 +230,10 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector128<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> LessThan<T>(System.Runtime.Intrinsics.Vector128<T> left, System.Runtime.Intrinsics.Vector128<T> right) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -362,13 +359,10 @@ namespace System.Runtime.Intrinsics
         public static (System.Runtime.Intrinsics.Vector128<float> Sin, System.Runtime.Intrinsics.Vector128<float> Cos) SinCos(System.Runtime.Intrinsics.Vector128<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<T> Sqrt<T>(System.Runtime.Intrinsics.Vector128<T> vector) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector128<T> source, T* destination) { throw null; }
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector128<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -682,13 +676,10 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector256<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> LessThan<T>(System.Runtime.Intrinsics.Vector256<T> left, System.Runtime.Intrinsics.Vector256<T> right) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -814,13 +805,10 @@ namespace System.Runtime.Intrinsics
         public static (System.Runtime.Intrinsics.Vector256<float> Sin, System.Runtime.Intrinsics.Vector256<float> Cos) SinCos(System.Runtime.Intrinsics.Vector256<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<T> Sqrt<T>(System.Runtime.Intrinsics.Vector256<T> vector) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector256<T> source, T* destination) { throw null; }
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector256<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -1135,13 +1123,10 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector512<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> LessThan<T>(System.Runtime.Intrinsics.Vector512<T> left, System.Runtime.Intrinsics.Vector512<T> right) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -1267,13 +1252,10 @@ namespace System.Runtime.Intrinsics
         public static (System.Runtime.Intrinsics.Vector512<float> Sin, System.Runtime.Intrinsics.Vector512<float> Cos) SinCos(System.Runtime.Intrinsics.Vector512<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<T> Sqrt<T>(System.Runtime.Intrinsics.Vector512<T> vector) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector512<T> source, T* destination) { throw null; }
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector512<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -1557,13 +1539,10 @@ namespace System.Runtime.Intrinsics
         public static System.Runtime.Intrinsics.Vector64<T> LessThanOrEqual<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> LessThan<T>(System.Runtime.Intrinsics.Vector64<T> left, System.Runtime.Intrinsics.Vector64<T> right) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> Load<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAligned<T>(T* source) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<T> LoadAlignedNonTemporal<T>(T* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> LoadUnsafe<T>(ref readonly T source) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -1681,13 +1660,10 @@ namespace System.Runtime.Intrinsics
         public static (System.Runtime.Intrinsics.Vector64<float> Sin, System.Runtime.Intrinsics.Vector64<float> Cos) SinCos(System.Runtime.Intrinsics.Vector64<float> vector) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<T> Sqrt<T>(System.Runtime.Intrinsics.Vector64<T> vector) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal<T>(this System.Runtime.Intrinsics.Vector64<T> source, T* destination) { throw null; }
         public static void StoreUnsafe<T>(this System.Runtime.Intrinsics.Vector64<T> source, ref T destination) { throw null; }
         [System.CLSCompliantAttribute(false)]
@@ -2367,275 +2343,140 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Runtime.Intrinsics.Vector64<sbyte> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<ushort> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<uint> LeadingZeroCount(System.Runtime.Intrinsics.Vector64<uint> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<int> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<long> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<sbyte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector128<ulong> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<byte> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<short> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<int> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<int> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<sbyte> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<sbyte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<float> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<ushort> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<uint> LoadAndInsertScalar(System.Runtime.Intrinsics.Vector64<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>, System.Runtime.Intrinsics.Vector64<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>, System.Runtime.Intrinsics.Vector64<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>, System.Runtime.Intrinsics.Vector64<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>, System.Runtime.Intrinsics.Vector64<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>, System.Runtime.Intrinsics.Vector64<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>, System.Runtime.Intrinsics.Vector64<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>, System.Runtime.Intrinsics.Vector64<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadAndReplicateToVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadAndReplicateToVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadAndReplicateToVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadAndReplicateToVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadAndReplicateToVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadAndReplicateToVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadAndReplicateToVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<byte> LoadAndReplicateToVector64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<short> LoadAndReplicateToVector64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<int> LoadAndReplicateToVector64(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<sbyte> LoadAndReplicateToVector64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<float> LoadAndReplicateToVector64(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<ushort> LoadAndReplicateToVector64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<uint> LoadAndReplicateToVector64(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadAndReplicateToVector64x2(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadAndReplicateToVector64x2(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadAndReplicateToVector64x2(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadAndReplicateToVector64x2(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadAndReplicateToVector64x2(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadAndReplicateToVector64x2(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadAndReplicateToVector64x2(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) LoadAndReplicateToVector64x3(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) LoadAndReplicateToVector64x3(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) LoadAndReplicateToVector64x3(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) LoadAndReplicateToVector64x3(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) LoadAndReplicateToVector64x3(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) LoadAndReplicateToVector64x3(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) LoadAndReplicateToVector64x3(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) LoadAndReplicateToVector64x4(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) LoadAndReplicateToVector64x4(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) LoadAndReplicateToVector64x4(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) LoadAndReplicateToVector64x4(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) LoadAndReplicateToVector64x4(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) LoadAndReplicateToVector64x4(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) LoadAndReplicateToVector64x4(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<byte> LoadVector64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<double> LoadVector64(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<short> LoadVector64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<int> LoadVector64(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<long> LoadVector64(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<sbyte> LoadVector64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<float> LoadVector64(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<ushort> LoadVector64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<uint> LoadVector64(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector64<ulong> LoadVector64(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) Load2xVector64AndUnzip(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) Load2xVector64AndUnzip(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) Load2xVector64AndUnzip(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) Load2xVector64AndUnzip(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) Load2xVector64AndUnzip(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) Load2xVector64AndUnzip(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) Load2xVector64AndUnzip(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) Load3xVector64AndUnzip(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) Load3xVector64AndUnzip(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) Load3xVector64AndUnzip(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) Load3xVector64AndUnzip(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) Load3xVector64AndUnzip(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) Load3xVector64AndUnzip(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) Load3xVector64AndUnzip(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) Load4xVector64AndUnzip(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) Load4xVector64AndUnzip(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) Load4xVector64AndUnzip(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) Load4xVector64AndUnzip(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) Load4xVector64AndUnzip(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) Load4xVector64AndUnzip(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) Load4xVector64AndUnzip(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) Load2xVector64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) Load2xVector64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) Load2xVector64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) Load2xVector64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) Load2xVector64(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) Load2xVector64(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) Load2xVector64(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) Load3xVector64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) Load3xVector64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) Load3xVector64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) Load3xVector64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) Load3xVector64(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) Load3xVector64(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) Load3xVector64(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) Load4xVector64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) Load4xVector64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) Load4xVector64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) Load4xVector64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) Load4xVector64(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) Load4xVector64(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) Load4xVector64(float* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<byte> Max(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> Max(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
@@ -3476,205 +3317,105 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Runtime.Intrinsics.Vector128<short> SignExtendWideningUpper(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<double> SqrtScalar(System.Runtime.Intrinsics.Vector64<double> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector64<float> SqrtScalar(System.Runtime.Intrinsics.Vector64<float> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, System.Runtime.Intrinsics.Vector64<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, System.Runtime.Intrinsics.Vector64<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, System.Runtime.Intrinsics.Vector64<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, System.Runtime.Intrinsics.Vector64<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, System.Runtime.Intrinsics.Vector64<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, System.Runtime.Intrinsics.Vector64<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, System.Runtime.Intrinsics.Vector64<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, System.Runtime.Intrinsics.Vector64<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, System.Runtime.Intrinsics.Vector64<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, System.Runtime.Intrinsics.Vector64<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, System.Runtime.Intrinsics.Vector128<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, System.Runtime.Intrinsics.Vector64<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(double* address, System.Runtime.Intrinsics.Vector128<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, System.Runtime.Intrinsics.Vector128<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, System.Runtime.Intrinsics.Vector64<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, System.Runtime.Intrinsics.Vector128<int> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, System.Runtime.Intrinsics.Vector64<int> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(long* address, System.Runtime.Intrinsics.Vector128<long> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, System.Runtime.Intrinsics.Vector64<sbyte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, System.Runtime.Intrinsics.Vector128<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, System.Runtime.Intrinsics.Vector64<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, System.Runtime.Intrinsics.Vector64<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, System.Runtime.Intrinsics.Vector128<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, System.Runtime.Intrinsics.Vector64<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector64<byte> value1, System.Runtime.Intrinsics.Vector64<byte> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> value1, System.Runtime.Intrinsics.Vector64<sbyte> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector64<short> value1, System.Runtime.Intrinsics.Vector64<short> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> value1, System.Runtime.Intrinsics.Vector64<ushort> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector64<byte> value1, System.Runtime.Intrinsics.Vector64<byte> value2, System.Runtime.Intrinsics.Vector64<byte> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> value1, System.Runtime.Intrinsics.Vector64<sbyte> value2, System.Runtime.Intrinsics.Vector64<sbyte> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector64<short> value1, System.Runtime.Intrinsics.Vector64<short> value2, System.Runtime.Intrinsics.Vector64<short> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> value1, System.Runtime.Intrinsics.Vector64<ushort> value2, System.Runtime.Intrinsics.Vector64<ushort> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2, System.Runtime.Intrinsics.Vector64<int> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2, System.Runtime.Intrinsics.Vector64<uint> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2, System.Runtime.Intrinsics.Vector64<float> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector64<byte> value1, System.Runtime.Intrinsics.Vector64<byte> value2, System.Runtime.Intrinsics.Vector64<byte> value3, System.Runtime.Intrinsics.Vector64<byte> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> value1, System.Runtime.Intrinsics.Vector64<sbyte> value2, System.Runtime.Intrinsics.Vector64<sbyte> value3, System.Runtime.Intrinsics.Vector64<sbyte> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector64<short> value1, System.Runtime.Intrinsics.Vector64<short> value2, System.Runtime.Intrinsics.Vector64<short> value3, System.Runtime.Intrinsics.Vector64<short> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> value1, System.Runtime.Intrinsics.Vector64<ushort> value2, System.Runtime.Intrinsics.Vector64<ushort> value3, System.Runtime.Intrinsics.Vector64<ushort> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2, System.Runtime.Intrinsics.Vector64<int> value3, System.Runtime.Intrinsics.Vector64<int> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2, System.Runtime.Intrinsics.Vector64<uint> value3, System.Runtime.Intrinsics.Vector64<uint> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2, System.Runtime.Intrinsics.Vector64<float> value3, System.Runtime.Intrinsics.Vector64<float> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Store(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2, System.Runtime.Intrinsics.Vector64<byte> Value3, System.Runtime.Intrinsics.Vector64<byte> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2, System.Runtime.Intrinsics.Vector64<sbyte> Value3, System.Runtime.Intrinsics.Vector64<sbyte> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2, System.Runtime.Intrinsics.Vector64<short> Value3, System.Runtime.Intrinsics.Vector64<short> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2, System.Runtime.Intrinsics.Vector64<ushort> Value3, System.Runtime.Intrinsics.Vector64<ushort> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2, System.Runtime.Intrinsics.Vector64<int> Value3, System.Runtime.Intrinsics.Vector64<int> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2, System.Runtime.Intrinsics.Vector64<uint> Value3, System.Runtime.Intrinsics.Vector64<uint> Value4) value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2, System.Runtime.Intrinsics.Vector64<float> Value3, System.Runtime.Intrinsics.Vector64<float> Value4) value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<byte> Subtract(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> Subtract(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> right) { throw null; }
@@ -4044,343 +3785,174 @@ namespace System.Runtime.Intrinsics.Arm
             public static System.Runtime.Intrinsics.Vector64<ushort> InsertSelectedScalar(System.Runtime.Intrinsics.Vector64<ushort> result, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte resultIndex, System.Runtime.Intrinsics.Vector64<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte valueIndex) { throw null; }
             public static System.Runtime.Intrinsics.Vector64<uint> InsertSelectedScalar(System.Runtime.Intrinsics.Vector64<uint> result, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte resultIndex, System.Runtime.Intrinsics.Vector128<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte valueIndex) { throw null; }
             public static System.Runtime.Intrinsics.Vector64<uint> InsertSelectedScalar(System.Runtime.Intrinsics.Vector64<uint> result, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte resultIndex, System.Runtime.Intrinsics.Vector64<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte valueIndex) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>, System.Runtime.Intrinsics.Vector128<byte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>, System.Runtime.Intrinsics.Vector128<sbyte>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index, sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>, System.Runtime.Intrinsics.Vector128<short>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>, System.Runtime.Intrinsics.Vector128<ushort>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index, ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>, System.Runtime.Intrinsics.Vector128<int>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>, System.Runtime.Intrinsics.Vector128<uint>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>, System.Runtime.Intrinsics.Vector128<long>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>, System.Runtime.Intrinsics.Vector128<ulong>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>, System.Runtime.Intrinsics.Vector128<float>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index, float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndInsertScalar((System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>, System.Runtime.Intrinsics.Vector128<double>) values, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index, double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadAndReplicateToVector128(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadAndReplicateToVector128(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadAndReplicateToVector128(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadAndReplicateToVector128x2(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadAndReplicateToVector128x2(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadAndReplicateToVector128x2(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadAndReplicateToVector128x2(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadAndReplicateToVector128x2(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadAndReplicateToVector128x2(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadAndReplicateToVector128x2(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadAndReplicateToVector128x2(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadAndReplicateToVector128x2(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadAndReplicateToVector128x2(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) LoadAndReplicateToVector128x3(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) LoadAndReplicateToVector128x3(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) LoadAndReplicateToVector128x3(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) LoadAndReplicateToVector128x3(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) LoadAndReplicateToVector128x3(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) LoadAndReplicateToVector128x3(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) LoadAndReplicateToVector128x3(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) LoadAndReplicateToVector128x3(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) LoadAndReplicateToVector128x3(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) LoadAndReplicateToVector128x3(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) LoadAndReplicateToVector128x4(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) LoadAndReplicateToVector128x4(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) LoadAndReplicateToVector128x4(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) LoadAndReplicateToVector128x4(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) LoadAndReplicateToVector128x4(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) LoadAndReplicateToVector128x4(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) LoadAndReplicateToVector128x4(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) LoadAndReplicateToVector128x4(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) LoadAndReplicateToVector128x4(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) LoadAndReplicateToVector128x4(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadPairScalarVector64(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadPairScalarVector64(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadPairScalarVector64(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadPairScalarVector64NonTemporal(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadPairScalarVector64NonTemporal(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadPairScalarVector64NonTemporal(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadPairVector128(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadPairVector128(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadPairVector128(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadPairVector128(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadPairVector128(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadPairVector128(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadPairVector128(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadPairVector128(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadPairVector128(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadPairVector128(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) LoadPairVector128NonTemporal(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) LoadPairVector128NonTemporal(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) LoadPairVector128NonTemporal(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) LoadPairVector128NonTemporal(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) LoadPairVector128NonTemporal(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) LoadPairVector128NonTemporal(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) LoadPairVector128NonTemporal(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) LoadPairVector128NonTemporal(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) LoadPairVector128NonTemporal(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) LoadPairVector128NonTemporal(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadPairVector64(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<double> Value1, System.Runtime.Intrinsics.Vector64<double> Value2) LoadPairVector64(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadPairVector64(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadPairVector64(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<long> Value1, System.Runtime.Intrinsics.Vector64<long> Value2) LoadPairVector64(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadPairVector64(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadPairVector64(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadPairVector64(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadPairVector64(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<ulong> Value1, System.Runtime.Intrinsics.Vector64<ulong> Value2) LoadPairVector64(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<byte> Value1, System.Runtime.Intrinsics.Vector64<byte> Value2) LoadPairVector64NonTemporal(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<double> Value1, System.Runtime.Intrinsics.Vector64<double> Value2) LoadPairVector64NonTemporal(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<short> Value1, System.Runtime.Intrinsics.Vector64<short> Value2) LoadPairVector64NonTemporal(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<int> Value1, System.Runtime.Intrinsics.Vector64<int> Value2) LoadPairVector64NonTemporal(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<long> Value1, System.Runtime.Intrinsics.Vector64<long> Value2) LoadPairVector64NonTemporal(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<sbyte> Value1, System.Runtime.Intrinsics.Vector64<sbyte> Value2) LoadPairVector64NonTemporal(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<float> Value1, System.Runtime.Intrinsics.Vector64<float> Value2) LoadPairVector64NonTemporal(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<ushort> Value1, System.Runtime.Intrinsics.Vector64<ushort> Value2) LoadPairVector64NonTemporal(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<uint> Value1, System.Runtime.Intrinsics.Vector64<uint> Value2) LoadPairVector64NonTemporal(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector64<ulong> Value1, System.Runtime.Intrinsics.Vector64<ulong> Value2) LoadPairVector64NonTemporal(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) Load2xVector128AndUnzip(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) Load2xVector128AndUnzip(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) Load2xVector128AndUnzip(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) Load2xVector128AndUnzip(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) Load2xVector128AndUnzip(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) Load2xVector128AndUnzip(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) Load2xVector128AndUnzip(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) Load2xVector128AndUnzip(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) Load2xVector128AndUnzip(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) Load2xVector128AndUnzip(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) Load3xVector128AndUnzip(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) Load3xVector128AndUnzip(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) Load3xVector128AndUnzip(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) Load3xVector128AndUnzip(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) Load3xVector128AndUnzip(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) Load3xVector128AndUnzip(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) Load3xVector128AndUnzip(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) Load3xVector128AndUnzip(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) Load3xVector128AndUnzip(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) Load3xVector128AndUnzip(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) Load4xVector128AndUnzip(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) Load4xVector128AndUnzip(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) Load4xVector128AndUnzip(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) Load4xVector128AndUnzip(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) Load4xVector128AndUnzip(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) Load4xVector128AndUnzip(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) Load4xVector128AndUnzip(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) Load4xVector128AndUnzip(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) Load4xVector128AndUnzip(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) Load4xVector128AndUnzip(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) Load2xVector128(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) Load2xVector128(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) Load2xVector128(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) Load2xVector128(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) Load2xVector128(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) Load2xVector128(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) Load2xVector128(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) Load2xVector128(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) Load2xVector128(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) Load2xVector128(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) Load3xVector128(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) Load3xVector128(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) Load3xVector128(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) Load3xVector128(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) Load3xVector128(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) Load3xVector128(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) Load3xVector128(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) Load3xVector128(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) Load3xVector128(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) Load3xVector128(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) Load4xVector128(byte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) Load4xVector128(sbyte* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) Load4xVector128(short* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) Load4xVector128(ushort* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) Load4xVector128(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) Load4xVector128(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) Load4xVector128(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) Load4xVector128(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) Load4xVector128(float* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) Load4xVector128(double* address) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<double> Max(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
             public static System.Runtime.Intrinsics.Vector64<byte> MaxAcross(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
@@ -4580,277 +4152,141 @@ namespace System.Runtime.Intrinsics.Arm
             public static System.Runtime.Intrinsics.Vector128<double> Sqrt(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<float> Sqrt(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector64<float> Sqrt(System.Runtime.Intrinsics.Vector64<float> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(byte* address, System.Runtime.Intrinsics.Vector128<byte> value1, System.Runtime.Intrinsics.Vector128<byte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(byte* address, System.Runtime.Intrinsics.Vector64<byte> value1, System.Runtime.Intrinsics.Vector64<byte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(double* address, System.Runtime.Intrinsics.Vector128<double> value1, System.Runtime.Intrinsics.Vector128<double> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(double* address, System.Runtime.Intrinsics.Vector64<double> value1, System.Runtime.Intrinsics.Vector64<double> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(short* address, System.Runtime.Intrinsics.Vector128<short> value1, System.Runtime.Intrinsics.Vector128<short> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(short* address, System.Runtime.Intrinsics.Vector64<short> value1, System.Runtime.Intrinsics.Vector64<short> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(int* address, System.Runtime.Intrinsics.Vector128<int> value1, System.Runtime.Intrinsics.Vector128<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(int* address, System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(long* address, System.Runtime.Intrinsics.Vector128<long> value1, System.Runtime.Intrinsics.Vector128<long> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(long* address, System.Runtime.Intrinsics.Vector64<long> value1, System.Runtime.Intrinsics.Vector64<long> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> value1, System.Runtime.Intrinsics.Vector128<sbyte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(sbyte* address, System.Runtime.Intrinsics.Vector64<sbyte> value1, System.Runtime.Intrinsics.Vector64<sbyte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(float* address, System.Runtime.Intrinsics.Vector128<float> value1, System.Runtime.Intrinsics.Vector128<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(float* address, System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> value1, System.Runtime.Intrinsics.Vector128<ushort> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(ushort* address, System.Runtime.Intrinsics.Vector64<ushort> value1, System.Runtime.Intrinsics.Vector64<ushort> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(uint* address, System.Runtime.Intrinsics.Vector128<uint> value1, System.Runtime.Intrinsics.Vector128<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(uint* address, System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> value1, System.Runtime.Intrinsics.Vector128<ulong> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePair(ulong* address, System.Runtime.Intrinsics.Vector64<ulong> value1, System.Runtime.Intrinsics.Vector64<ulong> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(byte* address, System.Runtime.Intrinsics.Vector128<byte> value1, System.Runtime.Intrinsics.Vector128<byte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(byte* address, System.Runtime.Intrinsics.Vector64<byte> value1, System.Runtime.Intrinsics.Vector64<byte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(double* address, System.Runtime.Intrinsics.Vector128<double> value1, System.Runtime.Intrinsics.Vector128<double> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(double* address, System.Runtime.Intrinsics.Vector64<double> value1, System.Runtime.Intrinsics.Vector64<double> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(short* address, System.Runtime.Intrinsics.Vector128<short> value1, System.Runtime.Intrinsics.Vector128<short> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(short* address, System.Runtime.Intrinsics.Vector64<short> value1, System.Runtime.Intrinsics.Vector64<short> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(int* address, System.Runtime.Intrinsics.Vector128<int> value1, System.Runtime.Intrinsics.Vector128<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(int* address, System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(long* address, System.Runtime.Intrinsics.Vector128<long> value1, System.Runtime.Intrinsics.Vector128<long> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(long* address, System.Runtime.Intrinsics.Vector64<long> value1, System.Runtime.Intrinsics.Vector64<long> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> value1, System.Runtime.Intrinsics.Vector128<sbyte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector64<sbyte> value1, System.Runtime.Intrinsics.Vector64<sbyte> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(float* address, System.Runtime.Intrinsics.Vector128<float> value1, System.Runtime.Intrinsics.Vector128<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(float* address, System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> value1, System.Runtime.Intrinsics.Vector128<ushort> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector64<ushort> value1, System.Runtime.Intrinsics.Vector64<ushort> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(uint* address, System.Runtime.Intrinsics.Vector128<uint> value1, System.Runtime.Intrinsics.Vector128<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(uint* address, System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> value1, System.Runtime.Intrinsics.Vector128<ulong> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector64<ulong> value1, System.Runtime.Intrinsics.Vector64<ulong> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalar(int* address, System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalar(float* address, System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalar(uint* address, System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalarNonTemporal(int* address, System.Runtime.Intrinsics.Vector64<int> value1, System.Runtime.Intrinsics.Vector64<int> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalarNonTemporal(float* address, System.Runtime.Intrinsics.Vector64<float> value1, System.Runtime.Intrinsics.Vector64<float> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StorePairScalarNonTemporal(uint* address, System.Runtime.Intrinsics.Vector64<uint> value1, System.Runtime.Intrinsics.Vector64<uint> value2) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector128<byte> value1, System.Runtime.Intrinsics.Vector128<byte> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> value1, System.Runtime.Intrinsics.Vector128<sbyte> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector128<short> value1, System.Runtime.Intrinsics.Vector128<short> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> value1, System.Runtime.Intrinsics.Vector128<ushort> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector128<int> value1, System.Runtime.Intrinsics.Vector128<int> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector128<uint> value1, System.Runtime.Intrinsics.Vector128<uint> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(long* address, (System.Runtime.Intrinsics.Vector128<long> value1, System.Runtime.Intrinsics.Vector128<long> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> value1, System.Runtime.Intrinsics.Vector128<ulong> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector128<float> value1, System.Runtime.Intrinsics.Vector128<float> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(double* address, (System.Runtime.Intrinsics.Vector128<double> value1, System.Runtime.Intrinsics.Vector128<double> value2) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector128<byte> value1, System.Runtime.Intrinsics.Vector128<byte> value2, System.Runtime.Intrinsics.Vector128<byte> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> value1, System.Runtime.Intrinsics.Vector128<sbyte> value2, System.Runtime.Intrinsics.Vector128<sbyte> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector128<short> value1, System.Runtime.Intrinsics.Vector128<short> value2, System.Runtime.Intrinsics.Vector128<short> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> value1, System.Runtime.Intrinsics.Vector128<ushort> value2, System.Runtime.Intrinsics.Vector128<ushort> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector128<int> value1, System.Runtime.Intrinsics.Vector128<int> value2, System.Runtime.Intrinsics.Vector128<int> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector128<uint> value1, System.Runtime.Intrinsics.Vector128<uint> value2, System.Runtime.Intrinsics.Vector128<uint> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(long* address, (System.Runtime.Intrinsics.Vector128<long> value1, System.Runtime.Intrinsics.Vector128<long> value2, System.Runtime.Intrinsics.Vector128<long> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> value1, System.Runtime.Intrinsics.Vector128<ulong> value2, System.Runtime.Intrinsics.Vector128<ulong> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector128<float> value1, System.Runtime.Intrinsics.Vector128<float> value2, System.Runtime.Intrinsics.Vector128<float> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(double* address, (System.Runtime.Intrinsics.Vector128<double> value1, System.Runtime.Intrinsics.Vector128<double> value2, System.Runtime.Intrinsics.Vector128<double> value3) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(byte* address, (System.Runtime.Intrinsics.Vector128<byte> value1, System.Runtime.Intrinsics.Vector128<byte> value2, System.Runtime.Intrinsics.Vector128<byte> value3, System.Runtime.Intrinsics.Vector128<byte> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> value1, System.Runtime.Intrinsics.Vector128<sbyte> value2, System.Runtime.Intrinsics.Vector128<sbyte> value3, System.Runtime.Intrinsics.Vector128<sbyte> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(15))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(short* address, (System.Runtime.Intrinsics.Vector128<short> value1, System.Runtime.Intrinsics.Vector128<short> value2, System.Runtime.Intrinsics.Vector128<short> value3, System.Runtime.Intrinsics.Vector128<short> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> value1, System.Runtime.Intrinsics.Vector128<ushort> value2, System.Runtime.Intrinsics.Vector128<ushort> value3, System.Runtime.Intrinsics.Vector128<ushort> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(7))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(int* address, (System.Runtime.Intrinsics.Vector128<int> value1, System.Runtime.Intrinsics.Vector128<int> value2, System.Runtime.Intrinsics.Vector128<int> value3, System.Runtime.Intrinsics.Vector128<int> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(uint* address, (System.Runtime.Intrinsics.Vector128<uint> value1, System.Runtime.Intrinsics.Vector128<uint> value2, System.Runtime.Intrinsics.Vector128<uint> value3, System.Runtime.Intrinsics.Vector128<uint> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(long* address, (System.Runtime.Intrinsics.Vector128<long> value1, System.Runtime.Intrinsics.Vector128<long> value2, System.Runtime.Intrinsics.Vector128<long> value3, System.Runtime.Intrinsics.Vector128<long> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> value1, System.Runtime.Intrinsics.Vector128<ulong> value2, System.Runtime.Intrinsics.Vector128<ulong> value3, System.Runtime.Intrinsics.Vector128<ulong> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(float* address, (System.Runtime.Intrinsics.Vector128<float> value1, System.Runtime.Intrinsics.Vector128<float> value2, System.Runtime.Intrinsics.Vector128<float> value3, System.Runtime.Intrinsics.Vector128<float> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(3))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreSelectedScalar(double* address, (System.Runtime.Intrinsics.Vector128<double> value1, System.Runtime.Intrinsics.Vector128<double> value2, System.Runtime.Intrinsics.Vector128<double> value3, System.Runtime.Intrinsics.Vector128<double> value4) value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(1))] byte index) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void StoreVectorAndZip(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreVectorAndZip(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static void Store(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, System.Runtime.Intrinsics.Vector128<short> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(byte* address, (System.Runtime.Intrinsics.Vector128<byte> Value1, System.Runtime.Intrinsics.Vector128<byte> Value2, System.Runtime.Intrinsics.Vector128<byte> Value3, System.Runtime.Intrinsics.Vector128<byte> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(sbyte* address, (System.Runtime.Intrinsics.Vector128<sbyte> Value1, System.Runtime.Intrinsics.Vector128<sbyte> Value2, System.Runtime.Intrinsics.Vector128<sbyte> Value3, System.Runtime.Intrinsics.Vector128<sbyte> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(short* address, (System.Runtime.Intrinsics.Vector128<short> Value1, System.Runtime.Intrinsics.Vector128<short> Value2, Vector128<short> Value3, System.Runtime.Intrinsics.Vector128<short> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(ushort* address, (System.Runtime.Intrinsics.Vector128<ushort> Value1, System.Runtime.Intrinsics.Vector128<ushort> Value2, System.Runtime.Intrinsics.Vector128<ushort> Value3, System.Runtime.Intrinsics.Vector128<ushort> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(int* address, (System.Runtime.Intrinsics.Vector128<int> Value1, System.Runtime.Intrinsics.Vector128<int> Value2, System.Runtime.Intrinsics.Vector128<int> Value3, System.Runtime.Intrinsics.Vector128<int> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(uint* address, (System.Runtime.Intrinsics.Vector128<uint> Value1, System.Runtime.Intrinsics.Vector128<uint> Value2, System.Runtime.Intrinsics.Vector128<uint> Value3, System.Runtime.Intrinsics.Vector128<uint> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(long* address, (System.Runtime.Intrinsics.Vector128<long> Value1, System.Runtime.Intrinsics.Vector128<long> Value2, System.Runtime.Intrinsics.Vector128<long> Value3, System.Runtime.Intrinsics.Vector128<long> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(ulong* address, (System.Runtime.Intrinsics.Vector128<ulong> Value1, System.Runtime.Intrinsics.Vector128<ulong> Value2, System.Runtime.Intrinsics.Vector128<ulong> Value3, System.Runtime.Intrinsics.Vector128<ulong> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(float* address, (System.Runtime.Intrinsics.Vector128<float> Value1, System.Runtime.Intrinsics.Vector128<float> Value2, System.Runtime.Intrinsics.Vector128<float> Value3, System.Runtime.Intrinsics.Vector128<float> Value4) value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void Store(double* address, (System.Runtime.Intrinsics.Vector128<double> Value1, System.Runtime.Intrinsics.Vector128<double> Value2, System.Runtime.Intrinsics.Vector128<double> Value3, System.Runtime.Intrinsics.Vector128<double> Value4) value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<double> Subtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
             public static System.Runtime.Intrinsics.Vector64<byte> SubtractSaturateScalar(System.Runtime.Intrinsics.Vector64<byte> left, System.Runtime.Intrinsics.Vector64<byte> right) { throw null; }
@@ -5703,489 +5139,281 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<float> FusedMultiplySubtractBySelectedScalar(System.Numerics.Vector<float> minuend, System.Numerics.Vector<float> left, System.Numerics.Vector<float> right, [ConstantExpected] byte rightIndex) { throw null; }
         public static System.Numerics.Vector<double> FusedMultiplySubtractNegated(System.Numerics.Vector<double> minuend, System.Numerics.Vector<double> left, System.Numerics.Vector<double> right) { throw null; }
         public static System.Numerics.Vector<float> FusedMultiplySubtractNegated(System.Numerics.Vector<float> minuend, System.Numerics.Vector<float> left, System.Numerics.Vector<float> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<short> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch16Bit(System.Numerics.Vector<ushort> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<int> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch32Bit(System.Numerics.Vector<uint> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<long> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, void* address, System.Numerics.Vector<int> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, void* address, System.Numerics.Vector<long> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, void* address, System.Numerics.Vector<uint> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch64Bit(System.Numerics.Vector<ulong> mask, void* address, System.Numerics.Vector<ulong> indices, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, void* address, System.Numerics.Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, void* address, System.Numerics.Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, void* address, System.Numerics.Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<byte> mask, void* address, System.Numerics.Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, void* address, System.Numerics.Vector<int> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, void* address, System.Numerics.Vector<long> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         // public static void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, System.Numerics.Vector<uint> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, void* address, System.Numerics.Vector<uint> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, System.Numerics.Vector<ulong> addresses, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void GatherPrefetch8Bit(System.Numerics.Vector<sbyte> mask, void* address, System.Numerics.Vector<ulong> offsets, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVector(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<double> GatherVector(System.Numerics.Vector<double> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVector(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVector(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVector(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVector(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVector(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVector(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVector(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVector(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<float> GatherVector(System.Numerics.Vector<float> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVector(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVector(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVector(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVector(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVector(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVector(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVector(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorByteZeroExtend(System.Numerics.Vector<int> mask, byte* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorByteZeroExtend(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorByteZeroExtend(System.Numerics.Vector<int> mask, byte* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorByteZeroExtend(System.Numerics.Vector<long> mask, byte* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorByteZeroExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorByteZeroExtend(System.Numerics.Vector<long> mask, byte* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorByteZeroExtend(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorByteZeroExtend(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorByteZeroExtend(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorByteZeroExtend(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorByteZeroExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorByteZeroExtend(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, byte* address, System.Numerics.Vector<int> offsets) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, byte* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, byte* address, System.Numerics.Vector<long> offsets) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, byte* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<int> offsets) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<long> offsets) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorFirstFaulting(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<double> GatherVectorFirstFaulting(System.Numerics.Vector<double> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorFirstFaulting(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorFirstFaulting(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorFirstFaulting(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorFirstFaulting(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorFirstFaulting(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorFirstFaulting(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorFirstFaulting(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<float> GatherVectorFirstFaulting(System.Numerics.Vector<float> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorFirstFaulting(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorFirstFaulting(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorFirstFaulting(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorFirstFaulting(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorFirstFaulting(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorFirstFaulting(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16SignExtend(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorInt16SignExtend(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16SignExtend(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16SignExtend(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorInt16SignExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16SignExtend(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16SignExtend(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorInt16SignExtend(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16SignExtend(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16SignExtend(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorInt16SignExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16SignExtend(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtend(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32SignExtend(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, short* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt16WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, short* address, System.Numerics.Vector<ulong> offsets) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorInt32SignExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32SignExtend(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32SignExtend(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorInt32SignExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32SignExtend(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> indices) { throw null; }
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32WithByteOffsetsSignExtend(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtend(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorInt32WithByteOffsetsSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, int* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorSByteSignExtend(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorSByteSignExtend(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorSByteSignExtend(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorSByteSignExtend(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorSByteSignExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorSByteSignExtend(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorSByteSignExtend(System.Numerics.Vector<uint> mask, sbyte* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorSByteSignExtend(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorSByteSignExtend(System.Numerics.Vector<uint> mask, sbyte* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorSByteSignExtend(System.Numerics.Vector<ulong> mask, sbyte* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorSByteSignExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorSByteSignExtend(System.Numerics.Vector<ulong> mask, sbyte* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<int> offsets) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<long> offsets) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, sbyte* address, System.Numerics.Vector<int> offsets) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, sbyte* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, sbyte* address, System.Numerics.Vector<long> offsets) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, sbyte* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtend(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtend(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static System.Numerics.Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, ushort* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, ushort* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> indices) { throw null; }
         // public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtend(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtend(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32WithByteOffsetsZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtend(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, uint* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> indices) { throw null; }
         public static System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> indices) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorWithByteOffsetFirstFaulting(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorWithByteOffsets(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> GatherVectorWithByteOffsets(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorWithByteOffsets(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> GatherVectorWithByteOffsets(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorWithByteOffsets(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> GatherVectorWithByteOffsets(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorWithByteOffsets(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> GatherVectorWithByteOffsets(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorWithByteOffsets(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> GatherVectorWithByteOffsets(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorWithByteOffsets(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> offsets) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> GatherVectorWithByteOffsets(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> offsets) { throw null; }
         public static ulong GetActiveElementCount(System.Numerics.Vector<byte> mask, System.Numerics.Vector<byte> from) { throw null; }
         public static ulong GetActiveElementCount(System.Numerics.Vector<double> mask, System.Numerics.Vector<double> from) { throw null; }
@@ -6229,309 +5457,157 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<uint> LeadingZeroCount(System.Numerics.Vector<uint> value) { throw null; }
         public static System.Numerics.Vector<ulong> LeadingZeroCount(System.Numerics.Vector<long> value) { throw null; }
         public static System.Numerics.Vector<ulong> LeadingZeroCount(System.Numerics.Vector<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<byte> LoadVector(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> LoadVector(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVector(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVector(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVector(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<sbyte> LoadVector(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> LoadVector(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVector(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVector(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVector(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<byte> LoadVector128AndReplicateToVector(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> LoadVector128AndReplicateToVector(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVector128AndReplicateToVector(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVector128AndReplicateToVector(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVector128AndReplicateToVector(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<sbyte> LoadVector128AndReplicateToVector(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> LoadVector128AndReplicateToVector(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVector128AndReplicateToVector(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVector128AndReplicateToVector(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVector128AndReplicateToVector(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorByteNonFaultingZeroExtendToInt16(System.Numerics.Vector<short> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorByteNonFaultingZeroExtendToInt32(System.Numerics.Vector<int> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorByteNonFaultingZeroExtendToInt64(System.Numerics.Vector<long> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorByteNonFaultingZeroExtendToUInt16(System.Numerics.Vector<ushort> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorByteNonFaultingZeroExtendToUInt32(System.Numerics.Vector<uint> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorByteNonFaultingZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<short> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<ushort> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorByteZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorByteZeroExtendToInt16(System.Numerics.Vector<short> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorByteZeroExtendToInt32(System.Numerics.Vector<int> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorByteZeroExtendToInt64(System.Numerics.Vector<long> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorByteZeroExtendToUInt16(System.Numerics.Vector<ushort> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorByteZeroExtendToUInt32(System.Numerics.Vector<uint> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorByteZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorInt16NonFaultingSignExtendToInt32(System.Numerics.Vector<int> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt16NonFaultingSignExtendToInt64(System.Numerics.Vector<long> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorInt16NonFaultingSignExtendToUInt32(System.Numerics.Vector<uint> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt16NonFaultingSignExtendToUInt64(System.Numerics.Vector<ulong> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<int> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<long> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<uint> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt16SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorInt16SignExtendToInt32(System.Numerics.Vector<int> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt16SignExtendToInt64(System.Numerics.Vector<long> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorInt16SignExtendToUInt32(System.Numerics.Vector<uint> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt16SignExtendToUInt64(System.Numerics.Vector<ulong> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt32NonFaultingSignExtendToInt64(System.Numerics.Vector<long> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt32NonFaultingSignExtendToUInt64(System.Numerics.Vector<ulong> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<long> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt32SignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorInt32SignExtendToInt64(System.Numerics.Vector<long> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorInt32SignExtendToUInt64(System.Numerics.Vector<ulong> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<byte> LoadVectorNonFaulting(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> LoadVectorNonFaulting(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorNonFaulting(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorNonFaulting(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorNonFaulting(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<sbyte> LoadVectorNonFaulting(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> LoadVectorNonFaulting(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorNonFaulting(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorNonFaulting(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorNonFaulting(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<byte> LoadVectorNonTemporal(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> LoadVectorNonTemporal(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorNonTemporal(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorNonTemporal(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorNonTemporal(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<sbyte> LoadVectorNonTemporal(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> LoadVectorNonTemporal(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorNonTemporal(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorNonTemporal(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<byte> LoadVectorFirstFaulting(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<double> LoadVectorFirstFaulting(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorFirstFaulting(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorFirstFaulting(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorFirstFaulting(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<sbyte> LoadVectorFirstFaulting(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<float> LoadVectorFirstFaulting(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorFirstFaulting(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorFirstFaulting(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorFirstFaulting(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorSByteNonFaultingSignExtendToInt16(System.Numerics.Vector<short> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorSByteNonFaultingSignExtendToInt32(System.Numerics.Vector<int> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorSByteNonFaultingSignExtendToInt64(System.Numerics.Vector<long> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorSByteNonFaultingSignExtendToUInt16(System.Numerics.Vector<ushort> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorSByteNonFaultingSignExtendToUInt32(System.Numerics.Vector<uint> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorSByteNonFaultingSignExtendToUInt64(System.Numerics.Vector<ulong> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<short> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<int> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<long> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<ushort> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<uint> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorSByteSignExtendFirstFaulting(System.Numerics.Vector<ulong> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<short> LoadVectorSByteSignExtendToInt16(System.Numerics.Vector<short> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorSByteSignExtendToInt32(System.Numerics.Vector<int> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorSByteSignExtendToInt64(System.Numerics.Vector<long> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ushort> LoadVectorSByteSignExtendToUInt16(System.Numerics.Vector<ushort> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorSByteSignExtendToUInt32(System.Numerics.Vector<uint> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorSByteSignExtendToUInt64(System.Numerics.Vector<ulong> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorUInt16NonFaultingZeroExtendToInt32(System.Numerics.Vector<int> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt16NonFaultingZeroExtendToInt64(System.Numerics.Vector<long> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorUInt16NonFaultingZeroExtendToUInt32(System.Numerics.Vector<uint> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt16NonFaultingZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<int> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<uint> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt16ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<int> LoadVectorUInt16ZeroExtendToInt32(System.Numerics.Vector<int> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt16ZeroExtendToInt64(System.Numerics.Vector<long> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<uint> LoadVectorUInt16ZeroExtendToUInt32(System.Numerics.Vector<uint> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt16ZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt32NonFaultingZeroExtendToInt64(System.Numerics.Vector<long> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt32NonFaultingZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<long> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt32ZeroExtendFirstFaulting(System.Numerics.Vector<ulong> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<long> LoadVectorUInt32ZeroExtendToInt64(System.Numerics.Vector<long> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Numerics.Vector<ulong> LoadVectorUInt32ZeroExtendToUInt64(System.Numerics.Vector<ulong> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<byte>, System.Numerics.Vector<byte>) Load2xVectorAndUnzip(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<double>, System.Numerics.Vector<double>) Load2xVectorAndUnzip(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<short>, System.Numerics.Vector<short>) Load2xVectorAndUnzip(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<int>, System.Numerics.Vector<int>) Load2xVectorAndUnzip(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<long>, System.Numerics.Vector<long>) Load2xVectorAndUnzip(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>) Load2xVectorAndUnzip(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<float>, System.Numerics.Vector<float>) Load2xVectorAndUnzip(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>) Load2xVectorAndUnzip(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<uint>, System.Numerics.Vector<uint>) Load2xVectorAndUnzip(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>) Load2xVectorAndUnzip(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<byte>, System.Numerics.Vector<byte>, System.Numerics.Vector<byte>) Load3xVectorAndUnzip(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<double>, System.Numerics.Vector<double>, System.Numerics.Vector<double>) Load3xVectorAndUnzip(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<short>, System.Numerics.Vector<short>, System.Numerics.Vector<short>) Load3xVectorAndUnzip(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<int>, System.Numerics.Vector<int>, System.Numerics.Vector<int>) Load3xVectorAndUnzip(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<long>, System.Numerics.Vector<long>, System.Numerics.Vector<long>) Load3xVectorAndUnzip(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>) Load3xVectorAndUnzip(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<float>, System.Numerics.Vector<float>, System.Numerics.Vector<float>) Load3xVectorAndUnzip(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>) Load3xVectorAndUnzip(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<uint>, System.Numerics.Vector<uint>, System.Numerics.Vector<uint>) Load3xVectorAndUnzip(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>) Load3xVectorAndUnzip(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<byte>, System.Numerics.Vector<byte>, System.Numerics.Vector<byte>, System.Numerics.Vector<byte>) Load4xVectorAndUnzip(System.Numerics.Vector<byte> mask, byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<double>, System.Numerics.Vector<double>, System.Numerics.Vector<double>, System.Numerics.Vector<double>) Load4xVectorAndUnzip(System.Numerics.Vector<double> mask, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<short>, System.Numerics.Vector<short>, System.Numerics.Vector<short>, System.Numerics.Vector<short>) Load4xVectorAndUnzip(System.Numerics.Vector<short> mask, short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<int>, System.Numerics.Vector<int>, System.Numerics.Vector<int>, System.Numerics.Vector<int>) Load4xVectorAndUnzip(System.Numerics.Vector<int> mask, int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<long>, System.Numerics.Vector<long>, System.Numerics.Vector<long>, System.Numerics.Vector<long>) Load4xVectorAndUnzip(System.Numerics.Vector<long> mask, long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>, System.Numerics.Vector<sbyte>) Load4xVectorAndUnzip(System.Numerics.Vector<sbyte> mask, sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<float>, System.Numerics.Vector<float>, System.Numerics.Vector<float>, System.Numerics.Vector<float>) Load4xVectorAndUnzip(System.Numerics.Vector<float> mask, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>, System.Numerics.Vector<ushort>) Load4xVectorAndUnzip(System.Numerics.Vector<ushort> mask, ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<uint>, System.Numerics.Vector<uint>, System.Numerics.Vector<uint>, System.Numerics.Vector<uint>) Load4xVectorAndUnzip(System.Numerics.Vector<uint> mask, uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe (System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>, System.Numerics.Vector<ulong>) Load4xVectorAndUnzip(System.Numerics.Vector<ulong> mask, ulong* address) { throw null; }
         public static System.Numerics.Vector<byte> Max(System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
         public static System.Numerics.Vector<double> Max(System.Numerics.Vector<double> left, System.Numerics.Vector<double> right) { throw null; }
@@ -6654,13 +5730,9 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ulong> PopCount(System.Numerics.Vector<double> value) { throw null; }
         public static System.Numerics.Vector<ulong> PopCount(System.Numerics.Vector<long> value) { throw null; }
         public static System.Numerics.Vector<ulong> PopCount(System.Numerics.Vector<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch16Bit(System.Numerics.Vector<ushort> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch32Bit(System.Numerics.Vector<uint> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch64Bit(System.Numerics.Vector<ulong> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch8Bit(System.Numerics.Vector<byte> mask, void* address, [ConstantExpected] SvePrefetchType prefetchType) { throw null; }
         public static System.Numerics.Vector<double> ReciprocalEstimate(System.Numerics.Vector<double> value) { throw null; }
         public static System.Numerics.Vector<float> ReciprocalEstimate(System.Numerics.Vector<float> value) { throw null; }
@@ -6802,133 +5874,77 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ulong> SaturatingIncrementByActiveElementCount(System.Numerics.Vector<ulong> value, System.Numerics.Vector<ulong> from) { throw null; }
         public static System.Numerics.Vector<double> Scale(System.Numerics.Vector<double> left, System.Numerics.Vector<long> right) { throw null; }
         public static System.Numerics.Vector<float> Scale(System.Numerics.Vector<float> left, System.Numerics.Vector<int> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> indicies, System.Numerics.Vector<double> data) { throw null; }
         public static unsafe void Scatter(System.Numerics.Vector<double> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> indicies, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> indicies, System.Numerics.Vector<int> data) { throw null; }
         // public static void Scatter(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> indicies, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> indicies, System.Numerics.Vector<long> data) { throw null; }
         public static void Scatter(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> indicies, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> indicies, System.Numerics.Vector<float> data) { throw null; }
         // public static void Scatter(System.Numerics.Vector<float> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> indicies, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> indicies, System.Numerics.Vector<uint> data) { throw null; }
         // public static void Scatter(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> indicies, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> indicies, System.Numerics.Vector<ulong> data) { throw null; }
         public static void Scatter(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> indicies, System.Numerics.Vector<ulong> data) { throw null; }
         // public static void Scatter16BitNarrowing(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<int> data) { throw null; }
         public static void Scatter16BitNarrowing(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         // public static void Scatter16BitNarrowing(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> indices, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> indices, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> indices, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> indices, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowing(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowing(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         // public static void Scatter8BitNarrowing(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<int> data) { throw null; }
         public static void Scatter8BitNarrowing(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         // public static void Scatter8BitNarrowing(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
         public static void Scatter8BitNarrowing(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowing(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<int> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsets(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         public static void SetFfr(System.Numerics.Vector<double> value) { throw null; }
         public static void SetFfr(System.Numerics.Vector<byte> value) { throw null; }
@@ -6996,129 +6012,67 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ulong> Splice(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right) { throw null; }
         public static System.Numerics.Vector<double> Sqrt(System.Numerics.Vector<double> value) { throw null; }
         public static System.Numerics.Vector<float> Sqrt(System.Numerics.Vector<float> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<byte> mask, byte* address, System.Numerics.Vector<byte> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<byte> mask, byte* address, (System.Numerics.Vector<byte> Value1, System.Numerics.Vector<byte> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<byte> mask, byte* address, (System.Numerics.Vector<byte> Value1, System.Numerics.Vector<byte> Value2, System.Numerics.Vector<byte> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<byte> mask, byte* address, (System.Numerics.Vector<byte> Value1, System.Numerics.Vector<byte> Value2, System.Numerics.Vector<byte> Value3, System.Numerics.Vector<byte> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<double> mask, double* address, (System.Numerics.Vector<double> Value1, System.Numerics.Vector<double> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<double> mask, double* address, (System.Numerics.Vector<double> Value1, System.Numerics.Vector<double> Value2, System.Numerics.Vector<double> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<double> mask, double* address, (System.Numerics.Vector<double> Value1, System.Numerics.Vector<double> Value2, System.Numerics.Vector<double> Value3, System.Numerics.Vector<double> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<short> mask, short* address, System.Numerics.Vector<short> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<short> mask, short* address, (System.Numerics.Vector<short> Value1, System.Numerics.Vector<short> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<short> mask, short* address, (System.Numerics.Vector<short> Value1, System.Numerics.Vector<short> Value2, System.Numerics.Vector<short> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<short> mask, short* address, (System.Numerics.Vector<short> Value1, System.Numerics.Vector<short> Value2, System.Numerics.Vector<short> Value3, System.Numerics.Vector<short> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<int> mask, int* address, (System.Numerics.Vector<int> Value1, System.Numerics.Vector<int> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<int> mask, int* address, (System.Numerics.Vector<int> Value1, System.Numerics.Vector<int> Value2, System.Numerics.Vector<int> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<int> mask, int* address, (System.Numerics.Vector<int> Value1, System.Numerics.Vector<int> Value2, System.Numerics.Vector<int> Value3, System.Numerics.Vector<int> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<long> mask, long* address, (System.Numerics.Vector<long> Value1, System.Numerics.Vector<long> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<long> mask, long* address, (System.Numerics.Vector<long> Value1, System.Numerics.Vector<long> Value2, System.Numerics.Vector<long> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<long> mask, long* address, (System.Numerics.Vector<long> Value1, System.Numerics.Vector<long> Value2, System.Numerics.Vector<long> Value3, System.Numerics.Vector<long> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<sbyte> mask, sbyte* address, System.Numerics.Vector<sbyte> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<sbyte> mask, sbyte* address, (System.Numerics.Vector<sbyte> Value1, System.Numerics.Vector<sbyte> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<sbyte> mask, sbyte* address, (System.Numerics.Vector<sbyte> Value1, System.Numerics.Vector<sbyte> Value2, System.Numerics.Vector<sbyte> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<sbyte> mask, sbyte* address, (System.Numerics.Vector<sbyte> Value1, System.Numerics.Vector<sbyte> Value2, System.Numerics.Vector<sbyte> Value3, System.Numerics.Vector<sbyte> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<float> mask, float* address, (System.Numerics.Vector<float> Value1, System.Numerics.Vector<float> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<float> mask, float* address, (System.Numerics.Vector<float> Value1, System.Numerics.Vector<float> Value2, System.Numerics.Vector<float> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<float> mask, float* address, (System.Numerics.Vector<float> Value1, System.Numerics.Vector<float> Value2, System.Numerics.Vector<float> Value3, System.Numerics.Vector<float> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ushort> mask, ushort* address, System.Numerics.Vector<ushort> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ushort> mask, ushort* address, (System.Numerics.Vector<ushort> Value1, System.Numerics.Vector<ushort> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ushort> mask, ushort* address, (System.Numerics.Vector<ushort> Value1, System.Numerics.Vector<ushort> Value2, System.Numerics.Vector<ushort> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ushort> mask, ushort* address, (System.Numerics.Vector<ushort> Value1, System.Numerics.Vector<ushort> Value2, System.Numerics.Vector<ushort> Value3, System.Numerics.Vector<ushort> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<uint> mask, uint* address, (System.Numerics.Vector<uint> Value1, System.Numerics.Vector<uint> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<uint> mask, uint* address, (System.Numerics.Vector<uint> Value1, System.Numerics.Vector<uint> Value2, System.Numerics.Vector<uint> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<uint> mask, uint* address, (System.Numerics.Vector<uint> Value1, System.Numerics.Vector<uint> Value2, System.Numerics.Vector<uint> Value3, System.Numerics.Vector<uint> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ulong> mask, ulong* address, (System.Numerics.Vector<ulong> Value1, System.Numerics.Vector<ulong> Value2) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ulong> mask, ulong* address, (System.Numerics.Vector<ulong> Value1, System.Numerics.Vector<ulong> Value2, System.Numerics.Vector<ulong> Value3) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAndZip(System.Numerics.Vector<ulong> mask, ulong* address, (System.Numerics.Vector<ulong> Value1, System.Numerics.Vector<ulong> Value2, System.Numerics.Vector<ulong> Value3, System.Numerics.Vector<ulong> Value4) data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<short> mask, sbyte* address, System.Numerics.Vector<short> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<ushort> mask, byte* address, System.Numerics.Vector<ushort> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNarrowing(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<byte> mask, byte* address, System.Numerics.Vector<byte> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<short> mask, short* address, System.Numerics.Vector<short> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<sbyte> mask, sbyte* address, System.Numerics.Vector<sbyte> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<ushort> mask, ushort* address, System.Numerics.Vector<ushort> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> data) { throw null; }
         public static System.Numerics.Vector<byte> Subtract(System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
         public static System.Numerics.Vector<double> Subtract(System.Numerics.Vector<double> left, System.Numerics.Vector<double> right) { throw null; }
@@ -7816,59 +6770,35 @@ namespace System.Runtime.Intrinsics.Arm
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         // public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<int> mask, short* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, short* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<uint> mask, ushort* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter16BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, ushort* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, int* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter32BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, uint* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         // public static unsafe void Scatter8BitNarrowingNonTemporal(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<int> data) { throw null; }
         public static unsafe void Scatter8BitNarrowingNonTemporal(System.Numerics.Vector<long> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<long> data) { throw null; }
         // public static unsafe void Scatter8BitNarrowingNonTemporal(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
         public static unsafe void Scatter8BitNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<int> mask, sbyte* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<long> mask, sbyte* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<uint> mask, byte* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Scatter8BitWithByteOffsetsNarrowingNonTemporal(System.Numerics.Vector<ulong> mask, byte* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<double> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<double> data) { throw null; }
         // public static unsafe void ScatterNonTemporal(System.Numerics.Vector<int> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<int> data) { throw null; }
@@ -7876,35 +6806,20 @@ namespace System.Runtime.Intrinsics.Arm
         // public static unsafe void ScatterNonTemporal(System.Numerics.Vector<float> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<float> data) { throw null; }
         // public static unsafe void ScatterNonTemporal(System.Numerics.Vector<uint> mask, System.Numerics.Vector<uint> addresses, System.Numerics.Vector<uint> data) { throw null; }
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<ulong> mask, System.Numerics.Vector<ulong> addresses, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> indices, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<double> mask, double* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<double> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<int> mask, int* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<int> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<long> mask, long* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<long> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<float> mask, float* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<float> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<uint> mask, uint* address, System.Numerics.Vector<uint> offsets, System.Numerics.Vector<uint> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<long> offsets, System.Numerics.Vector<ulong> data) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void ScatterWithByteOffsetsNonTemporal(System.Numerics.Vector<ulong> mask, ulong* address, System.Numerics.Vector<ulong> offsets, System.Numerics.Vector<ulong> data) { throw null; }
         public static System.Numerics.Vector<short> ShiftArithmeticRounded(System.Numerics.Vector<short> value, System.Numerics.Vector<short> count) { throw null; }
         public static System.Numerics.Vector<int> ShiftArithmeticRounded(System.Numerics.Vector<int> value, System.Numerics.Vector<int> count) { throw null; }
@@ -8223,15 +7138,10 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<float> Blend(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> BlendVariable(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right, System.Runtime.Intrinsics.Vector256<double> mask) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> BlendVariable(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right, System.Runtime.Intrinsics.Vector256<float> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> BroadcastScalarToVector128(float* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> BroadcastScalarToVector256(double* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> BroadcastScalarToVector256(float* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> BroadcastVector128ToVector256(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> BroadcastVector128ToVector256(float* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Ceiling(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Ceiling(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
@@ -8305,77 +7215,41 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> LoadAlignedVector256(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> LoadAlignedVector256(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> LoadAlignedVector256(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> LoadAlignedVector256(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> LoadAlignedVector256(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> LoadAlignedVector256(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> LoadAlignedVector256(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> LoadAlignedVector256(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> LoadAlignedVector256(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> LoadAlignedVector256(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> LoadDquVector256(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> LoadDquVector256(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> LoadDquVector256(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> LoadDquVector256(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> LoadDquVector256(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> LoadDquVector256(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> LoadDquVector256(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> LoadDquVector256(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> LoadVector256(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> LoadVector256(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> LoadVector256(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> LoadVector256(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> LoadVector256(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> LoadVector256(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> LoadVector256(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> LoadVector256(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> LoadVector256(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> LoadVector256(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { }
         public static System.Runtime.Intrinsics.Vector256<double> Max(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Max(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
@@ -8421,65 +7295,35 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<float> Shuffle(System.Runtime.Intrinsics.Vector256<float> value, System.Runtime.Intrinsics.Vector256<float> right, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> Sqrt(System.Runtime.Intrinsics.Vector256<double> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Sqrt(System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(byte* address, System.Runtime.Intrinsics.Vector256<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(double* address, System.Runtime.Intrinsics.Vector256<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(short* address, System.Runtime.Intrinsics.Vector256<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(int* address, System.Runtime.Intrinsics.Vector256<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(long* address, System.Runtime.Intrinsics.Vector256<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(float* address, System.Runtime.Intrinsics.Vector256<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(uint* address, System.Runtime.Intrinsics.Vector256<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> source) { }
         public static System.Runtime.Intrinsics.Vector256<double> Subtract(System.Runtime.Intrinsics.Vector256<double> left, System.Runtime.Intrinsics.Vector256<double> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<float> Subtract(System.Runtime.Intrinsics.Vector256<float> left, System.Runtime.Intrinsics.Vector256<float> right) { throw null; }
@@ -8591,13 +7435,9 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<ushort> BlendVariable(System.Runtime.Intrinsics.Vector256<ushort> left, System.Runtime.Intrinsics.Vector256<ushort> right, System.Runtime.Intrinsics.Vector256<ushort> mask) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<uint> BlendVariable(System.Runtime.Intrinsics.Vector256<uint> left, System.Runtime.Intrinsics.Vector256<uint> right, System.Runtime.Intrinsics.Vector256<uint> mask) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> BlendVariable(System.Runtime.Intrinsics.Vector256<ulong> left, System.Runtime.Intrinsics.Vector256<ulong> right, System.Runtime.Intrinsics.Vector256<ulong> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> BroadcastScalarToVector128(byte* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> BroadcastScalarToVector128(short* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> BroadcastScalarToVector128(int* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> BroadcastScalarToVector128(long* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<byte> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
@@ -8609,21 +7449,13 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<ushort> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<uint> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<ulong> BroadcastScalarToVector128(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> BroadcastScalarToVector128(sbyte* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> BroadcastScalarToVector128(ushort* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> BroadcastScalarToVector128(uint* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> BroadcastScalarToVector128(ulong* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> BroadcastScalarToVector256(byte* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> BroadcastScalarToVector256(short* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> BroadcastScalarToVector256(int* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> BroadcastScalarToVector256(long* source) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<byte> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<double> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
@@ -8635,29 +7467,17 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<ushort> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<uint> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> BroadcastScalarToVector256(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> BroadcastScalarToVector256(sbyte* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> BroadcastScalarToVector256(ushort* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> BroadcastScalarToVector256(uint* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> BroadcastScalarToVector256(ulong* source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> BroadcastVector128ToVector256(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> BroadcastVector128ToVector256(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> BroadcastVector128ToVector256(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> BroadcastVector128ToVector256(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> BroadcastVector128ToVector256(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> BroadcastVector128ToVector256(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> BroadcastVector128ToVector256(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> BroadcastVector128ToVector256(ulong* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<byte> CompareEqual(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<short> CompareEqual(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
@@ -8673,29 +7493,20 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<sbyte> CompareGreaterThan(System.Runtime.Intrinsics.Vector256<sbyte> left, System.Runtime.Intrinsics.Vector256<sbyte> right) { throw null; }
         public static int ConvertToInt32(System.Runtime.Intrinsics.Vector256<int> value) { throw null; }
         public static uint ConvertToUInt32(System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> ConvertToVector256Int16(byte* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<short> ConvertToVector256Int16(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<short> ConvertToVector256Int16(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> ConvertToVector256Int16(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(short* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> ConvertToVector256Int32(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(int* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
@@ -8703,11 +7514,8 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ConvertToVector256Int64(uint* address) { throw null; }
         public static new System.Runtime.Intrinsics.Vector128<byte> ExtractVector128(System.Runtime.Intrinsics.Vector256<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static new System.Runtime.Intrinsics.Vector128<short> ExtractVector128(System.Runtime.Intrinsics.Vector256<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
@@ -8717,101 +7525,53 @@ namespace System.Runtime.Intrinsics.X86
         public static new System.Runtime.Intrinsics.Vector128<ushort> ExtractVector128(System.Runtime.Intrinsics.Vector256<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static new System.Runtime.Intrinsics.Vector128<uint> ExtractVector128(System.Runtime.Intrinsics.Vector256<uint> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static new System.Runtime.Intrinsics.Vector128<ulong> ExtractVector128(System.Runtime.Intrinsics.Vector256<ulong> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<double> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<double> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<int> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<int> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<int> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<long> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<long> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<float> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<float> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<float> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<uint> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<uint> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector128<uint> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector128<ulong> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> GatherMaskVector128(System.Runtime.Intrinsics.Vector128<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, System.Runtime.Intrinsics.Vector128<ulong> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<double> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<double> source, double* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<double> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<int> source, int* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<int> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<long> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<long> source, long* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<long> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<float> source, float* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<float> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<uint> source, uint* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, System.Runtime.Intrinsics.Vector256<uint> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, System.Runtime.Intrinsics.Vector256<ulong> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> GatherMaskVector256(System.Runtime.Intrinsics.Vector256<ulong> source, ulong* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, System.Runtime.Intrinsics.Vector256<ulong> mask, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> GatherVector128(double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> GatherVector128(double* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> GatherVector128(int* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> GatherVector128(long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> GatherVector128(long* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> GatherVector128(float* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> GatherVector128(uint* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> GatherVector128(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> GatherVector128(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> GatherVector256(double* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> GatherVector256(double* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> GatherVector256(int* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> GatherVector256(long* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> GatherVector256(long* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> GatherVector256(float* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> GatherVector256(uint* baseAddress, System.Runtime.Intrinsics.Vector256<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> GatherVector256(ulong* baseAddress, System.Runtime.Intrinsics.Vector128<int> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> GatherVector256(ulong* baseAddress, System.Runtime.Intrinsics.Vector256<long> index, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Min = (byte)(1), Max = (byte)(8))] byte scale) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<short> HorizontalAdd(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<int> HorizontalAdd(System.Runtime.Intrinsics.Vector256<int> left, System.Runtime.Intrinsics.Vector256<int> right) { throw null; }
@@ -8827,53 +7587,29 @@ namespace System.Runtime.Intrinsics.X86
         public static new System.Runtime.Intrinsics.Vector256<ushort> InsertVector128(System.Runtime.Intrinsics.Vector256<ushort> value, System.Runtime.Intrinsics.Vector128<ushort> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static new System.Runtime.Intrinsics.Vector256<uint> InsertVector128(System.Runtime.Intrinsics.Vector256<uint> value, System.Runtime.Intrinsics.Vector128<uint> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static new System.Runtime.Intrinsics.Vector256<ulong> InsertVector128(System.Runtime.Intrinsics.Vector256<ulong> value, System.Runtime.Intrinsics.Vector128<ulong> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> LoadAlignedVector256NonTemporal(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> LoadAlignedVector256NonTemporal(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> LoadAlignedVector256NonTemporal(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> LoadAlignedVector256NonTemporal(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> LoadAlignedVector256NonTemporal(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> LoadAlignedVector256NonTemporal(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> LoadAlignedVector256NonTemporal(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> LoadAlignedVector256NonTemporal(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { }
         public static System.Runtime.Intrinsics.Vector256<byte> Max(System.Runtime.Intrinsics.Vector256<byte> left, System.Runtime.Intrinsics.Vector256<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<short> Max(System.Runtime.Intrinsics.Vector256<short> left, System.Runtime.Intrinsics.Vector256<short> right) { throw null; }
@@ -9260,45 +7996,25 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<ushort> Compress(System.Runtime.Intrinsics.Vector256<ushort> merge, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<uint> Compress(System.Runtime.Intrinsics.Vector256<uint> merge, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> Compress(System.Runtime.Intrinsics.Vector256<ulong> merge, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> ConvertScalarToVector128Double(System.Runtime.Intrinsics.Vector128<double> upper, uint value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> ConvertScalarToVector128Single(System.Runtime.Intrinsics.Vector128<float> upper, uint value) { throw null; }
@@ -9451,45 +8167,25 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<ushort> Expand(System.Runtime.Intrinsics.Vector256<ushort> merge, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<uint> Expand(System.Runtime.Intrinsics.Vector256<uint> merge, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> Expand(System.Runtime.Intrinsics.Vector256<ulong> merge, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> ExpandLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> ExpandLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ExpandLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> ExpandLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> ExpandLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> ExpandLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> ExpandLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> ExpandLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> ExpandLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> ExpandLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> ExpandLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> ExpandLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Fixup(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, System.Runtime.Intrinsics.Vector128<int> table, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Fixup(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, System.Runtime.Intrinsics.Vector128<long> table, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
@@ -9529,133 +8225,69 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector256<uint> LeadingZeroCount(System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<long> LeadingZeroCount(System.Runtime.Intrinsics.Vector256<long> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector256<ulong> LeadingZeroCount(System.Runtime.Intrinsics.Vector256<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> MaskLoad(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> MaskLoad(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> MaskLoad(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> MaskLoad(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<byte> MaskLoad(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<short> MaskLoad(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> MaskLoad(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ushort> MaskLoad(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> MaskLoadAligned(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> MaskLoadAligned(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> MaskLoadAligned(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> MaskLoadAligned(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> MaskLoadAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> MaskLoadAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<double> MaskLoadAligned(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<int> MaskLoadAligned(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<long> MaskLoadAligned(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<float> MaskLoadAligned(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<uint> MaskLoadAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector256<ulong> MaskLoadAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static new unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> Max(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<ulong> Max(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
@@ -9882,17 +8514,11 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector512<int> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<uint> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<float> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<long> BroadcastVector128ToVector512(long* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<ulong> BroadcastVector128ToVector512(ulong* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<double> BroadcastVector128ToVector512(double* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<int> BroadcastVector256ToVector512(int* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<uint> BroadcastVector256ToVector512(uint* address) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<float> BroadcastVector256ToVector512(float* address) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<double> Classify(System.Runtime.Intrinsics.Vector512<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpected] byte control) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<float> Classify(System.Runtime.Intrinsics.Vector512<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpected] byte control) { throw null; }
@@ -9900,13 +8526,9 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector512<short> Compress(System.Runtime.Intrinsics.Vector512<short> merge, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<sbyte> Compress(System.Runtime.Intrinsics.Vector512<sbyte> merge, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<ushort> Compress(System.Runtime.Intrinsics.Vector512<ushort> merge, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> source) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<float> ConvertToVector256Single(System.Runtime.Intrinsics.Vector512<long> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<float> ConvertToVector256Single(System.Runtime.Intrinsics.Vector512<ulong> value) { throw null; }
@@ -9936,13 +8558,9 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector512<short> Expand(System.Runtime.Intrinsics.Vector512<short> merge, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<sbyte> Expand(System.Runtime.Intrinsics.Vector512<sbyte> merge, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector512<ushort> Expand(System.Runtime.Intrinsics.Vector512<ushort> merge, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector512<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> merge) { throw null; }
             public static new System.Runtime.Intrinsics.Vector128<long> ExtractVector128(System.Runtime.Intrinsics.Vector512<long> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
             public static new System.Runtime.Intrinsics.Vector128<ulong> ExtractVector128(System.Runtime.Intrinsics.Vector512<ulong> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
@@ -10010,9 +8628,7 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<uint> MoveScalar(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> MoveScalar(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<ushort> MoveScalar(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(short* address, System.Runtime.Intrinsics.Vector128<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { throw null; }
         public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx10v1.X64
         {
@@ -10190,29 +8806,17 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<short> ConvertToVector512Int16(System.Runtime.Intrinsics.Vector256<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ushort> ConvertToVector512UInt16(System.Runtime.Intrinsics.Vector256<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ushort> ConvertToVector512UInt16(System.Runtime.Intrinsics.Vector256<byte> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static System.Runtime.Intrinsics.Vector512<byte> LoadVector512(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static System.Runtime.Intrinsics.Vector512<short> LoadVector512(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static System.Runtime.Intrinsics.Vector512<sbyte> LoadVector512(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static System.Runtime.Intrinsics.Vector512<ushort> LoadVector512(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<byte> MaskLoad(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<short> MaskLoad(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> MaskLoad(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> MaskLoad(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<byte> Max(System.Runtime.Intrinsics.Vector512<byte> left, System.Runtime.Intrinsics.Vector512<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<short> Max(System.Runtime.Intrinsics.Vector512<short> left, System.Runtime.Intrinsics.Vector512<short> right) { throw null; }
@@ -10268,13 +8872,9 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<ushort> ShuffleHigh(System.Runtime.Intrinsics.Vector512<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<short> ShuffleLow(System.Runtime.Intrinsics.Vector512<short> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ushort> ShuffleLow(System.Runtime.Intrinsics.Vector512<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static void Store(byte* address, System.Runtime.Intrinsics.Vector512<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static void Store(short* address, System.Runtime.Intrinsics.Vector512<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static void Store(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public new unsafe static void Store(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> source) { }
         public static System.Runtime.Intrinsics.Vector512<byte> Subtract(System.Runtime.Intrinsics.Vector512<byte> left, System.Runtime.Intrinsics.Vector512<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<short> Subtract(System.Runtime.Intrinsics.Vector512<short> left, System.Runtime.Intrinsics.Vector512<short> right) { throw null; }
@@ -10366,37 +8966,21 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector128<sbyte> ConvertToVector128SByte(System.Runtime.Intrinsics.Vector256<ushort> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<sbyte> ConvertToVector128SByteWithSaturation(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<sbyte> ConvertToVector128SByteWithSaturation(System.Runtime.Intrinsics.Vector256<short> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<byte> MaskLoad(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<short> MaskLoad(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> MaskLoad(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ushort> MaskLoad(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<byte> MaskLoad(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<short> MaskLoad(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> MaskLoad(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<ushort> MaskLoad(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> source) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<short> PermuteVar8x16(System.Runtime.Intrinsics.Vector128<short> left, System.Runtime.Intrinsics.Vector128<short> control) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<ushort> PermuteVar8x16(System.Runtime.Intrinsics.Vector128<ushort> left, System.Runtime.Intrinsics.Vector128<ushort> control) { throw null; }
@@ -10477,17 +9061,11 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<int> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<uint> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> BroadcastPairScalarToVector512(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> BroadcastVector128ToVector512(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> BroadcastVector128ToVector512(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> BroadcastVector128ToVector512(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> BroadcastVector256ToVector512(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> BroadcastVector256ToVector512(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> BroadcastVector256ToVector512(uint* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Classify(System.Runtime.Intrinsics.Vector512<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpected] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> Classify(System.Runtime.Intrinsics.Vector512<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpected] byte control) { throw null; }
@@ -10663,17 +9241,11 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<float> BroadcastScalarToVector512(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<uint> BroadcastScalarToVector512(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ulong> BroadcastScalarToVector512(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> BroadcastVector128ToVector512(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> BroadcastVector128ToVector512(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> BroadcastVector128ToVector512(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> BroadcastVector256ToVector512(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> BroadcastVector256ToVector512(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> BroadcastVector256ToVector512(ulong* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Compare(System.Runtime.Intrinsics.Vector512<double> left, System.Runtime.Intrinsics.Vector512<double> right, [System.Diagnostics.CodeAnalysis.ConstantExpected(Max = System.Runtime.Intrinsics.X86.FloatComparisonMode.UnorderedTrueSignaling)] System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<float> Compare(System.Runtime.Intrinsics.Vector512<float> left, System.Runtime.Intrinsics.Vector512<float> right, [System.Diagnostics.CodeAnalysis.ConstantExpected(Max = System.Runtime.Intrinsics.X86.FloatComparisonMode.UnorderedTrueSignaling)] System.Runtime.Intrinsics.X86.FloatComparisonMode mode) { throw null; }
@@ -10731,17 +9303,11 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<float> Compress(System.Runtime.Intrinsics.Vector512<float> merge, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<uint> Compress(System.Runtime.Intrinsics.Vector512<uint> merge, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ulong> Compress(System.Runtime.Intrinsics.Vector512<ulong> merge, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> ConvertScalarToVector128Double(System.Runtime.Intrinsics.Vector128<double> upper, uint value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> ConvertScalarToVector128Single(System.Runtime.Intrinsics.Vector128<float> upper, uint value) { throw null; }
@@ -10842,17 +9408,11 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<float> Expand(System.Runtime.Intrinsics.Vector512<float> merge, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<uint> Expand(System.Runtime.Intrinsics.Vector512<uint> merge, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ulong> Expand(System.Runtime.Intrinsics.Vector512<ulong> merge, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> ExpandLoad(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> ExpandLoad(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> ExpandLoad(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> ExpandLoad(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> ExpandLoad(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> ExpandLoad(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> merge) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<byte> ExtractVector128(System.Runtime.Intrinsics.Vector512<byte> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> ExtractVector128(System.Runtime.Intrinsics.Vector512<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
@@ -10942,109 +9502,57 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<ushort> InsertVector256(System.Runtime.Intrinsics.Vector512<ushort> value, System.Runtime.Intrinsics.Vector256<ushort> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<uint> InsertVector256(System.Runtime.Intrinsics.Vector512<uint> value, System.Runtime.Intrinsics.Vector256<uint> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ulong> InsertVector256(System.Runtime.Intrinsics.Vector512<ulong> value, System.Runtime.Intrinsics.Vector256<ulong> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<byte> LoadAlignedVector512(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> LoadAlignedVector512(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<short> LoadAlignedVector512(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> LoadAlignedVector512(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> LoadAlignedVector512(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> LoadAlignedVector512(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> LoadAlignedVector512(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> LoadAlignedVector512(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> LoadAlignedVector512(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> LoadAlignedVector512(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<byte> LoadAlignedVector512NonTemporal(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<short> LoadAlignedVector512NonTemporal(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> LoadAlignedVector512NonTemporal(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> LoadAlignedVector512NonTemporal(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> LoadAlignedVector512NonTemporal(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> LoadAlignedVector512NonTemporal(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> LoadAlignedVector512NonTemporal(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> LoadAlignedVector512NonTemporal(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<byte> LoadVector512(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> LoadVector512(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<short> LoadVector512(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> LoadVector512(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> LoadVector512(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> LoadVector512(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> LoadVector512(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> LoadVector512(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> LoadVector512(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> LoadVector512(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<double> MaskLoadAligned(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<int> MaskLoadAligned(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<long> MaskLoadAligned(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<float> MaskLoadAligned(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<uint> MaskLoadAligned(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ulong> MaskLoadAligned(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(double* address, System.Runtime.Intrinsics.Vector512<double> mask, System.Runtime.Intrinsics.Vector512<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(int* address, System.Runtime.Intrinsics.Vector512<int> mask, System.Runtime.Intrinsics.Vector512<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(long* address, System.Runtime.Intrinsics.Vector512<long> mask, System.Runtime.Intrinsics.Vector512<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(float* address, System.Runtime.Intrinsics.Vector512<float> mask, System.Runtime.Intrinsics.Vector512<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(uint* address, System.Runtime.Intrinsics.Vector512<uint> mask, System.Runtime.Intrinsics.Vector512<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskStoreAligned(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> mask, System.Runtime.Intrinsics.Vector512<ulong> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<double> Max(System.Runtime.Intrinsics.Vector512<double> left, System.Runtime.Intrinsics.Vector512<double> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<int> Max(System.Runtime.Intrinsics.Vector512<int> left, System.Runtime.Intrinsics.Vector512<int> right) { throw null; }
@@ -11190,65 +9698,35 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<double> Sqrt(System.Runtime.Intrinsics.Vector512<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpected(Max = System.Runtime.Intrinsics.X86.FloatRoundingMode.ToZero)] System.Runtime.Intrinsics.X86.FloatRoundingMode mode) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> SqrtScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpected(Max = System.Runtime.Intrinsics.X86.FloatRoundingMode.ToZero)] System.Runtime.Intrinsics.X86.FloatRoundingMode mode) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> SqrtScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpected(Max = System.Runtime.Intrinsics.X86.FloatRoundingMode.ToZero)] System.Runtime.Intrinsics.X86.FloatRoundingMode mode) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, System.Runtime.Intrinsics.Vector512<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, System.Runtime.Intrinsics.Vector512<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, System.Runtime.Intrinsics.Vector512<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, System.Runtime.Intrinsics.Vector512<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, System.Runtime.Intrinsics.Vector512<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, System.Runtime.Intrinsics.Vector512<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, System.Runtime.Intrinsics.Vector512<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(byte* address, System.Runtime.Intrinsics.Vector512<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(double* address, System.Runtime.Intrinsics.Vector512<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(short* address, System.Runtime.Intrinsics.Vector512<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(int* address, System.Runtime.Intrinsics.Vector512<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(long* address, System.Runtime.Intrinsics.Vector512<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(float* address, System.Runtime.Intrinsics.Vector512<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(uint* address, System.Runtime.Intrinsics.Vector512<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(byte* address, System.Runtime.Intrinsics.Vector512<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(double* address, System.Runtime.Intrinsics.Vector512<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(short* address, System.Runtime.Intrinsics.Vector512<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(int* address, System.Runtime.Intrinsics.Vector512<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(long* address, System.Runtime.Intrinsics.Vector512<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(float* address, System.Runtime.Intrinsics.Vector512<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(uint* address, System.Runtime.Intrinsics.Vector512<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector512<ulong> source) { }
         public static System.Runtime.Intrinsics.Vector512<double> Subtract(System.Runtime.Intrinsics.Vector512<double> left, System.Runtime.Intrinsics.Vector512<double> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<int> Subtract(System.Runtime.Intrinsics.Vector512<int> left, System.Runtime.Intrinsics.Vector512<int> right) { throw null; }
@@ -11428,29 +9906,17 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector256<float> Compress(System.Runtime.Intrinsics.Vector256<float> merge, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<uint> Compress(System.Runtime.Intrinsics.Vector256<uint> merge, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<ulong> Compress(System.Runtime.Intrinsics.Vector256<ulong> merge, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<byte> ConvertToVector128Byte(System.Runtime.Intrinsics.Vector128<int> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<byte> ConvertToVector128Byte(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
@@ -11536,29 +10002,17 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector256<float> Expand(System.Runtime.Intrinsics.Vector256<float> merge, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<uint> Expand(System.Runtime.Intrinsics.Vector256<uint> merge, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<ulong> Expand(System.Runtime.Intrinsics.Vector256<ulong> merge, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<double> ExpandLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<int> ExpandLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<long> ExpandLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<float> ExpandLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<uint> ExpandLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ulong> ExpandLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<double> ExpandLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<int> ExpandLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<long> ExpandLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<float> ExpandLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<uint> ExpandLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<ulong> ExpandLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<double> Fixup(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, System.Runtime.Intrinsics.Vector128<long> table, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<float> Fixup(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, System.Runtime.Intrinsics.Vector128<int> table, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
@@ -11572,101 +10026,53 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector128<float> GetMantissa(System.Runtime.Intrinsics.Vector128<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(0x0F))] byte control) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<double> GetMantissa(System.Runtime.Intrinsics.Vector256<double> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(0x0F))] byte control) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<float> GetMantissa(System.Runtime.Intrinsics.Vector256<float> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute(Max = (byte)(0x0F))] byte control) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<double> MaskLoad(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<int> MaskLoad(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<long> MaskLoad(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<float> MaskLoad(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<uint> MaskLoad(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<ulong> MaskLoad(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<double> MaskLoadAligned(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<int> MaskLoadAligned(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<long> MaskLoadAligned(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<float> MaskLoadAligned(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<uint> MaskLoadAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ulong> MaskLoadAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<double> MaskLoadAligned(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<int> MaskLoadAligned(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<long> MaskLoadAligned(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<float> MaskLoadAligned(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<uint> MaskLoadAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<ulong> MaskLoadAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStore(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(double* address, System.Runtime.Intrinsics.Vector128<double> mask, System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(int* address, System.Runtime.Intrinsics.Vector128<int> mask, System.Runtime.Intrinsics.Vector128<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(long* address, System.Runtime.Intrinsics.Vector128<long> mask, System.Runtime.Intrinsics.Vector128<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(float* address, System.Runtime.Intrinsics.Vector128<float> mask, System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> mask, System.Runtime.Intrinsics.Vector128<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> mask, System.Runtime.Intrinsics.Vector128<ulong> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(double* address, System.Runtime.Intrinsics.Vector256<double> mask, System.Runtime.Intrinsics.Vector256<double> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(int* address, System.Runtime.Intrinsics.Vector256<int> mask, System.Runtime.Intrinsics.Vector256<int> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(long* address, System.Runtime.Intrinsics.Vector256<long> mask, System.Runtime.Intrinsics.Vector256<long> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(float* address, System.Runtime.Intrinsics.Vector256<float> mask, System.Runtime.Intrinsics.Vector256<float> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(uint* address, System.Runtime.Intrinsics.Vector256<uint> mask, System.Runtime.Intrinsics.Vector256<uint> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void MaskStoreAligned(ulong* address, System.Runtime.Intrinsics.Vector256<ulong> mask, System.Runtime.Intrinsics.Vector256<ulong> source) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<long> Max(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<ulong> Max(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
@@ -11835,25 +10241,17 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector512<short> Compress(System.Runtime.Intrinsics.Vector512<short> merge, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<sbyte> Compress(System.Runtime.Intrinsics.Vector512<sbyte> merge, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ushort> Compress(System.Runtime.Intrinsics.Vector512<ushort> merge, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<byte> Expand(System.Runtime.Intrinsics.Vector512<byte> merge, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<short> Expand(System.Runtime.Intrinsics.Vector512<short> merge, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<sbyte> Expand(System.Runtime.Intrinsics.Vector512<sbyte> merge, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector512<ushort> Expand(System.Runtime.Intrinsics.Vector512<ushort> merge, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector512<byte> mask, System.Runtime.Intrinsics.Vector512<byte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector512<short> mask, System.Runtime.Intrinsics.Vector512<short> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector512<sbyte> mask, System.Runtime.Intrinsics.Vector512<sbyte> merge) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector512<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector512<ushort> mask, System.Runtime.Intrinsics.Vector512<ushort> merge) { throw null; }
         public new abstract partial class VL : System.Runtime.Intrinsics.X86.Avx512Vbmi.VL
         {
@@ -11867,21 +10265,13 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector256<short> Compress(System.Runtime.Intrinsics.Vector256<short> merge, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<sbyte> Compress(System.Runtime.Intrinsics.Vector256<sbyte> merge, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<ushort> Compress(System.Runtime.Intrinsics.Vector256<ushort> merge, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> source) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void CompressStore(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> source) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<byte> Expand(System.Runtime.Intrinsics.Vector128<byte> merge, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector128<short> Expand(System.Runtime.Intrinsics.Vector128<short> merge, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
@@ -11891,21 +10281,13 @@ namespace System.Runtime.Intrinsics.X86
             public static System.Runtime.Intrinsics.Vector256<short> Expand(System.Runtime.Intrinsics.Vector256<short> merge, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<sbyte> Expand(System.Runtime.Intrinsics.Vector256<sbyte> merge, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> value) { throw null; }
             public static System.Runtime.Intrinsics.Vector256<ushort> Expand(System.Runtime.Intrinsics.Vector256<ushort> merge, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector128<byte> mask, System.Runtime.Intrinsics.Vector128<byte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector128<short> mask, System.Runtime.Intrinsics.Vector128<short> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> mask, System.Runtime.Intrinsics.Vector128<sbyte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector128<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> mask, System.Runtime.Intrinsics.Vector128<ushort> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<byte> ExpandLoad(byte* address, System.Runtime.Intrinsics.Vector256<byte> mask, System.Runtime.Intrinsics.Vector256<byte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<short> ExpandLoad(short* address, System.Runtime.Intrinsics.Vector256<short> mask, System.Runtime.Intrinsics.Vector256<short> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<sbyte> ExpandLoad(sbyte* address, System.Runtime.Intrinsics.Vector256<sbyte> mask, System.Runtime.Intrinsics.Vector256<sbyte> merge) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe System.Runtime.Intrinsics.Vector256<ushort> ExpandLoad(ushort* address, System.Runtime.Intrinsics.Vector256<ushort> mask, System.Runtime.Intrinsics.Vector256<ushort> merge) { throw null; }
         }
         public new abstract partial class X64 : System.Runtime.Intrinsics.X86.Avx512Vbmi.X64
@@ -11964,7 +10346,6 @@ namespace System.Runtime.Intrinsics.X86
         internal Bmi2() { }
         public static new bool IsSupported { get { throw null; } }
         public static uint MultiplyNoFlags(uint left, uint right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe uint MultiplyNoFlags(uint left, uint right, uint* low) { throw null; }
         public static uint ParallelBitDeposit(uint value, uint mask) { throw null; }
         public static uint ParallelBitExtract(uint value, uint mask) { throw null; }
@@ -11974,7 +10355,6 @@ namespace System.Runtime.Intrinsics.X86
             internal X64() { }
             public static new bool IsSupported { get { throw null; } }
             public static ulong MultiplyNoFlags(ulong left, ulong right) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe ulong MultiplyNoFlags(ulong left, ulong right, ulong* low) { throw null; }
             public static ulong ParallelBitDeposit(ulong value, ulong mask) { throw null; }
             public static ulong ParallelBitExtract(ulong value, ulong mask) { throw null; }
@@ -12169,15 +10549,10 @@ namespace System.Runtime.Intrinsics.X86
         public static int ConvertToInt32WithTruncation(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Divide(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> DivideScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadAlignedVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadHigh(System.Runtime.Intrinsics.Vector128<float> lower, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadLow(System.Runtime.Intrinsics.Vector128<float> upper, float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadScalarVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<float> LoadVector128(float* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Max(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> MaxScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
@@ -12190,13 +10565,9 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<float> Multiply(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> MultiplyScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Or(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch0(void* address) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch1(void* address) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Prefetch2(void* address) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void PrefetchNonTemporal(void* address) { }
         public static System.Runtime.Intrinsics.Vector128<float> Reciprocal(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> ReciprocalScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
@@ -12208,18 +10579,12 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<float> Sqrt(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> SqrtScalar(System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> SqrtScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
         public static void StoreFence() { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreHigh(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreLow(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(float* address, System.Runtime.Intrinsics.Vector128<float> source) { }
         public static System.Runtime.Intrinsics.Vector128<float> Subtract(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> SubtractScalar(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
@@ -12344,60 +10709,33 @@ namespace System.Runtime.Intrinsics.X86
         public static ushort Extract(System.Runtime.Intrinsics.Vector128<ushort> value, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> Insert(System.Runtime.Intrinsics.Vector128<short> value, short data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<ushort> Insert(System.Runtime.Intrinsics.Vector128<ushort> value, ushort data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadAlignedVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadAlignedVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadAlignedVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadAlignedVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadAlignedVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadAlignedVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadAlignedVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadAlignedVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadAlignedVector128(ulong* address) { throw null; }
         public static void LoadFence() { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadHigh(System.Runtime.Intrinsics.Vector128<double> lower, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadLow(System.Runtime.Intrinsics.Vector128<double> upper, double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadScalarVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadScalarVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadScalarVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadScalarVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadScalarVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskMove(System.Runtime.Intrinsics.Vector128<byte> source, System.Runtime.Intrinsics.Vector128<byte> mask, byte* address) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void MaskMove(System.Runtime.Intrinsics.Vector128<sbyte> source, System.Runtime.Intrinsics.Vector128<sbyte> mask, sbyte* address) { }
         public static System.Runtime.Intrinsics.Vector128<byte> Max(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Max(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
@@ -12488,77 +10826,41 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<double> Sqrt(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> SqrtScalar(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> SqrtScalar(System.Runtime.Intrinsics.Vector128<double> upper, System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAligned(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(byte* address, System.Runtime.Intrinsics.Vector128<byte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(short* address, System.Runtime.Intrinsics.Vector128<short> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(sbyte* address, System.Runtime.Intrinsics.Vector128<sbyte> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ushort* address, System.Runtime.Intrinsics.Vector128<ushort> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreAlignedNonTemporal(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreHigh(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreLow(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(int* address, int value) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreNonTemporal(uint* address, uint value) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(double* address, System.Runtime.Intrinsics.Vector128<double> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(int* address, System.Runtime.Intrinsics.Vector128<int> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(long* address, System.Runtime.Intrinsics.Vector128<long> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(uint* address, System.Runtime.Intrinsics.Vector128<uint> source) { }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreScalar(ulong* address, System.Runtime.Intrinsics.Vector128<ulong> source) { }
         public static System.Runtime.Intrinsics.Vector128<byte> Subtract(System.Runtime.Intrinsics.Vector128<byte> left, System.Runtime.Intrinsics.Vector128<byte> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> Subtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
@@ -12613,9 +10915,7 @@ namespace System.Runtime.Intrinsics.X86
             public static long ConvertToInt64(System.Runtime.Intrinsics.Vector128<long> value) { throw null; }
             public static long ConvertToInt64WithTruncation(System.Runtime.Intrinsics.Vector128<double> value) { throw null; }
             public static ulong ConvertToUInt64(System.Runtime.Intrinsics.Vector128<ulong> value) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreNonTemporal(long* address, long value) { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public static unsafe void StoreNonTemporal(ulong* address, ulong value) { }
         }
     }
@@ -12630,23 +10930,14 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<float> HorizontalAdd(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> HorizontalSubtract(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<double> LoadAndDuplicateToVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadDquVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadDquVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadDquVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadDquVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadDquVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadDquVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadDquVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadDquVector128(ulong* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> MoveAndDuplicate(System.Runtime.Intrinsics.Vector128<double> source) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> MoveHighAndDuplicate(System.Runtime.Intrinsics.Vector128<float> source) { throw null; }
@@ -12684,29 +10975,20 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<float> CeilingScalar(System.Runtime.Intrinsics.Vector128<float> upper, System.Runtime.Intrinsics.Vector128<float> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> CompareEqual(System.Runtime.Intrinsics.Vector128<long> left, System.Runtime.Intrinsics.Vector128<long> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<ulong> CompareEqual(System.Runtime.Intrinsics.Vector128<ulong> left, System.Runtime.Intrinsics.Vector128<ulong> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(byte* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> ConvertToVector128Int16(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(short* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> ConvertToVector128Int32(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(int* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<byte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<short> value) { throw null; }
@@ -12714,11 +10996,8 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<sbyte> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<ushort> value) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(System.Runtime.Intrinsics.Vector128<uint> value) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> ConvertToVector128Int64(uint* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<double> DotProduct(System.Runtime.Intrinsics.Vector128<double> left, System.Runtime.Intrinsics.Vector128<double> right, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> DotProduct(System.Runtime.Intrinsics.Vector128<float> left, System.Runtime.Intrinsics.Vector128<float> right, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte control) { throw null; }
@@ -12737,21 +11016,13 @@ namespace System.Runtime.Intrinsics.X86
         public static System.Runtime.Intrinsics.Vector128<sbyte> Insert(System.Runtime.Intrinsics.Vector128<sbyte> value, sbyte data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<float> Insert(System.Runtime.Intrinsics.Vector128<float> value, System.Runtime.Intrinsics.Vector128<float> data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<uint> Insert(System.Runtime.Intrinsics.Vector128<uint> value, uint data, [System.Diagnostics.CodeAnalysis.ConstantExpectedAttribute] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<byte> LoadAlignedVector128NonTemporal(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<short> LoadAlignedVector128NonTemporal(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<int> LoadAlignedVector128NonTemporal(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<long> LoadAlignedVector128NonTemporal(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<sbyte> LoadAlignedVector128NonTemporal(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ushort> LoadAlignedVector128NonTemporal(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<uint> LoadAlignedVector128NonTemporal(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe System.Runtime.Intrinsics.Vector128<ulong> LoadAlignedVector128NonTemporal(ulong* address) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<int> Max(System.Runtime.Intrinsics.Vector128<int> left, System.Runtime.Intrinsics.Vector128<int> right) { throw null; }
         public static System.Runtime.Intrinsics.Vector128<sbyte> Max(System.Runtime.Intrinsics.Vector128<sbyte> left, System.Runtime.Intrinsics.Vector128<sbyte> right) { throw null; }
@@ -13288,153 +11559,79 @@ namespace System.Runtime.Intrinsics.Wasm
         public static Vector128<double> CompareGreaterThanOrEqual(Vector128<double> left, Vector128<double> right) { throw null; }
         public static Vector128<nint> CompareGreaterThanOrEqual(Vector128<nint> left, Vector128<nint> right) { throw null; }
         public static Vector128<nuint> CompareGreaterThanOrEqual(Vector128<nuint> left, Vector128<nuint> right) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<sbyte> LoadVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<byte> LoadVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<short> LoadVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ushort> LoadVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<int> LoadVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<uint> LoadVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<long> LoadVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ulong> LoadVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<float> LoadVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<double> LoadVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nint> LoadVector128(nint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nuint> LoadVector128(nuint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<int> LoadScalarVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<uint> LoadScalarVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<long> LoadScalarVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ulong> LoadScalarVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<float> LoadScalarVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<double> LoadScalarVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nint> LoadScalarVector128(nint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nuint> LoadScalarVector128(nuint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<sbyte> LoadScalarAndSplatVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<byte> LoadScalarAndSplatVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<short> LoadScalarAndSplatVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ushort> LoadScalarAndSplatVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<int> LoadScalarAndSplatVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<uint> LoadScalarAndSplatVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<long> LoadScalarAndSplatVector128(long* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ulong> LoadScalarAndSplatVector128(ulong* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<float> LoadScalarAndSplatVector128(float* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<double> LoadScalarAndSplatVector128(double* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nint> LoadScalarAndSplatVector128(nint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nuint> LoadScalarAndSplatVector128(nuint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<sbyte> LoadScalarAndInsert(sbyte* address, Vector128<sbyte> vector, [ConstantExpected(Max = (byte)(15))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<byte> LoadScalarAndInsert(byte* address, Vector128<byte> vector, [ConstantExpected(Max = (byte)(15))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<short> LoadScalarAndInsert(short* address, Vector128<short> vector, [ConstantExpected(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ushort> LoadScalarAndInsert(ushort* address, Vector128<ushort> vector, [ConstantExpected(Max = (byte)(7))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<int> LoadScalarAndInsert(int* address, Vector128<int> vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<uint> LoadScalarAndInsert(uint* address, Vector128<uint> vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<long> LoadScalarAndInsert(long* address, Vector128<long> vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ulong> LoadScalarAndInsert(ulong* address, Vector128<ulong> vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<float> LoadScalarAndInsert(float* address, Vector128<float> vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<double> LoadScalarAndInsert(double* address, Vector128<double> vector, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nint> LoadScalarAndInsert(nint* address, Vector128<nint> vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<nuint> LoadScalarAndInsert(nuint* address, Vector128<nuint> vector, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<short> LoadWideningVector128(sbyte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ushort> LoadWideningVector128(byte* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<int> LoadWideningVector128(short* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<uint> LoadWideningVector128(ushort* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<long> LoadWideningVector128(int* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe Vector128<ulong> LoadWideningVector128(uint* address) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(sbyte* address, Vector128<sbyte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(byte* address, Vector128<byte> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(short* address, Vector128<short> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ushort* address, Vector128<ushort> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(int* address, Vector128<int> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(uint* address, Vector128<uint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(long* address, Vector128<long> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(ulong* address, Vector128<ulong> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(float* address, Vector128<float> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(double* address, Vector128<double> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(nint* address, Vector128<nint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void Store(nuint* address, Vector128<nuint> source) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(sbyte* address, Vector128<sbyte> source, [ConstantExpected(Max = (byte)(15))] byte index) { throw null; } // takes ImmLaneIdx16
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(byte* address, Vector128<byte> source, [ConstantExpected(Max = (byte)(15))] byte index) { throw null; } // takes ImmLaneIdx16
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(short* address, Vector128<short> source, [ConstantExpected(Max = (byte)(7))] byte index) { throw null; } // takes ImmLaneIdx8
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ushort* address, Vector128<ushort> source, [ConstantExpected(Max = (byte)(7))] byte index) { throw null; } // takes ImmLaneIdx8
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(int* address, Vector128<int> source, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; } // takes ImmLaneIdx4
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(uint* address, Vector128<uint> source, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; } // takes ImmLaneIdx4
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(long* address, Vector128<long> source, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; } // takes ImmLaneIdx2
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(ulong* address, Vector128<ulong> source, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; } // takes ImmLaneIdx2
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(float* address, Vector128<float> source, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; } // takes ImmLaneIdx4
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(double* address, Vector128<double> source, [ConstantExpected(Max = (byte)(1))] byte index) { throw null; } // takes ImmLaneIdx2
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(nint* address, Vector128<nint> source, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe void StoreSelectedScalar(nuint* address, Vector128<nuint> source, [ConstantExpected(Max = (byte)(3))] byte index) { throw null; }
         public static Vector128<float> Negate(Vector128<float> value) { throw null; }
         public static Vector128<double> Negate(Vector128<double> value) { throw null; }

--- a/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
+++ b/src/libraries/System.Runtime.Loader/ref/System.Runtime.Loader.cs
@@ -9,7 +9,6 @@ namespace System.Reflection.Metadata
     public static partial class AssemblyExtensions
     {
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static bool TryGetRawMetadata(this System.Reflection.Assembly assembly, out byte* blob, out int length) { throw null; }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Assembly, AllowMultiple=true)]

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -419,7 +419,6 @@ namespace System
         private int _dummyPrimitive;
         public ArgIterator(System.RuntimeArgumentHandle arglist) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe ArgIterator(System.RuntimeArgumentHandle arglist, void* ptr) { throw null; }
         public void End() { }
         public override bool Equals(object? o) { throw null; }
@@ -930,10 +929,8 @@ namespace System
         public static int ByteLength(System.Array array) { throw null; }
         public static byte GetByte(System.Array array, int index) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void MemoryCopy(void* source, void* destination, long destinationSizeInBytes, long sourceBytesToCopy) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void MemoryCopy(void* source, void* destination, ulong destinationSizeInBytes, ulong sourceBytesToCopy) { }
         public static void SetByte(System.Array array, int index, byte value) { }
     }
@@ -5110,7 +5107,6 @@ namespace System
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe ReadOnlySpan(void* pointer, int length) { throw null; }
         public ReadOnlySpan(ref readonly T reference) { throw null; }
         public ReadOnlySpan(T[]? array) { throw null; }
@@ -5574,7 +5570,6 @@ namespace System
         private readonly object _dummy;
         private readonly int _dummyPrimitive;
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe Span(void* pointer, int length) { throw null; }
         public Span(ref T reference) { throw null; }
         public Span(T[]? array) { throw null; }
@@ -5632,23 +5627,18 @@ namespace System
     {
         public static readonly string Empty;
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe String(char* value) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe String(char* value, int startIndex, int length) { }
         public String(char c, int count) { }
         public String(char[]? value) { }
         public String(char[] value, int startIndex, int length) { }
         public String(System.ReadOnlySpan<char> value) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe String(sbyte* value) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe String(sbyte* value, int startIndex, int length) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe String(sbyte* value, int startIndex, int length, System.Text.Encoding enc) { }
         [System.Runtime.CompilerServices.IndexerName("Chars")]
         public char this[int index] { get { throw null; } }
@@ -11198,10 +11188,8 @@ namespace System.IO
     {
         protected UnmanagedMemoryStream() { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe UnmanagedMemoryStream(byte* pointer, long length) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe UnmanagedMemoryStream(byte* pointer, long length, long capacity, System.IO.FileAccess access) { }
         public UnmanagedMemoryStream(System.Runtime.InteropServices.SafeBuffer buffer, long offset, long length) { }
         public UnmanagedMemoryStream(System.Runtime.InteropServices.SafeBuffer buffer, long offset, long length, System.IO.FileAccess access) { }
@@ -11212,13 +11200,11 @@ namespace System.IO
         public override long Length { get { throw null; } }
         public override long Position { get { throw null; } set { } }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe byte* PositionPointer { get { throw null; } set { } }
         protected override void Dispose(bool disposing) { }
         public override void Flush() { }
         public override System.Threading.Tasks.Task FlushAsync(System.Threading.CancellationToken cancellationToken) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         protected unsafe void Initialize(byte* pointer, long length, long capacity, System.IO.FileAccess access) { }
         protected void Initialize(System.Runtime.InteropServices.SafeBuffer buffer, long offset, long length, System.IO.FileAccess access) { }
         public override int Read(byte[] buffer, int offset, int count) { throw null; }
@@ -14402,7 +14388,6 @@ namespace System.Runtime.CompilerServices
         [System.CLSCompliantAttribute(false)]
         public unsafe static void* AsPointer<T>(ref readonly T value) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static ref T AsRef<T>(void* source) where T : allows ref struct { throw null; }
         public static ref T AsRef<T>(scoped ref readonly T source) where T : allows ref struct { throw null; }
         [return: System.Diagnostics.CodeAnalysis.NotNullIfNotNullAttribute("o")]
@@ -14413,28 +14398,22 @@ namespace System.Runtime.CompilerServices
         [System.CLSCompliantAttribute(false)]
         public static void CopyBlock(ref byte destination, ref readonly byte source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void CopyBlock(void* destination, void* source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public static void CopyBlockUnaligned(ref byte destination, ref readonly byte source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void CopyBlockUnaligned(void* destination, void* source, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Copy<T>(void* destination, ref readonly T source) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Copy<T>(ref T destination, void* source) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
         public static void InitBlock(ref byte startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void InitBlock(void* startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
         public static void InitBlockUnaligned(ref byte startAddress, byte value, uint byteCount) { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void InitBlockUnaligned(void* startAddress, byte value, uint byteCount) { }
         public static bool IsAddressGreaterThan<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
         public static bool IsAddressGreaterThanOrEqualTo<T>([System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T left, [System.Diagnostics.CodeAnalysis.AllowNull] ref readonly T right) where T : allows ref struct { throw null; }
@@ -14444,10 +14423,8 @@ namespace System.Runtime.CompilerServices
         public static ref T NullRef<T>() where T : allows ref struct { throw null; }
         public static T ReadUnaligned<T>(scoped ref readonly byte source) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static T ReadUnaligned<T>(void* source) where T : allows ref struct { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static T Read<T>(void* source) where T : allows ref struct { throw null; }
         public static int SizeOf<T>() where T : allows ref struct { throw null; }
         public static void SkipInit<T>(out T value) where T : allows ref struct { throw null; }
@@ -14463,10 +14440,8 @@ namespace System.Runtime.CompilerServices
         public static ref T Unbox<T>(object box) where T : struct { throw null; }
         public static void WriteUnaligned<T>(ref byte destination, T value) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void WriteUnaligned<T>(void* destination, T value) where T : allows ref struct { }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Write<T>(void* destination, T value) where T : allows ref struct { }
     }
     [System.AttributeUsageAttribute(System.AttributeTargets.Method, AllowMultiple=false, Inherited=false)]
@@ -14704,14 +14679,12 @@ namespace System.Runtime.InteropServices
     public static class GCHandleExtensions
     {
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public static unsafe T* GetAddressOfArrayData<T>(
 #nullable disable
             this System.Runtime.InteropServices.PinnedGCHandle<T[]> handle)
 #nullable restore
             { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
 #nullable disable
         public static unsafe char* GetAddressOfStringData(
 #nullable disable
@@ -14752,10 +14725,8 @@ namespace System.Runtime.InteropServices
         public static System.Span<TTo> Cast<TFrom, TTo>(System.Span<TFrom> span) where TFrom : struct where TTo : struct { throw null; }
         public static System.Memory<T> CreateFromPinnedArray<T>(T[]? array, int start, int length) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.ReadOnlySpan<byte> CreateReadOnlySpanFromNullTerminated(byte* value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.ReadOnlySpan<char> CreateReadOnlySpanFromNullTerminated(char* value) { throw null; }
         public static System.ReadOnlySpan<T> CreateReadOnlySpan<T>(scoped ref readonly T reference, int length) { throw null; }
         public static System.Span<T> CreateSpan<T>(scoped ref T reference, int length) { throw null; }
@@ -15001,7 +14972,6 @@ namespace System.Runtime.InteropServices.Marshalling
             public ref TUnmanagedElement GetPinnableReference() { throw null; }
             public static ref T GetPinnableReference(System.ReadOnlySpan<T> managed) { throw null; }
             public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe TUnmanagedElement* ToUnmanaged() { throw null; }
         }
         public partial struct ManagedToUnmanagedOut
@@ -15009,7 +14979,6 @@ namespace System.Runtime.InteropServices.Marshalling
             private object _dummy;
             private int _dummyPrimitive;
             public void Free() { }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe void FromUnmanaged(TUnmanagedElement* unmanaged) { }
             public System.Span<T> GetManagedValuesDestination(int numElements) { throw null; }
             public System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(int numElements) { throw null; }
@@ -15017,10 +14986,8 @@ namespace System.Runtime.InteropServices.Marshalling
         }
         public static partial class UnmanagedToManagedOut
         {
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements(System.ReadOnlySpan<T> managed, out int numElements) { throw null; }
             public static System.ReadOnlySpan<T> GetManagedValuesSource(System.ReadOnlySpan<T> managed) { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         }
     }
@@ -15065,16 +15032,12 @@ namespace System.Runtime.InteropServices.Marshalling
     [System.Runtime.InteropServices.Marshalling.CustomMarshallerAttribute(typeof(System.Span<>), System.Runtime.InteropServices.Marshalling.MarshalMode.ManagedToUnmanagedIn, typeof(System.Runtime.InteropServices.Marshalling.SpanMarshaller<,>.ManagedToUnmanagedIn))]
     public static partial class SpanMarshaller<T, TUnmanagedElement> where TUnmanagedElement : unmanaged
     {
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.Span<T> AllocateContainerForManagedElements(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         public unsafe static TUnmanagedElement* AllocateContainerForUnmanagedElements(System.Span<T> managed, out int numElements) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Free(TUnmanagedElement* unmanaged) { }
         public static System.Span<T> GetManagedValuesDestination(System.Span<T> managed) { throw null; }
         public static System.ReadOnlySpan<T> GetManagedValuesSource(System.Span<T> managed) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.Span<TUnmanagedElement> GetUnmanagedValuesDestination(TUnmanagedElement* unmanaged, int numElements) { throw null; }
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.ReadOnlySpan<TUnmanagedElement> GetUnmanagedValuesSource(TUnmanagedElement* unmanaged, int numElements) { throw null; }
         public ref partial struct ManagedToUnmanagedIn
         {
@@ -15087,7 +15050,6 @@ namespace System.Runtime.InteropServices.Marshalling
             public ref TUnmanagedElement GetPinnableReference() { throw null; }
             public static ref T GetPinnableReference(System.Span<T> managed) { throw null; }
             public System.Span<TUnmanagedElement> GetUnmanagedValuesDestination() { throw null; }
-            [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
             public unsafe TUnmanagedElement* ToUnmanaged() { throw null; }
         }
     }
@@ -15801,18 +15763,15 @@ namespace System.Text
         public System.Text.DecoderFallback? Fallback { get { throw null; } set { } }
         public System.Text.DecoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual void Convert(byte* bytes, int byteCount, char* chars, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
         public virtual void Convert(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, int charCount, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
         public virtual void Convert(System.ReadOnlySpan<byte> bytes, System.Span<char> chars, bool flush, out int bytesUsed, out int charsUsed, out bool completed) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetCharCount(byte* bytes, int count, bool flush) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
         public virtual int GetCharCount(byte[] bytes, int index, int count, bool flush) { throw null; }
         public virtual int GetCharCount(System.ReadOnlySpan<byte> bytes, bool flush) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetChars(byte* bytes, int byteCount, char* chars, int charCount, bool flush) { throw null; }
         public abstract int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex);
         public virtual int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex, bool flush) { throw null; }
@@ -15886,17 +15845,14 @@ namespace System.Text
         public System.Text.EncoderFallback? Fallback { get { throw null; } set { } }
         public System.Text.EncoderFallbackBuffer FallbackBuffer { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual void Convert(char* chars, int charCount, byte* bytes, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
         public virtual void Convert(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, int byteCount, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
         public virtual void Convert(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush, out int charsUsed, out int bytesUsed, out bool completed) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetByteCount(char* chars, int count, bool flush) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count, bool flush);
         public virtual int GetByteCount(System.ReadOnlySpan<char> chars, bool flush) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetBytes(char* chars, int charCount, byte* bytes, int byteCount, bool flush) { throw null; }
         public abstract int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex, bool flush);
         public virtual int GetBytes(System.ReadOnlySpan<char> chars, System.Span<byte> bytes, bool flush) { throw null; }
@@ -16003,7 +15959,6 @@ namespace System.Text
         public static System.IO.Stream CreateTranscodingStream(System.IO.Stream innerStream, System.Text.Encoding innerStreamEncoding, System.Text.Encoding outerStreamEncoding, bool leaveOpen = false) { throw null; }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetByteCount(char* chars, int count) { throw null; }
         public virtual int GetByteCount(char[] chars) { throw null; }
         public abstract int GetByteCount(char[] chars, int index, int count);
@@ -16011,7 +15966,6 @@ namespace System.Text
         public virtual int GetByteCount(string s) { throw null; }
         public int GetByteCount(string s, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public virtual byte[] GetBytes(char[] chars) { throw null; }
         public virtual byte[] GetBytes(char[] chars, int index, int count) { throw null; }
@@ -16021,13 +15975,11 @@ namespace System.Text
         public byte[] GetBytes(string s, int index, int count) { throw null; }
         public virtual int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetCharCount(byte* bytes, int count) { throw null; }
         public virtual int GetCharCount(byte[] bytes) { throw null; }
         public abstract int GetCharCount(byte[] bytes, int index, int count);
         public virtual int GetCharCount(System.ReadOnlySpan<byte> bytes) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe virtual int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public virtual char[] GetChars(byte[] bytes) { throw null; }
         public virtual char[] GetChars(byte[] bytes, int index, int count) { throw null; }
@@ -16045,7 +15997,6 @@ namespace System.Text
         public abstract int GetMaxCharCount(int byteCount);
         public virtual byte[] GetPreamble() { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe string GetString(byte* bytes, int byteCount) { throw null; }
         public virtual string GetString(byte[] bytes) { throw null; }
         public virtual string GetString(byte[] bytes, int index, int count) { throw null; }
@@ -16217,7 +16168,6 @@ namespace System.Text
         public System.Text.StringBuilder Append(char value) { throw null; }
         public System.Text.StringBuilder Append(System.Text.Rune value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe System.Text.StringBuilder Append(char* value, int valueCount) { throw null; }
         public System.Text.StringBuilder Append(char value, int repeatCount) { throw null; }
         public System.Text.StringBuilder Append(char[]? value) { throw null; }

--- a/src/libraries/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
+++ b/src/libraries/System.Text.Encoding.Extensions/ref/System.Text.Encoding.Extensions.cs
@@ -11,24 +11,20 @@ namespace System.Text
         public ASCIIEncoding() { }
         public override bool IsSingleByte { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(System.ReadOnlySpan<char> chars) { throw null; }
         public override int GetByteCount(string chars) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(System.ReadOnlySpan<char> chars, System.Span<byte> bytes) { throw null; }
         public override int GetBytes(string chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         public override int GetCharCount(System.ReadOnlySpan<byte> bytes) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override int GetChars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars) { throw null; }
@@ -49,21 +45,17 @@ namespace System.Text
         public override System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -82,21 +74,17 @@ namespace System.Text
         public override System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -115,21 +103,17 @@ namespace System.Text
         public UTF7Encoding(bool allowOptionals) { }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(string s) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override System.Text.Decoder GetDecoder() { throw null; }
@@ -147,24 +131,20 @@ namespace System.Text
         public override System.ReadOnlySpan<byte> Preamble { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? value) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetByteCount(char* chars, int count) { throw null; }
         public override int GetByteCount(char[] chars, int index, int count) { throw null; }
         public override int GetByteCount(System.ReadOnlySpan<char> chars) { throw null; }
         public override int GetByteCount(string chars) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetBytes(char* chars, int charCount, byte* bytes, int byteCount) { throw null; }
         public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         public override int GetBytes(System.ReadOnlySpan<char> chars, System.Span<byte> bytes) { throw null; }
         public override int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetCharCount(byte* bytes, int count) { throw null; }
         public override int GetCharCount(byte[] bytes, int index, int count) { throw null; }
         public override int GetCharCount(System.ReadOnlySpan<byte> bytes) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount) { throw null; }
         public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex) { throw null; }
         public override int GetChars(System.ReadOnlySpan<byte> bytes, System.Span<char> chars) { throw null; }

--- a/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
+++ b/src/libraries/System.Threading.Overlapped/ref/System.Threading.Overlapped.cs
@@ -29,7 +29,6 @@ namespace System.Threading
         public int OffsetHigh { get { throw null; } set { } }
         public int OffsetLow { get { throw null; } set { } }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static void Free(System.Threading.NativeOverlapped* nativeOverlappedPtr) { }
         [System.CLSCompliantAttribute(false)]
         [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use Pack(IOCompletionCallback?, object?) instead.")]
@@ -37,7 +36,6 @@ namespace System.Threading
         [System.CLSCompliantAttribute(false)]
         public unsafe System.Threading.NativeOverlapped* Pack(System.Threading.IOCompletionCallback? iocb, object? userData) { throw null; }
         [System.CLSCompliantAttribute(false)]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static System.Threading.Overlapped Unpack(System.Threading.NativeOverlapped* nativeOverlappedPtr) { throw null; }
         [System.CLSCompliantAttribute(false)]
         [System.ObsoleteAttribute("This overload is not safe and has been deprecated. Use UnsafePack(IOCompletionCallback?, object?) instead.")]

--- a/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
+++ b/src/libraries/System.Threading.ThreadPool/ref/System.Threading.ThreadPool.cs
@@ -55,7 +55,6 @@ namespace System.Threading
         public static bool SetMinThreads(int workerThreads, int completionPortThreads) { throw null; }
         [System.CLSCompliantAttribute(false)]
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
-        [System.Diagnostics.CodeAnalysis.RequiresUnsafeAttribute]
         public unsafe static bool UnsafeQueueNativeOverlapped(System.Threading.NativeOverlapped* overlapped) { throw null; }
         public static bool UnsafeQueueUserWorkItem(System.Threading.IThreadPoolWorkItem callBack, bool preferLocal) { throw null; }
         public static bool UnsafeQueueUserWorkItem(System.Threading.WaitCallback callBack, object? state) { throw null; }

--- a/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
+++ b/src/mono/System.Private.CoreLib/src/System/ArgIterator.cs
@@ -31,7 +31,6 @@ namespace System
         }
 
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public unsafe ArgIterator(RuntimeArgumentHandle arglist, void* ptr)
         {
             sig = IntPtr.Zero;

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Emit/DynamicILInfo.cs
@@ -110,7 +110,6 @@ namespace System.Reflection.Emit
         }
 
         [CLSCompliantAttribute(false)]
-        [RequiresUnsafe]
         public unsafe void SetCode(byte* code, int codeSize, int maxStackSize)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(codeSize);
@@ -128,7 +127,6 @@ namespace System.Reflection.Emit
 
         // FIXME:
         [CLSCompliantAttribute(false)]
-        [RequiresUnsafe]
         public unsafe void SetExceptions(byte* exceptions, int exceptionsSize)
         {
             throw new NotImplementedException();
@@ -141,7 +139,6 @@ namespace System.Reflection.Emit
         }
 
         [CLSCompliantAttribute(false)]
-        [RequiresUnsafe]
         public unsafe void SetLocalSignature(byte* localSignature, int signatureSize)
         {
             byte[] b = new byte[signatureSize];

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -9,7 +9,6 @@ namespace System.Reflection.Metadata
     public static class AssemblyExtensions
     {
         [CLSCompliant(false)]
-        [RequiresUnsafe]
         public static unsafe bool TryGetRawMetadata(this Assembly assembly, out byte* blob, out int length)
         {
             ArgumentNullException.ThrowIfNull(assembly);


### PR DESCRIPTION
It won't be possible to be used in source with new compiler (https://github.com/dotnet/roslyn/pull/83295). Specifically, it will result in
```
error CS9379: Do not use 'RequiresUnsafeAttribute' in source; use the 'unsafe' modifier instead.
```
Related to https://github.com/dotnet/runtime/issues/125800 and https://github.com/dotnet/roslyn/issues/81207.