### PR TITLE
[Wasm RyuJit] add length prefix to each jit code contribution

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2304,6 +2304,12 @@ void CodeGen::genEmitMachineCode()
 
     m_compiler->unwindReserve();
 
+#if defined(TARGET_WASM)
+    // For Wasm we know know the exact size of each function and funclet.
+    //
+    GetEmitter()->emitUpdateFuncletLocations();
+#endif
+
     bool trackedStackPtrsContig; // are tracked stk-ptrs contiguous ?
 
 #ifdef TARGET_64BIT

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -101,6 +101,8 @@ void CodeGen::genMarkLabelsForCodegen()
 //
 void CodeGen::genBeginFnProlog()
 {
+    GetEmitter()->emitIns(INS_code_size);
+
     FuncInfoDsc* const func = m_compiler->funGetFunc(ROOT_FUNC_IDX);
     assert(func->funWasmLocalDecls != nullptr);
 
@@ -348,6 +350,8 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
 {
     assert(m_compiler->bbIsFuncletBeg(block));
     JITDUMP("*************** In genFuncletProlog()\n");
+
+    GetEmitter()->emitIns(INS_code_size);
 
     // Local sig for the funclet
     //

--- a/src/coreclr/jit/emitfmtswasm.h
+++ b/src/coreclr/jit/emitfmtswasm.h
@@ -30,6 +30,7 @@ IF_DEF(NONE,          IS_NONE, NONE)
 IF_DEF(OPCODE,        IS_NONE, NONE) // <opcode>
 IF_DEF(BLOCK,         IS_NONE, NONE) // <opcode> <sig = 0x40>
 IF_DEF(RAW_ULEB128,   IS_NONE, NONE) // <ULEB128 immediate>
+IF_DEF(CODE_SIZE,     IS_NONE, NONE)
 IF_DEF(ULEB128,       IS_NONE, NONE) // <opcode> <ULEB128 immediate>
 IF_DEF(FUNCIDX,       IS_NONE, NONE) // <opcode> <ULEB128 immediate (function index reloc)>
 IF_DEF(SLEB128,       IS_NONE, NONE) // <opcode> <LEB128 immediate (signed)>

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -502,6 +502,10 @@ unsigned emitter::instrDesc::idCodeSize() const
             assert(!idIsCnsReloc());
             size = SizeOfULEB128(emitGetInsSC(this));
             break;
+        case IF_CODE_SIZE:
+            assert(!idIsCnsReloc());
+            size = PADDED_RELOC_SIZE;
+            break;
         case IF_LOCAL_DECL:
         {
             assert(idIsLclVarDecl());
@@ -590,6 +594,22 @@ size_t emitter::emitOutputULEB128(uint8_t* destination, uint64_t value)
         buffer[0] = (uint8_t)value;
         return 1;
     }
+}
+
+size_t emitter::emitOutputULEB128Padded(uint8_t* destination, uint64_t value)
+{
+    uint8_t* buffer = destination + writeableOffset;
+    int      i      = 0;
+
+    for (; i < PADDED_RELOC_SIZE - 1; i++)
+    {
+        buffer[i] = (uint8_t)((value & 0x7F) | 0x80);
+        value >>= 7;
+    }
+
+    buffer[i] = (uint8_t)value;
+
+    return PADDED_RELOC_SIZE;
 }
 
 size_t emitter::emitOutputSLEB128(uint8_t* destination, int64_t value)
@@ -836,6 +856,17 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             dst += emitOutputULEB128(dst, (int64_t)emitGetInsSC(id));
             break;
         }
+        case IF_CODE_SIZE:
+        {
+            // We always emit this as 5 bytes
+            FuncInfoDsc* const func        = m_compiler->funGetFunc(emitCurIG->igFuncIdx);
+            UNATIVE_OFFSET     startOffset = func->startLoc->CodeOffset(this);
+            UNATIVE_OFFSET     endOffset   = func->endLoc->CodeOffset(this);
+            assert(endOffset >= (startOffset + PADDED_RELOC_SIZE));
+            unsigned const size = endOffset - startOffset - PADDED_RELOC_SIZE;
+            dst += emitOutputULEB128Padded(dst, (int64_t)size);
+            break;
+        }
         default:
             NYI_WASM("emitOutputInstr");
             break;
@@ -1080,6 +1111,26 @@ void emitter::emitDispIns(
             // TODO: catch type
             // target label
             dispJumpTargetIfAny();
+        }
+        break;
+
+        case IF_CODE_SIZE:
+        {
+            FuncInfoDsc* const func = m_compiler->funGetFunc(emitCurIG->igFuncIdx);
+
+            emitLocation* const startLoc = func->startLoc;
+            emitLocation* const endLoc   = func->endLoc;
+
+            if (startLoc != nullptr)
+            {
+                assert(endLoc != nullptr);
+                UNATIVE_OFFSET codeSize = endLoc->CodeOffset(this) - startLoc->CodeOffset(this) - PADDED_RELOC_SIZE;
+                printf(" %u", codeSize);
+            }
+            else
+            {
+                printf(" <not yet determined>");
+            }
         }
         break;
 

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -60,6 +60,7 @@ bool emitInsIsStore(instruction ins);
 insFormat emitInsFormat(instruction ins);
 
 size_t emitOutputULEB128(uint8_t* destination, uint64_t value);
+size_t emitOutputULEB128Padded(uint8_t* destination, uint64_t value);
 size_t emitOutputSLEB128(uint8_t* destination, int64_t value);
 size_t emitRawBytes(uint8_t* destination, const void* source, size_t count);
 size_t emitOutputOpcode(BYTE* dst, instruction ins);

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -28,12 +28,13 @@
 
 // control flow
 //
-INST2(invalid,              "INVALID",              0, IF_NONE,         0xFC, BAD_CODE)
+INST2(invalid,             "INVALID",              0, IF_NONE,          0xFC, BAD_CODE)
 INST(unreachable,          "unreachable",          0, IF_OPCODE,        0x00)
 INST(label,                "label",                0, IF_RAW_ULEB128,   0x00)
 INST(catch_ref,            "catch_ref",            0, IF_CATCH_DECL,    0x00)
 INST(local_cnt,            "local.cnt",            0, IF_RAW_ULEB128,   0x00)
 INST(local_decl,           "local",                0, IF_LOCAL_DECL,    0x00)
+INST(code_size,            "code.size",            0, IF_CODE_SIZE,     0x00)
 INST(nop,                  "nop",                  0, IF_OPCODE,        0x01)
 INST(block,                "block",                0, IF_BLOCK,         0x02)
 INST(loop,                 "loop",                 0, IF_BLOCK,         0x03)

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -77,8 +77,6 @@ void Compiler::unwindEmit(void* pHotCode, void* pColdCode)
     assert(!compGeneratingProlog);
     assert(!compGeneratingEpilog);
 
-    GetEmitter()->emitUpdateFuncletLocations();
-
     for (FuncInfoDsc* const func : Funcs())
     {
         unwindEmitFunc(func, pHotCode, pColdCode);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -359,8 +359,9 @@ namespace ILCompiler.ObjectWriter
             byte[] data = new byte[codeSize];
             body.Encode(data);
 
-            // The code writer should already be set up to write the function body size as a prefix, so just emit the function body here
-            Debug.Assert(codeWriter.HasLengthPrefix);
+            // We must emit the length prefix explicitly
+            Debug.Assert(!codeWriter.HasLengthPrefix);
+            codeWriter.WriteULEB128((ulong)codeSize);
             codeWriter.EmitData(data);
             _uniqueSymbols.Add(name.ToString(), _methodCount);
             _methodCount++;
@@ -481,20 +482,11 @@ namespace ILCompiler.ObjectWriter
 
         private protected override SectionWriter.Params WriterParams(ObjectNodeSection section)
         {
-            if (section == ObjectNodeSection.WasmCodeSection)
-            {
-                return new SectionWriter.Params
-                {
-                    LengthEncodeFormat = LengthEncodeFormat.ULEB128
-                };
-            }
-
             return new SectionWriter.Params
             {
                 LengthEncodeFormat = LengthEncodeFormat.None
             };
         }
-
 
         private protected override void CreateSection(ObjectNodeSection section, Utf8String comdatName, Utf8String symbolName, int sectionIndex, Stream sectionStream)
         {


### PR DESCRIPTION
And no longer do this on the host side. This will let the host split out funclets without having to parse the JIT-generated code.