### PR TITLE
Make Task-returning sync methods into async

### DIFF
--- a/eng/CodeAnalysis.src.globalconfig
+++ b/eng/CodeAnalysis.src.globalconfig
@@ -1951,3 +1951,6 @@ dotnet_diagnostic.IDE2005.severity = silent
 
 # IDE2006: Blank line not allowed after arrow expression clause token
 dotnet_diagnostic.IDE2006.severity = silent
+
+# ASYNC0001: Method can be converted to async
+dotnet_diagnostic.ASYNC0001.severity = warning

--- a/src/libraries/Common/src/System/IO/DelegatingStream.cs
+++ b/src/libraries/Common/src/System/IO/DelegatingStream.cs
@@ -75,9 +75,9 @@ namespace System.IO
             base.Dispose(disposing);
         }
 
-        public override ValueTask DisposeAsync()
+        public override async ValueTask DisposeAsync()
         {
-            return _innerStream.DisposeAsync();
+            await _innerStream.DisposeAsync().ConfigureAwait(false);
         }
 
         #region Read
@@ -102,14 +102,16 @@ namespace System.IO
             return _innerStream.ReadByte();
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+#pragma warning disable CA1835
+            return await _innerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA1835
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return _innerStream.ReadAsync(buffer, cancellationToken);
+            return await _innerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
@@ -127,9 +129,9 @@ namespace System.IO
             _innerStream.CopyTo(destination, bufferSize);
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            return _innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
+            await _innerStream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         #endregion Read
@@ -141,9 +143,9 @@ namespace System.IO
             _innerStream.Flush();
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
-            return _innerStream.FlushAsync(cancellationToken);
+            await _innerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override void SetLength(long value)
@@ -166,14 +168,16 @@ namespace System.IO
             _innerStream.WriteByte(value);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+#pragma warning disable CA1835
+            await _innerStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+#pragma warning restore CA1835
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return _innerStream.WriteAsync(buffer, cancellationToken);
+            await _innerStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)

--- a/src/libraries/Common/src/System/IO/ReadOnlyMemoryStream.cs
+++ b/src/libraries/Common/src/System/IO/ReadOnlyMemoryStream.cs
@@ -123,13 +123,12 @@ namespace System.IO
             }
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             EnsureNotClosed();
-            return cancellationToken.IsCancellationRequested ?
-                Task.FromCanceled<int>(cancellationToken) :
-                Task.FromResult(ReadBuffer(new Span<byte>(buffer, offset, count)));
+            cancellationToken.ThrowIfCancellationRequested();
+            return ReadBuffer(new Span<byte>(buffer, offset, count));
         }
 
 #if !NETFRAMEWORK && !NETSTANDARD2_0

--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -33,9 +33,9 @@ namespace System.Net.Http
             return task.Result;
         }
 
-        internal static Task<byte[]?> DownloadAssetAsync(string uri, TimeSpan downloadTimeout)
+        internal static async Task<byte[]?> DownloadAssetAsync(string uri, TimeSpan downloadTimeout)
         {
-            return DownloadAssetCore(uri, downloadTimeout, async: true);
+            return await DownloadAssetCore(uri, downloadTimeout, async: true).ConfigureAwait(false);
         }
 
         private static async Task<byte[]?> DownloadAssetCore(string uri, TimeSpan downloadTimeout, bool async)

--- a/src/libraries/Common/src/System/Net/ReadWriteAdapter.cs
+++ b/src/libraries/Common/src/System/Net/ReadWriteAdapter.cs
@@ -20,16 +20,16 @@ namespace System.Net
 
     internal readonly struct AsyncReadWriteAdapter : IReadWriteAdapter
     {
-        public static ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
-            stream.ReadAsync(buffer, cancellationToken);
+        public static async ValueTask<int> ReadAsync(Stream stream, Memory<byte> buffer, CancellationToken cancellationToken) =>
+            await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-        public static ValueTask<int> ReadAtLeastAsync(Stream stream, Memory<byte> buffer, int minimumBytes, bool throwOnEndOfStream, CancellationToken cancellationToken) =>
-            stream.ReadAtLeastAsync(buffer, minimumBytes, throwOnEndOfStream, cancellationToken);
+        public static async ValueTask<int> ReadAtLeastAsync(Stream stream, Memory<byte> buffer, int minimumBytes, bool throwOnEndOfStream, CancellationToken cancellationToken) =>
+            await stream.ReadAtLeastAsync(buffer, minimumBytes, throwOnEndOfStream, cancellationToken).ConfigureAwait(false);
 
-        public static ValueTask WriteAsync(Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) =>
-            stream.WriteAsync(buffer, cancellationToken);
+        public static async ValueTask WriteAsync(Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken) =>
+            await stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-        public static Task FlushAsync(Stream stream, CancellationToken cancellationToken) => stream.FlushAsync(cancellationToken);
+        public static async Task FlushAsync(Stream stream, CancellationToken cancellationToken) => await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         public static Task WaitAsync(TaskCompletionSource<bool> waiter) => waiter.Task;
         public static Task WaitAsync(Task task) => task;
@@ -68,9 +68,9 @@ namespace System.Net
             return Task.CompletedTask;
         }
 
-        public static ValueTask<T> WaitAsync<T>(ValueTask<T> task)
+        public static async ValueTask<T> WaitAsync<T>(ValueTask<T> task)
         {
-            return ValueTask.FromResult(task.AsTask().GetAwaiter().GetResult());
+            return await task.ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -29,6 +29,7 @@
     <StrongNameKeyId>Open</StrongNameKeyId>
     <!-- Microsoft.Extensions projects have a separate StrongNameKeyId -->
     <StrongNameKeyId Condition="$(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">MicrosoftAspNetCore</StrongNameKeyId>
+    <NoWarn>$(NoWarn);CA1835</NoWarn>
     <!-- We can't generate an apphost without restoring the targeting pack. -->
     <UseAppHost>false</UseAppHost>
     <EnableDefaultItems>false</EnableDefaultItems>

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -38,7 +38,6 @@
          to avoid issues with multitargeting.
     -->
     <NoWarn Condition="$(TargetFrameworks.Contains('net4')) or $(TargetFrameworks.Contains('netstandard'))">$(NoWarn);CA1510;CA1511;CA1512;CA1513;CA1845;CA1846;CA1847</NoWarn>
-
     <!-- Microsoft.NET.Sdk enables some warnings as errors out of the box.
          We want to remove some items from this list so they don't fail the build.
          Can't use 'WarningsNotAsErrors' element because vbproj doesn't honor it.
@@ -144,6 +143,14 @@
     and '$(RuntimeAsyncSupported)' == 'true'">
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
+
+  <!-- Wire in the PreferAsyncAwait analyzer for all library source projects -->
+  <ItemGroup Condition="'$(IsSourceProject)' == 'true'
+    and $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <ProjectReference Include="$(LibrariesProjectRoot)..\tools\PreferAsyncAwait\PreferAsyncAwait.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)codeOptimization.targets" />
   <Import Project="$(RepositoryEngineeringDir)references.targets" />

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/DistributedCacheExtensions.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Extensions.Caching.Distributed
         /// <param name="token">Optional. A <see cref="CancellationToken" /> to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous set operation.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="key"/> or <paramref name="value"/> is null.</exception>
-        public static Task SetAsync(this IDistributedCache cache, string key, byte[] value, CancellationToken token = default(CancellationToken))
+        public static async Task SetAsync(this IDistributedCache cache, string key, byte[] value, CancellationToken token = default(CancellationToken))
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(value);
 
-            return cache.SetAsync(key, value, DefaultOptions, token);
+            await cache.SetAsync(key, value, DefaultOptions, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,9 +84,9 @@ namespace Microsoft.Extensions.Caching.Distributed
         /// <param name="token">Optional. A <see cref="CancellationToken" /> to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous set operation.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="key"/> or <paramref name="value"/> is null.</exception>
-        public static Task SetStringAsync(this IDistributedCache cache, string key, string value, CancellationToken token = default(CancellationToken))
+        public static async Task SetStringAsync(this IDistributedCache cache, string key, string value, CancellationToken token = default(CancellationToken))
         {
-            return cache.SetStringAsync(key, value, DefaultOptions, token);
+            await cache.SetStringAsync(key, value, DefaultOptions, token).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,12 +99,12 @@ namespace Microsoft.Extensions.Caching.Distributed
         /// <param name="token">Optional. A <see cref="CancellationToken" /> to cancel the operation.</param>
         /// <returns>A task that represents the asynchronous set operation.</returns>
         /// <exception cref="System.ArgumentNullException"><paramref name="key"/> or <paramref name="value"/> is null.</exception>
-        public static Task SetStringAsync(this IDistributedCache cache, string key, string value, DistributedCacheEntryOptions options, CancellationToken token = default(CancellationToken))
+        public static async Task SetStringAsync(this IDistributedCache cache, string key, string value, DistributedCacheEntryOptions options, CancellationToken token = default(CancellationToken))
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(value);
 
-            return cache.SetAsync(key, Encoding.UTF8.GetBytes(value), options, token);
+            await cache.SetAsync(key, Encoding.UTF8.GetBytes(value), options, token).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/Hybrid/HybridCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/Hybrid/HybridCache.cs
@@ -42,9 +42,9 @@ public abstract class HybridCache
     /// <param name="tags">The tags to associate with this cache item.</param>
     /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
     /// <returns>The data, either from cache or the underlying data service.</returns>
-    public ValueTask<T> GetOrCreateAsync<T>(string key, Func<CancellationToken, ValueTask<T>> factory,
+    public async ValueTask<T> GetOrCreateAsync<T>(string key, Func<CancellationToken, ValueTask<T>> factory,
         HybridCacheEntryOptions? options = null, IEnumerable<string>? tags = null, CancellationToken cancellationToken = default)
-        => GetOrCreateAsync(key, factory, WrappedCallbackCache<T>.Instance, options, tags, cancellationToken);
+        => await GetOrCreateAsync(key, factory, WrappedCallbackCache<T>.Instance, options, tags, cancellationToken).ConfigureAwait(false);
 
 #if NET
     /// <summary>
@@ -144,7 +144,7 @@ public abstract class HybridCache
     private static class WrappedCallbackCache<T> // per-T memoized helper that allows GetOrCreateAsync<T> and GetOrCreateAsync<TState, T> to share an implementation
     {
         // for the simple usage scenario (no TState), pack the original callback as the "state", and use a wrapper function that just unrolls and invokes from the state
-        public static readonly Func<Func<CancellationToken, ValueTask<T>>, CancellationToken, ValueTask<T>> Instance = static (callback, ct) => callback(ct);
+        public static readonly Func<Func<CancellationToken, ValueTask<T>>, CancellationToken, ValueTask<T>> Instance = static async (callback, ct) => await callback(ct).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheExtensions.cs
@@ -207,9 +207,9 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <param name="key">The key of the entry to look for or create.</param>
         /// <param name="factory">The factory task that creates the value associated with this key if the key does not exist in the cache.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public static Task<TItem?> GetOrCreateAsync<TItem>(this IMemoryCache cache, object key, Func<ICacheEntry, Task<TItem>> factory)
+        public static async Task<TItem?> GetOrCreateAsync<TItem>(this IMemoryCache cache, object key, Func<ICacheEntry, Task<TItem>> factory)
         {
-            return GetOrCreateAsync<TItem>(cache, key, factory, null);
+            return await GetOrCreateAsync<TItem>(cache, key, factory, null).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryDistributedCache.cs
@@ -57,11 +57,11 @@ namespace Microsoft.Extensions.Caching.Distributed
         /// <param name="key">The key of the item to get.</param>
         /// <param name="token">The <see cref="CancellationToken"/> to use to cancel operation.</param>
         /// <returns>The task for getting the byte array value associated with the specified key from the cache.</returns>
-        public Task<byte[]?> GetAsync(string key, CancellationToken token = default(CancellationToken))
+        public async Task<byte[]?> GetAsync(string key, CancellationToken token = default(CancellationToken))
         {
             ArgumentNullException.ThrowIfNull(key);
 
-            return Task.FromResult(Get(key));
+            return Get(key);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceLookup/ServiceProviderEngineScope.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Extensions.DependencyInjection.ServiceLookup
                 {
                     // sync over async, for the rare case that an object only implements IAsyncDisposable and may end up starving the thread pool.
                     object? localService = service; // copy to avoid closure on other paths
-                    Task.Run(() => ((IAsyncDisposable)localService).DisposeAsync().AsTask()).GetAwaiter().GetResult();
+                    Task.Run(async () => await ((IAsyncDisposable)localService).DisposeAsync().ConfigureAwait(false)).GetAwaiter().GetResult();
                 }
 
                 ThrowHelper.ThrowObjectDisposedException();

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/src/ServiceProvider.cs
@@ -194,10 +194,10 @@ namespace Microsoft.Extensions.DependencyInjection
         /// synchronization context. Services should not rely on disposal continuations running on any particular context.
         /// </remarks>
         /// <returns>A value task that represents the asynchronous operation.</returns>
-        public ValueTask DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             DisposeCore();
-            return Root.DisposeAsync();
+            await Root.DisposeAsync().ConfigureAwait(false);
         }
 
         private void DisposeCore()

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Extensions.Hosting
             _stoppingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
             // Execute all of ExecuteAsync asynchronously, and store the task we're executing so that we can wait for it later.
-            _executeTask = Task.Run(() => ExecuteAsync(_stoppingCts.Token), _stoppingCts.Token);
+            _executeTask = Task.Run(async () => await ExecuteAsync(_stoppingCts.Token).ConfigureAwait(false), _stoppingCts.Token);
 
             // Always return a completed task.  Any result from ExecuteAsync will be handled by the Host.
             return Task.CompletedTask;

--- a/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/HostingHostBuilderExtensions.cs
@@ -386,9 +386,9 @@ namespace Microsoft.Extensions.Hosting
         [UnsupportedOSPlatform("browser")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        public static Task RunConsoleAsync(this IHostBuilder hostBuilder, CancellationToken cancellationToken = default)
+        public static async Task RunConsoleAsync(this IHostBuilder hostBuilder, CancellationToken cancellationToken = default)
         {
-            return hostBuilder.UseConsoleLifetime().Build().RunAsync(cancellationToken);
+            await hostBuilder.UseConsoleLifetime().Build().RunAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -402,9 +402,9 @@ namespace Microsoft.Extensions.Hosting
         [UnsupportedOSPlatform("browser")]
         [UnsupportedOSPlatform("ios")]
         [UnsupportedOSPlatform("tvos")]
-        public static Task RunConsoleAsync(this IHostBuilder hostBuilder, Action<ConsoleLifetimeOptions> configureOptions, CancellationToken cancellationToken = default)
+        public static async Task RunConsoleAsync(this IHostBuilder hostBuilder, Action<ConsoleLifetimeOptions> configureOptions, CancellationToken cancellationToken = default)
         {
-            return hostBuilder.UseConsoleLifetime(configureOptions).Build().RunAsync(cancellationToken);
+            await hostBuilder.UseConsoleLifetime(configureOptions).Build().RunAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 if (_hostedLifecycleServices is not null)
                 {
                     await ForeachService(_hostedLifecycleServices, cancellationToken, concurrent, abortOnFirstException, exceptions,
-                        (service, token) => service.StartingAsync(token)).ConfigureAwait(false);
+async (service, token) => await service.StartingAsync(token).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Exceptions in StartingAsync cause startup to be aborted.
                     LogAndRethrow();
@@ -143,7 +143,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                 if (_hostedLifecycleServices is not null)
                 {
                     await ForeachService(_hostedLifecycleServices, cancellationToken, concurrent, abortOnFirstException, exceptions,
-                        (service, token) => service.StartedAsync(token)).ConfigureAwait(false);
+async (service, token) => await service.StartedAsync(token).ConfigureAwait(false)).ConfigureAwait(false);
                 }
 
                 // Exceptions in StartedAsync cause startup to be aborted.
@@ -260,7 +260,7 @@ namespace Microsoft.Extensions.Hosting.Internal
                     if (reversedLifetimeServices is not null)
                     {
                         await ForeachService(reversedLifetimeServices, cancellationToken, concurrent, abortOnFirstException: false, exceptions,
-                            (service, token) => service.StoppingAsync(token)).ConfigureAwait(false);
+async (service, token) => await service.StoppingAsync(token).ConfigureAwait(false)).ConfigureAwait(false);
                     }
 
                     // Cancel IHostApplicationLifetime.ApplicationStopping.
@@ -268,14 +268,14 @@ namespace Microsoft.Extensions.Hosting.Internal
                     _applicationLifetime.StopApplication();
 
                     // Call StopAsync().
-                    await ForeachService(reversedServices, cancellationToken, concurrent, abortOnFirstException: false, exceptions, (service, token) =>
-                        service.StopAsync(token)).ConfigureAwait(false);
+                    await ForeachService(reversedServices, cancellationToken, concurrent, abortOnFirstException: false, exceptions, async (service, token) =>
+                        await service.StopAsync(token).ConfigureAwait(false)).ConfigureAwait(false);
 
                     // Call StoppedAsync().
                     if (reversedLifetimeServices is not null)
                     {
-                        await ForeachService(reversedLifetimeServices, cancellationToken, concurrent, abortOnFirstException: false, exceptions, (service, token) =>
-                            service.StoppedAsync(token)).ConfigureAwait(false);
+                        await ForeachService(reversedLifetimeServices, cancellationToken, concurrent, abortOnFirstException: false, exceptions, async (service, token) =>
+                            await service.StoppedAsync(token).ConfigureAwait(false)).ConfigureAwait(false);
                     }
                 }
 

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingHttpMessageHandler.cs
@@ -46,10 +46,10 @@ namespace Microsoft.Extensions.Http.Logging
             _options = options;
         }
 
-        private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return Core(request, useAsync, cancellationToken);
+            return await Core(request, useAsync, cancellationToken).ConfigureAwait(false);
 
             async Task<HttpResponseMessage> Core(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
             {
@@ -83,8 +83,8 @@ namespace Microsoft.Extensions.Http.Logging
 
         /// <inheritdoc />
         /// <remarks>Logs the request to and response from the sent <see cref="HttpRequestMessage"/>.</remarks>
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            => SendCoreAsync(request, useAsync: true, cancellationToken);
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => await SendCoreAsync(request, useAsync: true, cancellationToken).ConfigureAwait(false);
 
 #if NET
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
+++ b/src/libraries/Microsoft.Extensions.Http/src/Logging/LoggingScopeHttpMessageHandler.cs
@@ -45,10 +45,10 @@ namespace Microsoft.Extensions.Http.Logging
             _options = options;
         }
 
-        private Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> SendCoreAsync(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return Core(request, useAsync, cancellationToken);
+            return await Core(request, useAsync, cancellationToken).ConfigureAwait(false);
 
             async Task<HttpResponseMessage> Core(HttpRequestMessage request, bool useAsync, CancellationToken cancellationToken)
             {
@@ -84,8 +84,8 @@ namespace Microsoft.Extensions.Http.Logging
 
         /// <inheritdoc />
         /// <remarks>Logs the request to and response from the sent <see cref="HttpRequestMessage"/>.</remarks>
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-            => SendCoreAsync(request, useAsync: true, cancellationToken);
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => await SendCoreAsync(request, useAsync: true, cancellationToken).ConfigureAwait(false);
 
 #if NET
         /// <inheritdoc />

--- a/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
+++ b/src/libraries/System.Console/src/System/IO/SyncTextReader.cs
@@ -91,9 +91,9 @@ namespace System.IO
         // No explicit locking is needed, as they all just delegate
         //
 
-        public override Task<string?> ReadLineAsync()
+        public override async Task<string?> ReadLineAsync()
         {
-            return Task.FromResult(ReadLine());
+            return ReadLine();
         }
 
         public override ValueTask<string?> ReadLineAsync(CancellationToken cancellationToken)
@@ -103,9 +103,9 @@ namespace System.IO
                 new ValueTask<string?>(ReadLine());
         }
 
-        public override Task<string> ReadToEndAsync()
+        public override async Task<string> ReadToEndAsync()
         {
-            return Task.FromResult(ReadToEnd());
+            return ReadToEnd();
         }
 
         public override Task<string> ReadToEndAsync(CancellationToken cancellationToken)
@@ -115,7 +115,7 @@ namespace System.IO
                 Task.FromResult(ReadToEnd());
         }
 
-        public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
+        public override async Task<int> ReadBlockAsync(char[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
@@ -124,10 +124,10 @@ namespace System.IO
             if (buffer.Length - index < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            return Task.FromResult(ReadBlock(buffer, index, count));
+            return ReadBlock(buffer, index, count);
         }
 
-        public override Task<int> ReadAsync(char[] buffer, int index, int count)
+        public override async Task<int> ReadAsync(char[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
@@ -136,7 +136,7 @@ namespace System.IO
             if (buffer.Length - index < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
 
-            return Task.FromResult(Read(buffer, index, count));
+            return Read(buffer, index, count);
         }
     }
 }

--- a/src/libraries/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/AdapterUtil.Common.cs
@@ -19,7 +19,7 @@ namespace System.Data.Common
         // location so that the catcher of the exception will have the appropriate call stack.
         // This class is used so that there will be compile time checking of error messages.
 
-        internal static Task<T> CreatedTaskWithCancellation<T>() => Task.FromCanceled<T>(new CancellationToken(true));
+        internal static async Task<T> CreatedTaskWithCancellation<T>() => await Task.FromCanceled<T>(new CancellationToken(true)).ConfigureAwait(false);
 
         // this method accepts BID format as an argument, this attribute allows FXCopBid rule to validate calls to it
         static partial void TraceException(string trace, Exception e)

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbBatch.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbBatch.cs
@@ -35,13 +35,13 @@ namespace System.Data.Common
 
         protected abstract DbDataReader ExecuteDbDataReader(CommandBehavior behavior);
 
-        public Task<DbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken = default)
-            => ExecuteDbDataReaderAsync(CommandBehavior.Default, cancellationToken);
+        public async Task<DbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken = default)
+            => await ExecuteDbDataReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
 
-        public Task<DbDataReader> ExecuteReaderAsync(
+        public async Task<DbDataReader> ExecuteReaderAsync(
             CommandBehavior behavior,
             CancellationToken cancellationToken = default)
-            => ExecuteDbDataReaderAsync(behavior, cancellationToken);
+            => await ExecuteDbDataReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
 
         protected abstract Task<DbDataReader> ExecuteDbDataReaderAsync(
             CommandBehavior behavior,

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbCommand.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbCommand.cs
@@ -116,13 +116,13 @@ namespace System.Data.Common
 
         IDataReader IDbCommand.ExecuteReader(CommandBehavior behavior) => ExecuteDbDataReader(behavior);
 
-        public Task<int> ExecuteNonQueryAsync() => ExecuteNonQueryAsync(CancellationToken.None);
+        public async Task<int> ExecuteNonQueryAsync() => await ExecuteNonQueryAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public virtual Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
+        public virtual async Task<int> ExecuteNonQueryAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<int>();
+                return await ADP.CreatedTaskWithCancellation<int>().ConfigureAwait(false);
             }
             else
             {
@@ -134,11 +134,11 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult(ExecuteNonQuery());
+                    return ExecuteNonQuery();
                 }
                 catch (Exception e)
                 {
-                    return Task.FromException<int>(e);
+                    return await Task.FromException<int>(e).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -147,23 +147,23 @@ namespace System.Data.Common
             }
         }
 
-        public Task<DbDataReader> ExecuteReaderAsync() =>
-            ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None);
+        public async Task<DbDataReader> ExecuteReaderAsync() =>
+            await ExecuteReaderAsync(CommandBehavior.Default, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<DbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
-            ExecuteReaderAsync(CommandBehavior.Default, cancellationToken);
+        public async Task<DbDataReader> ExecuteReaderAsync(CancellationToken cancellationToken) =>
+            await ExecuteReaderAsync(CommandBehavior.Default, cancellationToken).ConfigureAwait(false);
 
-        public Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior) =>
-            ExecuteReaderAsync(behavior, CancellationToken.None);
+        public async Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior) =>
+            await ExecuteReaderAsync(behavior, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
-            ExecuteDbDataReaderAsync(behavior, cancellationToken);
+        public async Task<DbDataReader> ExecuteReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) =>
+            await ExecuteDbDataReaderAsync(behavior, cancellationToken).ConfigureAwait(false);
 
-        protected virtual Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
+        protected virtual async Task<DbDataReader> ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<DbDataReader>();
+                return await ADP.CreatedTaskWithCancellation<DbDataReader>().ConfigureAwait(false);
             }
             else
             {
@@ -175,11 +175,11 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult<DbDataReader>(ExecuteReader(behavior));
+                    return ExecuteReader(behavior);
                 }
                 catch (Exception e)
                 {
-                    return Task.FromException<DbDataReader>(e);
+                    return await Task.FromException<DbDataReader>(e).ConfigureAwait(false);
                 }
                 finally
                 {
@@ -188,14 +188,14 @@ namespace System.Data.Common
             }
         }
 
-        public Task<object?> ExecuteScalarAsync() =>
-            ExecuteScalarAsync(CancellationToken.None);
+        public async Task<object?> ExecuteScalarAsync() =>
+            await ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public virtual Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
+        public virtual async Task<object?> ExecuteScalarAsync(CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<object?>();
+                return await ADP.CreatedTaskWithCancellation<object?>().ConfigureAwait(false);
             }
             else
             {
@@ -207,11 +207,11 @@ namespace System.Data.Common
 
                 try
                 {
-                    return Task.FromResult<object?>(ExecuteScalar());
+                    return ExecuteScalar();
                 }
                 catch (Exception e)
                 {
-                    return Task.FromException<object?>(e);
+                    return await Task.FromException<object?>(e).ConfigureAwait(false);
                 }
                 finally
                 {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbConnection.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbConnection.cs
@@ -81,11 +81,11 @@ namespace System.Data.Common
             }
         }
 
-        public ValueTask<DbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
-            => BeginDbTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
+        public async ValueTask<DbTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default)
+            => await BeginDbTransactionAsync(IsolationLevel.Unspecified, cancellationToken).ConfigureAwait(false);
 
-        public ValueTask<DbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
-            => BeginDbTransactionAsync(isolationLevel, cancellationToken);
+        public async ValueTask<DbTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default)
+            => await BeginDbTransactionAsync(isolationLevel, cancellationToken).ConfigureAwait(false);
 
         public abstract void Close();
 
@@ -226,20 +226,20 @@ namespace System.Data.Common
         /// </summary>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task<DataTable> GetSchemaAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<DataTable> GetSchemaAsync(CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<DataTable>(cancellationToken);
+                return await Task.FromCanceled<DataTable>(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                return Task.FromResult(GetSchema());
+                return GetSchema();
             }
             catch (Exception e)
             {
-                return Task.FromException<DataTable>(e);
+                return await Task.FromException<DataTable>(e).ConfigureAwait(false);
             }
         }
 
@@ -256,22 +256,22 @@ namespace System.Data.Common
         /// <param name="collectionName">Specifies the name of the schema to return.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task<DataTable> GetSchemaAsync(
+        public virtual async Task<DataTable> GetSchemaAsync(
             string collectionName,
             CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<DataTable>(cancellationToken);
+                return await Task.FromCanceled<DataTable>(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                return Task.FromResult(GetSchema(collectionName));
+                return GetSchema(collectionName);
             }
             catch (Exception e)
             {
-                return Task.FromException<DataTable>(e);
+                return await Task.FromException<DataTable>(e).ConfigureAwait(false);
             }
         }
 
@@ -289,21 +289,21 @@ namespace System.Data.Common
         /// <param name="restrictionValues">Specifies a set of restriction values for the requested schema.</param>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task<DataTable> GetSchemaAsync(string collectionName, string?[] restrictionValues,
+        public virtual async Task<DataTable> GetSchemaAsync(string collectionName, string?[] restrictionValues,
             CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<DataTable>(cancellationToken);
+                return await Task.FromCanceled<DataTable>(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                return Task.FromResult(GetSchema(collectionName, restrictionValues));
+                return GetSchema(collectionName, restrictionValues);
             }
             catch (Exception e)
             {
-                return Task.FromException<DataTable>(e);
+                return await Task.FromException<DataTable>(e).ConfigureAwait(false);
             }
         }
 
@@ -319,7 +319,7 @@ namespace System.Data.Common
 
         public abstract void Open();
 
-        public Task OpenAsync() => OpenAsync(CancellationToken.None);
+        public async Task OpenAsync() => await OpenAsync(CancellationToken.None).ConfigureAwait(false);
 
         public virtual Task OpenAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReader.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataReader.cs
@@ -100,20 +100,20 @@ namespace System.Data.Common
         /// </summary>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task<DataTable?> GetSchemaTableAsync(CancellationToken cancellationToken = default)
+        public virtual async Task<DataTable?> GetSchemaTableAsync(CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<DataTable?>(cancellationToken);
+                return await Task.FromCanceled<DataTable?>(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                return Task.FromResult(GetSchemaTable());
+                return GetSchemaTable();
             }
             catch (Exception e)
             {
-                return Task.FromException<DataTable?>(e);
+                return await Task.FromException<DataTable?>(e).ConfigureAwait(false);
             }
         }
 
@@ -129,21 +129,21 @@ namespace System.Data.Common
         /// </summary>
         /// <param name="cancellationToken">The cancellation instruction.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public virtual Task<ReadOnlyCollection<DbColumn>> GetColumnSchemaAsync(
+        public virtual async Task<ReadOnlyCollection<DbColumn>> GetColumnSchemaAsync(
             CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<ReadOnlyCollection<DbColumn>>(cancellationToken);
+                return await Task.FromCanceled<ReadOnlyCollection<DbColumn>>(cancellationToken).ConfigureAwait(false);
             }
 
             try
             {
-                return Task.FromResult(this.GetColumnSchema());
+                return this.GetColumnSchema();
             }
             catch (Exception e)
             {
-                return Task.FromException<ReadOnlyCollection<DbColumn>>(e);
+                return await Task.FromException<ReadOnlyCollection<DbColumn>>(e).ConfigureAwait(false);
             }
         }
 
@@ -244,24 +244,24 @@ namespace System.Data.Common
 
         public virtual T GetFieldValue<T>(int ordinal) => (T)GetValue(ordinal);
 
-        public Task<T> GetFieldValueAsync<T>(int ordinal) =>
-            GetFieldValueAsync<T>(ordinal, CancellationToken.None);
+        public async Task<T> GetFieldValueAsync<T>(int ordinal) =>
+            await GetFieldValueAsync<T>(ordinal, CancellationToken.None).ConfigureAwait(false);
 
-        public virtual Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
+        public virtual async Task<T> GetFieldValueAsync<T>(int ordinal, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ADP.CreatedTaskWithCancellation<T>();
+                return await ADP.CreatedTaskWithCancellation<T>().ConfigureAwait(false);
             }
             else
             {
                 try
                 {
-                    return Task.FromResult<T>(GetFieldValue<T>(ordinal));
+                    return GetFieldValue<T>(ordinal);
                 }
                 catch (Exception e)
                 {
-                    return Task.FromException<T>(e);
+                    return await Task.FromException<T>(e).ConfigureAwait(false);
                 }
             }
         }
@@ -270,7 +270,7 @@ namespace System.Data.Common
 
         public abstract bool IsDBNull(int ordinal);
 
-        public Task<bool> IsDBNullAsync(int ordinal) => IsDBNullAsync(ordinal, CancellationToken.None);
+        public async Task<bool> IsDBNullAsync(int ordinal) => await IsDBNullAsync(ordinal, CancellationToken.None).ConfigureAwait(false);
 
         public virtual Task<bool> IsDBNullAsync(int ordinal, CancellationToken cancellationToken)
         {
@@ -295,7 +295,7 @@ namespace System.Data.Common
 
         public abstract bool Read();
 
-        public Task<bool> ReadAsync() => ReadAsync(CancellationToken.None);
+        public async Task<bool> ReadAsync() => await ReadAsync(CancellationToken.None).ConfigureAwait(false);
 
         public virtual Task<bool> ReadAsync(CancellationToken cancellationToken)
         {
@@ -316,7 +316,7 @@ namespace System.Data.Common
             }
         }
 
-        public Task<bool> NextResultAsync() => NextResultAsync(CancellationToken.None);
+        public async Task<bool> NextResultAsync() => await NextResultAsync(CancellationToken.None).ConfigureAwait(false);
 
         public virtual Task<bool> NextResultAsync(CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSource.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DbDataSource.cs
@@ -63,8 +63,8 @@ namespace System.Data.Common
         public DbConnection OpenConnection()
             => OpenDbConnection();
 
-        public ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
-            => OpenDbConnectionAsync(cancellationToken);
+        public async ValueTask<DbConnection> OpenConnectionAsync(CancellationToken cancellationToken = default)
+            => await OpenDbConnectionAsync(cancellationToken).ConfigureAwait(false);
 
         public DbCommand CreateCommand(string? commandText = null)
             => CreateDbCommand(commandText);
@@ -334,8 +334,8 @@ namespace System.Data.Common
             public override void Prepare()
                 => throw ExceptionBuilder.NotSupportedOnDataSourceCommand();
 
-            public override Task PrepareAsync(CancellationToken cancellationToken = default)
-                => Task.FromException(ExceptionBuilder.NotSupportedOnDataSourceCommand());
+            public override async Task PrepareAsync(CancellationToken cancellationToken = default)
+                => throw ExceptionBuilder.NotSupportedOnDataSourceCommand();
 
             // The below are incompatible with commands executed directly against DbDataSource, since no DbConnection
             // is involved at the user API level and the DbCommandWrapper owns the DbConnection.
@@ -563,8 +563,8 @@ namespace System.Data.Common
             public override void Prepare()
                 => throw ExceptionBuilder.NotSupportedOnDataSourceBatch();
 
-            public override Task PrepareAsync(CancellationToken cancellationToken = default)
-                => Task.FromException(ExceptionBuilder.NotSupportedOnDataSourceBatch());
+            public override async Task PrepareAsync(CancellationToken cancellationToken = default)
+                => throw ExceptionBuilder.NotSupportedOnDataSourceBatch();
 
             // The below are incompatible with batches executed directly against DbDataSource, since no DbConnection
             // is involved at the user API level and the DbBatchWrapper owns the DbConnection.

--- a/src/libraries/System.Data.Common/src/System/Data/DataReaderExtensions.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/DataReaderExtensions.cs
@@ -96,11 +96,11 @@ namespace System.Data
             return reader.GetFieldValue<T>(reader.GetOrdinal(name));
         }
 
-        public static Task<T> GetFieldValueAsync<T>(this DbDataReader reader, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<T> GetFieldValueAsync<T>(this DbDataReader reader, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             ArgumentNullException.ThrowIfNull(reader);
 
-            return reader.GetFieldValueAsync<T>(reader.GetOrdinal(name), cancellationToken);
+            return await reader.GetFieldValueAsync<T>(reader.GetOrdinal(name), cancellationToken).ConfigureAwait(false);
         }
 
         public static float GetFloat(this DbDataReader reader, string name)
@@ -189,11 +189,11 @@ namespace System.Data
             return reader.IsDBNull(reader.GetOrdinal(name));
         }
 
-        public static Task<bool> IsDBNullAsync(this DbDataReader reader, string name, CancellationToken cancellationToken = default(CancellationToken))
+        public static async Task<bool> IsDBNullAsync(this DbDataReader reader, string name, CancellationToken cancellationToken = default(CancellationToken))
         {
             ArgumentNullException.ThrowIfNull(reader);
 
-            return reader.IsDBNullAsync(reader.GetOrdinal(name), cancellationToken);
+            return await reader.IsDBNullAsync(reader.GetOrdinal(name), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SeekableSubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SeekableSubReadStream.cs
@@ -67,15 +67,15 @@ namespace System.Formats.Tar
             return 0;
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
             ThrowIfDisposed();
             VerifyPositionInSuperStream();
-            return ReadAsyncCore(buffer, cancellationToken);
+            return await ReadAsyncCore(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override long Seek(long offset, SeekOrigin origin)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/SubReadStream.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -68,13 +68,13 @@ namespace System.Formats.Tar
 
         private int LimitByRemaining(int bufferSize) => (int)Math.Min(Remaining, bufferSize);
 
-        internal ValueTask AdvanceToEndAsync(CancellationToken cancellationToken)
+        internal async ValueTask AdvanceToEndAsync(CancellationToken cancellationToken)
         {
             _hasReachedEnd = true;
 
             long remaining = Remaining;
             _positionInSuperStream = _endInSuperStream;
-            return TarHelpers.AdvanceStreamAsync(_superStream, remaining, cancellationToken);
+            await TarHelpers.AdvanceStreamAsync(_superStream, remaining, cancellationToken).ConfigureAwait(false);
         }
 
         internal void AdvanceToEnd()
@@ -125,25 +125,25 @@ namespace System.Formats.Tar
             return Read(new Span<byte>(ref b)) == 1 ? b : -1;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                return await Task.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
             ThrowIfDisposed();
             ThrowIfBeyondEndOfStream();
-            return ReadAsyncCore(buffer, cancellationToken);
+            return await ReadAsyncCore(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         protected async ValueTask<int> ReadAsyncCore(Memory<byte> buffer, CancellationToken cancellationToken)

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarEntry.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -241,19 +241,19 @@ namespace System.Formats.Tar
         /// <para>An I/O problem occurred.</para></exception>
         /// <exception cref="InvalidOperationException">Attempted to extract an unsupported entry type.</exception>
         /// <exception cref="UnauthorizedAccessException">Operation not permitted due to insufficient permissions.</exception>
-        public Task ExtractToFileAsync(string destinationFileName, bool overwrite, CancellationToken cancellationToken = default)
+        public async Task ExtractToFileAsync(string destinationFileName, bool overwrite, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
             ArgumentException.ThrowIfNullOrEmpty(destinationFileName);
             if (EntryType is TarEntryType.SymbolicLink or TarEntryType.HardLink or TarEntryType.GlobalExtendedAttributes)
             {
-                return Task.FromException(new InvalidOperationException(SR.Format(SR.TarEntryTypeNotSupportedForExtracting, EntryType)));
+                await Task.FromException(new InvalidOperationException(SR.Format(SR.TarEntryTypeNotSupportedForExtracting, EntryType))).ConfigureAwait(false);
             }
             // HardLink entries are rejected above. hardLinkMode will not be used.
-            return ExtractToFileInternalAsync(destinationFileName, linkTargetPath: null, overwrite, TarHardLinkMode.PreserveLink, cancellationToken);
+            await ExtractToFileInternalAsync(destinationFileName, linkTargetPath: null, overwrite, TarHardLinkMode.PreserveLink, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarFile.cs
@@ -77,8 +77,8 @@ namespace System.Formats.Tar
         }
 
         /// <inheritdoc cref="CreateFromDirectoryAsync(string, Stream, bool, TarEntryFormat, CancellationToken)" />
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, CancellationToken cancellationToken = default)
-            => CreateFromDirectoryAsync(sourceDirectoryName, destination, includeBaseDirectory, TarEntryFormat.Pax, cancellationToken);
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, CancellationToken cancellationToken = default)
+            => await CreateFromDirectoryAsync(sourceDirectoryName, destination, includeBaseDirectory, TarEntryFormat.Pax, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Asynchronously creates a tar stream that contains all the filesystem entries from the specified directory.
@@ -96,10 +96,10 @@ namespace System.Formats.Tar
         /// <exception cref="DirectoryNotFoundException">The <paramref name="sourceDirectoryName"/> directory path was not found.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="format"/> is either <see cref="TarEntryFormat.Unknown"/>, or not one of the other enum values.</exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, TarEntryFormat format, CancellationToken cancellationToken = default)
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, TarEntryFormat format, CancellationToken cancellationToken = default)
         {
             ValidateFormat(format);
-            return CreateFromDirectoryAsync(sourceDirectoryName, destination, includeBaseDirectory, new TarWriterOptions() { Format = format }, cancellationToken);
+            await CreateFromDirectoryAsync(sourceDirectoryName, destination, includeBaseDirectory, new TarWriterOptions() { Format = format }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -118,11 +118,11 @@ namespace System.Formats.Tar
         /// <exception cref="DirectoryNotFoundException">The <paramref name="sourceDirectoryName"/> directory path was not found.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><see cref="TarWriterOptions.Format"/> is either <see cref="TarEntryFormat.Unknown"/>, or not one of the other enum values.</exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, TarWriterOptions options, CancellationToken cancellationToken = default)
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, bool includeBaseDirectory, TarWriterOptions options, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
             ArgumentException.ThrowIfNullOrEmpty(sourceDirectoryName);
             ArgumentNullException.ThrowIfNull(destination);
@@ -130,18 +130,18 @@ namespace System.Formats.Tar
 
             if (!destination.CanWrite)
             {
-                return Task.FromException(new ArgumentException(SR.IO_NotSupported_UnwritableStream, nameof(destination)));
+                await Task.FromException(new ArgumentException(SR.IO_NotSupported_UnwritableStream, nameof(destination))).ConfigureAwait(false);
             }
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName));
+                await Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName)).ConfigureAwait(false);
             }
 
             // Rely on Path.GetFullPath for validation of paths
             sourceDirectoryName = Path.GetFullPath(sourceDirectoryName);
 
-            return CreateFromDirectoryInternalAsync(sourceDirectoryName, destination, includeBaseDirectory, leaveOpen: true, options, cancellationToken);
+            await CreateFromDirectoryInternalAsync(sourceDirectoryName, destination, includeBaseDirectory, leaveOpen: true, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc cref="CreateFromDirectory(string, string, bool, TarEntryFormat)" />
@@ -200,8 +200,8 @@ namespace System.Formats.Tar
         }
 
         /// <inheritdoc cref="CreateFromDirectoryAsync(string, string, bool, TarEntryFormat, CancellationToken)" />
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, CancellationToken cancellationToken = default)
-            => CreateFromDirectoryAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, TarEntryFormat.Pax, cancellationToken);
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, CancellationToken cancellationToken = default)
+            => await CreateFromDirectoryAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, TarEntryFormat.Pax, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Asynchronously creates a tar archive from the contents of the specified directory, and outputs them into the specified path. Can optionally include the base directory as the prefix for the entry names.
@@ -217,10 +217,10 @@ namespace System.Formats.Tar
         /// <exception cref="DirectoryNotFoundException">The <paramref name="sourceDirectoryName"/> directory path was not found.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="format"/> is either <see cref="TarEntryFormat.Unknown"/>, or not one of the other enum values.</exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, TarEntryFormat format, CancellationToken cancellationToken = default)
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, TarEntryFormat format, CancellationToken cancellationToken = default)
         {
             ValidateFormat(format);
-            return CreateFromDirectoryAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, new TarWriterOptions() { Format = format }, cancellationToken);
+            await CreateFromDirectoryAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, new TarWriterOptions() { Format = format }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -237,11 +237,11 @@ namespace System.Formats.Tar
         /// <exception cref="DirectoryNotFoundException">The <paramref name="sourceDirectoryName"/> directory path was not found.</exception>
         /// <exception cref="ArgumentOutOfRangeException"><see cref="TarWriterOptions.Format"/> is either <see cref="TarEntryFormat.Unknown"/>, or not one of the other enum values.</exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, TarWriterOptions options, CancellationToken cancellationToken = default)
+        public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationFileName, bool includeBaseDirectory, TarWriterOptions options, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
             ArgumentException.ThrowIfNullOrEmpty(sourceDirectoryName);
             ArgumentException.ThrowIfNullOrEmpty(destinationFileName);
@@ -253,10 +253,10 @@ namespace System.Formats.Tar
 
             if (!Directory.Exists(sourceDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName));
+                await Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, sourceDirectoryName), sourceDirectoryName)).ConfigureAwait(false);
             }
 
-            return CreateFromDirectoryInternalAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, options, cancellationToken);
+            await CreateFromDirectoryInternalAsync(sourceDirectoryName, destinationFileName, includeBaseDirectory, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -338,8 +338,8 @@ namespace System.Formats.Tar
         /// <para>-or-</para>
         /// <para><paramref name="source"/> does not support reading.</para></exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default)
-            => ExtractToDirectoryAsync(source, destinationDirectoryName, new TarExtractOptions { OverwriteFiles = overwriteFiles }, cancellationToken);
+        public static async Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default)
+            => await ExtractToDirectoryAsync(source, destinationDirectoryName, new TarExtractOptions { OverwriteFiles = overwriteFiles }, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Asynchronously extracts the contents of a stream that represents a tar archive into the specified directory.
@@ -360,11 +360,11 @@ namespace System.Formats.Tar
         /// <para>-or-</para>
         /// <para><paramref name="source"/> does not support reading.</para></exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, TarExtractOptions options, CancellationToken cancellationToken = default)
+        public static async Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, TarExtractOptions options, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
             ArgumentNullException.ThrowIfNull(source);
             ArgumentException.ThrowIfNullOrEmpty(destinationDirectoryName);
@@ -372,19 +372,19 @@ namespace System.Formats.Tar
 
             if (!source.CanRead)
             {
-                return Task.FromException(new ArgumentException(SR.IO_NotSupported_UnreadableStream, nameof(source)));
+                await Task.FromException(new ArgumentException(SR.IO_NotSupported_UnreadableStream, nameof(source))).ConfigureAwait(false);
             }
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName));
+                await Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName)).ConfigureAwait(false);
             }
 
             // Rely on Path.GetFullPath for validation of paths
             destinationDirectoryName = Path.GetFullPath(destinationDirectoryName);
             destinationDirectoryName = PathInternal.EnsureTrailingSeparator(destinationDirectoryName);
 
-            return ExtractToDirectoryInternalAsync(source, destinationDirectoryName, options, leaveOpen: true, cancellationToken);
+            await ExtractToDirectoryInternalAsync(source, destinationDirectoryName, options, leaveOpen: true, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -466,8 +466,8 @@ namespace System.Formats.Tar
         /// <para>-or-</para>
         /// <para><paramref name="sourceFileName"/> or <paramref name="destinationDirectoryName"/> is empty.</para></exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task ExtractToDirectoryAsync(string sourceFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default)
-            => ExtractToDirectoryAsync(sourceFileName, destinationDirectoryName, new TarExtractOptions { OverwriteFiles = overwriteFiles }, cancellationToken);
+        public static async Task ExtractToDirectoryAsync(string sourceFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default)
+            => await ExtractToDirectoryAsync(sourceFileName, destinationDirectoryName, new TarExtractOptions { OverwriteFiles = overwriteFiles }, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Asynchronously extracts the contents of a tar file into the specified directory.
@@ -487,11 +487,11 @@ namespace System.Formats.Tar
         /// <para>-or-</para>
         /// <para><paramref name="sourceFileName"/> or <paramref name="destinationDirectoryName"/> is empty.</para></exception>
         /// <exception cref="IOException">An I/O exception occurred.</exception>
-        public static Task ExtractToDirectoryAsync(string sourceFileName, string destinationDirectoryName, TarExtractOptions options, CancellationToken cancellationToken = default)
+        public static async Task ExtractToDirectoryAsync(string sourceFileName, string destinationDirectoryName, TarExtractOptions options, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
             ArgumentException.ThrowIfNullOrEmpty(sourceFileName);
             ArgumentException.ThrowIfNullOrEmpty(destinationDirectoryName);
@@ -504,15 +504,15 @@ namespace System.Formats.Tar
 
             if (!File.Exists(sourceFileName))
             {
-                return Task.FromException(new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, sourceFileName)));
+                await Task.FromException(new FileNotFoundException(SR.Format(SR.IO_FileNotFound_FileName, sourceFileName))).ConfigureAwait(false);
             }
 
             if (!Directory.Exists(destinationDirectoryName))
             {
-                return Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName));
+                await Task.FromException(new DirectoryNotFoundException(SR.Format(SR.IO_PathNotFound_Path, destinationDirectoryName), destinationDirectoryName)).ConfigureAwait(false);
             }
 
-            return ExtractToDirectoryInternalAsync(sourceFileName, destinationDirectoryName, options, cancellationToken);
+            await ExtractToDirectoryInternalAsync(sourceFileName, destinationDirectoryName, options, cancellationToken).ConfigureAwait(false);
         }
 
         // Creates an archive from the contents of a directory.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Write.cs
@@ -200,15 +200,15 @@ namespace System.Formats.Tar
         }
 
         // Writes the current header as a PAX Global Extended Attributes entry into the archive stream and returns the value of the final checksum.
-        internal Task WriteAsPaxGlobalExtendedAttributesAsync(Stream archiveStream, Memory<byte> buffer, int globalExtendedAttributesEntryNumber, CancellationToken cancellationToken)
+        internal async Task WriteAsPaxGlobalExtendedAttributesAsync(Stream archiveStream, Memory<byte> buffer, int globalExtendedAttributesEntryNumber, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                await Task.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             VerifyGlobalExtendedAttributesDataIsValid(globalExtendedAttributesEntryNumber);
-            return WriteAsPaxExtendedAttributesAsync(archiveStream, buffer, ExtendedAttributes, isGea: true, globalExtendedAttributesEntryNumber, cancellationToken);
+            await WriteAsPaxExtendedAttributesAsync(archiveStream, buffer, ExtendedAttributes, isGea: true, globalExtendedAttributesEntryNumber, cancellationToken).ConfigureAwait(false);
         }
 
         // Verifies the data is valid for writing a Global Extended Attributes entry.
@@ -232,17 +232,17 @@ namespace System.Formats.Tar
             }
         }
 
-        internal Task WriteAsV7Async(Stream archiveStream, Memory<byte> buffer, CancellationToken cancellationToken)
+        internal async Task WriteAsV7Async(Stream archiveStream, Memory<byte> buffer, CancellationToken cancellationToken)
         {
             Debug.Assert(archiveStream.CanSeek || _dataStream == null || _dataStream.CanSeek);
 
             if (archiveStream.CanSeek && _dataStream is { CanSeek: false })
             {
-                return WriteWithUnseekableDataStreamAsync(TarEntryFormat.V7, archiveStream, buffer, shouldAdvanceToEnd: true, cancellationToken);
+                await WriteWithUnseekableDataStreamAsync(TarEntryFormat.V7, archiveStream, buffer, shouldAdvanceToEnd: true, cancellationToken).ConfigureAwait(false);
             }
 
             // Else: Seek status of archive does not matter
-            return WriteWithSeekableDataStreamAsync(TarEntryFormat.V7, archiveStream, buffer, cancellationToken);
+            await WriteWithSeekableDataStreamAsync(TarEntryFormat.V7, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
         }
 
         internal void WriteAsUstar(Stream archiveStream, Span<byte> buffer)
@@ -259,17 +259,17 @@ namespace System.Formats.Tar
             }
         }
 
-        internal Task WriteAsUstarAsync(Stream archiveStream, Memory<byte> buffer, CancellationToken cancellationToken)
+        internal async Task WriteAsUstarAsync(Stream archiveStream, Memory<byte> buffer, CancellationToken cancellationToken)
         {
             Debug.Assert(archiveStream.CanSeek || _dataStream == null || _dataStream.CanSeek);
 
             if (archiveStream.CanSeek && _dataStream is { CanSeek: false })
             {
-                return WriteWithUnseekableDataStreamAsync(TarEntryFormat.Ustar, archiveStream, buffer, shouldAdvanceToEnd: true, cancellationToken);
+                await WriteWithUnseekableDataStreamAsync(TarEntryFormat.Ustar, archiveStream, buffer, shouldAdvanceToEnd: true, cancellationToken).ConfigureAwait(false);
             }
 
             // Else: Seek status of archive does not matter
-            return WriteWithSeekableDataStreamAsync(TarEntryFormat.Ustar, archiveStream, buffer, cancellationToken);
+            await WriteWithSeekableDataStreamAsync(TarEntryFormat.Ustar, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
         }
 
         // Writes the current header as a PAX entry into the archive stream.
@@ -499,12 +499,12 @@ namespace System.Formats.Tar
         }
 
         // Asynchronously writes the current header as a PAX Extended Attributes entry into the archive stream and returns the value of the final checksum.
-        private Task WriteAsPaxExtendedAttributesAsync(Stream archiveStream, Memory<byte> buffer, Dictionary<string, string> extendedAttributes, bool isGea, int globalExtendedAttributesEntryNumber, CancellationToken cancellationToken)
+        private async Task WriteAsPaxExtendedAttributesAsync(Stream archiveStream, Memory<byte> buffer, Dictionary<string, string> extendedAttributes, bool isGea, int globalExtendedAttributesEntryNumber, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteAsPaxExtendedAttributesShared(isGea, globalExtendedAttributesEntryNumber, extendedAttributes);
             Debug.Assert(_dataStream == null || (extendedAttributes.Count > 0 && _dataStream.CanSeek)); // We generate the extended attributes data stream, should always be seekable
-            return WriteWithSeekableDataStreamAsync(TarEntryFormat.Pax, archiveStream, buffer, cancellationToken);
+            await WriteWithSeekableDataStreamAsync(TarEntryFormat.Pax, archiveStream, buffer, cancellationToken).ConfigureAwait(false);
         }
 
         // Initializes the name, mode and type flag of a PAX extended attributes entry.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarReader.cs
@@ -172,17 +172,17 @@ namespace System.Formats.Tar
         /// <para>-or-</para>
         /// <para>Two or more Extended Attributes entries were found consecutively in the current <see cref="TarEntryFormat.Pax"/> archive.</para></exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>
-        public ValueTask<TarEntry?> GetNextEntryAsync(bool copyData = false, CancellationToken cancellationToken = default)
+        public async ValueTask<TarEntry?> GetNextEntryAsync(bool copyData = false, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<TarEntry?>(cancellationToken);
+                return await ValueTask.FromCanceled<TarEntry?>(cancellationToken).ConfigureAwait(false);
             }
 
             if (_reachedEndMarkers)
             {
                 // Avoid advancing the stream if we already found the end of the archive.
-                return ValueTask.FromResult<TarEntry?>(null);
+                return null;
             }
 
             Debug.Assert(_archiveStream.CanRead);
@@ -190,10 +190,10 @@ namespace System.Formats.Tar
             if (_archiveStream.CanSeek && _archiveStream.Length == 0)
             {
                 // Attempting to get the next entry on an empty tar stream
-                return ValueTask.FromResult<TarEntry?>(null);
+                return null;
             }
 
-            return GetNextEntryInternalAsync(copyData, cancellationToken);
+            return await GetNextEntryInternalAsync(copyData, cancellationToken).ConfigureAwait(false);
         }
 
         // Moves the underlying archive stream position pointer to the beginning of the next header.

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarWriter.cs
@@ -183,15 +183,15 @@ namespace System.Formats.Tar
         /// <para>The entry will be created using the format specified in the <see cref="TarWriter(Stream, TarEntryFormat, bool)"/> constructor, or will use <see cref="TarEntryFormat.Pax"/> if other constructors are used.</para>
         /// <para>If the format is <see cref="TarEntryFormat.Pax"/>, the <c>atime</c> and <c>ctime</c> from the file will be stored in the <see cref="PaxTarEntry.ExtendedAttributes"/> dictionary. If the format is <see cref="TarEntryFormat.Gnu"/>, this method will not set a value for <see cref="GnuTarEntry.AccessTime"/> and <see cref="GnuTarEntry.ChangeTime"/> because most TAR tools do not support these fields for this format.</para>
         /// </remarks>
-        public Task WriteEntryAsync(string fileName, string? entryName, CancellationToken cancellationToken = default)
+        public async Task WriteEntryAsync(string fileName, string? entryName, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             (string fullPath, string actualEntryName) = ValidateWriteEntryArguments(fileName, entryName);
-            return ReadFileFromDiskAndWriteToArchiveStreamAsEntryAsync(fullPath, actualEntryName, cancellationToken);
+            await ReadFileFromDiskAndWriteToArchiveStreamAsEntryAsync(fullPath, actualEntryName, cancellationToken).ConfigureAwait(false);
         }
 
         // Reads an entry from disk and writes it into the archive stream.
@@ -299,18 +299,18 @@ namespace System.Formats.Tar
         /// <exception cref="ObjectDisposedException">The archive stream is disposed.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="entry"/> is <see langword="null"/>.</exception>
         /// <exception cref="IOException">An I/O problem occurred.</exception>
-        public Task WriteEntryAsync(TarEntry entry, CancellationToken cancellationToken = default)
+        public async Task WriteEntryAsync(TarEntry entry, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             ObjectDisposedException.ThrowIf(_isDisposed, this);
             ArgumentNullException.ThrowIfNull(entry);
             ValidateEntryLinkName(entry._header._typeFlag, entry._header._linkName);
             ValidateStreamsSeekability(entry);
-            return WriteEntryAsyncInternal(entry, cancellationToken);
+            await WriteEntryAsyncInternal(entry, cancellationToken).ConfigureAwait(false);
         }
 
         // Portion of the WriteEntry(entry) method that rents a buffer and writes to the archive.

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/dec/BrotliStream.Decompress.cs
@@ -126,10 +126,10 @@ namespace System.IO.Compression
         /// <remarks><para>This method enables you to perform resource-intensive I/O operations without blocking the main thread. This performance consideration is particularly important in apps where a time-consuming stream operation can block the UI thread and make your app appear as if it is not working. The async methods are used in conjunction with the <see langword="async" /> and <see langword="await" /> keywords in Visual Basic and C#.</para>
         /// <para>Use the <see cref="System.IO.Compression.BrotliStream.CanRead" /> property to determine whether the current instance supports reading.</para>
         /// <para>If the operation is canceled before it completes, the returned task contains the <see cref="System.Threading.Tasks.TaskStatus.Canceled" /> value for the <see cref="System.Threading.Tasks.Task.Status" /> property.</para></remarks>
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads a sequence of bytes from the current Brotli stream, writes them to a byte memory range, advances the position within the Brotli stream by the number of bytes read, and monitors cancellation requests.</summary>
@@ -139,7 +139,7 @@ namespace System.IO.Compression
         /// <remarks><para>This method enables you to perform resource-intensive I/O operations without blocking the main thread. This performance consideration is particularly important in apps where a time-consuming stream operation can block the UI thread and make your app appear as if it is not working. The async methods are used in conjunction with the <see langword="async" /> and <see langword="await" /> keywords in Visual Basic and C#.</para>
         /// <para>Use the <see cref="System.IO.Compression.BrotliStream.CanRead" /> property to determine whether the current instance supports reading.</para>
         /// <para>If the operation is canceled before it completes, the returned task contains the <see cref="System.Threading.Tasks.TaskStatus.Canceled" /> value for the <see cref="System.Threading.Tasks.Task.Status" /> property.</para></remarks>
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (_mode != CompressionMode.Decompress)
                 throw new InvalidOperationException(SR.BrotliStream_Compress_UnsupportedOperation);
@@ -148,10 +148,10 @@ namespace System.IO.Compression
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
-            return Core(buffer, cancellationToken);
+            return await Core(buffer, cancellationToken).ConfigureAwait(false);
 
             async ValueTask<int> Core(Memory<byte> buffer, CancellationToken cancellationToken)
             {

--- a/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
+++ b/src/libraries/System.IO.Compression.Brotli/src/System/IO/Compression/enc/BrotliStream.Compress.cs
@@ -128,10 +128,10 @@ namespace System.IO.Compression
         /// <remarks><para>This method enables you to perform resource-intensive I/O operations without blocking the main thread. This performance consideration is particularly important in apps where a time-consuming stream operation can block the UI thread and make your app appear as if it is not working. The async methods are used in conjunction with the <see langword="async" /> and <see langword="await" /> keywords in Visual Basic and C#.</para>
         /// <para>Use the <see cref="System.IO.Compression.BrotliStream.CanWrite" /> property to determine whether the current instance supports writing.</para>
         /// <para>If the operation is canceled before it completes, the returned task contains the <see cref="System.Threading.Tasks.TaskStatus.Canceled" /> value for the <see cref="System.Threading.Tasks.Task.Status" /> property.</para></remarks>
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously writes compressed bytes to the underlying Brotli stream from the specified byte memory range.</summary>

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.Async.cs
@@ -33,7 +33,7 @@ public static partial class ZipFile
     /// to specify relative or absolute path information. Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is an opened <see cref="ZipArchive"/> in <see cref="ZipArchiveMode.Read"/> mode.</returns>
-    public static Task<ZipArchive> OpenReadAsync(string archiveFileName, CancellationToken cancellationToken = default) => OpenAsync(archiveFileName, ZipArchiveMode.Read, cancellationToken);
+    public static async Task<ZipArchive> OpenReadAsync(string archiveFileName, CancellationToken cancellationToken = default) => await OpenAsync(archiveFileName, ZipArchiveMode.Read, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously opens a <code>ZipArchive</code> on the specified <code>archiveFileName</code> in the specified <code>ZipArchiveMode</code> mode.
@@ -73,7 +73,7 @@ public static partial class ZipFile
     /// Note that creating a Zip file with the <code>ZipArchiveMode.Create</code> mode is more efficient when creating a new Zip file.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is an opened <see cref="ZipArchive"/> in the requested <paramref name="mode"/>.</returns>
-    public static Task<ZipArchive> OpenAsync(string archiveFileName, ZipArchiveMode mode, CancellationToken cancellationToken = default) => OpenAsync(archiveFileName, mode, entryNameEncoding: null, cancellationToken);
+    public static async Task<ZipArchive> OpenAsync(string archiveFileName, ZipArchiveMode mode, CancellationToken cancellationToken = default) => await OpenAsync(archiveFileName, mode, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously opens a <code>ZipArchive</code> on the specified <code>archiveFileName</code> in the specified <code>ZipArchiveMode</code> mode.
@@ -216,8 +216,8 @@ public static partial class ZipFile
     /// <param name="destinationArchiveFileName">The name of the archive to be created.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to disk.</returns>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, CancellationToken cancellationToken = default) =>
-        DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null, cancellationToken);
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, CancellationToken cancellationToken = default) =>
+        await DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// <p>Asynchronously creates a Zip archive at the path <code>destinationArchiveFileName</code> that contains the files and directories in the directory
@@ -265,8 +265,8 @@ public static partial class ZipFile
     /// should be included directly in the archive.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to disk.</returns>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, CompressionLevel compressionLevel, bool includeBaseDirectory, CancellationToken cancellationToken = default) =>
-        DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding: null, cancellationToken);
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName, CompressionLevel compressionLevel, bool includeBaseDirectory, CancellationToken cancellationToken = default) =>
+        await DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// <p>Asynchronously creates a Zip archive at the path <code>destinationArchiveFileName</code> that contains the files and directories in the directory
@@ -337,9 +337,9 @@ public static partial class ZipFile
     /// </param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to disk.</returns>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName,
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName,
                                            CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
-        DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding, cancellationToken);
+        await DoCreateFromDirectoryAsync(sourceDirectoryName, destinationArchiveFileName, compressionLevel, includeBaseDirectory, entryNameEncoding, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously creates a zip archive in the specified stream that contains the files and directories from the specified directory.
@@ -365,8 +365,8 @@ public static partial class ZipFile
     ///An I/O error occurred while opening a file to be archived.</exception>
     /// <exception cref="NotSupportedException"><paramref name="sourceDirectoryName" /> contains an invalid format.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, CancellationToken cancellationToken = default) =>
-       DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null, cancellationToken);
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, CancellationToken cancellationToken = default) =>
+       await DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel: null, includeBaseDirectory: false, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously creates a zip archive in the specified stream that contains the files and directories from the specified directory, uses the specified compression level, and optionally includes the base directory.
@@ -395,8 +395,8 @@ public static partial class ZipFile
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="compressionLevel"/> is not a valid <see cref="CompressionLevel"/> value.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
     /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to the specified stream.</returns>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, CancellationToken cancellationToken = default) =>
-        DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel, includeBaseDirectory, entryNameEncoding: null, cancellationToken);
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination, CompressionLevel compressionLevel, bool includeBaseDirectory, CancellationToken cancellationToken = default) =>
+        await DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel, includeBaseDirectory, entryNameEncoding: null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously creates a zip archive in the specified stream that contains the files and directories from the specified directory, uses the specified compression level and character encoding for entry names, and optionally includes the base directory.
@@ -426,9 +426,9 @@ public static partial class ZipFile
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="compressionLevel"/> is not a valid <see cref="CompressionLevel"/> value.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
     /// <returns>A task that represents the asynchronous create operation. The task completes when the archive has been written to the specified stream.</returns>
-    public static Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination,
+    public static async Task CreateFromDirectoryAsync(string sourceDirectoryName, Stream destination,
                                            CompressionLevel compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
-        DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel, includeBaseDirectory, entryNameEncoding, cancellationToken);
+        await DoCreateFromDirectoryAsync(sourceDirectoryName, destination, compressionLevel, includeBaseDirectory, entryNameEncoding, cancellationToken).ConfigureAwait(false);
 
     private static async Task DoCreateFromDirectoryAsync(string sourceDirectoryName, string destinationArchiveFileName,
                                               CompressionLevel? compressionLevel, bool includeBaseDirectory, Encoding? entryNameEncoding, CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Extract.Async.cs
@@ -41,8 +41,8 @@ public static partial class ZipFile
     /// <param name="destinationDirectoryName">The path to the directory in which to place the extracted files, specified as a relative or absolute path. A relative path is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: false, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all of the files in the specified archive to a directory on the file system.
@@ -77,8 +77,8 @@ public static partial class ZipFile
     /// <param name="overwriteFiles">True to indicate overwrite.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: overwriteFiles, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: overwriteFiles, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all of the files in the specified archive to a directory on the file system.
@@ -134,8 +134,8 @@ public static partial class ZipFile
     /// </param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: entryNameEncoding, overwriteFiles: false, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(string sourceArchiveFileName, string destinationDirectoryName, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(sourceArchiveFileName, destinationDirectoryName, entryNameEncoding: entryNameEncoding, overwriteFiles: false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all of the files in the specified archive to a directory on the file system.
@@ -233,8 +233,8 @@ public static partial class ZipFile
     /// An archive entry was compressed by using a compression method that is not supported.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: false, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all the files from the zip archive stored in the specified stream and places them in the specified destination directory on the file system, and optionally allows choosing if the files in the destination directory should be overwritten.
@@ -265,8 +265,8 @@ public static partial class ZipFile
     /// An archive entry was compressed by using a compression method that is not supported.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: overwriteFiles, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, bool overwriteFiles, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: null, overwriteFiles: overwriteFiles, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all the files from the zip archive stored in the specified stream and places them in the specified destination directory on the file system and uses the specified character encoding for entry names.
@@ -305,8 +305,8 @@ public static partial class ZipFile
     /// An archive entry was compressed by using a compression method that is not supported.</exception>
     /// <exception cref="OperationCanceledException">An asynchronous operation is cancelled.</exception>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: entryNameEncoding, overwriteFiles: false, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(Stream source, string destinationDirectoryName, Encoding? entryNameEncoding, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(source, destinationDirectoryName, entryNameEncoding: entryNameEncoding, overwriteFiles: false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously extracts all the files from the zip archive stored in the specified stream and places them in the specified destination directory on the file system, uses the specified character encoding for entry names, and optionally allows choosing if the files in the destination directory should be overwritten.

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Create.Async.cs
@@ -43,8 +43,8 @@ public static partial class ZipFileExtensions
     /// <param name="entryName">The name of the entry to be created.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation. The value of the task is the newly created entry.</returns>
-    public static Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination, string sourceFileName, string entryName, CancellationToken cancellationToken = default) =>
-        DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, null, cancellationToken);
+    public static async Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination, string sourceFileName, string entryName, CancellationToken cancellationToken = default) =>
+        await DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, null, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// <p>Asynchronously adds a file from the file system to the archive under the specified entry name.
@@ -76,9 +76,9 @@ public static partial class ZipFileExtensions
     /// <param name="compressionLevel">The level of the compression (speed/memory vs. compressed size trade-off).</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous operation. The value of the task is the newly created entry.</returns>
-    public static Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination,
+    public static async Task<ZipArchiveEntry> CreateEntryFromFileAsync(this ZipArchive destination,
                                                       string sourceFileName, string entryName, CompressionLevel compressionLevel, CancellationToken cancellationToken = default) =>
-        DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, compressionLevel, cancellationToken);
+        await DoCreateEntryFromFileAsync(destination, sourceFileName, entryName, compressionLevel, cancellationToken).ConfigureAwait(false);
 
     internal static async Task<ZipArchiveEntry> DoCreateEntryFromFileAsync(this ZipArchive destination, string sourceFileName, string entryName,
                                                     CompressionLevel? compressionLevel, CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchive.Extract.Async.cs
@@ -37,8 +37,8 @@ public static partial class ZipFileExtensions
     /// Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when all entries have been extracted or an error occurs.</returns>
-    public static Task ExtractToDirectoryAsync(this ZipArchive source, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
-        ExtractToDirectoryAsync(source, destinationDirectoryName, overwriteFiles: false, cancellationToken);
+    public static async Task ExtractToDirectoryAsync(this ZipArchive source, string destinationDirectoryName, CancellationToken cancellationToken = default) =>
+        await ExtractToDirectoryAsync(source, destinationDirectoryName, overwriteFiles: false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Extracts all of the files in the archive to a directory on the file system. The specified directory may already exist.

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.Async.cs
@@ -35,8 +35,8 @@ public static partial class ZipFileExtensions
     /// Relative path information is interpreted as relative to the current working directory.</param>
     /// <param name="cancellationToken">The cancellation token to monitor for cancellation requests.</param>
     /// <returns>A task that represents the asynchronous extract operation. The task completes when the entry contents have been written to the destination file.</returns>
-    public static Task ExtractToFileAsync(this ZipArchiveEntry source, string destinationFileName, CancellationToken cancellationToken = default) =>
-        ExtractToFileAsync(source, destinationFileName, false, cancellationToken);
+    public static async Task ExtractToFileAsync(this ZipArchiveEntry source, string destinationFileName, CancellationToken cancellationToken = default) =>
+        await ExtractToFileAsync(source, destinationFileName, false, cancellationToken).ConfigureAwait(false);
 
     /// <summary>
     /// Asynchronously creates a file on the file system with the entry's contents and the specified name.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -245,7 +245,7 @@ namespace System.IO.Compression
             }
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             // We use this checking order for compat to earlier versions:
             if (_asyncOperations != 0)
@@ -254,10 +254,10 @@ namespace System.IO.Compression
             ValidateBufferArguments(buffer, offset, count);
             EnsureNotDisposed();
 
-            return ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            return await ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             // We use this checking order for compat to earlier versions:
             if (_asyncOperations != 0)
@@ -265,7 +265,7 @@ namespace System.IO.Compression
 
             EnsureNotDisposed();
 
-            return ReadAsyncInternal(buffer, cancellationToken);
+            return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -420,27 +420,27 @@ namespace System.IO.Compression
             return TaskToAsyncResult.End<int>(asyncResult);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsyncMemory(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsyncMemory(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (GetType() != typeof(DeflateStream))
             {
                 // Ensure that existing streams derived from DeflateStream and that override ReadAsync(byte[],...)
                 // get their existing behaviors when the newer Memory-based overload is used.
-                return base.ReadAsync(buffer, cancellationToken);
+                return await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                return ReadAsyncMemory(buffer, cancellationToken);
+                return await ReadAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        internal ValueTask<int> ReadAsyncMemory(Memory<byte> buffer, CancellationToken cancellationToken)
+        internal async ValueTask<int> ReadAsyncMemory(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             EnsureDecompressionMode();
             EnsureNoActiveAsyncOperation();
@@ -448,13 +448,13 @@ namespace System.IO.Compression
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             EnsureBufferInitialized();
             Debug.Assert(_inflater != null);
 
-            return Core(buffer, cancellationToken);
+            return await Core(buffer, cancellationToken).ConfigureAwait(false);
 
             async ValueTask<int> Core(Memory<byte> buffer, CancellationToken cancellationToken)
             {
@@ -819,23 +819,23 @@ namespace System.IO.Compression
             TaskToAsyncResult.End(asyncResult);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsyncMemory(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsyncMemory(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (GetType() != typeof(DeflateStream))
             {
                 // Ensure that existing streams derived from DeflateStream and that override WriteAsync(byte[],...)
                 // get their existing behaviors when the newer Memory-based overload is used.
-                return base.WriteAsync(buffer, cancellationToken);
+                await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                return WriteAsyncMemory(buffer, cancellationToken);
+                await WriteAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
             }
         }
 
@@ -896,7 +896,7 @@ namespace System.IO.Compression
             new CopyToStream(this, destination, bufferSize).CopyFromSourceToDestination();
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             ValidateCopyToArguments(destination, bufferSize);
 
@@ -907,11 +907,11 @@ namespace System.IO.Compression
             // Early check for cancellation
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                await Task.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             // Do the copy
-            return new CopyToStream(this, destination, bufferSize, cancellationToken).CopyFromSourceToDestinationAsync();
+            await new CopyToStream(this, destination, bufferSize, cancellationToken).CopyFromSourceToDestinationAsync().ConfigureAwait(false);
         }
 
         private sealed class CopyToStream : Stream
@@ -1041,11 +1041,11 @@ namespace System.IO.Compression
                 return WriteAsyncCore(buffer.AsMemory(offset, count), cancellationToken).AsTask();
             }
 
-            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {
                 _deflateStream.EnsureNotDisposed();
 
-                return WriteAsyncCore(buffer, cancellationToken);
+                await WriteAsyncCore(buffer, cancellationToken).ConfigureAwait(false);
             }
 
             private async ValueTask WriteAsyncCore(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -208,60 +208,61 @@ namespace System.IO.Compression
             }
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
-            return _deflateStream.ReadAsync(buffer, offset, count, cancellationToken);
+            ValidateBufferArguments(buffer, offset, count);
+            return await _deflateStream.ReadAsyncMemory(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (GetType() != typeof(GZipStream))
             {
                 // GZipStream is not sealed, and a derived type may have overridden ReadAsync(byte[], int, int) prior
                 // to this ReadAsync(Memory<byte>) overload being introduced.  In that case, this ReadAsync(Memory<byte>) overload
                 // should use the behavior of ReadAsync(byte[],int,int) overload.
-                return base.ReadAsync(buffer, cancellationToken);
+                return await base.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 CheckDeflateStream();
-                return _deflateStream.ReadAsyncMemory(buffer, cancellationToken);
+                return await _deflateStream.ReadAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
-            return _deflateStream.WriteAsync(buffer, offset, count, cancellationToken);
+            await _deflateStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (GetType() != typeof(GZipStream))
             {
                 // GZipStream is not sealed, and a derived type may have overridden WriteAsync(byte[], int, int) prior
                 // to this WriteAsync(ReadOnlyMemory<byte>) overload being introduced.  In that case, this
                 // WriteAsync(ReadOnlyMemory<byte>) overload should use the behavior of Write(byte[],int,int) overload.
-                return base.WriteAsync(buffer, cancellationToken);
+                await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 CheckDeflateStream();
-                return _deflateStream.WriteAsyncMemory(buffer, cancellationToken);
+                await _deflateStream.WriteAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
             }
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             CheckDeflateStream();
-            return _deflateStream.FlushAsync(cancellationToken);
+            await _deflateStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             CheckDeflateStream();
-            return _deflateStream.CopyToAsync(destination, bufferSize, cancellationToken);
+            await _deflateStream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         private void CheckDeflateStream()

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/PositionPreservingWriteOnlyStreamWrapper.cs
@@ -55,16 +55,16 @@ namespace System.IO.Compression
             _stream.WriteByte(value);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             _position += count;
-            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+            await _stream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))
         {
             _position += buffer.Length;
-            return _stream.WriteAsync(buffer, cancellationToken);
+            await _stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override bool CanTimeout => _stream.CanTimeout;
@@ -80,7 +80,7 @@ namespace System.IO.Compression
         }
 
         public override void Flush() => _stream.Flush();
-        public override Task FlushAsync(CancellationToken cancellationToken) => _stream.FlushAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         public override void Close()
         {
@@ -93,7 +93,7 @@ namespace System.IO.Compression
                 _stream.Dispose();
         }
 
-        public override ValueTask DisposeAsync() => _stream.DisposeAsync();
+        public override async ValueTask DisposeAsync() => await _stream.DisposeAsync().ConfigureAwait(false);
 
         public override long Length
         {

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZLibStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZLibStream.cs
@@ -91,10 +91,10 @@ namespace System.IO.Compression
         /// <summary>Asynchronously clears all buffers for this stream, causes any buffered data to be written to the underlying device, and monitors cancellation requests.</summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous flush operation.</returns>
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             ThrowIfClosed();
-            return _deflateStream.FlushAsync(cancellationToken);
+            await _deflateStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>This method is not supported and always throws a <see cref="NotSupportedException"/>.</summary>
@@ -156,20 +156,20 @@ namespace System.IO.Compression
         /// <param name="count">The maximum number of bytes to read.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous completion of the operation.</returns>
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfClosed();
-            return _deflateStream.ReadAsync(buffer, offset, count, cancellationToken);
+            return await _deflateStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads a sequence of bytes from the current stream, advances the position within the stream by the number of bytes read, and monitors cancellation requests.</summary>
         /// <param name="buffer">The byte span to read the data into.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous completion of the operation.</returns>
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfClosed();
-            return _deflateStream.ReadAsyncMemory(buffer, cancellationToken);
+            return await _deflateStream.ReadAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Begins an asynchronous write operation.</summary>
@@ -214,20 +214,20 @@ namespace System.IO.Compression
         /// <param name="count">The maximum number of bytes to write.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous completion of the operation.</returns>
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfClosed();
-            return _deflateStream.WriteAsync(buffer, offset, count, cancellationToken);
+            await _deflateStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously writes a sequence of bytes to the current stream, advances the current position within this stream by the number of bytes written, and monitors cancellation requests.</summary>
         /// <param name="buffer">The buffer to write data from.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous completion of the operation.</returns>
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfClosed();
-            return _deflateStream.WriteAsyncMemory(buffer, cancellationToken);
+            await _deflateStream.WriteAsyncMemory(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Writes a byte to the current position in the stream and advances the position within the stream by one byte.</summary>
@@ -252,10 +252,10 @@ namespace System.IO.Compression
         /// <param name="bufferSize">The size, in bytes, of the buffer. This value must be greater than zero.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <returns>A task that represents the asynchronous copy operation.</returns>
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             ThrowIfClosed();
-            return _deflateStream.CopyToAsync(destination, bufferSize, cancellationToken);
+            await _deflateStream.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Releases all resources used by the <see cref="Stream"/>.</summary>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -468,12 +468,12 @@ public partial class ZipArchiveEntry
         }
     }
 
-    private ValueTask WriteDataDescriptorAsync(CancellationToken cancellationToken)
+    private async ValueTask WriteDataDescriptorAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         byte[] dataDescriptor = new byte[MaxSizeOfDataDescriptor];
         int bytesToWrite = PrepareToWriteDataDescriptor(dataDescriptor);
-        return _archive.ArchiveStream.WriteAsync(dataDescriptor.AsMemory(0, bytesToWrite), cancellationToken);
+        await _archive.ArchiveStream.WriteAsync(dataDescriptor.AsMemory(0, bytesToWrite), cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task UnloadStreamsAsync()

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -1651,10 +1651,10 @@ namespace System.IO.Compression
             public override void WriteByte(byte value) =>
                 Write(new ReadOnlySpan<byte>(in value));
 
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 ValidateBufferArguments(buffer, offset, count);
-                return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+                await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
             }
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -1688,12 +1688,12 @@ namespace System.IO.Compression
                 _crcSizeStream.Flush();
             }
 
-            public override Task FlushAsync(CancellationToken cancellationToken)
+            public override async Task FlushAsync(CancellationToken cancellationToken)
             {
                 ThrowIfDisposed();
                 Debug.Assert(CanWrite);
 
-                return _crcSizeStream.FlushAsync(cancellationToken);
+                await _crcSizeStream.FlushAsync(cancellationToken).ConfigureAwait(false);
             }
 
             protected override void Dispose(bool disposing)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipBlocks.Async.cs
@@ -42,13 +42,13 @@ internal sealed partial class ZipGenericExtraField
 
 internal sealed partial class Zip64ExtraField
 {
-    public ValueTask WriteBlockAsync(Stream stream, CancellationToken cancellationToken)
+    public async ValueTask WriteBlockAsync(Stream stream, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         byte[] extraFieldData = new byte[TotalSize];
         WriteBlockCore(extraFieldData);
-        return stream.WriteAsync(extraFieldData, cancellationToken);
+        await stream.WriteAsync(extraFieldData, cancellationToken).ConfigureAwait(false);
     }
 
 }
@@ -68,13 +68,13 @@ internal sealed partial class Zip64EndOfCentralDirectoryLocator
         return zip64EOCDLocator;
     }
 
-    public static ValueTask WriteBlockAsync(Stream stream, long zip64EOCDRecordStart, CancellationToken cancellationToken)
+    public static async ValueTask WriteBlockAsync(Stream stream, long zip64EOCDRecordStart, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         byte[] blockContents = new byte[TotalSize];
         WriteBlockCore(blockContents, zip64EOCDRecordStart);
-        return stream.WriteAsync(blockContents, cancellationToken);
+        await stream.WriteAsync(blockContents, cancellationToken).ConfigureAwait(false);
     }
 }
 
@@ -95,14 +95,14 @@ internal sealed partial class Zip64EndOfCentralDirectoryRecord
         return zip64EOCDRecord;
     }
 
-    public static ValueTask WriteBlockAsync(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory, CancellationToken cancellationToken)
+    public static async ValueTask WriteBlockAsync(Stream stream, long numberOfEntries, long startOfCentralDirectory, long sizeOfCentralDirectory, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
         byte[] blockContents = new byte[BlockConstantSectionSize];
         WriteBlockCore(blockContents, numberOfEntries, startOfCentralDirectory, sizeOfCentralDirectory);
         // write Zip 64 EOCD record
-        return stream.WriteAsync(blockContents, cancellationToken);
+        await stream.WriteAsync(blockContents, cancellationToken).ConfigureAwait(false);
     }
 }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCustomStreams.cs
@@ -118,20 +118,20 @@ namespace System.IO.Compression
             return _baseStream.ReadByte();
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ThrowIfCantRead();
 
-            return _baseStream.ReadAsync(buffer, offset, count, cancellationToken);
+            return await _baseStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             ThrowIfCantRead();
 
-            return _baseStream.ReadAsync(buffer, cancellationToken);
+            return await _baseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -179,22 +179,22 @@ namespace System.IO.Compression
             _baseStream.WriteByte(value);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ThrowIfCantWrite();
 
             NotifyWrite();
-            return _baseStream.WriteAsync(buffer, offset, count, cancellationToken);
+            await _baseStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             ThrowIfCantWrite();
 
             NotifyWrite();
-            return _baseStream.WriteAsync(buffer, cancellationToken);
+            await _baseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private void NotifyWrite()
@@ -214,12 +214,12 @@ namespace System.IO.Compression
             _baseStream.Flush();
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ThrowIfCantWrite();
 
-            return _baseStream.FlushAsync(cancellationToken);
+            await _baseStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)
@@ -374,17 +374,17 @@ namespace System.IO.Compression
             return Read(new Span<byte>(ref b)) == 1 ? b : -1;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             ThrowIfCantRead();
-            return Core(buffer, cancellationToken);
+            return await Core(buffer, cancellationToken).ConfigureAwait(false);
 
             async ValueTask<int> Core(Memory<byte> buffer, CancellationToken cancellationToken)
             {
@@ -631,10 +631,10 @@ namespace System.IO.Compression
         public override void WriteByte(byte value) =>
             Write(new ReadOnlySpan<byte>(in value));
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -802,12 +802,12 @@ namespace System.IO.Compression
             return Read(new Span<byte>(ref b)) == 1 ? b : -1;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ValidateBufferArguments(buffer, offset, count);
 
-            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            return await ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Compress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Compress.cs
@@ -259,10 +259,10 @@ namespace System.IO.Compression
         /// <exception cref="InvalidOperationException">The <see cref="CompressionMode" /> value was <see cref="CompressionMode.Decompress"/> when the object was created, or concurrent read operations were attempted.</exception>
         /// <exception cref="ObjectDisposedException">The stream is disposed.</exception>
         /// <exception cref="IOException">Failed to compress data to the underlying stream.</exception>
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously writes compressed bytes to the underlying stream from the specified memory.</summary>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -164,10 +164,10 @@ namespace System.IO.Compression
         /// <exception cref="InvalidDataException">The data is in an invalid format.</exception>
         /// <exception cref="ObjectDisposedException">The stream is disposed.</exception>
         /// <exception cref="IOException">Failed to decompress data from the underlying stream.</exception>
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads decompressed bytes from the underlying stream and places them in the specified memory.</summary>

--- a/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
+++ b/src/libraries/System.IO.Hashing/src/System/IO/Hashing/NonCryptographicHashAlgorithm.cs
@@ -121,13 +121,13 @@ namespace System.IO.Hashing
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="stream"/> is <see langword="null"/>.
         /// </exception>
-        public Task AppendAsync(Stream stream, CancellationToken cancellationToken = default)
+        public async Task AppendAsync(Stream stream, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(stream);
 
-            return stream.CopyToAsync(
+            await stream.CopyToAsync(
                 new CopyToDestinationStream(this),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
+++ b/src/libraries/System.IO.IsolatedStorage/src/System/IO/IsolatedStorage/IsolatedStorageFileStream.cs
@@ -233,9 +233,9 @@ namespace System.IO.IsolatedStorage
             _fs.Flush(flushToDisk);
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
-            return _fs.FlushAsync(cancellationToken);
+            await _fs.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override void SetLength(long value)
@@ -253,14 +253,14 @@ namespace System.IO.IsolatedStorage
             return _fs.Read(buffer);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, Threading.CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, Threading.CancellationToken cancellationToken)
         {
-            return _fs.ReadAsync(buffer, offset, count, cancellationToken);
+            return await _fs.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
         {
-            return _fs.ReadAsync(buffer, cancellationToken);
+            return await _fs.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override int ReadByte()
@@ -285,14 +285,14 @@ namespace System.IO.IsolatedStorage
             _fs.Write(buffer);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _fs.WriteAsync(buffer, offset, count, cancellationToken);
+            await _fs.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
         {
-            return _fs.WriteAsync(buffer, cancellationToken);
+            await _fs.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override void WriteByte(byte value)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeReader.cs
@@ -21,9 +21,9 @@ namespace System.IO.Pipelines
 
             public override bool TryRead(out ReadResult result) => _pipe.TryRead(out result);
 
-            public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default) => _pipe.ReadAsync(cancellationToken);
+            public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default) => await _pipe.ReadAsync(cancellationToken).ConfigureAwait(false);
 
-            protected override ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumBytes, CancellationToken cancellationToken) => _pipe.ReadAtLeastAsync(minimumBytes, cancellationToken);
+            protected override async ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumBytes, CancellationToken cancellationToken) => await _pipe.ReadAtLeastAsync(minimumBytes, cancellationToken).ConfigureAwait(false);
 
             public override void AdvanceTo(SequencePosition consumed) => _pipe.AdvanceReader(consumed);
 

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/Pipe.DefaultPipeWriter.cs
@@ -29,7 +29,7 @@ namespace System.IO.Pipelines
             public override void OnReaderCompleted(Action<Exception?, object?> callback, object? state) => _pipe.OnReaderCompleted(callback, state);
 #pragma warning restore CS0672 // Member overrides obsolete member
 
-            public override ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) => _pipe.FlushAsync(cancellationToken);
+            public override async ValueTask<FlushResult> FlushAsync(CancellationToken cancellationToken = default) => await _pipe.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             public override void Advance(int bytes) => _pipe.Advance(bytes);
 
@@ -45,9 +45,9 @@ namespace System.IO.Pipelines
 
             public override long UnflushedBytes => _pipe.GetUnflushedBytes();
 
-            public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+            public override async ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
             {
-                return _pipe.WriteAsync(source, cancellationToken);
+                return await _pipe.WriteAsync(source, cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReader.cs
@@ -48,14 +48,14 @@ namespace System.IO.Pipelines
         ///     examine at least <paramref name="minimumSize" /> bytes in order to avoid an <see cref="System.InvalidOperationException" />.
         ///     </para>
         /// </remarks>
-        public ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default)
+        public async ValueTask<ReadResult> ReadAtLeastAsync(int minimumSize, CancellationToken cancellationToken = default)
         {
             if (minimumSize < 0)
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.minimumSize);
             }
 
-            return ReadAtLeastAsyncCore(minimumSize, cancellationToken);
+            return await ReadAtLeastAsyncCore(minimumSize, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads a sequence of bytes from the current <see cref="System.IO.Pipelines.PipeReader" />.</summary>
@@ -174,7 +174,7 @@ namespace System.IO.Pipelines
         /// <param name="destination">The pipe writer to which the contents of the current stream will be copied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task that represents the asynchronous copy operation.</returns>
-        public virtual Task CopyToAsync(PipeWriter destination, CancellationToken cancellationToken = default)
+        public virtual async Task CopyToAsync(PipeWriter destination, CancellationToken cancellationToken = default)
         {
             if (destination is null)
             {
@@ -183,20 +183,20 @@ namespace System.IO.Pipelines
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
-            return CopyToAsyncCore(
+            await CopyToAsyncCore(
                 destination,
-                (destination, memory, cancellationToken) => destination.WriteAsync(memory, cancellationToken),
-                cancellationToken);
+async (destination, memory, cancellationToken) => await destination.WriteAsync(memory, cancellationToken).ConfigureAwait(false),
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads the bytes from the <see cref="System.IO.Pipelines.PipeReader" /> and writes them to the specified stream, using a specified cancellation token.</summary>
         /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task that represents the asynchronous copy operation.</returns>
-        public virtual Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default)
+        public virtual async Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default)
         {
             if (destination is null)
             {
@@ -205,10 +205,10 @@ namespace System.IO.Pipelines
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
-            return CopyToAsyncCore(destination, (destination, memory, cancellationToken) =>
+            await CopyToAsyncCore(destination, (destination, memory, cancellationToken) =>
             {
                 ValueTask task = destination.WriteAsync(memory, cancellationToken);
 
@@ -226,7 +226,7 @@ namespace System.IO.Pipelines
 
                 return Awaited(task);
             },
-            cancellationToken);
+            cancellationToken).ConfigureAwait(false);
         }
 
         private async Task CopyToAsyncCore<TStream>(TStream destination, Func<TStream, ReadOnlyMemory<byte>, CancellationToken, ValueTask<FlushResult>> writeAsync, CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
@@ -80,14 +80,14 @@ namespace System.IO.Pipelines
         public sealed override int EndRead(IAsyncResult asyncResult) =>
             TaskToAsyncResult.End<int>(asyncResult);
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             if (buffer is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.buffer);
             }
 
-            return ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsyncInternal(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
 #if (!NETSTANDARD2_0 && !NETFRAMEWORK)
@@ -96,9 +96,9 @@ namespace System.IO.Pipelines
             return ReadInternal(buffer);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return ReadAsyncInternal(buffer, cancellationToken);
+            return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 #endif
 
@@ -148,12 +148,12 @@ namespace System.IO.Pipelines
             return 0;
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             StreamHelpers.ValidateCopyToArgs(this, destination, bufferSize);
 
             // Delegate to CopyToAsync on the PipeReader
-            return _pipeReader.CopyToAsync(destination, cancellationToken);
+            await _pipeReader.CopyToAsync(destination, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeWriter.cs
@@ -110,10 +110,10 @@ namespace System.IO.Pipelines
         /// <param name="source">The read-only byte memory region to write.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task that represents the asynchronous write operation, and wraps the flush asynchronous operation.</returns>
-        public virtual ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        public virtual async ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
             this.Write(source.Span);
-            return FlushAsync(cancellationToken);
+            return await FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously reads the bytes from the specified stream and writes them to the <see cref="System.IO.Pipelines.PipeWriter" />.</summary>

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeExtensions.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeExtensions.cs
@@ -14,7 +14,7 @@ namespace System.IO.Pipelines
         /// <param name="destination">The writer to which the contents of the source stream will be copied.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="System.Threading.CancellationToken.None" />.</param>
         /// <returns>A task that represents the asynchronous copy operation.</returns>
-        public static Task CopyToAsync(this Stream source, PipeWriter destination, CancellationToken cancellationToken = default)
+        public static async Task CopyToAsync(this Stream source, PipeWriter destination, CancellationToken cancellationToken = default)
         {
             if (source is null)
             {
@@ -27,10 +27,10 @@ namespace System.IO.Pipelines
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
-            return destination.CopyFromAsync(source, cancellationToken);
+            await destination.CopyFromAsync(source, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -200,14 +200,14 @@ namespace System.IO.Pipelines
         }
 
         /// <inheritdoc />
-        public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+        public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
         {
-            return ReadInternalAsync(null, cancellationToken);
+            return await ReadInternalAsync(null, cancellationToken).ConfigureAwait(false);
         }
 
-        protected override ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, CancellationToken cancellationToken)
+        protected override async ValueTask<ReadResult> ReadAtLeastAsyncCore(int minimumSize, CancellationToken cancellationToken)
         {
-            return ReadInternalAsync(minimumSize, cancellationToken);
+            return await ReadInternalAsync(minimumSize, cancellationToken).ConfigureAwait(false);
         }
 
         private ValueTask<ReadResult> ReadInternalAsync(int? minimumSize, CancellationToken cancellationToken)

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeWriter.cs
@@ -276,9 +276,9 @@ namespace System.IO.Pipelines
         /// <inheritdoc />
         public override long UnflushedBytes => _bytesBuffered;
 
-        public override ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
+        public override async ValueTask<FlushResult> WriteAsync(ReadOnlyMemory<byte> source, CancellationToken cancellationToken = default)
         {
-            return FlushAsyncInternal(writeToStream: true, data: source, cancellationToken);
+            return await FlushAsyncInternal(writeToStream: true, data: source, cancellationToken).ConfigureAwait(false);
         }
 
         private void Cancel()

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.cs
@@ -165,24 +165,24 @@ namespace System.IO.Pipes
             throw new TimeoutException();
         }
 
-        public Task ConnectAsync()
+        public async Task ConnectAsync()
         {
             // We cannot avoid creating lambda here by using Connect method
             // unless we don't care about start time to be measured before the thread is started
-            return ConnectAsync(Timeout.Infinite, CancellationToken.None);
+            await ConnectAsync(Timeout.Infinite, CancellationToken.None).ConfigureAwait(false);
         }
 
-        public Task ConnectAsync(int timeout)
+        public async Task ConnectAsync(int timeout)
         {
-            return ConnectAsync(timeout, CancellationToken.None);
+            await ConnectAsync(timeout, CancellationToken.None).ConfigureAwait(false);
         }
 
-        public Task ConnectAsync(CancellationToken cancellationToken)
+        public async Task ConnectAsync(CancellationToken cancellationToken)
         {
-            return ConnectAsync(Timeout.Infinite, cancellationToken);
+            await ConnectAsync(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task ConnectAsync(int timeout, CancellationToken cancellationToken)
+        public async Task ConnectAsync(int timeout, CancellationToken cancellationToken)
         {
             CheckConnectOperationsClient();
 
@@ -190,20 +190,20 @@ namespace System.IO.Pipes
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled(cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             int startTime = Environment.TickCount; // We need to measure time here, not in the lambda
 
-            return Task.Factory.StartNew(static state =>
+            await Task.Factory.StartNew(static state =>
             {
                 var tuple = ((NamedPipeClientStream stream, int timeout, CancellationToken cancellationToken, int startTime))state!;
                 tuple.stream.ConnectInternal(tuple.timeout, tuple.cancellationToken, tuple.startTime);
-            }, (this, timeout, cancellationToken, startTime), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }, (this, timeout, cancellationToken, startTime), cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).ConfigureAwait(false);
         }
 
-        public Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>
-            ConnectAsync(ToTimeoutMilliseconds(timeout), cancellationToken);
+        public async Task ConnectAsync(TimeSpan timeout, CancellationToken cancellationToken = default) =>
+            await ConnectAsync(ToTimeoutMilliseconds(timeout), cancellationToken).ConfigureAwait(false);
 
         private static int ToTimeoutMilliseconds(TimeSpan timeout)
         {

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.cs
@@ -154,9 +154,9 @@ namespace System.IO.Pipes
             Dispose(false);
         }
 
-        public Task WaitForConnectionAsync()
+        public async Task WaitForConnectionAsync()
         {
-            return WaitForConnectionAsync(CancellationToken.None);
+            await WaitForConnectionAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         public IAsyncResult BeginWaitForConnection(AsyncCallback? callback, object? state) =>

--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -55,7 +55,7 @@ namespace System.IO.Pipes
             return ReadCore(buffer);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             if (!CanRead)
@@ -65,7 +65,7 @@ namespace System.IO.Pipes
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return Task.FromCanceled<int>(cancellationToken);
+                return await Task.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             CheckReadOperations();
@@ -73,10 +73,10 @@ namespace System.IO.Pipes
             if (count == 0)
             {
                 UpdateMessageCompletion(false);
-                return Task.FromResult(0);
+                return 0;
             }
 
-            return ReadAsyncCore(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsyncCore(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AggregateAsync.cs
@@ -19,7 +19,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
-        public static ValueTask<TSource> AggregateAsync<TSource>(
+        public static async ValueTask<TSource> AggregateAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TSource, TSource> func,
             CancellationToken cancellationToken = default)
@@ -27,7 +27,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(func);
 
-            return Impl(source, func, cancellationToken);
+            return await Impl(source, func, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -60,7 +60,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements.</exception>
-        public static ValueTask<TSource> AggregateAsync<TSource>(
+        public static async ValueTask<TSource> AggregateAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TSource, CancellationToken, ValueTask<TSource>> func,
             CancellationToken cancellationToken = default)
@@ -68,7 +68,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(func);
 
-            return Impl(source, func, cancellationToken);
+            return await Impl(source, func, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -102,7 +102,7 @@ namespace System.Linq
         /// <returns>The final accumulator value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(
+        public static async ValueTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(
             this IAsyncEnumerable<TSource> source,
             TAccumulate seed,
             Func<TAccumulate, TSource, TAccumulate> func,
@@ -111,7 +111,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(func);
 
-            return Impl(source.WithCancellation(cancellationToken), seed, func);
+            return await Impl(source.WithCancellation(cancellationToken), seed, func).ConfigureAwait(false);
 
             static async ValueTask<TAccumulate> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -139,7 +139,7 @@ namespace System.Linq
         /// <returns>The final accumulator value.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(
+        public static async ValueTask<TAccumulate> AggregateAsync<TSource, TAccumulate>(
             this IAsyncEnumerable<TSource> source, TAccumulate seed,
             Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> func,
             CancellationToken cancellationToken = default)
@@ -147,7 +147,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(func);
 
-            return Impl(source, seed, func, cancellationToken);
+            return await Impl(source, seed, func, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TAccumulate> Impl(
                 IAsyncEnumerable<TSource> source, TAccumulate seed,
@@ -182,7 +182,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="resultSelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(
+        public static async ValueTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(
             this IAsyncEnumerable<TSource> source,
             TAccumulate seed,
             Func<TAccumulate, TSource, TAccumulate> func,
@@ -193,7 +193,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(func);
             ArgumentNullException.ThrowIfNull(resultSelector);
 
-            return Impl(source.WithCancellation(cancellationToken), seed, func, resultSelector);
+            return await Impl(source.WithCancellation(cancellationToken), seed, func, resultSelector).ConfigureAwait(false);
 
             static async ValueTask<TResult> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -229,7 +229,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="func"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="resultSelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(
+        public static async ValueTask<TResult> AggregateAsync<TSource, TAccumulate, TResult>(
             this IAsyncEnumerable<TSource> source,
             TAccumulate seed,
             Func<TAccumulate, TSource, CancellationToken, ValueTask<TAccumulate>> func,
@@ -240,7 +240,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(func);
             ArgumentNullException.ThrowIfNull(resultSelector);
 
-            return Impl(source, seed, func, resultSelector, cancellationToken);
+            return await Impl(source, seed, func, resultSelector, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TResult> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AllAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AllAsync.cs
@@ -21,7 +21,7 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> AllAsync<TSource>(
+        public static async ValueTask<bool> AllAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -29,7 +29,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate);
+            return await Impl(source.WithCancellation(cancellationToken), predicate).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -58,7 +58,7 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> AllAsync<TSource>(
+        public static async ValueTask<bool> AllAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken,
             ValueTask<bool>> predicate,
@@ -67,7 +67,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AnyAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AnyAsync.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns><see langword="true"/> if the source sequence contains any elements; otherwise, <see langword="false"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> AnyAsync<TSource>(
+        public static async ValueTask<bool> AnyAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -45,7 +45,7 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> AnyAsync<TSource>(
+        public static async ValueTask<bool> AnyAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -53,7 +53,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate);
+            return await Impl(source.WithCancellation(cancellationToken), predicate).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -82,7 +82,7 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> AnyAsync<TSource>(
+        public static async ValueTask<bool> AnyAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -90,7 +90,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AverageAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/AverageAsync.cs
@@ -17,13 +17,13 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The sum of the elements in the sequence is larger than <see cref="long.MaxValue"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double> AverageAsync(
+        public static async ValueTask<double> AverageAsync(
             this IAsyncEnumerable<int> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<int> source)
@@ -52,13 +52,13 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The sum of the elements in the sequence is larger than <see cref="long.MaxValue"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double> AverageAsync(
+        public static async ValueTask<double> AverageAsync(
             this IAsyncEnumerable<long> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<long> source)
@@ -86,12 +86,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<float> AverageAsync(
+        public static async ValueTask<float> AverageAsync(
             this IAsyncEnumerable<float> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<float> Impl(
                 ConfiguredCancelableAsyncEnumerable<float> source)
@@ -119,12 +119,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double> AverageAsync(
+        public static async ValueTask<double> AverageAsync(
             this IAsyncEnumerable<double> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<double> source)
@@ -152,12 +152,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<decimal> AverageAsync(
+        public static async ValueTask<decimal> AverageAsync(
             this IAsyncEnumerable<decimal> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<decimal> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal> source)
@@ -186,12 +186,12 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The sum of the elements in the sequence is larger than <see cref="long.MaxValue"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double?> AverageAsync(
+        public static async ValueTask<double?> AverageAsync(
             this IAsyncEnumerable<int?> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<int?> source)
@@ -218,12 +218,12 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The sum of the elements in the sequence is larger than <see cref="long.MaxValue"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double?> AverageAsync(
+        public static async ValueTask<double?> AverageAsync(
             this IAsyncEnumerable<long?> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<long?> source)
@@ -249,12 +249,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values, or null if the source sequence is empty or contains only values that are null.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<float?> AverageAsync(
+        public static async ValueTask<float?> AverageAsync(
             this IAsyncEnumerable<float?> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<float?> Impl(
                 ConfiguredCancelableAsyncEnumerable<float?> source)
@@ -280,12 +280,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values, or null if the source sequence is empty or contains only values that are null.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<double?> AverageAsync(
+        public static async ValueTask<double?> AverageAsync(
             this IAsyncEnumerable<double?> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<double?> source)
@@ -311,12 +311,12 @@ namespace System.Linq
         /// <returns>The average of the sequence of values, or null if the source sequence is empty or contains only values that are null.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException"><paramref name="source"/> contains no elements (via the returned task).</exception>
-        public static ValueTask<decimal?> AverageAsync(
+        public static async ValueTask<decimal?> AverageAsync(
             this IAsyncEnumerable<decimal?> source, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<decimal?> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal?> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ContainsAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ContainsAsync.cs
@@ -18,7 +18,7 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns><see langword="true"/> if the source sequence contains an element that has the specified value; otherwise, <see langword="false"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<bool> ContainsAsync<TSource>(
+        public static async ValueTask<bool> ContainsAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             TSource value,
             IEqualityComparer<TSource>? comparer = null,
@@ -26,7 +26,7 @@ namespace System.Linq
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken), value, comparer ?? EqualityComparer<TSource>.Default);
+            return await Impl(source.WithCancellation(cancellationToken), value, comparer ?? EqualityComparer<TSource>.Default).ConfigureAwait(false);
 
             async static ValueTask<bool> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/CountAsync.cs
@@ -17,13 +17,13 @@ namespace System.Linq
         /// <returns>The number of elements in the input sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The number of elements in source is larger than <see cref="int.MaxValue"/> (via the returned task).</exception>
-        public static ValueTask<int> CountAsync<TSource>(
+        public static async ValueTask<int> CountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<int> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -49,7 +49,7 @@ namespace System.Linq
         /// <returns>The number of elements in the input sequence that satisfy the condition in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The number of elements that satisfy the condition is larger than <see cref="int.MaxValue"/> (via the returned task).</exception>
-        public static ValueTask<int> CountAsync<TSource>(
+        public static async ValueTask<int> CountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -57,7 +57,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate);
+            return await Impl(source.WithCancellation(cancellationToken), predicate).ConfigureAwait(false);
 
             static async ValueTask<int> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -84,7 +84,7 @@ namespace System.Linq
         /// <returns>The number of elements in the input sequence that satisfy the condition in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="OverflowException">The number of elements that satisfy the condition is larger than <see cref="int.MaxValue"/> (via the returned task).</exception>
-        public static ValueTask<int> CountAsync<TSource>(
+        public static async ValueTask<int> CountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -92,7 +92,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<int> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -118,13 +118,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The number of elements in the input sequence that satisfy the condition in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<long> LongCountAsync<TSource>(
+        public static async ValueTask<long> LongCountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<long> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -149,7 +149,7 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The number of elements in the input sequence that satisfy the condition in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<long> LongCountAsync<TSource>(
+        public static async ValueTask<long> LongCountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -157,7 +157,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate);
+            return await Impl(source.WithCancellation(cancellationToken), predicate).ConfigureAwait(false);
 
             static async ValueTask<long> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -183,7 +183,7 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The number of elements in the input sequence that satisfy the condition in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<long> LongCountAsync<TSource>(
+        public static async ValueTask<long> LongCountAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -191,7 +191,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<long> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ElementAtAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ElementAtAsync.cs
@@ -37,14 +37,14 @@ namespace System.Linq
         /// element at the specified position in the source sequence.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             int index,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return ElementAtOrDefaultAsync(source, index, throwIfNotFound: false, cancellationToken);
+            return await ElementAtOrDefaultAsync(source, index, throwIfNotFound: false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Returns the element at a specified index in a sequence.</summary>
@@ -88,19 +88,19 @@ namespace System.Linq
         /// <para>The default value for reference and nullable types is <see langword="null" />.</para>
         /// </remarks>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Index index,
             CancellationToken cancellationToken = default)
         {
             if (!index.IsFromEnd)
             {
-                return ElementAtOrDefaultAsync(source, index.Value, cancellationToken);
+                return await ElementAtOrDefaultAsync(source, index.Value, cancellationToken).ConfigureAwait(false);
             }
 
             ArgumentNullException.ThrowIfNull(source);
 
-            return ElementAtFromEndOrDefault(source, index.Value, throwIfNotFound: false, cancellationToken);
+            return await ElementAtFromEndOrDefault(source, index.Value, throwIfNotFound: false, cancellationToken).ConfigureAwait(false);
         }
 
         private static async ValueTask<TSource?> ElementAtOrDefaultAsync<TSource>(

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/FirstAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/FirstAsync.cs
@@ -17,13 +17,13 @@ namespace System.Linq
         /// <returns>The first element in the specified sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty (via the returned task).</exception>
-        public static ValueTask<TSource> FirstAsync<TSource>(
+        public static async ValueTask<TSource> FirstAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -52,7 +52,7 @@ namespace System.Linq
         /// The source sequence is empty, or no element in the sequence satisfies
         /// the condition in predicate (via the returned task).
         /// </exception>
-        public static ValueTask<TSource> FirstAsync<TSource>(
+        public static async ValueTask<TSource> FirstAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -60,7 +60,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate);
+            return await Impl(source.WithCancellation(cancellationToken), predicate).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -91,7 +91,7 @@ namespace System.Linq
         /// The source sequence is empty, or no element in the sequence satisfies
         /// the condition in predicate (via the returned task).
         /// </exception>
-        public static ValueTask<TSource> FirstAsync<TSource>(
+        public static async ValueTask<TSource> FirstAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -99,7 +99,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -137,14 +137,14 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns><paramref name="defaultValue" /> if <paramref name="source" /> is empty; otherwise, the first element in <paramref name="source" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> FirstOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> FirstOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             TSource defaultValue,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, defaultValue, cancellationToken);
+            return await Impl(source, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -168,11 +168,11 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource?> FirstOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> FirstOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default) =>
-            FirstOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await FirstOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the first element of the sequence that satisfies a condition or a default value if no such element is found.</summary>
         /// <typeparam name="TSource"></typeparam>
@@ -185,11 +185,11 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource?> FirstOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> FirstOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default) =>
-            FirstOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await FirstOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the first element of the sequence that satisfies a condition or a default value if no such element is found.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -200,7 +200,7 @@ namespace System.Linq
         /// <returns><paramref name="defaultValue" /> if <paramref name="source" /> is empty or if no element passes the test specified by <paramref name="predicate" />; otherwise, the first element in <paramref name="source" /> that passes the test specified by <paramref name="predicate" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> FirstOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> FirstOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             TSource defaultValue,
@@ -209,7 +209,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source.WithCancellation(cancellationToken), predicate, defaultValue);
+            return await Impl(source.WithCancellation(cancellationToken), predicate, defaultValue).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -237,7 +237,7 @@ namespace System.Linq
         /// <returns><paramref name="defaultValue" /> if <paramref name="source" /> is empty or if no element passes the test specified by <paramref name="predicate" />; otherwise, the first element in <paramref name="source" /> that passes the test specified by <paramref name="predicate" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> FirstOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> FirstOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             TSource defaultValue,
@@ -246,7 +246,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, defaultValue, cancellationToken);
+            return await Impl(source, predicate, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LastAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/LastAsync.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         /// <returns>The value at the last position in the source sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">The source sequence is empty (via the returned task).</exception>
-        public static ValueTask<TSource> LastAsync<TSource>(
+        public static async ValueTask<TSource> LastAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -58,7 +58,7 @@ namespace System.Linq
         /// The source sequence is empty, or no element in the sequence satisfies
         /// the condition in predicate (via the returned task).
         /// </exception>
-        public static ValueTask<TSource> LastAsync<TSource>(
+        public static async ValueTask<TSource> LastAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -66,7 +66,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -112,7 +112,7 @@ namespace System.Linq
         /// The source sequence is empty, or no element in the sequence satisfies
         /// the condition in predicate (via the returned task).
         /// </exception>
-        public static ValueTask<TSource> LastAsync<TSource>(
+        public static async ValueTask<TSource> LastAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -120,7 +120,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -163,10 +163,10 @@ namespace System.Linq
         /// otherwise, the last element in the <see cref="IAsyncEnumerable{T}"/>.
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<TSource?> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default) =>
-            LastOrDefaultAsync(source, default(TSource), cancellationToken);
+            await LastOrDefaultAsync(source, default(TSource), cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the last element of a sequence, or a default value if the sequence contains no elements.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -175,14 +175,14 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns><paramref name="defaultValue" /> if the source sequence is empty; otherwise, the last element in the <see cref="IAsyncEnumerable{T}" />.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             TSource defaultValue,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, defaultValue, cancellationToken);
+            return await Impl(source, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source, TSource defaultValue, CancellationToken cancellationToken)
@@ -211,11 +211,11 @@ namespace System.Linq
         /// <returns>The default value of <typeparamref name="TSource"/> if the sequence is empty or if no elements pass the test in the predicate function; otherwise, the last element that passes the test in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource?> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default) =>
-            LastOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await LastOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the last element of a sequence that satisfies a condition or a default value if no such element is found.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -225,11 +225,11 @@ namespace System.Linq
         /// <returns>The default value of <typeparamref name="TSource"/> if the sequence is empty or if no elements pass the test in the predicate function; otherwise, the last element that passes the test in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource?> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default) =>
-            LastOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await LastOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the last element of a sequence that satisfies a condition or a default value if no such element is found.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -240,7 +240,7 @@ namespace System.Linq
         /// <returns><paramref name="defaultValue" /> if the sequence is empty or if no elements pass the test in the predicate function; otherwise, the last element that passes the test in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             TSource defaultValue,
@@ -249,7 +249,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, defaultValue, cancellationToken);
+            return await Impl(source, predicate, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -293,7 +293,7 @@ namespace System.Linq
         /// <returns><paramref name="defaultValue" /> if the sequence is empty or if no elements pass the test in the predicate function; otherwise, the last element that passes the test in the predicate function.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource> LastOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> LastOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             TSource defaultValue,
@@ -302,7 +302,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, defaultValue, cancellationToken);
+            return await Impl(source, predicate, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask<bool>> predicate, TSource defaultValue, CancellationToken cancellationToken)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxByAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MaxByAsync.cs
@@ -22,7 +22,7 @@ namespace System.Linq
         /// <remarks>
         /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
         /// </remarks>
-        public static ValueTask<TSource?> MaxByAsync<TSource, TKey>(
+        public static async ValueTask<TSource?> MaxByAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             IComparer<TKey>? comparer = null,
@@ -31,7 +31,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken);
+            return await Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource?> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -132,7 +132,7 @@ namespace System.Linq
         /// <remarks>
         /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
         /// </remarks>
-        public static ValueTask<TSource?> MaxByAsync<TSource, TKey>(
+        public static async ValueTask<TSource?> MaxByAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             IComparer<TKey>? comparer = null,
@@ -141,7 +141,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken);
+            return await Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource?> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinByAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/MinByAsync.cs
@@ -22,7 +22,7 @@ namespace System.Linq
         /// <remarks>
         /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
         /// </remarks>
-        public static ValueTask<TSource?> MinByAsync<TSource, TKey>(
+        public static async ValueTask<TSource?> MinByAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             IComparer<TKey>? comparer = null,
@@ -31,7 +31,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken);
+            return await Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource?> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -132,7 +132,7 @@ namespace System.Linq
         /// <remarks>
         /// <para>If <typeparamref name="TKey" /> is a reference type and the source sequence is empty or contains only values that are <see langword="null" />, this method returns <see langword="null" />.</para>
         /// </remarks>
-        public static ValueTask<TSource?> MinByAsync<TSource, TKey>(
+        public static async ValueTask<TSource?> MinByAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             IComparer<TKey>? comparer = null,
@@ -141,7 +141,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken);
+            return await Impl(source, keySelector, comparer ?? Comparer<TKey>.Default, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource?> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/OrderBy.cs
@@ -202,8 +202,8 @@ namespace System.Linq
 
             protected OrderedIterator(IAsyncEnumerable<TElement> source) => _source = source;
 
-            private protected ValueTask<int[]> CreateSortedMapAsync(TElement[] buffer, CancellationToken cancellationToken) =>
-                GetEnumerableSorter().SortAsync(buffer, buffer.Length, cancellationToken);
+            private protected async ValueTask<int[]> CreateSortedMapAsync(TElement[] buffer, CancellationToken cancellationToken) =>
+                await GetEnumerableSorter().SortAsync(buffer, buffer.Length, cancellationToken).ConfigureAwait(false);
 
             internal abstract EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement>? next = null);
 

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SequenceEqualAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SequenceEqualAsync.cs
@@ -19,7 +19,7 @@ namespace System.Linq
         /// <see langword="true"/> if the two source sequences are of equal length and their corresponding
         /// elements compare equal according to comparer; otherwise, <see langword="false"/>.
         /// </returns>
-        public static ValueTask<bool> SequenceEqualAsync<TSource>(
+        public static async ValueTask<bool> SequenceEqualAsync<TSource>(
             this IAsyncEnumerable<TSource> first,
             IAsyncEnumerable<TSource> second,
             IEqualityComparer<TSource>? comparer = null,
@@ -28,7 +28,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(first);
             ArgumentNullException.ThrowIfNull(second);
 
-            return Impl(first, second, comparer ?? EqualityComparer<TSource>.Default, cancellationToken);
+            return await Impl(first, second, comparer ?? EqualityComparer<TSource>.Default, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> Impl(
                 IAsyncEnumerable<TSource> first,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SingleAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SingleAsync.cs
@@ -20,13 +20,13 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> sequence is empty (via the returned task).</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> sequence contains more than one element. (via the returned task).</exception>
-        public static ValueTask<TSource> SingleAsync<TSource>(
+        public static async ValueTask<TSource> SingleAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, cancellationToken);
+            return await Impl(source, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
@@ -62,7 +62,7 @@ namespace System.Linq
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> sequence is empty (via the returned task).</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate"/> (via the returned task).</exception>
-        public static ValueTask<TSource> SingleAsync<TSource>(
+        public static async ValueTask<TSource> SingleAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default)
@@ -70,7 +70,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -115,7 +115,7 @@ namespace System.Linq
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> sequence is empty (via the returned task).</exception>
         /// <exception cref="InvalidOperationException">No element satisfies the condition in <paramref name="predicate"/> (via the returned task).</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate"/> (via the returned task).</exception>
-        public static ValueTask<TSource> SingleAsync<TSource>(
+        public static async ValueTask<TSource> SingleAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default)
@@ -123,7 +123,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, cancellationToken);
+            return await Impl(source, predicate, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -167,10 +167,10 @@ namespace System.Linq
         /// </returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="InvalidOperationException">The <paramref name="source"/> sequence contains more than one element. (via the returned task).</exception>
-        public static ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default) =>
-            SingleOrDefaultAsync(source, default(TSource), cancellationToken);
+            await SingleOrDefaultAsync(source, default(TSource), cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the only element of a sequence, or a default value if the sequence is empty; this method throws an exception if there is more than one element in the sequence.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -180,14 +180,14 @@ namespace System.Linq
         /// <returns>The single element of the input sequence, or <paramref name="defaultValue" /> if the sequence contains no elements.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
-        public static ValueTask<TSource> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             TSource defaultValue,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source, defaultValue, cancellationToken);
+            return await Impl(source, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -227,11 +227,11 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
-        public static ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             CancellationToken cancellationToken = default) =>
-            SingleOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await SingleOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Returns the only element of a sequence that satisfies a specified condition or
@@ -249,11 +249,11 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
         /// <exception cref="InvalidOperationException">The input sequence contains more than one element.</exception>
-        public static ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource?> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             CancellationToken cancellationToken = default) =>
-            SingleOrDefaultAsync(source, predicate!, default, cancellationToken);
+            await SingleOrDefaultAsync(source, predicate!, default, cancellationToken).ConfigureAwait(false);
 
         /// <summary>Returns the only element of a sequence that satisfies a specified condition or a default value if no such element exists; this method throws an exception if more than one element satisfies the condition.</summary>
         /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
@@ -265,7 +265,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate" />.</exception>
-        public static ValueTask<TSource> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, bool> predicate,
             TSource defaultValue,
@@ -274,7 +274,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, defaultValue, cancellationToken);
+            return await Impl(source, predicate, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -315,7 +315,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
         /// <exception cref="InvalidOperationException">More than one element satisfies the condition in <paramref name="predicate" />.</exception>
-        public static ValueTask<TSource> SingleOrDefaultAsync<TSource>(
+        public static async ValueTask<TSource> SingleOrDefaultAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<bool>> predicate,
             TSource defaultValue,
@@ -324,7 +324,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(predicate);
 
-            return Impl(source, predicate, defaultValue, cancellationToken);
+            return await Impl(source, predicate, defaultValue, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<TSource> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SumAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/SumAsync.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="OverflowException">The sum is larger than <see cref="int.MaxValue"/>.</exception>
-        public static ValueTask<int> SumAsync(
+        public static async ValueTask<int> SumAsync(
             this IAsyncEnumerable<int> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<int> Impl(
                 ConfiguredCancelableAsyncEnumerable<int> source)
@@ -42,13 +42,13 @@ namespace System.Linq
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="OverflowException">The sum is larger than <see cref="long.MaxValue"/>.</exception>
-        public static ValueTask<long> SumAsync(
+        public static async ValueTask<long> SumAsync(
             this IAsyncEnumerable<long> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<long> Impl(
                 ConfiguredCancelableAsyncEnumerable<long> source)
@@ -67,13 +67,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<float> SumAsync(
+        public static async ValueTask<float> SumAsync(
             this IAsyncEnumerable<float> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<float> Impl(
                 ConfiguredCancelableAsyncEnumerable<float> source)
@@ -92,13 +92,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<double> SumAsync(
+        public static async ValueTask<double> SumAsync(
             this IAsyncEnumerable<double> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double> Impl(
                 ConfiguredCancelableAsyncEnumerable<double> source)
@@ -117,13 +117,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<decimal> SumAsync(
+        public static async ValueTask<decimal> SumAsync(
             this IAsyncEnumerable<decimal> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<decimal> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal> source)
@@ -143,13 +143,13 @@ namespace System.Linq
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="OverflowException">The sum is larger than <see cref="int.MaxValue"/>.</exception>
-        public static ValueTask<int?> SumAsync(
+        public static async ValueTask<int?> SumAsync(
             this IAsyncEnumerable<int?> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<int?> Impl(
                 ConfiguredCancelableAsyncEnumerable<int?> source)
@@ -172,13 +172,13 @@ namespace System.Linq
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
         /// <exception cref="OverflowException">The sum is larger than <see cref="long.MaxValue"/>.</exception>
-        public static ValueTask<long?> SumAsync(
+        public static async ValueTask<long?> SumAsync(
             this IAsyncEnumerable<long?> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<long?> Impl(
                 ConfiguredCancelableAsyncEnumerable<long?> source)
@@ -200,13 +200,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<float?> SumAsync(
+        public static async ValueTask<float?> SumAsync(
             this IAsyncEnumerable<float?> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<float?> Impl(
                 ConfiguredCancelableAsyncEnumerable<float?> source)
@@ -228,13 +228,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<double?> SumAsync(
+        public static async ValueTask<double?> SumAsync(
             this IAsyncEnumerable<double?> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<double?> Impl(
                 ConfiguredCancelableAsyncEnumerable<double?> source)
@@ -256,13 +256,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The sum of the values in the sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<decimal?> SumAsync(
+        public static async ValueTask<decimal?> SumAsync(
             this IAsyncEnumerable<decimal?> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<decimal?> Impl(
                 ConfiguredCancelableAsyncEnumerable<decimal?> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToArrayAsync.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>An array that contains the elements from the input sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<TSource[]> ToArrayAsync<TSource>(
+        public static async ValueTask<TSource[]> ToArrayAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<TSource[]> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToDictionaryAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToDictionaryAsync.cs
@@ -21,14 +21,14 @@ namespace System.Linq
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/> that contains keys and values from <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(
+        public static async ValueTask<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(
             this IAsyncEnumerable<KeyValuePair<TKey, TValue>> source,
             IEqualityComparer<TKey>? comparer = null,
             CancellationToken cancellationToken = default) where TKey : notnull
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken), comparer);
+            return await Impl(source.WithCancellation(cancellationToken), comparer).ConfigureAwait(false);
 
             static async ValueTask<Dictionary<TKey, TValue>> Impl(
                 ConfiguredCancelableAsyncEnumerable<KeyValuePair<TKey, TValue>> source,
@@ -55,9 +55,9 @@ namespace System.Linq
         /// <returns>A <see cref="Dictionary{TKey,TValue}"/> that contains keys and values from <paramref name="source"/>.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(
+        public static async ValueTask<Dictionary<TKey, TValue>> ToDictionaryAsync<TKey, TValue>(
             this IAsyncEnumerable<(TKey Key, TValue Value)> source, IEqualityComparer<TKey>? comparer = null, CancellationToken cancellationToken = default) where TKey : notnull =>
-            source.ToDictionaryAsync(vt => vt.Key, vt => vt.Value, comparer, cancellationToken);
+            await source.ToDictionaryAsync(vt => vt.Key, vt => vt.Value, comparer, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Creates a <see cref="Dictionary{TKey, TValue}"/> from an <see cref="IAsyncEnumerable{T}"/>
@@ -73,7 +73,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
+        public static async ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             IEqualityComparer<TKey>? comparer = null,
@@ -82,7 +82,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source.WithCancellation(cancellationToken), keySelector, comparer);
+            return await Impl(source.WithCancellation(cancellationToken), keySelector, comparer).ConfigureAwait(false);
 
             static async ValueTask<Dictionary<TKey, TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -112,7 +112,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
+        public static async ValueTask<Dictionary<TKey, TSource>> ToDictionaryAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             IEqualityComparer<TKey>? comparer = null,
@@ -121,7 +121,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, cancellationToken);
+            return await Impl(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<Dictionary<TKey, TSource>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -155,7 +155,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="elementSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
+        public static async ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
@@ -166,7 +166,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(keySelector);
             ArgumentNullException.ThrowIfNull(elementSelector);
 
-            return Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer);
+            return await Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer).ConfigureAwait(false);
 
             static async ValueTask<Dictionary<TKey, TElement>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -201,7 +201,7 @@ namespace System.Linq
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="elementSelector"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="source"/> contains one or more duplicate keys (via the returned task).</exception>
-        public static ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
+        public static async ValueTask<Dictionary<TKey, TElement>> ToDictionaryAsync<TSource, TKey, TElement>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             Func<TSource, CancellationToken, ValueTask<TElement>> elementSelector,
@@ -212,7 +212,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(keySelector);
             ArgumentNullException.ThrowIfNull(elementSelector);
 
-            return Impl(source, keySelector, elementSelector, comparer, cancellationToken);
+            return await Impl(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<Dictionary<TKey, TElement>> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToHashSetAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToHashSetAsync.cs
@@ -17,14 +17,14 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>A <see cref="HashSet{T}"/> that contains values of type <typeparamref name="TSource"/> selected from the input sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
-        public static ValueTask<HashSet<TSource>> ToHashSetAsync<TSource>(
+        public static async ValueTask<HashSet<TSource>> ToHashSetAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             IEqualityComparer<TSource>? comparer = null,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken), comparer);
+            return await Impl(source.WithCancellation(cancellationToken), comparer).ConfigureAwait(false);
 
             static async ValueTask<HashSet<TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToListAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToListAsync.cs
@@ -16,13 +16,13 @@ namespace System.Linq
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> to monitor for cancellation requests. The default is <see cref="CancellationToken.None"/>.</param>
         /// <returns>A list that contains the elements from the input sequence.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-        public static ValueTask<List<TSource>> ToListAsync<TSource>(
+        public static async ValueTask<List<TSource>> ToListAsync<TSource>(
             this IAsyncEnumerable<TSource> source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
-            return Impl(source.WithCancellation(cancellationToken));
+            return await Impl(source.WithCancellation(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<List<TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source)

--- a/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToLookupAsync.cs
+++ b/src/libraries/System.Linq.AsyncEnumerable/src/System/Linq/ToLookupAsync.cs
@@ -25,7 +25,7 @@ namespace System.Linq
         /// <returns>A <see cref="ILookup{TKey, TElement}"/> that contains keys and values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(
+        public static async ValueTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             IEqualityComparer<TKey>? comparer = null,
@@ -34,7 +34,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source.WithCancellation(cancellationToken), keySelector, comparer);
+            return await Impl(source.WithCancellation(cancellationToken), keySelector, comparer).ConfigureAwait(false);
 
             static async ValueTask<ILookup<TKey, TSource>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -73,7 +73,7 @@ namespace System.Linq
         /// <returns>A <see cref="ILookup{TKey, TElement}"/> that contains keys and values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(
+        public static async ValueTask<ILookup<TKey, TSource>> ToLookupAsync<TSource, TKey>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             IEqualityComparer<TKey>? comparer = null,
@@ -82,7 +82,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(keySelector);
 
-            return Impl(source, keySelector, comparer, cancellationToken);
+            return await Impl(source, keySelector, comparer, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<ILookup<TKey, TSource>> Impl(
                 IAsyncEnumerable<TSource> source,
@@ -124,7 +124,7 @@ namespace System.Linq
         /// <returns>A <see cref="ILookup{TKey, TElement}"/> that contains keys and values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(
+        public static async ValueTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, TKey> keySelector,
             Func<TSource, TElement> elementSelector,
@@ -135,7 +135,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(keySelector);
             ArgumentNullException.ThrowIfNull(elementSelector);
 
-            return Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer);
+            return await Impl(source.WithCancellation(cancellationToken), keySelector, elementSelector, comparer).ConfigureAwait(false);
 
             static async ValueTask<ILookup<TKey, TElement>> Impl(
                 ConfiguredCancelableAsyncEnumerable<TSource> source,
@@ -177,7 +177,7 @@ namespace System.Linq
         /// <returns>A <see cref="ILookup{TKey, TElement}"/> that contains keys and values.</returns>
         /// <exception cref="ArgumentNullException"><paramref name="source"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentNullException"><paramref name="keySelector"/> is <see langword="null"/>.</exception>
-        public static ValueTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(
+        public static async ValueTask<ILookup<TKey, TElement>> ToLookupAsync<TSource, TKey, TElement>(
             this IAsyncEnumerable<TSource> source,
             Func<TSource, CancellationToken, ValueTask<TKey>> keySelector,
             Func<TSource, CancellationToken, ValueTask<TElement>> elementSelector,
@@ -188,7 +188,7 @@ namespace System.Linq
             ArgumentNullException.ThrowIfNull(keySelector);
             ArgumentNullException.ThrowIfNull(elementSelector);
 
-            return Impl(source, keySelector, elementSelector, comparer, cancellationToken);
+            return await Impl(source, keySelector, elementSelector, comparer, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<ILookup<TKey, TElement>> Impl(
                 IAsyncEnumerable<TSource> source,

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingPipeliningSpoolingTask.cs
@@ -176,7 +176,7 @@ namespace System.Linq.Parallel
                         QueryTask asyncTask = new OrderPreservingPipeliningSpoolingTask<TOutput, TKey>(
                             partitions[i], groupState, consumerWaiting, producerWaiting,
                             producerDone, i, buffers, bufferLocks[i], autoBuffered);
-                        asyncTask.RunAsynchronously(taskScheduler);
+                        _ = asyncTask.RunAsynchronously(taskScheduler);
                     }
                 });
 

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingSpoolingTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/OrderPreservingSpoolingTask.cs
@@ -95,7 +95,7 @@ namespace System.Linq.Parallel
                         TraceHelpers.TraceInfo("OrderPreservingSpoolingTask::Spool: Running partition[{0}] asynchronously", i);
                         QueryTask asyncTask = new OrderPreservingSpoolingTask<TInputOutput, TKey>(
                             i, groupState, results, sortHelpers[i]);
-                        asyncTask.RunAsynchronously(taskScheduler);
+                        _ = asyncTask.RunAsynchronously(taskScheduler);
                     }
 
                     // Run one task synchronously on the current thread.

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/QueryTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/QueryTask.cs
@@ -76,12 +76,12 @@ namespace System.Linq.Parallel
             ((QueryTask)o).BaseWork(null);
         };
 
-        internal Task RunAsynchronously(TaskScheduler taskScheduler)
+        internal async Task RunAsynchronously(TaskScheduler taskScheduler)
         {
             Debug.Assert(taskScheduler == TaskScheduler.Default, "PLINQ queries can currently execute only on the default scheduler.");
 
             TraceHelpers.TraceInfo("[timing]: {0}: Queue work {1} to occur asynchronously", DateTime.Now.Ticks, _taskIndex);
-            return Task.Factory.StartNew(s_baseWorkDelegate, this, CancellationToken.None, TaskCreationOptions.AttachedToParent | TaskCreationOptions.PreferFairness, taskScheduler);
+            await Task.Factory.StartNew(s_baseWorkDelegate, this, CancellationToken.None, TaskCreationOptions.AttachedToParent | TaskCreationOptions.PreferFairness, taskScheduler).ConfigureAwait(false);
         }
 
         //-----------------------------------------------------------------------------------

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/SpoolingTask.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Scheduling/SpoolingTask.cs
@@ -50,7 +50,7 @@ namespace System.Linq.Parallel
                         TraceHelpers.TraceInfo("SpoolingTask::Spool: Running partition[{0}] asynchronously", i);
 
                         QueryTask asyncTask = new StopAndGoSpoolingTask<TInputOutput, TIgnoreKey>(i, groupState, partitions[i], channels[i]);
-                        asyncTask.RunAsynchronously(taskScheduler);
+                        _ = asyncTask.RunAsynchronously(taskScheduler);
                     }
 
                     TraceHelpers.TraceInfo("SpoolingTask::Spool: Running partition[{0}] synchronously", maxToRunInParallel);
@@ -105,7 +105,7 @@ namespace System.Linq.Parallel
                         TraceHelpers.TraceInfo("SpoolingTask::Spool: Running partition[{0}] asynchronously", i);
 
                         QueryTask asyncTask = new PipelineSpoolingTask<TInputOutput, TIgnoreKey>(i, groupState, partitions[i], channels[i]);
-                        asyncTask.RunAsynchronously(taskScheduler);
+                        _ = asyncTask.RunAsynchronously(taskScheduler);
                     }
                 });
 
@@ -148,7 +148,7 @@ namespace System.Linq.Parallel
                         TraceHelpers.TraceInfo("SpoolingTask::Spool: Running partition[{0}] asynchronously", i);
 
                         QueryTask asyncTask = new ForAllSpoolingTask<TInputOutput, TIgnoreKey>(i, groupState, partitions[i]);
-                        asyncTask.RunAsynchronously(taskScheduler);
+                        _ = asyncTask.RunAsynchronously(taskScheduler);
                     }
 
                     TraceHelpers.TraceInfo("SpoolingTask::Spool: Running partition[{0}] synchronously", maxToRunInParallel);

--- a/src/libraries/System.Memory.Data/src/System/BinaryData.cs
+++ b/src/libraries/System.Memory.Data/src/System/BinaryData.cs
@@ -247,8 +247,8 @@ namespace System
         /// <param name="stream">Stream containing the data.</param>
         /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>A value representing all of the data remaining in <paramref name="stream"/>.</returns>
-        public static Task<BinaryData> FromStreamAsync(Stream stream, CancellationToken cancellationToken = default)
-            => FromStreamAsync(stream, mediaType: null, cancellationToken);
+        public static async Task<BinaryData> FromStreamAsync(Stream stream, CancellationToken cancellationToken = default)
+            => await FromStreamAsync(stream, mediaType: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Creates a <see cref="BinaryData"/> instance from the specified stream
@@ -260,12 +260,12 @@ namespace System
         /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>A value representing all of the data remaining in <paramref name="stream"/>.</returns>
         /// <seealso cref="MediaTypeNames"/>
-        public static Task<BinaryData> FromStreamAsync(Stream stream, string? mediaType,
+        public static async Task<BinaryData> FromStreamAsync(Stream stream, string? mediaType,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(stream);
 
-            return FromStreamAsync(stream, useAsync: true, mediaType, cancellationToken);
+            return await FromStreamAsync(stream, useAsync: true, mediaType, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<BinaryData> FromStreamAsync(Stream stream, bool useAsync,
@@ -334,8 +334,8 @@ namespace System
         /// <param name="path">The path to the file.</param>
         /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>A value representing all of the data from the file.</returns>
-        public static Task<BinaryData> FromFileAsync(string path, CancellationToken cancellationToken = default)
-            => FromFileAsync(path, mediaType: null, cancellationToken);
+        public static async Task<BinaryData> FromFileAsync(string path, CancellationToken cancellationToken = default)
+            => await FromFileAsync(path, mediaType: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Creates a <see cref="BinaryData"/> instance from the specified file
@@ -346,12 +346,12 @@ namespace System
         /// <param name="cancellationToken">A token that may be used to cancel the operation.</param>
         /// <returns>A value representing all of the data from the file.</returns>
         /// <seealso cref="MediaTypeNames"/>
-        public static Task<BinaryData> FromFileAsync(string path, string? mediaType,
+        public static async Task<BinaryData> FromFileAsync(string path, string? mediaType,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(path);
 
-            return Core();
+            return await Core().ConfigureAwait(false);
 
             async Task<BinaryData> Core()
             {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Delete.cs
@@ -16,7 +16,7 @@ namespace System.Net.Http.Json
     public static partial class HttpClientJsonExtensions
     {
         private static readonly Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> s_deleteAsync =
-            static (client, uri, cancellation) => client.DeleteAsync(uri, cancellation);
+            static async (client, uri, cancellation) => await client.DeleteAsync(uri, cancellation).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -30,8 +30,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -45,8 +45,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, options, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -60,8 +60,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -75,8 +75,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore<TValue>(s_deleteAsync, client, requestUri, options, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore<TValue>(s_deleteAsync, client, requestUri, options, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -88,8 +88,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -101,8 +101,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, context, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(s_deleteAsync, client, requestUri, type, context, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -114,8 +114,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -127,8 +127,8 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(s_deleteAsync, client, requestUri, jsonTypeInfo, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(s_deleteAsync, client, requestUri, jsonTypeInfo, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -141,8 +141,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -155,8 +155,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
+        public static async Task<object?> DeleteFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync(client, requestUri, type, options: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -169,8 +169,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a DELETE request to the specified Uri and returns the value that results from deserializing the response body as JSON in an asynchronous operation.
@@ -183,7 +183,7 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is <see langword="null"/>.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
-            DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
+        public static async Task<TValue?> DeleteFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
+            await DeleteFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Get.cs
@@ -16,58 +16,58 @@ namespace System.Net.Http.Json
     public static partial class HttpClientJsonExtensions
     {
         private static readonly Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> s_getAsync =
-            static (client, uri, cancellation) => client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation);
+            static async (client, uri, cancellation) => await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync(client, CreateUri(requestUri), type, options, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(static (client, uri, cancellation) => client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation), client, requestUri, type, options, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(static async (client, uri, cancellation) => await client.GetAsync(uri, HttpCompletionOption.ResponseHeadersRead, cancellation).ConfigureAwait(false), client, requestUri, type, options, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken);
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync<TValue>(client, CreateUri(requestUri), options, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore<TValue>(s_getAsync, client, requestUri, options, cancellationToken);
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore<TValue>(s_getAsync, client, requestUri, options, cancellationToken).ConfigureAwait(false);
 
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync(client, CreateUri(requestUri), type, context, cancellationToken).ConfigureAwait(false);
 
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(s_getAsync, client, requestUri, type, context, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(s_getAsync, client, requestUri, type, context, cancellationToken).ConfigureAwait(false);
 
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken);
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync(client, CreateUri(requestUri), jsonTypeInfo, cancellationToken).ConfigureAwait(false);
 
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(s_getAsync, client, requestUri, jsonTypeInfo, cancellationToken);
-
-        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
-        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(s_getAsync, client, requestUri, jsonTypeInfo, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
+        public static async Task<object?> GetFromJsonAsync(this HttpClient client, Uri? requestUri, Type type, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync(client, requestUri, type, options: null, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
-            GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken);
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken).ConfigureAwait(false);
+
+        [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
+        [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
+        public static async Task<TValue?> GetFromJsonAsync<TValue>(this HttpClient client, Uri? requestUri, CancellationToken cancellationToken = default) =>
+            await GetFromJsonAsync<TValue>(client, requestUri, options: null, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Patch.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Patch.cs
@@ -24,12 +24,12 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PatchAsync(requestUri, content, cancellationToken);
+            return await client.PatchAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -45,12 +45,12 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PatchAsync(requestUri, content, cancellationToken);
+            return await client.PatchAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -65,8 +65,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PatchAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PatchAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the <paramref name="value"/> serialized as JSON in the request body.
@@ -80,8 +80,8 @@ namespace System.Net.Http.Json
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PatchAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PatchAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a PATCH request to the specified Uri containing the <paramref name="value"/> serialized as JSON in the request body.
@@ -94,12 +94,12 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PatchAsync(requestUri, content, cancellationToken);
+            return await client.PatchAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -113,12 +113,12 @@ namespace System.Net.Http.Json
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         /// <exception cref="ArgumentNullException">The <paramref name="client"/> is null.</exception>
-        public static Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PatchAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PatchAsync(requestUri, content, cancellationToken);
+            return await client.PatchAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Post.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Post.cs
@@ -13,48 +13,48 @@ namespace System.Net.Http.Json
     {
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PostAsync(requestUri, content, cancellationToken);
+            return await client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PostAsync(requestUri, content, cancellationToken);
+            return await client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PostAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PostAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PostAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PostAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PostAsync(requestUri, content, cancellationToken);
+            return await client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
-        public static Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PostAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PostAsync(requestUri, content, cancellationToken);
+            return await client.PostAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Put.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.Put.cs
@@ -13,48 +13,48 @@ namespace System.Net.Http.Json
     {
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PutAsync(requestUri, content, cancellationToken);
+            return await client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonSerializerOptions? options = null, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, mediaType: null, options);
-            return client.PutAsync(requestUri, content, cancellationToken);
+            return await client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PutAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PutAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
-            => client.PutAsJsonAsync(requestUri, value, options: null, cancellationToken);
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, CancellationToken cancellationToken)
+            => await client.PutAsJsonAsync(requestUri, value, options: null, cancellationToken).ConfigureAwait(false);
 
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, [StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PutAsync(requestUri, content, cancellationToken);
+            return await client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
 
-        public static Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<HttpResponseMessage> PutAsJsonAsync<TValue>(this HttpClient client, Uri? requestUri, TValue value, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(client);
 
             JsonContent content = JsonContent.Create(value, jsonTypeInfo);
-            return client.PutAsync(requestUri, content, cancellationToken);
+            return await client.PutAsync(requestUri, content, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpClientJsonExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -16,19 +16,19 @@ namespace System.Net.Http.Json
     {
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options.type, options.options ?? JsonSerializerOptions.Web, cancellation), (type, options), cancellationToken);
+        private static async Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(getMethod, client, requestUri, static async (stream, options, cancellation) => await JsonSerializer.DeserializeAsync(stream, options.type, options.options ?? JsonSerializerOptions.Web, cancellation).ConfigureAwait(false), (type, options), cancellationToken).ConfigureAwait(false);
 
         [RequiresUnreferencedCode(HttpContentJsonExtensions.SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(HttpContentJsonExtensions.SerializationDynamicCodeMessage)]
-        private static Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync<TValue>(stream, options ?? JsonSerializerOptions.Web, cancellation), options, cancellationToken);
+        private static async Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonSerializerOptions? options, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(getMethod, client, requestUri, static async (stream, options, cancellation) => await JsonSerializer.DeserializeAsync<TValue>(stream, options ?? JsonSerializerOptions.Web, cancellation).ConfigureAwait(false), options, cancellationToken).ConfigureAwait(false);
 
-        private static Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
-            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options.type, options.context, cancellation), (type, context), cancellationToken);
+        private static async Task<object?> FromJsonAsyncCore(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default) =>
+            await FromJsonAsyncCore(getMethod, client, requestUri, static async (stream, options, cancellation) => await JsonSerializer.DeserializeAsync(stream, options.type, options.context, cancellation).ConfigureAwait(false), (type, context), cancellationToken).ConfigureAwait(false);
 
-        private static Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken) =>
-            FromJsonAsyncCore(getMethod, client, requestUri, static (stream, options, cancellation) => JsonSerializer.DeserializeAsync(stream, options, cancellation), jsonTypeInfo, cancellationToken);
+        private static async Task<TValue?> FromJsonAsyncCore<TValue>(Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod, HttpClient client, Uri? requestUri, JsonTypeInfo<TValue> jsonTypeInfo, CancellationToken cancellationToken) =>
+            await FromJsonAsyncCore(getMethod, client, requestUri, static async (stream, options, cancellation) => await JsonSerializer.DeserializeAsync(stream, options, cancellation).ConfigureAwait(false), jsonTypeInfo, cancellationToken).ConfigureAwait(false);
 
         private static Task<TValue?> FromJsonAsyncCore<TValue, TJsonOptions>(
             Func<HttpClient, Uri?, CancellationToken, Task<HttpResponseMessage>> getMethod,

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.cs
@@ -27,11 +27,11 @@ namespace System.Net.Http.Json
         /// <returns>The task object representing the asynchronous operation.</returns>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
-        public static Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
+        public static async Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(content);
 
-            return ReadFromJsonAsyncCore(content, type, options, cancellationToken);
+            return await ReadFromJsonAsyncCore(content, type, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -43,9 +43,9 @@ namespace System.Net.Http.Json
         /// <returns>The task object representing the asynchronous operation.</returns>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
-        public static Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, CancellationToken cancellationToken = default)
+        public static async Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, CancellationToken cancellationToken = default)
         {
-            return ReadFromJsonAsync(content, type, options: null, cancellationToken: cancellationToken);
+            return await ReadFromJsonAsync(content, type, options: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -58,11 +58,11 @@ namespace System.Net.Http.Json
         /// <returns>The task object representing the asynchronous operation.</returns>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
-        public static Task<T?> ReadFromJsonAsync<T>(this HttpContent content, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
+        public static async Task<T?> ReadFromJsonAsync<T>(this HttpContent content, JsonSerializerOptions? options, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(content);
 
-            return ReadFromJsonAsyncCore<T>(content, options, cancellationToken);
+            return await ReadFromJsonAsyncCore<T>(content, options, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -74,9 +74,9 @@ namespace System.Net.Http.Json
         /// <returns>The task object representing the asynchronous operation.</returns>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationDynamicCodeMessage)]
-        public static Task<T?> ReadFromJsonAsync<T>(this HttpContent content, CancellationToken cancellationToken = default)
+        public static async Task<T?> ReadFromJsonAsync<T>(this HttpContent content, CancellationToken cancellationToken = default)
         {
-            return ReadFromJsonAsync<T>(content, options: null, cancellationToken: cancellationToken);
+            return await ReadFromJsonAsync<T>(content, options: null, cancellationToken: cancellationToken).ConfigureAwait(false);
         }
 
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
@@ -99,18 +99,18 @@ namespace System.Net.Http.Json
             }
         }
 
-        public static Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
+        public static async Task<object?> ReadFromJsonAsync(this HttpContent content, Type type, JsonSerializerContext context, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(content);
 
-            return ReadFromJsonAsyncCore(content, type, context, cancellationToken);
+            return await ReadFromJsonAsyncCore(content, type, context, cancellationToken).ConfigureAwait(false);
         }
 
-        public static Task<T?> ReadFromJsonAsync<T>(this HttpContent content, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
+        public static async Task<T?> ReadFromJsonAsync<T>(this HttpContent content, JsonTypeInfo<T> jsonTypeInfo, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(content);
 
-            return ReadFromJsonAsyncCore(content, jsonTypeInfo, cancellationToken);
+            return await ReadFromJsonAsyncCore(content, jsonTypeInfo, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<object?> ReadFromJsonAsyncCore(HttpContent content, Type type, JsonSerializerContext context, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.netcoreapp.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/HttpContentJsonExtensions.netcoreapp.cs
@@ -10,9 +10,9 @@ namespace System.Net.Http.Json
 {
     public static partial class HttpContentJsonExtensions
     {
-        private static Task<Stream> ReadHttpContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
+        private static async Task<Stream> ReadHttpContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
         {
-            return content.ReadAsStreamAsync(cancellationToken);
+            return await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private static Stream GetTranscodingStream(Stream contentStream, Encoding sourceEncoding)

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.cs
@@ -101,8 +101,8 @@ namespace System.Net.Http.Json
             return new JsonContent(inputValue, jsonTypeInfo, mediaType);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
-            => SerializeToStreamAsyncCore(stream, CancellationToken.None);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => await SerializeToStreamAsyncCore(stream, CancellationToken.None).ConfigureAwait(false);
 
         protected override bool TryComputeLength(out long length)
         {

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.netcoreapp.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/JsonContent.netcoreapp.cs
@@ -23,7 +23,7 @@ namespace System.Net.Http.Json
             }
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
-            => SerializeToStreamAsyncCore(stream, cancellationToken);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+            => await SerializeToStreamAsyncCore(stream, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
+++ b/src/libraries/System.Net.Http.Json/src/System/Net/Http/Json/LengthLimitReadStream.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
@@ -38,8 +38,8 @@ namespace System.Net.Http.Json
         public override bool CanWrite => false;
 
 #if NET
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
-            ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
+            await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
@@ -83,7 +83,7 @@ namespace System.Net.Http.Json
         }
 
         public override void Flush() => _innerStream.Flush();
-        public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await _innerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
         public override void SetLength(long value) => _innerStream.SetLength(value);
         public override long Length => _innerStream.Length;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ByteArrayContent.cs
@@ -40,8 +40,8 @@ namespace System.Net.Http
         protected override void SerializeToStream(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
             stream.Write(_content, _offset, _count);
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            SerializeToStreamAsyncCore(stream, default);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            await SerializeToStreamAsyncCore(stream, default).ConfigureAwait(false);
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
             // Only skip the original protected virtual SerializeToStreamAsync if this
@@ -49,8 +49,8 @@ namespace System.Net.Http
             GetType() == typeof(ByteArrayContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
             base.SerializeToStreamAsync(stream, context, cancellationToken);
 
-        private protected Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken) =>
-            stream.WriteAsync(_content, _offset, _count, cancellationToken);
+        private protected async Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken) =>
+            await stream.WriteAsync(_content.AsMemory(_offset, _count), cancellationToken).ConfigureAwait(false);
 
         protected internal override bool TryComputeLength(out long length)
         {
@@ -61,8 +61,8 @@ namespace System.Net.Http
         protected override Stream CreateContentReadStream(CancellationToken cancellationToken) =>
             CreateMemoryStreamForByteArray();
 
-        protected override Task<Stream> CreateContentReadStreamAsync() =>
-            Task.FromResult<Stream>(CreateMemoryStreamForByteArray());
+        protected override async Task<Stream> CreateContentReadStreamAsync() =>
+            CreateMemoryStreamForByteArray();
 
         internal override Stream? TryCreateContentReadStream() =>
             GetType() == typeof(ByteArrayContent) ? CreateMemoryStreamForByteArray() : // type check ensures we use possible derived type's CreateContentReadStreamAsync override

--- a/src/libraries/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
@@ -50,12 +50,12 @@ namespace System.Net.Http
             return _innerHandler!.Send(request, cancellationToken);
         }
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
 
             SetOperationStarted();
-            return _innerHandler!.SendAsync(request, cancellationToken);
+            return await _innerHandler!.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/EmptyContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/EmptyContent.cs
@@ -29,8 +29,8 @@ namespace System.Net.Http
         protected override Stream CreateContentReadStream(CancellationToken cancellationToken) =>
             EmptyReadStream.Instance;
 
-        protected override Task<Stream> CreateContentReadStreamAsync() =>
-            Task.FromResult<Stream>(EmptyReadStream.Instance);
+        protected override async Task<Stream> CreateContentReadStreamAsync() =>
+            EmptyReadStream.Instance;
 
         protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
             cancellationToken.IsCancellationRequested ? Task.FromCanceled<Stream>(cancellationToken) :

--- a/src/libraries/System.Net.Http/src/System/Net/Http/EmptyReadStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/EmptyReadStream.cs
@@ -25,10 +25,10 @@ namespace System.Net.Http
             cancellationToken.IsCancellationRequested ? ValueTask.FromCanceled<int>(cancellationToken) :
             new ValueTask<int>(0);
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             ValidateCopyToArguments(destination, bufferSize);
-            return NopAsync(cancellationToken);
+            await NopAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.net_http_content_readonly_stream);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpBaseStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpBaseStream.cs
@@ -48,10 +48,10 @@ namespace System.Net.Http
             return Read(buffer.AsSpan(offset, count));
         }
 
-        public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public sealed override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override void Write(byte[] buffer, int offset, int count)
@@ -66,15 +66,15 @@ namespace System.Net.Http
         public sealed override void WriteByte(byte value) =>
             Write(new ReadOnlySpan<byte>(in value));
 
-        public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public sealed override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public override void Flush() => FlushAsync(default).GetAwaiter().GetResult();
 
-        public override Task FlushAsync(CancellationToken cancellationToken) => NopAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await NopAsync(cancellationToken).ConfigureAwait(false);
 
         protected static Task NopAsync(CancellationToken cancellationToken) =>
             cancellationToken.IsCancellationRequested ? Task.FromCanceled(cancellationToken) :

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -156,23 +156,23 @@ namespace System.Net.Http
 
         #region Simple Get Overloads
 
-        public Task<string> GetStringAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
-            GetStringAsync(CreateUri(requestUri));
+        public async Task<string> GetStringAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
+            await GetStringAsync(CreateUri(requestUri)).ConfigureAwait(false);
 
-        public Task<string> GetStringAsync(Uri? requestUri) =>
-            GetStringAsync(requestUri, CancellationToken.None);
+        public async Task<string> GetStringAsync(Uri? requestUri) =>
+            await GetStringAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<string> GetStringAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
-            GetStringAsync(CreateUri(requestUri), cancellationToken);
+        public async Task<string> GetStringAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
+            await GetStringAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
 
-        public Task<string> GetStringAsync(Uri? requestUri, CancellationToken cancellationToken)
+        public async Task<string> GetStringAsync(Uri? requestUri, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
             // Called outside of async state machine to propagate certain exception even without awaiting the returned task.
             CheckRequestBeforeSend(request);
 
-            return GetStringAsyncCore(request, cancellationToken);
+            return await GetStringAsyncCore(request, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<string> GetStringAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -228,23 +228,23 @@ namespace System.Net.Http
             }
         }
 
-        public Task<byte[]> GetByteArrayAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
-            GetByteArrayAsync(CreateUri(requestUri));
+        public async Task<byte[]> GetByteArrayAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
+            await GetByteArrayAsync(CreateUri(requestUri)).ConfigureAwait(false);
 
-        public Task<byte[]> GetByteArrayAsync(Uri? requestUri) =>
-            GetByteArrayAsync(requestUri, CancellationToken.None);
+        public async Task<byte[]> GetByteArrayAsync(Uri? requestUri) =>
+            await GetByteArrayAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<byte[]> GetByteArrayAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
-            GetByteArrayAsync(CreateUri(requestUri), cancellationToken);
+        public async Task<byte[]> GetByteArrayAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
+            await GetByteArrayAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
 
-        public Task<byte[]> GetByteArrayAsync(Uri? requestUri, CancellationToken cancellationToken)
+        public async Task<byte[]> GetByteArrayAsync(Uri? requestUri, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
             // Called outside of async state machine to propagate certain exception even without awaiting the returned task.
             CheckRequestBeforeSend(request);
 
-            return GetByteArrayAsyncCore(request, cancellationToken);
+            return await GetByteArrayAsyncCore(request, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<byte[]> GetByteArrayAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -303,23 +303,23 @@ namespace System.Net.Http
             }
         }
 
-        public Task<Stream> GetStreamAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
-            GetStreamAsync(CreateUri(requestUri));
+        public async Task<Stream> GetStreamAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
+            await GetStreamAsync(CreateUri(requestUri)).ConfigureAwait(false);
 
-        public Task<Stream> GetStreamAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
-            GetStreamAsync(CreateUri(requestUri), cancellationToken);
+        public async Task<Stream> GetStreamAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
+            await GetStreamAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
 
-        public Task<Stream> GetStreamAsync(Uri? requestUri) =>
-            GetStreamAsync(requestUri, CancellationToken.None);
+        public async Task<Stream> GetStreamAsync(Uri? requestUri) =>
+            await GetStreamAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<Stream> GetStreamAsync(Uri? requestUri, CancellationToken cancellationToken)
+        public async Task<Stream> GetStreamAsync(Uri? requestUri, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Get, requestUri);
 
             // Called outside of async state machine to propagate certain exception even without awaiting the returned task.
             CheckRequestBeforeSend(request);
 
-            return GetStreamAsyncCore(request, cancellationToken);
+            return await GetStreamAsyncCore(request, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<Stream> GetStreamAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -353,89 +353,89 @@ namespace System.Net.Http
 
         #region REST Send Overloads
 
-        public Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
-            GetAsync(CreateUri(requestUri));
+        public async Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
+            await GetAsync(CreateUri(requestUri)).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri) =>
-            GetAsync(requestUri, DefaultCompletionOption);
+        public async Task<HttpResponseMessage> GetAsync(Uri? requestUri) =>
+            await GetAsync(requestUri, DefaultCompletionOption).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpCompletionOption completionOption) =>
-            GetAsync(CreateUri(requestUri), completionOption);
+        public async Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpCompletionOption completionOption) =>
+            await GetAsync(CreateUri(requestUri), completionOption).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption) =>
-            GetAsync(requestUri, completionOption, CancellationToken.None);
+        public async Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption) =>
+            await GetAsync(requestUri, completionOption, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
-            GetAsync(CreateUri(requestUri), cancellationToken);
+        public async Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
+            await GetAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, CancellationToken cancellationToken) =>
-            GetAsync(requestUri, DefaultCompletionOption, cancellationToken);
+        public async Task<HttpResponseMessage> GetAsync(Uri? requestUri, CancellationToken cancellationToken) =>
+            await GetAsync(requestUri, DefaultCompletionOption, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken) =>
-            GetAsync(CreateUri(requestUri), completionOption, cancellationToken);
+        public async Task<HttpResponseMessage> GetAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken) =>
+            await GetAsync(CreateUri(requestUri), completionOption, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken) =>
-            SendAsync(CreateRequestMessage(HttpMethod.Get, requestUri), completionOption, cancellationToken);
+        public async Task<HttpResponseMessage> GetAsync(Uri? requestUri, HttpCompletionOption completionOption, CancellationToken cancellationToken) =>
+            await SendAsync(CreateRequestMessage(HttpMethod.Get, requestUri), completionOption, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PostAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
-            PostAsync(CreateUri(requestUri), content);
+        public async Task<HttpResponseMessage> PostAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
+            await PostAsync(CreateUri(requestUri), content).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent? content) =>
-            PostAsync(requestUri, content, CancellationToken.None);
+        public async Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent? content) =>
+            await PostAsync(requestUri, content, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PostAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
-            PostAsync(CreateUri(requestUri), content, cancellationToken);
+        public async Task<HttpResponseMessage> PostAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
+            await PostAsync(CreateUri(requestUri), content, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> PostAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Post, requestUri);
             request.Content = content;
-            return SendAsync(request, cancellationToken);
+            return await SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<HttpResponseMessage> PutAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
-            PutAsync(CreateUri(requestUri), content);
+        public async Task<HttpResponseMessage> PutAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
+            await PutAsync(CreateUri(requestUri), content).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent? content) =>
-            PutAsync(requestUri, content, CancellationToken.None);
+        public async Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent? content) =>
+            await PutAsync(requestUri, content, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PutAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
-            PutAsync(CreateUri(requestUri), content, cancellationToken);
+        public async Task<HttpResponseMessage> PutAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
+            await PutAsync(CreateUri(requestUri), content, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> PutAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Put, requestUri);
             request.Content = content;
-            return SendAsync(request, cancellationToken);
+            return await SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<HttpResponseMessage> PatchAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
-            PatchAsync(CreateUri(requestUri), content);
+        public async Task<HttpResponseMessage> PatchAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content) =>
+            await PatchAsync(CreateUri(requestUri), content).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent? content) =>
-            PatchAsync(requestUri, content, CancellationToken.None);
+        public async Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent? content) =>
+            await PatchAsync(requestUri, content, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PatchAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
-            PatchAsync(CreateUri(requestUri), content, cancellationToken);
+        public async Task<HttpResponseMessage> PatchAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, HttpContent? content, CancellationToken cancellationToken) =>
+            await PatchAsync(CreateUri(requestUri), content, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> PatchAsync(Uri? requestUri, HttpContent? content, CancellationToken cancellationToken)
         {
             HttpRequestMessage request = CreateRequestMessage(HttpMethod.Patch, requestUri);
             request.Content = content;
-            return SendAsync(request, cancellationToken);
+            return await SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
-            DeleteAsync(CreateUri(requestUri));
+        public async Task<HttpResponseMessage> DeleteAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri) =>
+            await DeleteAsync(CreateUri(requestUri)).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> DeleteAsync(Uri? requestUri) =>
-            DeleteAsync(requestUri, CancellationToken.None);
+        public async Task<HttpResponseMessage> DeleteAsync(Uri? requestUri) =>
+            await DeleteAsync(requestUri, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> DeleteAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
-            DeleteAsync(CreateUri(requestUri), cancellationToken);
+        public async Task<HttpResponseMessage> DeleteAsync([StringSyntax(StringSyntaxAttribute.Uri)] string? requestUri, CancellationToken cancellationToken) =>
+            await DeleteAsync(CreateUri(requestUri), cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> DeleteAsync(Uri? requestUri, CancellationToken cancellationToken) =>
-            SendAsync(CreateRequestMessage(HttpMethod.Delete, requestUri), cancellationToken);
+        public async Task<HttpResponseMessage> DeleteAsync(Uri? requestUri, CancellationToken cancellationToken) =>
+            await SendAsync(CreateRequestMessage(HttpMethod.Delete, requestUri), cancellationToken).ConfigureAwait(false);
 
         #endregion REST Send Overloads
 
@@ -505,22 +505,22 @@ namespace System.Net.Http
             }
         }
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) =>
-            SendAsync(request, DefaultCompletionOption, CancellationToken.None);
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request) =>
+            await SendAsync(request, DefaultCompletionOption, CancellationToken.None).ConfigureAwait(false);
 
-        public override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
-            SendAsync(request, DefaultCompletionOption, cancellationToken);
+        public override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            await SendAsync(request, DefaultCompletionOption, cancellationToken).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption) =>
-            SendAsync(request, completionOption, CancellationToken.None);
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption) =>
+            await SendAsync(request, completionOption, CancellationToken.None).ConfigureAwait(false);
 
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
         {
             // Called outside of async state machine to propagate certain exception even without awaiting the returned task.
             CheckRequestBeforeSend(request);
             (CancellationTokenSource cts, bool disposeCts, CancellationTokenSource pendingRequestsCts) = PrepareCancellationTokenSource(cancellationToken);
 
-            return Core(request, completionOption, cts, disposeCts, pendingRequestsCts, cancellationToken);
+            return await Core(request, completionOption, cts, disposeCts, pendingRequestsCts, cancellationToken).ConfigureAwait(false);
 
             async Task<HttpResponseMessage> Core(
                 HttpRequestMessage request, HttpCompletionOption completionOption,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.AnyMobile.cs
@@ -769,11 +769,11 @@ namespace System.Net.Http
             throw new PlatformNotSupportedException();
         }
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return Handler.SendAsync(request, cancellationToken);
+            return await Handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         // lazy-load the validator func so it can be trimmed by the ILLinker if it isn't used.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpClientHandler.cs
@@ -365,10 +365,10 @@ namespace System.Net.Http
 #endif
         }
 
-        protected internal override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected internal override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
-            return Handler.SendAsync(request, cancellationToken);
+            return await Handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
         // lazy-load the validator func so it can be trimmed by the ILLinker if it isn't used.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -94,13 +94,13 @@ namespace System.Net.Http
             return new MemoryStream(_bufferedContent.GetSingleBuffer(), 0, (int)_bufferedContent.Length, writable: false);
         }
 
-        public Task<string> ReadAsStringAsync() =>
-            ReadAsStringAsync(CancellationToken.None);
+        public async Task<string> ReadAsStringAsync() =>
+            await ReadAsStringAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public Task<string> ReadAsStringAsync(CancellationToken cancellationToken)
+        public async Task<string> ReadAsStringAsync(CancellationToken cancellationToken)
         {
             CheckDisposed();
-            return WaitAndReturnAsync(LoadIntoBufferAsync(cancellationToken), this, static s => s.ReadBufferedContentAsString());
+            return await WaitAndReturnAsync(LoadIntoBufferAsync(cancellationToken), this, static s => s.ReadBufferedContentAsString()).ConfigureAwait(false);
         }
 
         private string ReadBufferedContentAsString()
@@ -190,13 +190,13 @@ namespace System.Net.Http
             }
         }
 
-        public Task<byte[]> ReadAsByteArrayAsync() =>
-            ReadAsByteArrayAsync(CancellationToken.None);
+        public async Task<byte[]> ReadAsByteArrayAsync() =>
+            await ReadAsByteArrayAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public Task<byte[]> ReadAsByteArrayAsync(CancellationToken cancellationToken)
+        public async Task<byte[]> ReadAsByteArrayAsync(CancellationToken cancellationToken)
         {
             CheckDisposed();
-            return WaitAndReturnAsync(LoadIntoBufferAsync(cancellationToken), this, static s => s.ReadBufferedContentAsByteArray());
+            return await WaitAndReturnAsync(LoadIntoBufferAsync(cancellationToken), this, static s => s.ReadBufferedContentAsByteArray()).ConfigureAwait(false);
         }
 
         internal byte[] ReadBufferedContentAsByteArray()
@@ -236,8 +236,8 @@ namespace System.Net.Http
             }
         }
 
-        public Task<Stream> ReadAsStreamAsync() =>
-            ReadAsStreamAsync(CancellationToken.None);
+        public async Task<Stream> ReadAsStreamAsync() =>
+            await ReadAsStreamAsync(CancellationToken.None).ConfigureAwait(false);
 
         public Task<Stream> ReadAsStreamAsync(CancellationToken cancellationToken)
         {
@@ -306,8 +306,8 @@ namespace System.Net.Http
             throw new NotSupportedException(SR.Format(SR.net_http_missing_sync_implementation, GetType(), nameof(HttpContent), nameof(SerializeToStream)));
         }
 
-        protected virtual Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
-            SerializeToStreamAsync(stream, context);
+        protected virtual async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
+            await SerializeToStreamAsync(stream, context).ConfigureAwait(false);
 
         // TODO https://github.com/dotnet/runtime/issues/31316: Expose something to enable this publicly.  For very specific
         // HTTP/2 scenarios (e.g. gRPC), we need to be able to allow request content to continue sending after SendAsync has
@@ -338,26 +338,26 @@ namespace System.Net.Http
             }
         }
 
-        public Task CopyToAsync(Stream stream) =>
-            CopyToAsync(stream, CancellationToken.None);
+        public async Task CopyToAsync(Stream stream) =>
+            await CopyToAsync(stream, CancellationToken.None).ConfigureAwait(false);
 
-        public Task CopyToAsync(Stream stream, CancellationToken cancellationToken) =>
-            CopyToAsync(stream, null, cancellationToken);
+        public async Task CopyToAsync(Stream stream, CancellationToken cancellationToken) =>
+            await CopyToAsync(stream, null, cancellationToken).ConfigureAwait(false);
 
-        public Task CopyToAsync(Stream stream, TransportContext? context) =>
-            CopyToAsync(stream, context, CancellationToken.None);
+        public async Task CopyToAsync(Stream stream, TransportContext? context) =>
+            await CopyToAsync(stream, context, CancellationToken.None).ConfigureAwait(false);
 
-        public Task CopyToAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        public async Task CopyToAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
         {
             CheckDisposed();
             ArgumentNullException.ThrowIfNull(stream);
             try
             {
-                return WaitAsync(InternalCopyToAsync(stream, context, cancellationToken));
+                await WaitAsync(InternalCopyToAsync(stream, context, cancellationToken)).ConfigureAwait(false);
             }
             catch (Exception e) when (StreamCopyExceptionNeedsWrapping(e))
             {
-                return Task.FromException(GetStreamCopyException(e));
+                throw GetStreamCopyException(e);
             }
 
             static async Task WaitAsync(ValueTask copyTask)
@@ -438,14 +438,14 @@ namespace System.Net.Http
             _bufferedContent = tempBuffer;
         }
 
-        public Task LoadIntoBufferAsync() =>
-            LoadIntoBufferAsync(MaxBufferSize);
+        public async Task LoadIntoBufferAsync() =>
+            await LoadIntoBufferAsync(MaxBufferSize).ConfigureAwait(false);
 
         // No "CancellationToken" parameter needed since canceling the CTS will close the connection, resulting
         // in an exception being thrown while we're buffering.
         // If buffering is used without a connection, it is supposed to be fast, thus no cancellation required.
-        public Task LoadIntoBufferAsync(long maxBufferSize) =>
-            LoadIntoBufferAsync(maxBufferSize, CancellationToken.None);
+        public async Task LoadIntoBufferAsync(long maxBufferSize) =>
+            await LoadIntoBufferAsync(maxBufferSize, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
         /// Serialize the HTTP content to a memory buffer as an asynchronous operation.
@@ -458,8 +458,8 @@ namespace System.Net.Http
         /// </remarks>
         /// <exception cref="OperationCanceledException">The cancellation token was canceled. This exception is stored into the returned task.</exception>
         /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
-        public Task LoadIntoBufferAsync(CancellationToken cancellationToken) =>
-            LoadIntoBufferAsync(MaxBufferSize, cancellationToken);
+        public async Task LoadIntoBufferAsync(CancellationToken cancellationToken) =>
+            await LoadIntoBufferAsync(MaxBufferSize, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Serialize the HTTP content to a memory buffer as an asynchronous operation.
@@ -546,18 +546,18 @@ namespace System.Net.Http
             return CreateMemoryStreamFromBufferedContent();
         }
 
-        protected virtual Task<Stream> CreateContentReadStreamAsync()
+        protected virtual async Task<Stream> CreateContentReadStreamAsync()
         {
             // By default just buffer the content to a memory stream. Derived classes can override this behavior
             // if there is a better way to retrieve the content as stream (e.g. byte array/string use a more efficient
             // way, like wrapping a read-only MemoryStream around the bytes/string)
-            return WaitAndReturnAsync(LoadIntoBufferAsync(), this, static s => (Stream)s.CreateMemoryStreamFromBufferedContent());
+            return await WaitAndReturnAsync(LoadIntoBufferAsync(), this, static s => (Stream)s.CreateMemoryStreamFromBufferedContent()).ConfigureAwait(false);
         }
 
-        protected virtual Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken)
+        protected virtual async Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken)
         {
             // Drops the CT for compatibility reasons, see https://github.com/dotnet/runtime/issues/916#issuecomment-562083237
-            return CreateContentReadStreamAsync();
+            return await CreateContentReadStreamAsync().ConfigureAwait(false);
         }
 
         // As an optimization for internal consumers of HttpContent (e.g. HttpClient.GetStreamAsync), and for

--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
@@ -64,7 +64,7 @@ namespace System.Net.Http
             }
         }
 
-        public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        public virtual async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(request);
 
@@ -72,10 +72,10 @@ namespace System.Net.Http
 
             if (ShouldSendWithTelemetry(request))
             {
-                return SendAsyncWithTelemetry(_handler, request, cancellationToken);
+                return await SendAsyncWithTelemetry(_handler, request, cancellationToken).ConfigureAwait(false);
             }
 
-            return _handler.SendAsync(request, cancellationToken);
+            return await _handler.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             static async Task<HttpResponseMessage> SendAsyncWithTelemetry(HttpMessageHandler handler, HttpRequestMessage request, CancellationToken cancellationToken)
             {

--- a/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -190,8 +190,8 @@ namespace System.Net.Http
         // write "--" + boundary + "--"
         // Can't be canceled directly by the user.  If the overall request is canceled
         // then the stream will be closed an exception thrown.
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            SerializeToStreamAsyncCore(stream, context, default);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            await SerializeToStreamAsyncCore(stream, context, default).ConfigureAwait(false);
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
             // Only skip the original protected virtual SerializeToStreamAsync if this
@@ -239,8 +239,8 @@ namespace System.Net.Http
             return task.GetAwaiter().GetResult();
         }
 
-        protected override Task<Stream> CreateContentReadStreamAsync() =>
-            CreateContentReadStreamAsyncCore(async: true, CancellationToken.None).AsTask();
+        protected override async Task<Stream> CreateContentReadStreamAsync() =>
+            await CreateContentReadStreamAsyncCore(async: true, CancellationToken.None).ConfigureAwait(false);
 
         protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
             // Only skip the original protected virtual CreateContentReadStreamAsync if this
@@ -507,14 +507,14 @@ namespace System.Net.Http
                 }
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 ValidateBufferArguments(buffer, offset, count);
-                return ReadAsyncPrivate(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+                return await ReadAsyncPrivate(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
             }
 
-            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
-                ReadAsyncPrivate(buffer, cancellationToken);
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+                await ReadAsyncPrivate(buffer, cancellationToken).ConfigureAwait(false);
 
             public override IAsyncResult BeginRead(byte[] array, int offset, int count, AsyncCallback? asyncCallback, object? asyncState) =>
                 TaskToAsyncResult.Begin(ReadAsync(array, offset, count, CancellationToken.None), asyncCallback, asyncState);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/ReadOnlyMemoryContent.cs
@@ -19,11 +19,11 @@ namespace System.Net.Http
             stream.Write(_content.Span);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            stream.WriteAsync(_content).AsTask();
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            await stream.WriteAsync(_content).ConfigureAwait(false);
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
-            stream.WriteAsync(_content, cancellationToken).AsTask();
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
+            await stream.WriteAsync(_content, cancellationToken).ConfigureAwait(false);
 
         protected internal override bool TryComputeLength(out long length)
         {
@@ -34,8 +34,8 @@ namespace System.Net.Http
         protected override Stream CreateContentReadStream(CancellationToken cancellationToken) =>
             new ReadOnlyMemoryStream(_content);
 
-        protected override Task<Stream> CreateContentReadStreamAsync() =>
-            Task.FromResult<Stream>(new ReadOnlyMemoryStream(_content));
+        protected override async Task<Stream> CreateContentReadStreamAsync() =>
+            new ReadOnlyMemoryStream(_content);
 
         internal override Stream TryCreateContentReadStream() =>
             new ReadOnlyMemoryStream(_content);

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -202,15 +202,15 @@ namespace System.Net.Http
             return response!;
         }
 
-        public static Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, TokenImpersonationLevel impersonationLevel, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
+        public static async Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, TokenImpersonationLevel impersonationLevel, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
-            return SendWithNtAuthAsync(request, proxyUri, async, proxyCredentials, impersonationLevel, isProxyAuth: true, connection, connectionPool, cancellationToken);
+            return await SendWithNtAuthAsync(request, proxyUri, async, proxyCredentials, impersonationLevel, isProxyAuth: true, connection, connectionPool, cancellationToken).ConfigureAwait(false);
         }
 
-        public static Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpRequestMessage request, bool async, ICredentials credentials, TokenImpersonationLevel impersonationLevel, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
+        public static async Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpRequestMessage request, bool async, ICredentials credentials, TokenImpersonationLevel impersonationLevel, HttpConnection connection, HttpConnectionPool connectionPool, CancellationToken cancellationToken)
         {
             Debug.Assert(request.RequestUri != null);
-            return SendWithNtAuthAsync(request, request.RequestUri, async, credentials, impersonationLevel, isProxyAuth: false, connection, connectionPool, cancellationToken);
+            return await SendWithNtAuthAsync(request, request.RequestUri, async, credentials, impersonationLevel, isProxyAuth: false, connection, connectionPool, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -372,15 +372,15 @@ namespace System.Net.Http
             return response;
         }
 
-        public static ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, bool doRequestAuth, HttpConnectionPool pool, CancellationToken cancellationToken)
+        public static async ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, bool doRequestAuth, HttpConnectionPool pool, CancellationToken cancellationToken)
         {
-            return SendWithAuthAsync(request, proxyUri, async, proxyCredentials, preAuthenticate: GlobalHttpSettings.SocketsHttpHandler.ProxyPreAuthenticate, isProxyAuth: true, doRequestAuth, pool, cancellationToken);
+            return await SendWithAuthAsync(request, proxyUri, async, proxyCredentials, preAuthenticate: GlobalHttpSettings.SocketsHttpHandler.ProxyPreAuthenticate, isProxyAuth: true, doRequestAuth, pool, cancellationToken).ConfigureAwait(false);
         }
 
-        public static ValueTask<HttpResponseMessage> SendWithRequestAuthAsync(HttpRequestMessage request, bool async, ICredentials credentials, bool preAuthenticate, HttpConnectionPool pool, CancellationToken cancellationToken)
+        public static async ValueTask<HttpResponseMessage> SendWithRequestAuthAsync(HttpRequestMessage request, bool async, ICredentials credentials, bool preAuthenticate, HttpConnectionPool pool, CancellationToken cancellationToken)
         {
             Debug.Assert(request.RequestUri != null);
-            return SendWithAuthAsync(request, request.RequestUri, async, credentials, preAuthenticate, isProxyAuth: false, doRequestAuth: true, pool, cancellationToken);
+            return await SendWithAuthAsync(request, request.RequestUri, async, credentials, preAuthenticate, isProxyAuth: false, doRequestAuth: true, pool, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ConnectionPool/HttpConnectionPool.cs
@@ -340,7 +340,7 @@ namespace System.Net.Http
         // we will remove it from the list of available connections, if it is present there.
         // If not, then it must be unavailable at the moment; we will detect this and ensure it is not added back to the available pool.
 
-        public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
             // We need the User-Agent header when we send a CONNECT request to the proxy.
             // We must read the header early, before we return the ownership of the request back to the user.
@@ -353,40 +353,40 @@ namespace System.Net.Http
 
             if (doRequestAuth && Settings._credentials != null)
             {
-                return AuthenticationHelper.SendWithRequestAuthAsync(request, async, Settings._credentials, Settings._preAuthenticate, this, cancellationToken);
+                return await AuthenticationHelper.SendWithRequestAuthAsync(request, async, Settings._credentials, Settings._preAuthenticate, this, cancellationToken).ConfigureAwait(false);
             }
 
-            return SendWithProxyAuthAsync(request, async, doRequestAuth, cancellationToken);
+            return await SendWithProxyAuthAsync(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
         }
 
-        public ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        public async ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
             if (DoProxyAuth && ProxyCredentials is not null)
             {
-                return AuthenticationHelper.SendWithProxyAuthAsync(request, _proxyUri!, async, ProxyCredentials, doRequestAuth, this, cancellationToken);
+                return await AuthenticationHelper.SendWithProxyAuthAsync(request, _proxyUri!, async, ProxyCredentials, doRequestAuth, this, cancellationToken).ConfigureAwait(false);
             }
 
-            return SendWithVersionDetectionAndRetryAsync(request, async, doRequestAuth, cancellationToken);
+            return await SendWithVersionDetectionAndRetryAsync(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
         }
 
-        private Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpConnection connection, HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        private async Task<HttpResponseMessage> SendWithNtConnectionAuthAsync(HttpConnection connection, HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
             if (doRequestAuth && Settings._credentials != null)
             {
-                return AuthenticationHelper.SendWithNtConnectionAuthAsync(request, async, Settings._credentials, Settings._impersonationLevel, connection, this, cancellationToken);
+                return await AuthenticationHelper.SendWithNtConnectionAuthAsync(request, async, Settings._credentials, Settings._impersonationLevel, connection, this, cancellationToken).ConfigureAwait(false);
             }
 
-            return SendWithNtProxyAuthAsync(connection, request, async, cancellationToken);
+            return await SendWithNtProxyAuthAsync(connection, request, async, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpConnection connection, HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        public async Task<HttpResponseMessage> SendWithNtProxyAuthAsync(HttpConnection connection, HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             if (DoProxyAuth && ProxyCredentials is not null)
             {
-                return AuthenticationHelper.SendWithNtProxyAuthAsync(request, ProxyUri!, async, ProxyCredentials, HttpHandlerDefaults.DefaultImpersonationLevel, connection, this, cancellationToken);
+                return await AuthenticationHelper.SendWithNtProxyAuthAsync(request, ProxyUri!, async, ProxyCredentials, HttpHandlerDefaults.DefaultImpersonationLevel, connection, this, cancellationToken).ConfigureAwait(false);
             }
 
-            return connection.SendAsync(request, async, cancellationToken);
+            return await connection.SendAsync(request, async, cancellationToken).ConfigureAwait(false);
         }
 
         public async ValueTask<HttpResponseMessage> SendWithVersionDetectionAndRetryAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ContentLengthWriteStream.cs
@@ -34,18 +34,18 @@ namespace System.Net.Http
                 connection.Write(buffer);
             }
 
-            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored) // token ignored as it comes from SendAsync
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ignored) // token ignored as it comes from SendAsync
             {
                 BytesWritten += buffer.Length;
 
                 if (BytesWritten > _contentLength)
                 {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new HttpRequestException(SR.net_http_content_write_larger_than_content_length)));
+                    throw ExceptionDispatchInfo.SetCurrentStackTrace(new HttpRequestException(SR.net_http_content_write_larger_than_content_length));
                 }
 
                 HttpConnection connection = GetConnectionOrThrow();
                 Debug.Assert(connection._currentRequest != null);
-                return connection.WriteAsync(buffer);
+                await connection.WriteAsync(buffer).ConfigureAwait(false);
             }
 
             public override Task FinishAsync(bool async)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/DecompressionHandler.cs
@@ -167,8 +167,8 @@ namespace System.Net.Http
                 decompressedStream.CopyTo(stream);
             }
 
-            protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-                SerializeToStreamAsync(stream, context, CancellationToken.None);
+            protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+                await SerializeToStreamAsync(stream, context, CancellationToken.None).ConfigureAwait(false);
 
             protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
             {
@@ -185,8 +185,8 @@ namespace System.Net.Http
                 return task.GetAwaiter().GetResult();
             }
 
-            protected override Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
-                CreateContentReadStreamAsyncCore(async: true, cancellationToken).AsTask();
+            protected override async Task<Stream> CreateContentReadStreamAsync(CancellationToken cancellationToken) =>
+                await CreateContentReadStreamAsyncCore(async: true, cancellationToken).ConfigureAwait(false);
 
             private async ValueTask<Stream> CreateContentReadStreamAsyncCore(bool async, CancellationToken cancellationToken)
             {
@@ -288,11 +288,11 @@ namespace System.Net.Http
                     return _decompressionStream.Read(buffer);
                 }
 
-                public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+                public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
                 {
                     if (_decompressionStream is null)
                     {
-                        return CreateAndReadAsync(this, buffer, cancellationToken);
+                        return await CreateAndReadAsync(this, buffer, cancellationToken).ConfigureAwait(false);
 
                         static async ValueTask<int> CreateAndReadAsync(ZLibOrDeflateStream thisRef, Memory<byte> buffer, CancellationToken cancellationToken)
                         {
@@ -302,13 +302,13 @@ namespace System.Net.Http
                         }
                     }
 
-                    return _decompressionStream.ReadAsync(buffer, cancellationToken);
+                    return await _decompressionStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
                 }
 
-                public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+                public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
                 {
                     ValidateCopyToArguments(destination, bufferSize);
-                    return Core(destination, bufferSize, cancellationToken);
+                    await Core(destination, bufferSize, cancellationToken).ConfigureAwait(false);
                     async Task Core(Stream destination, int bufferSize, CancellationToken cancellationToken)
                     {
                         if (_decompressionStream is null)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -1137,8 +1137,8 @@ namespace System.Net.Http
             return (lastStreamId, errorCode);
         }
 
-        internal Task FlushAsync(CancellationToken cancellationToken) =>
-            PerformWriteAsync(0, 0, static (_, __) => true, cancellationToken);
+        internal async Task FlushAsync(CancellationToken cancellationToken) =>
+            await PerformWriteAsync(0, 0, static (_, __) => true, cancellationToken).ConfigureAwait(false);
 
         private abstract class WriteQueueEntry : TaskCompletionSource
         {
@@ -1287,20 +1287,20 @@ namespace System.Net.Http
             }
         }
 
-        private Task SendSettingsAckAsync() =>
-            PerformWriteAsync(FrameHeader.Size, this, static (thisRef, writeBuffer) =>
+        private async Task SendSettingsAckAsync() =>
+            await PerformWriteAsync(FrameHeader.Size, this, static (thisRef, writeBuffer) =>
             {
                 if (NetEventSource.Log.IsEnabled()) thisRef.Trace("Started writing.");
 
                 FrameHeader.WriteTo(writeBuffer.Span, 0, FrameType.Settings, FrameFlags.Ack, streamId: 0);
 
                 return true;
-            });
+            }).ConfigureAwait(false);
 
         /// <param name="pingContent">The 8-byte ping content to send, read as a big-endian integer.</param>
         /// <param name="isAck">Determine whether the frame is ping or ping ack.</param>
-        private Task SendPingAsync(long pingContent, bool isAck = false) =>
-            PerformWriteAsync(FrameHeader.Size + FrameHeader.PingLength, (thisRef: this, pingContent, isAck), static (state, writeBuffer) =>
+        private async Task SendPingAsync(long pingContent, bool isAck = false) =>
+            await PerformWriteAsync(FrameHeader.Size + FrameHeader.PingLength, (thisRef: this, pingContent, isAck), static (state, writeBuffer) =>
             {
                 if (NetEventSource.Log.IsEnabled()) state.thisRef.Trace($"Started writing. {nameof(pingContent)}={state.pingContent}");
 
@@ -1311,10 +1311,10 @@ namespace System.Net.Http
                 BinaryPrimitives.WriteInt64BigEndian(span.Slice(FrameHeader.Size), state.pingContent);
 
                 return true;
-            });
+            }).ConfigureAwait(false);
 
-        private Task SendRstStreamAsync(int streamId, Http2ProtocolErrorCode errorCode) =>
-            PerformWriteAsync(FrameHeader.Size + FrameHeader.RstStreamLength, (thisRef: this, streamId, errorCode), static (s, writeBuffer) =>
+        private async Task SendRstStreamAsync(int streamId, Http2ProtocolErrorCode errorCode) =>
+            await PerformWriteAsync(FrameHeader.Size + FrameHeader.RstStreamLength, (thisRef: this, streamId, errorCode), static (s, writeBuffer) =>
             {
                 if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.errorCode)}={s.errorCode}");
 
@@ -1323,7 +1323,7 @@ namespace System.Net.Http
                 BinaryPrimitives.WriteInt32BigEndian(span.Slice(FrameHeader.Size), (int)s.errorCode);
 
                 return true;
-            });
+            }).ConfigureAwait(false);
 
 
         internal void HeartBeat()
@@ -1758,21 +1758,21 @@ namespace System.Net.Http
             }
         }
 
-        private Task SendEndStreamAsync(int streamId) =>
-            PerformWriteAsync(FrameHeader.Size, (thisRef: this, streamId), static (s, writeBuffer) =>
+        private async Task SendEndStreamAsync(int streamId) =>
+            await PerformWriteAsync(FrameHeader.Size, (thisRef: this, streamId), static (s, writeBuffer) =>
             {
                 if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, "Started writing.");
 
                 FrameHeader.WriteTo(writeBuffer.Span, 0, FrameType.Data, FrameFlags.EndStream, s.streamId);
 
                 return true; // finished sending request body, so flush soon (but ok to wait for pending packets)
-            });
+            }).ConfigureAwait(false);
 
-        private Task SendWindowUpdateAsync(int streamId, int amount)
+        private async Task SendWindowUpdateAsync(int streamId, int amount)
         {
             // We update both the connection-level and stream-level windows at the same time
             Debug.Assert(amount > 0);
-            return PerformWriteAsync(FrameHeader.Size + FrameHeader.WindowUpdateLength, (thisRef: this, streamId, amount), static (s, writeBuffer) =>
+            await PerformWriteAsync(FrameHeader.Size + FrameHeader.WindowUpdateLength, (thisRef: this, streamId, amount), static (s, writeBuffer) =>
             {
                 if (NetEventSource.Log.IsEnabled()) s.thisRef.Trace(s.streamId, $"Started writing. {nameof(s.amount)}={s.amount}");
 
@@ -1781,7 +1781,7 @@ namespace System.Net.Http
                 BinaryPrimitives.WriteInt32BigEndian(span.Slice(FrameHeader.Size), s.amount);
 
                 return true;
-            });
+            }).ConfigureAwait(false);
         }
 
         private bool ExtendWindow(int amount)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Stream.cs
@@ -1503,7 +1503,7 @@ namespace System.Net.Http
 
                 public override void Write(ReadOnlySpan<byte> buffer) => throw new NotSupportedException(SR.net_http_content_readonly_stream);
 
-                public override ValueTask WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_readonly_stream)));
+                public override async ValueTask WriteAsync(ReadOnlyMemory<byte> destination, CancellationToken cancellationToken) => await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_readonly_stream))).ConfigureAwait(false);
             }
 
             private sealed class Http2WriteStream : Http2ReadWriteStream
@@ -1522,22 +1522,22 @@ namespace System.Net.Http
 
                 public override int Read(Span<byte> buffer) => throw new NotSupportedException(SR.net_http_content_writeonly_stream);
 
-                public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken) => ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_writeonly_stream)));
+                public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken) => await ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_writeonly_stream))).ConfigureAwait(false);
 
                 public override void CopyTo(Stream destination, int bufferSize) => throw new NotSupportedException(SR.net_http_content_writeonly_stream);
 
-                public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => Task.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_writeonly_stream)));
+                public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) => await Task.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_http_content_writeonly_stream))).ConfigureAwait(false);
 
-                public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+                public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
                 {
                     BytesWritten += buffer.Length;
 
                     if ((ulong)BytesWritten > (ulong)ContentLength) // If ContentLength == -1, this will always be false
                     {
-                        return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new HttpRequestException(SR.net_http_content_write_larger_than_content_length)));
+                        await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new HttpRequestException(SR.net_http_content_write_larger_than_content_length))).ConfigureAwait(false);
                     }
 
-                    return base.WriteAsync(buffer, cancellationToken);
+                    await base.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
                 }
             }
 
@@ -1602,21 +1602,21 @@ namespace System.Net.Http
                     return http2Stream.ReadData(destination, _responseMessage);
                 }
 
-                public override ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
+                public override async ValueTask<int> ReadAsync(Memory<byte> destination, CancellationToken cancellationToken)
                 {
                     Http2Stream? http2Stream = _http2Stream;
 
                     if (http2Stream == null)
                     {
-                        return ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http2ReadStream))));
+                        return await ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http2ReadStream)))).ConfigureAwait(false);
                     }
 
                     if (cancellationToken.IsCancellationRequested)
                     {
-                        return ValueTask.FromCanceled<int>(cancellationToken);
+                        return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
                     }
 
-                    return http2Stream.ReadDataAsync(destination, _responseMessage, cancellationToken);
+                    return await http2Stream.ReadDataAsync(destination, _responseMessage, cancellationToken).ConfigureAwait(false);
                 }
 
                 public override void CopyTo(Stream destination, int bufferSize)
@@ -1636,17 +1636,17 @@ namespace System.Net.Http
                         http2Stream.CopyToAsync(_responseMessage, destination, bufferSize, cancellationToken);
                 }
 
-                public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+                public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
                 {
 
                     Http2Stream? http2Stream = _http2Stream;
 
                     if (http2Stream == null)
                     {
-                        return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http2WriteStream))));
+                        await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http2WriteStream)))).ConfigureAwait(false);
                     }
 
-                    return http2Stream.SendDataAsync(buffer, cancellationToken);
+                    await http2Stream!.SendDataAsync(buffer, cancellationToken).ConfigureAwait(false);
                 }
 
                 public override Task FlushAsync(CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http3RequestStream.cs
@@ -581,11 +581,11 @@ namespace System.Net.Http
             }
         }
 
-        private ValueTask FlushSendBufferAsync(bool endStream, CancellationToken cancellationToken)
+        private async ValueTask FlushSendBufferAsync(bool endStream, CancellationToken cancellationToken)
         {
             ReadOnlyMemory<byte> toSend = _sendBuffer.ActiveMemory;
             _sendBuffer.Discard(toSend.Length);
-            return _stream.WriteAsync(toSend, endStream, cancellationToken);
+            await _stream.WriteAsync(toSend, endStream, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask DrainContentLength0Frames(CancellationToken cancellationToken)
@@ -1514,17 +1514,17 @@ namespace System.Net.Http
                 return stream.ReadResponseContent(_response, buffer);
             }
 
-            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+            public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken)
             {
                 Http3RequestStream? stream = _stream;
 
                 if (stream is null)
                 {
-                    return ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http3RequestStream))));
+                    throw ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http3RequestStream)));
                 }
 
                 Debug.Assert(_response != null);
-                return stream.ReadResponseContentAsync(_response, buffer, cancellationToken);
+                return await stream.ReadResponseContentAsync(_response, buffer, cancellationToken).ConfigureAwait(false);
             }
 
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
@@ -1565,30 +1565,24 @@ namespace System.Net.Http
                 throw new NotSupportedException();
             }
 
-            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken)
             {
                 BytesWritten += buffer.Length;
 
                 Http3RequestStream? stream = _stream;
 
-                if (stream is null)
-                {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http3WriteStream))));
-                }
+                ObjectDisposedException.ThrowIf(stream is null, typeof(Http3WriteStream));
 
-                return stream.WriteRequestContentAsync(buffer, cancellationToken);
+                await stream.WriteRequestContentAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
 
-            public override Task FlushAsync(CancellationToken cancellationToken)
+            public override async Task FlushAsync(CancellationToken cancellationToken)
             {
                 Http3RequestStream? stream = _stream;
 
-                if (stream is null)
-                {
-                    return Task.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(nameof(Http3WriteStream))));
-                }
+                ObjectDisposedException.ThrowIf(stream is null, typeof(Http3WriteStream));
 
-                return stream.FlushSendBufferAsync(endStream: false, cancellationToken).AsTask();
+                await stream.FlushSendBufferAsync(endStream: false, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -1487,13 +1487,13 @@ namespace System.Net.Http
             WriteToStream(source);
         }
 
-        private ValueTask WriteWithoutBufferingAsync(ReadOnlyMemory<byte> source, bool async)
+        private async ValueTask WriteWithoutBufferingAsync(ReadOnlyMemory<byte> source, bool async)
         {
             if (_writeBuffer.ActiveLength == 0)
             {
                 // There's nothing in the write buffer we need to flush.
                 // Just write the supplied data out to the stream.
-                return WriteToStreamAsync(source, async);
+                await WriteToStreamAsync(source, async).ConfigureAwait(false);
             }
 
             if (source.Length <= _writeBuffer.AvailableLength)
@@ -1503,12 +1503,12 @@ namespace System.Net.Http
                 // the content to the write buffer and then flush it, so that we
                 // can do a single send rather than two.
                 WriteToBuffer(source.Span);
-                return FlushAsync(async);
+                await FlushAsync(async).ConfigureAwait(false);
             }
 
             // There's data in the write buffer and the data we're writing doesn't fit after it.
             // Do two writes, one to flush the buffer and then another to write the supplied content.
-            return FlushThenWriteWithoutBufferingAsync(source, async);
+            await FlushThenWriteWithoutBufferingAsync(source, async).ConfigureAwait(false);
         }
 
         private async ValueTask FlushThenWriteWithoutBufferingAsync(ReadOnlyMemory<byte> source, bool async)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionHandler.cs
@@ -17,10 +17,10 @@ namespace System.Net.Http
             _doRequestAuth = doRequestAuth;
         }
 
-        internal override ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
+        internal override async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken)
         {
             bool doRequestAuth = _doRequestAuth && !request.IsAuthDisabled();
-            return _poolManager.SendAsync(request, async, doRequestAuth, cancellationToken);
+            return await _poolManager.SendAsync(request, async, doRequestAuth, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionPoolManager.cs
@@ -368,16 +368,16 @@ namespace System.Net.Http
             return pool.SendAsync(request, async, doRequestAuth, cancellationToken);
         }
 
-        public ValueTask<HttpResponseMessage> SendProxyConnectAsync(HttpRequestMessage request, Uri proxyUri, bool async, CancellationToken cancellationToken)
+        public async ValueTask<HttpResponseMessage> SendProxyConnectAsync(HttpRequestMessage request, Uri proxyUri, bool async, CancellationToken cancellationToken)
         {
-            return SendAsyncCore(request, proxyUri, async, doRequestAuth: false, isProxyConnect: true, cancellationToken);
+            return await SendAsyncCore(request, proxyUri, async, doRequestAuth: false, isProxyConnect: true, cancellationToken).ConfigureAwait(false);
         }
 
-        public ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
+        public async ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, bool doRequestAuth, CancellationToken cancellationToken)
         {
             if (_proxy == null)
             {
-                return SendAsyncCore(request, null, async, doRequestAuth, isProxyConnect: false, cancellationToken);
+                return await SendAsyncCore(request, null, async, doRequestAuth, isProxyConnect: false, cancellationToken).ConfigureAwait(false);
             }
 
             // Do proxy lookup.
@@ -393,7 +393,7 @@ namespace System.Net.Http
 
                         if (multiProxy.ReadNext(out proxyUri, out bool isFinalProxy) && !isFinalProxy)
                         {
-                            return SendAsyncMultiProxy(request, async, doRequestAuth, multiProxy, proxyUri, cancellationToken);
+                            return await SendAsyncMultiProxy(request, async, doRequestAuth, multiProxy, proxyUri, cancellationToken).ConfigureAwait(false);
                         }
                     }
                     else
@@ -414,7 +414,7 @@ namespace System.Net.Http
                 throw new NotSupportedException(SR.net_http_invalid_proxy_scheme);
             }
 
-            return SendAsyncCore(request, proxyUri, async, doRequestAuth, isProxyConnect: false, cancellationToken);
+            return await SendAsyncCore(request, proxyUri, async, doRequestAuth, isProxyConnect: false, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionResponseContent.cs
@@ -45,13 +45,13 @@ namespace System.Net.Http
             }
         }
 
-        protected sealed override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            SerializeToStreamAsync(stream, context, CancellationToken.None);
+        protected sealed override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            await SerializeToStreamAsync(stream, context, CancellationToken.None).ConfigureAwait(false);
 
-        protected sealed override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
+        protected sealed override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(stream);
-            return Impl(stream, cancellationToken);
+            await Impl(stream, cancellationToken).ConfigureAwait(false);
 
             async Task Impl(Stream stream, CancellationToken cancellationToken)
             {
@@ -72,8 +72,8 @@ namespace System.Net.Http
         protected sealed override Stream CreateContentReadStream(CancellationToken cancellationToken) =>
             ConsumeStream();
 
-        protected sealed override Task<Stream> CreateContentReadStreamAsync() =>
-            Task.FromResult<Stream>(ConsumeStream());
+        protected sealed override async Task<Stream> CreateContentReadStreamAsync() =>
+            ConsumeStream();
 
         internal sealed override Stream TryCreateContentReadStream() =>
             ConsumeStream();

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpMessageHandlerStage.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpMessageHandlerStage.cs
@@ -17,8 +17,8 @@ namespace System.Net.Http
                 sendTask.AsTask().GetAwaiter().GetResult();
         }
 
-        protected internal sealed override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
-            SendAsync(request, async: true, cancellationToken).AsTask();
+        protected internal sealed override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) =>
+            await SendAsync(request, async: true, cancellationToken).ConfigureAwait(false);
 
         internal abstract ValueTask<HttpResponseMessage> SendAsync(HttpRequestMessage request, bool async, CancellationToken cancellationToken);
     }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -53,8 +53,8 @@ namespace System.Net.Http
             StreamToStreamCopy.Copy(_content, stream, _bufferSize, !_content.CanSeek);
         }
 
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-            SerializeToStreamAsyncCore(stream, default);
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+            await SerializeToStreamAsyncCore(stream, default).ConfigureAwait(false);
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
             // Only skip the original protected virtual SerializeToStreamAsync if this
@@ -62,16 +62,16 @@ namespace System.Net.Http
             GetType() == typeof(StreamContent) ? SerializeToStreamAsyncCore(stream, cancellationToken) :
             base.SerializeToStreamAsync(stream, context, cancellationToken);
 
-        private Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken)
+        private async Task SerializeToStreamAsyncCore(Stream stream, CancellationToken cancellationToken)
         {
             Debug.Assert(stream != null);
             PrepareContent();
-            return StreamToStreamCopy.CopyAsync(
+            await StreamToStreamCopy.CopyAsync(
                 _content,
                 stream,
                 _bufferSize,
                 !_content.CanSeek, // If the stream can't be re-read, make sure that it gets disposed once it is consumed.
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         protected internal override bool TryComputeLength(out long length)
@@ -103,11 +103,11 @@ namespace System.Net.Http
             return new ReadOnlyStream(_content);
         }
 
-        protected override Task<Stream> CreateContentReadStreamAsync()
+        protected override async Task<Stream> CreateContentReadStreamAsync()
         {
             SeekToStartIfSeekable();
             // Wrap the stream with a read-only stream to prevent someone from writing to the stream.
-            return Task.FromResult<Stream>(new ReadOnlyStream(_content));
+            return new ReadOnlyStream(_content);
         }
 
         internal override Stream? TryCreateContentReadStream() =>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpInterop.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/WasiHttpHandler/WasiHttpInterop.cs
@@ -20,7 +20,7 @@ namespace System.Net.Http
 {
     internal static class WasiHttpInterop
     {
-        public static Task RegisterWasiPollable(IPoll.Pollable pollable, CancellationToken cancellationToken)
+        public static async Task RegisterWasiPollable(IPoll.Pollable pollable, CancellationToken cancellationToken)
         {
             var handle = pollable.Handle;
 
@@ -29,7 +29,7 @@ namespace System.Net.Http
             pollable.Handle = 0;
             GC.SuppressFinalize(pollable);
 
-            return CallRegisterWasiPollableHandle((Thread)null!, handle, true, cancellationToken);
+            await CallRegisterWasiPollableHandle((Thread)null!, handle, true, cancellationToken).ConfigureAwait(false);
 
             [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "RegisterWasiPollableHandle")]
             static extern Task CallRegisterWasiPollableHandle(Thread t, int handle, bool ownsPollable, CancellationToken cancellationToken);

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListener.cs
@@ -287,12 +287,12 @@ namespace System.Net
             }
         }
 
-        public Task<HttpListenerContext> GetContextAsync()
+        public async Task<HttpListenerContext> GetContextAsync()
         {
-            return Task.Factory.FromAsync(
+            return await Task.Factory.FromAsync(
                 (callback, state) => ((HttpListener)state!).BeginGetContext(callback, state),
                 iar => ((HttpListener)iar!.AsyncState!).EndGetContext(iar),
-                this);
+                this).ConfigureAwait(false);
         }
 
         public void Close()

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerContext.cs
@@ -22,14 +22,14 @@ namespace System.Net
 
         public HttpListenerResponse Response => _response ??= new HttpListenerResponse(this);
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol)
+        public async Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol)
         {
-            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, WebSocket.DefaultKeepAliveInterval);
+            return await AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, WebSocket.DefaultKeepAliveInterval).ConfigureAwait(false);
         }
 
-        public Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, TimeSpan keepAliveInterval)
+        public async Task<HttpListenerWebSocketContext> AcceptWebSocketAsync(string? subProtocol, TimeSpan keepAliveInterval)
         {
-            return AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, keepAliveInterval);
+            return await AcceptWebSocketAsync(subProtocol, HttpWebSocket.DefaultReceiveBufferSize, keepAliveInterval).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/HttpListenerRequest.cs
@@ -251,12 +251,12 @@ namespace System.Net
             return BeginGetClientCertificateCore(requestCallback, state);
         }
 
-        public Task<X509Certificate2?> GetClientCertificateAsync()
+        public async Task<X509Certificate2?> GetClientCertificateAsync()
         {
-            return Task.Factory.FromAsync(
+            return await Task.Factory.FromAsync(
                 (callback, state) => ((HttpListenerRequest)state!).BeginGetClientCertificate(callback, state),
                 iar => ((HttpListenerRequest)iar.AsyncState!).EndGetClientCertificate(iar),
-                this);
+                this).ConfigureAwait(false);
         }
 
         internal ListenerClientCertState ClientCertState { get; set; } = ListenerClientCertState.NotInitialized;

--- a/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
+++ b/src/libraries/System.Net.HttpListener/src/System/Net/Managed/WebSockets/HttpWebSocket.Managed.cs
@@ -106,17 +106,17 @@ namespace System.Net.WebSockets
 
             public override void Abort() => _inner.Abort();
 
-            public override Task CloseAsync(
+            public override async Task CloseAsync(
                 WebSocketCloseStatus closeStatus,
                 string? statusDescription,
                 CancellationToken cancellationToken) =>
-                _inner.CloseAsync(closeStatus, statusDescription, cancellationToken);
+                await _inner.CloseAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
 
-            public override Task CloseOutputAsync(
+            public override async Task CloseOutputAsync(
                 WebSocketCloseStatus closeStatus,
                 string? statusDescription,
                 CancellationToken cancellationToken) =>
-                _inner.CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
+                await _inner.CloseOutputAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
 
             public override void Dispose()
             {
@@ -163,17 +163,17 @@ namespace System.Net.WebSockets
                 Dispose(false);
             }
 
-            public override Task<WebSocketReceiveResult> ReceiveAsync(
+            public override async Task<WebSocketReceiveResult> ReceiveAsync(
                 ArraySegment<byte> buffer,
                 CancellationToken cancellationToken) =>
-                _inner.ReceiveAsync(buffer, cancellationToken);
+                await _inner.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-            public override Task SendAsync(
+            public override async Task SendAsync(
                 ArraySegment<byte> buffer,
                 WebSocketMessageType messageType,
                 bool endOfMessage,
                 CancellationToken cancellationToken) =>
-                _inner.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+                await _inner.SendAsync(buffer, messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/CloseableStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/CloseableStream.cs
@@ -34,9 +34,9 @@ namespace System.Net
             BaseStream.Write(buffer);
         }
 
-        protected override ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        protected override async ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return BaseStream.WriteAsync(buffer, cancellationToken);
+            await BaseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         protected override int ReadInternal(Span<byte> buffer)
@@ -44,9 +44,9 @@ namespace System.Net
             return BaseStream.Read(buffer);
         }
 
-        protected override ValueTask<int> ReadAsyncInternal(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        protected override async ValueTask<int> ReadAsyncInternal(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return BaseStream.ReadAsync(buffer, cancellationToken);
+            return await BaseStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/DelegatedStream.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/DelegatedStream.cs
@@ -95,9 +95,9 @@ namespace System.Net
             _stream.Flush();
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
-            return _stream.FlushAsync(cancellationToken);
+            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         // Abstract methods for derived classes to implement core logic
@@ -118,12 +118,12 @@ namespace System.Net
             return ReadInternal(buffer);
         }
 
-        public sealed override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public sealed override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (!CanRead)
                 throw new NotSupportedException(SR.ReadNotSupported);
 
-            return ReadAsyncInternal(buffer, cancellationToken);
+            return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public sealed override int Read(byte[] buffer, int offset, int count)
@@ -135,13 +135,13 @@ namespace System.Net
             return ReadInternal(buffer.AsSpan(offset, count));
         }
 
-        public sealed override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public sealed override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             if (!CanRead)
                 throw new NotSupportedException(SR.ReadNotSupported);
 
-            return ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            return await ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         public sealed override int ReadByte()
@@ -177,12 +177,12 @@ namespace System.Net
             WriteInternal(buffer);
         }
 
-        public sealed override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public sealed override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (!CanWrite)
                 throw new NotSupportedException(SR.WriteNotSupported);
 
-            return WriteAsyncInternal(buffer, cancellationToken);
+            await WriteAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public sealed override void Write(byte[] buffer, int offset, int count)
@@ -194,13 +194,13 @@ namespace System.Net
             WriteInternal(buffer.AsSpan(offset, count));
         }
 
-        public sealed override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public sealed override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             if (!CanWrite)
                 throw new NotSupportedException(SR.WriteNotSupported);
 
-            return WriteAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            await WriteAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpClient.cs
@@ -636,21 +636,21 @@ namespace System.Net.Mail
 
 
         //************* Task-based async public methods *************************
-        public Task SendMailAsync(string from, string recipients, string? subject, string? body)
+        public async Task SendMailAsync(string from, string recipients, string? subject, string? body)
         {
             var message = new MailMessage(from, recipients, subject, body);
-            return SendMailAsync(message, cancellationToken: default);
+            await SendMailAsync(message, cancellationToken: default).ConfigureAwait(false);
         }
 
-        public Task SendMailAsync(MailMessage message)
+        public async Task SendMailAsync(MailMessage message)
         {
-            return SendMailAsync(message, cancellationToken: default);
+            await SendMailAsync(message, cancellationToken: default).ConfigureAwait(false);
         }
 
-        public Task SendMailAsync(string from, string recipients, string? subject, string? body, CancellationToken cancellationToken)
+        public async Task SendMailAsync(string from, string recipients, string? subject, string? body, CancellationToken cancellationToken)
         {
             var message = new MailMessage(from, recipients, subject, body);
-            return SendMailAsync(message, cancellationToken);
+            await SendMailAsync(message, cancellationToken).ConfigureAwait(false);
         }
 
         public Task SendMailAsync(MailMessage message, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReader.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpReplyReader.cs
@@ -28,14 +28,14 @@ namespace System.Net.Mail
             _reader.Close(this);
         }
 
-        internal Task<LineInfo[]> ReadLinesAsync<TIOAdapter>(CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter
+        internal async Task<LineInfo[]> ReadLinesAsync<TIOAdapter>(CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter
         {
-            return _reader.ReadLinesAsync<TIOAdapter>(this, false, cancellationToken);
+            return await _reader.ReadLinesAsync<TIOAdapter>(this, false, cancellationToken).ConfigureAwait(false);
         }
 
-        internal Task<LineInfo> ReadLineAsync<TIOAdapter>(CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter
+        internal async Task<LineInfo> ReadLineAsync<TIOAdapter>(CancellationToken cancellationToken) where TIOAdapter : IReadWriteAdapter
         {
-            return _reader.ReadLineAsync<TIOAdapter>(this, cancellationToken);
+            return await _reader.ReadLineAsync<TIOAdapter>(this, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/Dns.cs
@@ -91,8 +91,8 @@ namespace System.Net
             return ipHostEntry;
         }
 
-        public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress) =>
-            GetHostEntryAsync(hostNameOrAddress, AddressFamily.Unspecified, CancellationToken.None);
+        public static async Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress) =>
+            await GetHostEntryAsync(hostNameOrAddress, AddressFamily.Unspecified, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
         /// Resolves a host name or IP address to an <see cref="IPHostEntry"/> instance as an asynchronous operation.
@@ -103,8 +103,8 @@ namespace System.Net
         /// The task object representing the asynchronous operation. The <see cref="Task{TResult}.Result"/> property on the task object returns
         /// an <see cref="IPHostEntry"/> instance that contains the address information about the host specified in <paramref name="hostNameOrAddress"/>.
         /// </returns>
-        public static Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, CancellationToken cancellationToken) =>
-            GetHostEntryAsync(hostNameOrAddress, AddressFamily.Unspecified, cancellationToken);
+        public static async Task<IPHostEntry> GetHostEntryAsync(string hostNameOrAddress, CancellationToken cancellationToken) =>
+            await GetHostEntryAsync(hostNameOrAddress, AddressFamily.Unspecified, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Resolves a host name or IP address to an <see cref="IPHostEntry"/> instance as an asynchronous operation.
@@ -149,7 +149,7 @@ namespace System.Net
             }
         }
 
-        public static Task<IPHostEntry> GetHostEntryAsync(IPAddress address)
+        public static async Task<IPHostEntry> GetHostEntryAsync(IPAddress address)
         {
             if (OperatingSystem.IsWasi()) throw new PlatformNotSupportedException(); // TODO remove with https://github.com/dotnet/runtime/pull/107185
 
@@ -161,13 +161,13 @@ namespace System.Net
                 throw new ArgumentException(SR.net_invalid_ip_addr, nameof(address));
             }
 
-            return RunAsync(static (s, activity) => {
+            return await RunAsync(static (s, activity) => {
                 if (OperatingSystem.IsWasi()) throw new PlatformNotSupportedException(); // TODO remove with https://github.com/dotnet/runtime/pull/107185
 
                 IPHostEntry ipHostEntry = GetHostEntryCore((IPAddress)s, AddressFamily.Unspecified, activity);
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.Info((IPAddress)s, $"{ipHostEntry} with {ipHostEntry.AddressList.Length} entries");
                 return ipHostEntry;
-            }, address, CancellationToken.None);
+            }, address, CancellationToken.None).ConfigureAwait(false);
         }
 
         public static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback? requestCallback, object? stateObject) =>

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -51,10 +51,10 @@ namespace System.Net.NetworkInformation
             return TaskToAsyncResult.End<UnicastIPAddressInformationCollection>(asyncResult);
         }
 
-        public sealed override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
+        public sealed override async Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
         {
-            return Task.Factory.StartNew(s => ((UnixIPGlobalProperties)s!).GetUnicastAddresses(), this,
-                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            return await Task.Factory.StartNew(s => ((UnixIPGlobalProperties)s!).GetUnicastAddresses(), this,
+                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).ConfigureAwait(false);
         }
 
         private struct Context

--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -530,39 +530,39 @@ namespace System.Net.NetworkInformation
             }, AsyncOperationManager.CreateOperation(userToken), CancellationToken.None, TaskContinuationOptions.DenyChildAttach, TaskScheduler.Default);
         }
 
-        public Task<PingReply> SendPingAsync(IPAddress address)
+        public async Task<PingReply> SendPingAsync(IPAddress address)
         {
-            return SendPingAsync(address, DefaultTimeout, DefaultSendBuffer, null);
+            return await SendPingAsync(address, DefaultTimeout, DefaultSendBuffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(string hostNameOrAddress)
+        public async Task<PingReply> SendPingAsync(string hostNameOrAddress)
         {
-            return SendPingAsync(hostNameOrAddress, DefaultTimeout, DefaultSendBuffer, null);
+            return await SendPingAsync(hostNameOrAddress, DefaultTimeout, DefaultSendBuffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(IPAddress address, int timeout)
+        public async Task<PingReply> SendPingAsync(IPAddress address, int timeout)
         {
-            return SendPingAsync(address, timeout, DefaultSendBuffer, null);
+            return await SendPingAsync(address, timeout, DefaultSendBuffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout)
+        public async Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout)
         {
-            return SendPingAsync(hostNameOrAddress, timeout, DefaultSendBuffer, null);
+            return await SendPingAsync(hostNameOrAddress, timeout, DefaultSendBuffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer)
+        public async Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer)
         {
-            return SendPingAsync(address, timeout, buffer, null);
+            return await SendPingAsync(address, timeout, buffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer)
+        public async Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer)
         {
-            return SendPingAsync(hostNameOrAddress, timeout, buffer, null);
+            return await SendPingAsync(hostNameOrAddress, timeout, buffer, null).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer, PingOptions? options)
+        public async Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer, PingOptions? options)
         {
-            return SendPingAsync(address, timeout, buffer, options, CancellationToken.None);
+            return await SendPingAsync(address, timeout, buffer, options, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -580,16 +580,16 @@ namespace System.Net.NetworkInformation
         /// <param name="options">A <see cref="PingOptions"/> object used to control fragmentation and Time-to-Live values for the ICMP echo message packet.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task<PingReply> SendPingAsync(IPAddress address, TimeSpan timeout, byte[]? buffer = null, PingOptions? options = null, CancellationToken cancellationToken = default)
+        public async Task<PingReply> SendPingAsync(IPAddress address, TimeSpan timeout, byte[]? buffer = null, PingOptions? options = null, CancellationToken cancellationToken = default)
         {
-            return SendPingAsync(address, ToTimeoutMilliseconds(timeout), buffer ?? DefaultSendBuffer, options, cancellationToken);
+            return await SendPingAsync(address, ToTimeoutMilliseconds(timeout), buffer ?? DefaultSendBuffer, options, cancellationToken).ConfigureAwait(false);
         }
 
-        private Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer, PingOptions? options, CancellationToken cancellationToken)
+        private async Task<PingReply> SendPingAsync(IPAddress address, int timeout, byte[] buffer, PingOptions? options, CancellationToken cancellationToken)
         {
             CheckArgs(address, timeout, buffer);
 
-            return SendPingAsyncInternal(
+            return await SendPingAsyncInternal(
                 // Need to snapshot the address here, so we're sure that it's not changed between now
                 // and the operation, and to be sure that IPAddress.ToString() is called and not some override.
                 GetAddressSnapshot(address),
@@ -597,12 +597,12 @@ namespace System.Net.NetworkInformation
                 timeout,
                 buffer,
                 options,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions? options)
+        public async Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions? options)
         {
-            return SendPingAsync(hostNameOrAddress, timeout, buffer, options, CancellationToken.None);
+            return await SendPingAsync(hostNameOrAddress, timeout, buffer, options, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -623,12 +623,12 @@ namespace System.Net.NetworkInformation
         /// <param name="options">A <see cref="PingOptions"/> object used to control fragmentation and Time-to-Live values for the ICMP echo message packet.</param>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task<PingReply> SendPingAsync(string hostNameOrAddress, TimeSpan timeout, byte[]? buffer = null, PingOptions? options = null, CancellationToken cancellationToken = default)
+        public async Task<PingReply> SendPingAsync(string hostNameOrAddress, TimeSpan timeout, byte[]? buffer = null, PingOptions? options = null, CancellationToken cancellationToken = default)
         {
-            return SendPingAsync(hostNameOrAddress, ToTimeoutMilliseconds(timeout), buffer ?? DefaultSendBuffer, options, cancellationToken);
+            return await SendPingAsync(hostNameOrAddress, ToTimeoutMilliseconds(timeout), buffer ?? DefaultSendBuffer, options, cancellationToken).ConfigureAwait(false);
         }
 
-        private Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions? options, CancellationToken cancellationToken)
+        private async Task<PingReply> SendPingAsync(string hostNameOrAddress, int timeout, byte[] buffer, PingOptions? options, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(hostNameOrAddress))
             {
@@ -637,19 +637,19 @@ namespace System.Net.NetworkInformation
 
             if (IPAddress.TryParse(hostNameOrAddress, out IPAddress? address))
             {
-                return SendPingAsync(address, timeout, buffer, options, cancellationToken);
+                return await SendPingAsync(address, timeout, buffer, options, cancellationToken).ConfigureAwait(false);
             }
 
             CheckArgs(timeout, buffer);
 
-            return SendPingAsyncInternal(
+            return await SendPingAsyncInternal(
                 hostNameOrAddress,
                 static async (hostName, cancellationToken) =>
                     (await Dns.GetHostAddressesAsync(hostName, cancellationToken).ConfigureAwait(false))[0],
                 timeout,
                 buffer,
                 options,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private static int ToTimeoutMilliseconds(TimeSpan timeout)

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicConnection.cs
@@ -59,7 +59,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
     /// <param name="options">Options for the connection.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>An asynchronous task that completes with the connected connection.</returns>
-    public static ValueTask<QuicConnection> ConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
+    public static async ValueTask<QuicConnection> ConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken = default)
     {
         if (!IsSupported)
         {
@@ -68,7 +68,7 @@ public sealed partial class QuicConnection : IAsyncDisposable
 
         // Validate and fill in defaults for the options.
         options.Validate(nameof(options));
-        return StartConnectAsync(options, cancellationToken);
+        return await StartConnectAsync(options, cancellationToken).ConfigureAwait(false);
 
         static async ValueTask<QuicConnection> StartConnectAsync(QuicClientConnectionOptions options, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicListener.cs
@@ -50,7 +50,7 @@ public sealed partial class QuicListener : IAsyncDisposable
     /// <param name="options">Options for the listener.</param>
     /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
     /// <returns>An asynchronous task that completes with the started listener.</returns>
-    public static ValueTask<QuicListener> ListenAsync(QuicListenerOptions options, CancellationToken cancellationToken = default)
+    public static async ValueTask<QuicListener> ListenAsync(QuicListenerOptions options, CancellationToken cancellationToken = default)
     {
         if (!IsSupported)
         {
@@ -67,7 +67,7 @@ public sealed partial class QuicListener : IAsyncDisposable
             NetEventSource.Info(listener, $"{listener} Listener listens on {listener.LocalEndPoint}");
         }
 
-        return ValueTask.FromResult(listener);
+        return listener;
     }
 
     /// <summary>

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.Stream.cs
@@ -140,10 +140,10 @@ public partial class QuicStream : Stream
     }
 
     /// <inheritdoc />
-    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
         ValidateBufferArguments(buffer, offset, count);
-        return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
     }
 
     // Write boilerplate.
@@ -198,10 +198,10 @@ public partial class QuicStream : Stream
     }
 
     /// <inheritdoc />
-    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken = default)
     {
         ValidateBufferArguments(buffer, offset, count);
-        return WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+        await WriteAsync(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
     }
 
     // Flush.

--- a/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
+++ b/src/libraries/System.Net.Quic/src/System/Net/Quic/QuicStream.cs
@@ -379,8 +379,8 @@ public sealed partial class QuicStream
     }
 
     /// <inheritdoc />
-    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
-        => WriteAsync(buffer, completeWrites: false, cancellationToken);
+    public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        => await WriteAsync(buffer, completeWrites: false, cancellationToken).ConfigureAwait(false);
 
 
     /// <inheritdoc cref="WriteAsync(ReadOnlyMemory{byte}, CancellationToken)"/>

--- a/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/FileWebRequest.cs
@@ -162,16 +162,16 @@ namespace System.Net
             return TaskToAsyncResult.Begin(t, callback, state);
         }
 
-        public override Task<Stream> GetRequestStreamAsync()
+        public override async Task<Stream> GetRequestStreamAsync()
         {
             CheckAndMarkAsyncGetRequestStreamPending();
-            return Task.Factory.StartNew<Stream>(s =>
+            return await Task.Factory.StartNew<Stream>(s =>
             {
                 FileWebRequest thisRef = (FileWebRequest)s!;
                 Stream writeStream = thisRef.CreateWriteStream();
                 thisRef._writePending = false;
                 return writeStream;
-            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).ConfigureAwait(false);
         }
 
         private void CheckAndMarkAsyncGetResponsePending()
@@ -223,16 +223,16 @@ namespace System.Net
             return TaskToAsyncResult.Begin(t, callback, state);
         }
 
-        public override Task<WebResponse> GetResponseAsync()
+        public override async Task<WebResponse> GetResponseAsync()
         {
             CheckAndMarkAsyncGetResponsePending();
-            return Task.Factory.StartNew(s =>
+            return await Task.Factory.StartNew(s =>
             {
                 var thisRef = (FileWebRequest)s!;
                 WebResponse response = thisRef.CreateResponse();
                 _readPending = false;
                 return response;
-            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+            }, this, CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default).ConfigureAwait(false);
         }
 
         public override Stream EndGetRequestStream(IAsyncResult asyncResult)
@@ -419,12 +419,12 @@ namespace System.Net
             }
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckAborted();
             try
             {
-                return base.ReadAsync(buffer, offset, count, cancellationToken);
+                return await base.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -433,12 +433,12 @@ namespace System.Net
             }
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckAborted();
             try
             {
-                return base.WriteAsync(buffer, offset, count, cancellationToken);
+                await base.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
             catch
             {
@@ -447,12 +447,12 @@ namespace System.Net
             }
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             CheckAborted();
             try
             {
-                return base.CopyToAsync(destination, bufferSize, cancellationToken);
+                await base.CopyToAsync(destination, bufferSize, cancellationToken).ConfigureAwait(false);
             }
             catch
             {

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebResponse.cs
@@ -405,9 +405,9 @@ namespace System.Net
                 return readBytes;
             }
 
-            public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                return ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+                return await ReadAsync(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
             }
 
             public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -422,7 +422,7 @@ namespace System.Net
             public override void SetLength(long value) => throw new NotSupportedException();
             public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-            public override ValueTask DisposeAsync() => innerStream.DisposeAsync();
+            public override async ValueTask DisposeAsync() => await innerStream.DisposeAsync().ConfigureAwait(false);
 
             protected override void Dispose(bool disposing)
             {

--- a/src/libraries/System.Net.Requests/src/System/Net/NetworkStreamWrapper.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/NetworkStreamWrapper.cs
@@ -185,14 +185,14 @@ namespace System.Net
             return Stream.EndRead(asyncResult);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return Stream.ReadAsync(buffer, offset, count, cancellationToken);
+            return await Stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return Stream.ReadAsync(buffer, cancellationToken);
+            return await Stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int size, AsyncCallback? callback, object? state)
@@ -205,14 +205,14 @@ namespace System.Net
             Stream.EndWrite(asyncResult);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return Stream.WriteAsync(buffer, offset, count, cancellationToken);
+            await Stream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
-            return Stream.WriteAsync(buffer, cancellationToken);
+            await Stream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override void Flush()
@@ -220,9 +220,9 @@ namespace System.Net
             Stream.Flush();
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
-            return Stream.FlushAsync(cancellationToken);
+            await Stream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override void SetLength(long value)

--- a/src/libraries/System.Net.Requests/src/System/Net/RequestBufferingStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/RequestBufferingStream.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -75,17 +75,17 @@ namespace System.Net
             _buffer.Write(buffer, offset, count);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ValidateBufferArguments(buffer, offset, count);
-            return _buffer.WriteAsync(buffer, offset, count, cancellationToken);
+            await _buffer.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
-            return _buffer.WriteAsync(buffer, cancellationToken);
+            await _buffer.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState)

--- a/src/libraries/System.Net.Requests/src/System/Net/RequestStream.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/RequestStream.cs
@@ -51,10 +51,10 @@ namespace System.Net
             _internalStream.Flush();
         }
 
-        public override Task FlushAsync(CancellationToken cancellationToken)
+        public override async Task FlushAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return _internalStream.FlushAsync(cancellationToken);
+            await _internalStream.FlushAsync(cancellationToken).ConfigureAwait(false);
         }
 
         public override long Length
@@ -99,17 +99,17 @@ namespace System.Net
             _internalStream.Write(new(buffer, offset, count));
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
             ValidateBufferArguments(buffer, offset, count);
-            return _internalStream.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            await _internalStream.WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
-            return _internalStream.WriteAsync(buffer, cancellationToken);
+            await _internalStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? asyncCallback, object? asyncState)

--- a/src/libraries/System.Net.Requests/src/System/Net/RequestStreamContent.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/RequestStreamContent.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -11,9 +11,9 @@ namespace System.Net
 {
     internal sealed class RequestStreamContent(TaskCompletionSource<Stream> getStreamTcs, TaskCompletionSource completeTcs) : HttpContent
     {
-        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
         {
-            return SerializeToStreamAsync(stream, context, default);
+            await SerializeToStreamAsync(stream, context, default).ConfigureAwait(false);
         }
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken)
         {

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NegotiateStream.cs
@@ -177,43 +177,43 @@ namespace System.Net.Security
             AuthenticateAsync<SyncReadWriteAdapter>(default(CancellationToken)).GetAwaiter().GetResult();
         }
 
-        public virtual Task AuthenticateAsClientAsync() =>
-            AuthenticateAsClientAsync((NetworkCredential)CredentialCache.DefaultCredentials, binding: null, string.Empty, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        public virtual async Task AuthenticateAsClientAsync() =>
+            await AuthenticateAsClientAsync((NetworkCredential)CredentialCache.DefaultCredentials, binding: null, string.Empty, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName) =>
-            AuthenticateAsClientAsync(credential, binding: null, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        public virtual async Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName) =>
+            await AuthenticateAsClientAsync(credential, binding: null, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(
+        public virtual async Task AuthenticateAsClientAsync(
             NetworkCredential credential, string targetName,
             ProtectionLevel requiredProtectionLevel,
             TokenImpersonationLevel allowedImpersonationLevel) =>
-            AuthenticateAsClientAsync(credential, binding: null, targetName, requiredProtectionLevel, allowedImpersonationLevel);
+            await AuthenticateAsClientAsync(credential, binding: null, targetName, requiredProtectionLevel, allowedImpersonationLevel).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(NetworkCredential credential, ChannelBinding? binding, string targetName) =>
-            AuthenticateAsClientAsync(credential, binding, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        public virtual async Task AuthenticateAsClientAsync(NetworkCredential credential, ChannelBinding? binding, string targetName) =>
+            await AuthenticateAsClientAsync(credential, binding, targetName, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(
+        public virtual async Task AuthenticateAsClientAsync(
             NetworkCredential credential, ChannelBinding? binding, string targetName, ProtectionLevel requiredProtectionLevel,
             TokenImpersonationLevel allowedImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, isServer: false, credential, targetName, binding, requiredProtectionLevel, allowedImpersonationLevel);
-            return AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken));
+            await AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken)).ConfigureAwait(false);
         }
 
-        public virtual Task AuthenticateAsServerAsync() =>
-            AuthenticateAsServerAsync((NetworkCredential)CredentialCache.DefaultCredentials, policy: null, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        public virtual async Task AuthenticateAsServerAsync() =>
+            await AuthenticateAsServerAsync((NetworkCredential)CredentialCache.DefaultCredentials, policy: null, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsServerAsync(ExtendedProtectionPolicy? policy) =>
-            AuthenticateAsServerAsync((NetworkCredential)CredentialCache.DefaultCredentials, policy, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification);
+        public virtual async Task AuthenticateAsServerAsync(ExtendedProtectionPolicy? policy) =>
+            await AuthenticateAsServerAsync((NetworkCredential)CredentialCache.DefaultCredentials, policy, ProtectionLevel.EncryptAndSign, TokenImpersonationLevel.Identification).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsServerAsync(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel) =>
-            AuthenticateAsServerAsync(credential, policy: null, requiredProtectionLevel, requiredImpersonationLevel);
+        public virtual async Task AuthenticateAsServerAsync(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel) =>
+            await AuthenticateAsServerAsync(credential, policy: null, requiredProtectionLevel, requiredImpersonationLevel).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsServerAsync(
+        public virtual async Task AuthenticateAsServerAsync(
             NetworkCredential credential, ExtendedProtectionPolicy? policy, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel)
         {
             ValidateCreateContext(DefaultPackage, credential, string.Empty, policy, requiredProtectionLevel, requiredImpersonationLevel);
-            return AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken));
+            await AuthenticateAsync<AsyncReadWriteAdapter>(default(CancellationToken)).ConfigureAwait(false);
         }
 
         public override bool IsAuthenticated => IsAuthenticatedCore;
@@ -293,8 +293,8 @@ namespace System.Net.Security
         public override void Flush() =>
             InnerStream.Flush();
 
-        public override Task FlushAsync(CancellationToken cancellationToken) =>
-            InnerStream.FlushAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) =>
+            await InnerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         public override int Read(byte[] buffer, int offset, int count)
         {
@@ -311,28 +311,28 @@ namespace System.Net.Security
             return vt.GetAwaiter().GetResult();
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
 
             ThrowIfFailed(authSuccessCheck: true);
             if (!CanGetSecureStream)
             {
-                return InnerStream.ReadAsync(buffer, offset, count, cancellationToken);
+                return await InnerStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
 
-            return ReadAsync<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsync<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfFailed(authSuccessCheck: true);
             if (!CanGetSecureStream)
             {
-                return InnerStream.ReadAsync(buffer, cancellationToken);
+                return await InnerStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             }
 
-            return ReadAsync<AsyncReadWriteAdapter>(buffer, cancellationToken);
+            return await ReadAsync<AsyncReadWriteAdapter>(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask<int> ReadAsync<TIOAdapter>(Memory<byte> buffer, CancellationToken cancellationToken)
@@ -475,17 +475,17 @@ namespace System.Net.Security
         }
 
         /// <returns>A <see cref="Task"/> that represents the asynchronous read operation.</returns>
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
 
             ThrowIfFailed(authSuccessCheck: true);
             if (!CanGetSecureStream)
             {
-                return InnerStream.WriteAsync(buffer, offset, count, cancellationToken);
+                await InnerStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
 
-            return WriteAsync<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken);
+            await WriteAsync<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <returns>A <see cref="ValueTask"/> that represents the asynchronous read operation.</returns>

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.cs
@@ -377,11 +377,11 @@ namespace System.Net.Security
         #endregion
 
         #region Task-based async public methods
-        public virtual Task AuthenticateAsClientAsync(string targetHost) => AuthenticateAsClientAsync(targetHost, null, false);
+        public virtual async Task AuthenticateAsClientAsync(string targetHost) => await AuthenticateAsClientAsync(targetHost, null, false).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(string targetHost, X509CertificateCollection? clientCertificates, bool checkCertificateRevocation) => AuthenticateAsClientAsync(targetHost, clientCertificates, SslProtocols.None, checkCertificateRevocation);
+        public virtual async Task AuthenticateAsClientAsync(string targetHost, X509CertificateCollection? clientCertificates, bool checkCertificateRevocation) => await AuthenticateAsClientAsync(targetHost, clientCertificates, SslProtocols.None, checkCertificateRevocation).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsClientAsync(string targetHost, X509CertificateCollection? clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+        public virtual async Task AuthenticateAsClientAsync(string targetHost, X509CertificateCollection? clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
         {
             SslClientAuthenticationOptions options = new SslClientAuthenticationOptions()
             {
@@ -392,22 +392,22 @@ namespace System.Net.Security
                 EncryptionPolicy = _sslAuthenticationOptions.EncryptionPolicy,
             };
 
-            return AuthenticateAsClientAsync(options);
+            await AuthenticateAsClientAsync(options).ConfigureAwait(false);
         }
 
-        public Task AuthenticateAsClientAsync(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken = default)
+        public async Task AuthenticateAsClientAsync(SslClientAuthenticationOptions sslClientAuthenticationOptions, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(sslClientAuthenticationOptions);
 
             ThrowIfExceptional();
             _sslAuthenticationOptions.UpdateOptions(sslClientAuthenticationOptions);
-            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
+            await ProcessAuthenticationAsync(isAsync: true, cancellationToken).ConfigureAwait(false);
         }
 
-        public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate) =>
-            AuthenticateAsServerAsync(serverCertificate, false, SslProtocols.None, false);
+        public virtual async Task AuthenticateAsServerAsync(X509Certificate serverCertificate) =>
+            await AuthenticateAsServerAsync(serverCertificate, false, SslProtocols.None, false).ConfigureAwait(false);
 
-        public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation)
+        public virtual async Task AuthenticateAsServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, bool checkCertificateRevocation)
         {
             SslServerAuthenticationOptions options = new SslServerAuthenticationOptions
             {
@@ -417,10 +417,10 @@ namespace System.Net.Security
                 EncryptionPolicy = _sslAuthenticationOptions.EncryptionPolicy,
             };
 
-            return AuthenticateAsServerAsync(options);
+            await AuthenticateAsServerAsync(options).ConfigureAwait(false);
         }
 
-        public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
+        public virtual async Task AuthenticateAsServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
         {
             SslServerAuthenticationOptions options = new SslServerAuthenticationOptions
             {
@@ -431,21 +431,21 @@ namespace System.Net.Security
                 EncryptionPolicy = _sslAuthenticationOptions.EncryptionPolicy,
             };
 
-            return AuthenticateAsServerAsync(options);
+            await AuthenticateAsServerAsync(options).ConfigureAwait(false);
         }
 
-        public Task AuthenticateAsServerAsync(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken = default)
+        public async Task AuthenticateAsServerAsync(SslServerAuthenticationOptions sslServerAuthenticationOptions, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(sslServerAuthenticationOptions);
             _sslAuthenticationOptions.UpdateOptions(sslServerAuthenticationOptions);
-            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
+            await ProcessAuthenticationAsync(isAsync: true, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, CancellationToken cancellationToken = default)
+        public async Task AuthenticateAsServerAsync(ServerOptionsSelectionCallback optionsCallback, object? state, CancellationToken cancellationToken = default)
         {
             _sslAuthenticationOptions.UpdateOptions(optionsCallback, state);
 
-            return ProcessAuthenticationAsync(isAsync: true, cancellationToken);
+            await ProcessAuthenticationAsync(isAsync: true, cancellationToken).ConfigureAwait(false);
         }
 
         public virtual Task ShutdownAsync()
@@ -689,12 +689,12 @@ namespace System.Net.Security
 
         public override void Flush() => InnerStream.Flush();
 
-        public override Task FlushAsync(CancellationToken cancellationToken) => InnerStream.FlushAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await InnerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         [SupportedOSPlatform("linux")]
         [SupportedOSPlatform("windows")]
         [SupportedOSPlatform("freebsd")]
-        public virtual Task NegotiateClientCertificateAsync(CancellationToken cancellationToken = default)
+        public virtual async Task NegotiateClientCertificateAsync(CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();
             if (RemoteCertificate != null)
@@ -702,7 +702,7 @@ namespace System.Net.Security
                 throw new InvalidOperationException(SR.net_ssl_certificate_exist);
             }
 
-            return RenegotiateAsync<AsyncReadWriteAdapter>(cancellationToken);
+            await RenegotiateAsync<AsyncReadWriteAdapter>(cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)
@@ -874,30 +874,30 @@ namespace System.Net.Security
             TaskToAsyncResult.End(asyncResult);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
-            return WriteAsyncInternal<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            await WriteAsyncInternal<AsyncReadWriteAdapter>(new ReadOnlyMemory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            return WriteAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken);
+            await WriteAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken).ConfigureAwait(false);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ThrowIfExceptionalOrNotAuthenticated();
             ValidateBufferArguments(buffer, offset, count);
-            return ReadAsyncInternal<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).AsTask();
+            return await ReadAsyncInternal<AsyncReadWriteAdapter>(new Memory<byte>(buffer, offset, count), cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             ThrowIfExceptionalOrNotAuthenticated();
-            return ReadAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken);
+            return await ReadAsyncInternal<AsyncReadWriteAdapter>(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private void ThrowIfExceptional()

--- a/src/libraries/System.Net.ServerSentEvents/src/System/Net/ServerSentEvents/SseFormatter.cs
+++ b/src/libraries/System.Net.ServerSentEvents/src/System/Net/ServerSentEvents/SseFormatter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -24,7 +24,7 @@ namespace System.Net.ServerSentEvents
         /// <param name="destination">The destination stream to write the events.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        public static Task WriteAsync(IAsyncEnumerable<SseItem<string>> source, Stream destination, CancellationToken cancellationToken = default)
+        public static async Task WriteAsync(IAsyncEnumerable<SseItem<string>> source, Stream destination, CancellationToken cancellationToken = default)
         {
             if (source is null)
             {
@@ -36,7 +36,7 @@ namespace System.Net.ServerSentEvents
                 ThrowHelper.ThrowArgumentNullException(nameof(destination));
             }
 
-            return WriteAsyncCore(source, destination, static (item, writer) => writer.WriteUtf8String(item.Data), cancellationToken);
+            await WriteAsyncCore(source, destination, static (item, writer) => writer.WriteUtf8String(item.Data), cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace System.Net.ServerSentEvents
         /// <param name="itemFormatter">The formatter for the data field of given event.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that can be used to cancel the write operation.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        public static Task WriteAsync<T>(IAsyncEnumerable<SseItem<T>> source, Stream destination, Action<SseItem<T>, IBufferWriter<byte>> itemFormatter, CancellationToken cancellationToken = default)
+        public static async Task WriteAsync<T>(IAsyncEnumerable<SseItem<T>> source, Stream destination, Action<SseItem<T>, IBufferWriter<byte>> itemFormatter, CancellationToken cancellationToken = default)
         {
             if (source is null)
             {
@@ -65,7 +65,7 @@ namespace System.Net.ServerSentEvents
                 ThrowHelper.ThrowArgumentNullException(nameof(itemFormatter));
             }
 
-            return WriteAsyncCore(source, destination, itemFormatter, cancellationToken);
+            await WriteAsyncCore(source, destination, itemFormatter, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task WriteAsyncCore<T>(IAsyncEnumerable<SseItem<T>> source, Stream destination, Action<SseItem<T>, IBufferWriter<byte>> itemFormatter, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -560,7 +560,7 @@ namespace System.Net.Sockets
         // Returns:
         //
         //     A Task<int> representing the read.
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             ThrowIfDisposed();
@@ -571,11 +571,11 @@ namespace System.Net.Sockets
 
             try
             {
-                return _streamSocket.ReceiveAsync(
+                return await _streamSocket.ReceiveAsync(
                     new Memory<byte>(buffer, offset, count),
                     SocketFlags.None,
                     fromNetworkStream: true,
-                    cancellationToken).AsTask();
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {
@@ -583,7 +583,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             bool canRead = CanRead; // Prevent race with Dispose.
             ThrowIfDisposed();
@@ -594,11 +594,11 @@ namespace System.Net.Sockets
 
             try
             {
-                return _streamSocket.ReceiveAsync(
+                return await _streamSocket.ReceiveAsync(
                     buffer,
                     SocketFlags.None,
                     fromNetworkStream: true,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {
@@ -621,7 +621,7 @@ namespace System.Net.Sockets
         // Returns:
         //
         //     A Task representing the write.
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
             ThrowIfDisposed();
@@ -632,10 +632,10 @@ namespace System.Net.Sockets
 
             try
             {
-                return _streamSocket.SendAsyncForNetworkStream(
+                await _streamSocket.SendAsyncForNetworkStream(
                     new ReadOnlyMemory<byte>(buffer, offset, count),
                     SocketFlags.None,
-                    cancellationToken).AsTask();
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {
@@ -643,7 +643,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             bool canWrite = CanWrite; // Prevent race with Dispose.
             ThrowIfDisposed();
@@ -654,10 +654,10 @@ namespace System.Net.Sockets
 
             try
             {
-                return _streamSocket.SendAsyncForNetworkStream(
+                await _streamSocket.SendAsyncForNetworkStream(
                     buffer,
                     SocketFlags.None,
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exception) when (!(exception is OutOfMemoryException))
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -29,21 +29,21 @@ namespace System.Net.Sockets
         /// Accepts an incoming connection.
         /// </summary>
         /// <returns>An asynchronous task that completes with the accepted Socket.</returns>
-        public Task<Socket> AcceptAsync() => AcceptAsync((Socket?)null, CancellationToken.None).AsTask();
+        public async Task<Socket> AcceptAsync() => await AcceptAsync((Socket?)null, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
         /// Accepts an incoming connection.
         /// </summary>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the accepted Socket.</returns>
-        public ValueTask<Socket> AcceptAsync(CancellationToken cancellationToken) => AcceptAsync((Socket?)null, cancellationToken);
+        public async ValueTask<Socket> AcceptAsync(CancellationToken cancellationToken) => await AcceptAsync((Socket?)null, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Accepts an incoming connection.
         /// </summary>
         /// <param name="acceptSocket">The socket to use for accepting the connection.</param>
         /// <returns>An asynchronous task that completes with the accepted Socket.</returns>
-        public Task<Socket> AcceptAsync(Socket? acceptSocket) => AcceptAsync(acceptSocket, CancellationToken.None).AsTask();
+        public async Task<Socket> AcceptAsync(Socket? acceptSocket) => await AcceptAsync(acceptSocket, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
         /// Accepts an incoming connection.
@@ -51,11 +51,11 @@ namespace System.Net.Sockets
         /// <param name="acceptSocket">The socket to use for accepting the connection.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the accepted Socket.</returns>
-        public ValueTask<Socket> AcceptAsync(Socket? acceptSocket, CancellationToken cancellationToken)
+        public async ValueTask<Socket> AcceptAsync(Socket? acceptSocket, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<Socket>(cancellationToken);
+                return await ValueTask.FromCanceled<Socket>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -67,7 +67,7 @@ namespace System.Net.Sockets
             saea.SetBuffer(null, 0, 0);
             saea.AcceptSocket = acceptSocket;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.AcceptAsync(this, cancellationToken);
+            return await saea.AcceptAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="remoteEP">The endpoint to connect to.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public Task ConnectAsync(EndPoint remoteEP) => ConnectAsync(remoteEP, default).AsTask();
+        public async Task ConnectAsync(EndPoint remoteEP) => await ConnectAsync(remoteEP, default).ConfigureAwait(false);
 
         /// <summary>
         /// Establishes a connection to a remote host.
@@ -83,11 +83,11 @@ namespace System.Net.Sockets
         /// <param name="remoteEP">The endpoint to connect to.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public ValueTask ConnectAsync(EndPoint remoteEP, CancellationToken cancellationToken)
+        public async ValueTask ConnectAsync(EndPoint remoteEP, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             // Use _singleBufferReceiveEventArgs so the AwaitableSocketAsyncEventArgs can be re-used later for receives.
@@ -101,7 +101,7 @@ namespace System.Net.Sockets
             // DoOperationConnectEx doesn't pass stale data to ConnectEx's lpSendBuffer.
             saea.SetBuffer(default);
 
-            return saea.ConnectAsync(this, cancellationToken);
+            await saea.ConnectAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace System.Net.Sockets
         /// <param name="address">The IPAddress of the remote host to connect to.</param>
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public Task ConnectAsync(IPAddress address, int port) => ConnectAsync(new IPEndPoint(address, port));
+        public async Task ConnectAsync(IPAddress address, int port) => await ConnectAsync(new IPEndPoint(address, port)).ConfigureAwait(false);
 
         /// <summary>
         /// Establishes a connection to a remote host.
@@ -119,7 +119,7 @@ namespace System.Net.Sockets
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public ValueTask ConnectAsync(IPAddress address, int port, CancellationToken cancellationToken) => ConnectAsync(new IPEndPoint(address, port), cancellationToken);
+        public async ValueTask ConnectAsync(IPAddress address, int port, CancellationToken cancellationToken) => await ConnectAsync(new IPEndPoint(address, port), cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Establishes a connection to a remote host.
@@ -127,7 +127,7 @@ namespace System.Net.Sockets
         /// <param name="addresses">A list of IPAddresses for the remote host that will be used to attempt to connect to the remote host.</param>
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public Task ConnectAsync(IPAddress[] addresses, int port) => ConnectAsync(addresses, port, CancellationToken.None).AsTask();
+        public async Task ConnectAsync(IPAddress[] addresses, int port) => await ConnectAsync(addresses, port, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
         /// Establishes a connection to a remote host.
@@ -136,7 +136,7 @@ namespace System.Net.Sockets
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public ValueTask ConnectAsync(IPAddress[] addresses, int port, CancellationToken cancellationToken)
+        public async ValueTask ConnectAsync(IPAddress[] addresses, int port, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
@@ -164,7 +164,7 @@ namespace System.Net.Sockets
 
             ValidateForMultiConnect();
 
-            return Core(addresses, port, cancellationToken);
+            await Core(addresses, port, cancellationToken).ConfigureAwait(false);
 
             async ValueTask Core(IPAddress[] addresses, int port, CancellationToken cancellationToken)
             {
@@ -204,7 +204,7 @@ namespace System.Net.Sockets
         /// <param name="host">The hostname of the remote host to connect to.</param>
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public Task ConnectAsync(string host, int port) => ConnectAsync(host, port, default).AsTask();
+        public async Task ConnectAsync(string host, int port) => await ConnectAsync(host, port, default).ConfigureAwait(false);
 
         /// <summary>
         /// Establishes a connection to a remote host.
@@ -213,14 +213,14 @@ namespace System.Net.Sockets
         /// <param name="port">The port on the remote host to connect to.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes when the connection is established.</returns>
-        public ValueTask ConnectAsync(string host, int port, CancellationToken cancellationToken)
+        public async ValueTask ConnectAsync(string host, int port, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(host);
 
             EndPoint ep = IPAddress.TryParse(host, out IPAddress? parsedAddress) ? (EndPoint)
                 new IPEndPoint(parsedAddress, port) :
                 new DnsEndPoint(host, port);
-            return ConnectAsync(ep, cancellationToken);
+            await ConnectAsync(ep, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -229,11 +229,11 @@ namespace System.Net.Sockets
         /// <param name="reuseSocket">Indicates whether the socket should be available for reuse after disconnect.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes when the socket is disconnected.</returns>
-        public ValueTask DisconnectAsync(bool reuseSocket, CancellationToken cancellationToken = default)
+        public async ValueTask DisconnectAsync(bool reuseSocket, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -243,7 +243,7 @@ namespace System.Net.Sockets
             saea.DisconnectReuseSocket = reuseSocket;
             saea.WrapExceptionsForNetworkStream = false;
 
-            return saea.DisconnectAsync(this, cancellationToken);
+            await saea.DisconnectAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -251,8 +251,8 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">The buffer for the received data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public Task<int> ReceiveAsync(ArraySegment<byte> buffer) =>
-            ReceiveAsync(buffer, SocketFlags.None);
+        public async Task<int> ReceiveAsync(ArraySegment<byte> buffer) =>
+            await ReceiveAsync(buffer, SocketFlags.None).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data from a connected socket.
@@ -260,12 +260,12 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the received data.</param>
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public Task<int> ReceiveAsync(ArraySegment<byte> buffer, SocketFlags socketFlags) => ReceiveAsync(buffer, socketFlags, fromNetworkStream: false);
+        public async Task<int> ReceiveAsync(ArraySegment<byte> buffer, SocketFlags socketFlags) => await ReceiveAsync(buffer, socketFlags, fromNetworkStream: false).ConfigureAwait(false);
 
-        internal Task<int> ReceiveAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, bool fromNetworkStream)
+        internal async Task<int> ReceiveAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, bool fromNetworkStream)
         {
             ValidateBuffer(buffer);
-            return ReceiveAsync(buffer, socketFlags, fromNetworkStream, default).AsTask();
+            return await ReceiveAsync(buffer, socketFlags, fromNetworkStream, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -274,8 +274,8 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the received data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public ValueTask<int> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
-            ReceiveAsync(buffer, SocketFlags.None, cancellationToken);
+        public async ValueTask<int> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            await ReceiveAsync(buffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data from a connected socket.
@@ -284,14 +284,14 @@ namespace System.Net.Sockets
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public ValueTask<int> ReceiveAsync(Memory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
-            ReceiveAsync(buffer, socketFlags, fromNetworkStream: false, cancellationToken);
+        public async ValueTask<int> ReceiveAsync(Memory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
+            await ReceiveAsync(buffer, socketFlags, fromNetworkStream: false, cancellationToken).ConfigureAwait(false);
 
-        internal ValueTask<int> ReceiveAsync(Memory<byte> buffer, SocketFlags socketFlags, bool fromNetworkStream, CancellationToken cancellationToken)
+        internal async ValueTask<int> ReceiveAsync(Memory<byte> buffer, SocketFlags socketFlags, bool fromNetworkStream, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -302,7 +302,7 @@ namespace System.Net.Sockets
             saea.SetBuffer(buffer);
             saea.SocketFlags = socketFlags;
             saea.WrapExceptionsForNetworkStream = fromNetworkStream;
-            return saea.ReceiveAsync(this, cancellationToken);
+            return await saea.ReceiveAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -310,8 +310,8 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffers">A list of buffers for the received data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public Task<int> ReceiveAsync(IList<ArraySegment<byte>> buffers) =>
-            ReceiveAsync(buffers, SocketFlags.None);
+        public async Task<int> ReceiveAsync(IList<ArraySegment<byte>> buffers) =>
+            await ReceiveAsync(buffers, SocketFlags.None).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data from a connected socket.
@@ -319,7 +319,7 @@ namespace System.Net.Sockets
         /// <param name="buffers">A list of buffers for the received data.</param>
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes received.</returns>
-        public Task<int> ReceiveAsync(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags)
+        public async Task<int> ReceiveAsync(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags)
         {
             ValidateBuffersList(buffers);
 
@@ -332,7 +332,7 @@ namespace System.Net.Sockets
 
             saea.BufferList = buffers;
             saea.SocketFlags = socketFlags;
-            return GetTaskForSendReceive(ReceiveAsync(saea), saea, fromNetworkStream: false, isReceive: true);
+            return await GetTaskForSendReceive(ReceiveAsync(saea), saea, fromNetworkStream: false, isReceive: true).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -341,8 +341,8 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the received data.</param>
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveFromResult"/> containing the number of bytes received and the endpoint of the sending host.</returns>
-        public Task<SocketReceiveFromResult> ReceiveFromAsync(ArraySegment<byte> buffer, EndPoint remoteEndPoint) =>
-            ReceiveFromAsync(buffer, SocketFlags.None, remoteEndPoint);
+        public async Task<SocketReceiveFromResult> ReceiveFromAsync(ArraySegment<byte> buffer, EndPoint remoteEndPoint) =>
+            await ReceiveFromAsync(buffer, SocketFlags.None, remoteEndPoint).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data and returns the endpoint of the sending host.
@@ -351,10 +351,10 @@ namespace System.Net.Sockets
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveFromResult"/> containing the number of bytes received and the endpoint of the sending host.</returns>
-        public Task<SocketReceiveFromResult> ReceiveFromAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint)
+        public async Task<SocketReceiveFromResult> ReceiveFromAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint)
         {
             ValidateBuffer(buffer);
-            return ReceiveFromAsync(buffer, socketFlags, remoteEndPoint, default).AsTask();
+            return await ReceiveFromAsync(buffer, socketFlags, remoteEndPoint, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -364,8 +364,8 @@ namespace System.Net.Sockets
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveFromResult"/> containing the number of bytes received and the endpoint of the sending host.</returns>
-        public ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Memory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken = default) =>
-            ReceiveFromAsync(buffer, SocketFlags.None, remoteEndPoint, cancellationToken);
+        public async ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Memory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken = default) =>
+            await ReceiveFromAsync(buffer, SocketFlags.None, remoteEndPoint, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data and returns the endpoint of the sending host.
@@ -375,13 +375,13 @@ namespace System.Net.Sockets
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveFromResult"/> containing the number of bytes received and the endpoint of the sending host.</returns>
-        public ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Memory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken = default)
+        public async ValueTask<SocketReceiveFromResult> ReceiveFromAsync(Memory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken = default)
         {
             ValidateReceiveFromEndpointAndState(remoteEndPoint, nameof(remoteEndPoint));
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<SocketReceiveFromResult>(cancellationToken);
+                return await ValueTask.FromCanceled<SocketReceiveFromResult>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -398,7 +398,7 @@ namespace System.Net.Sockets
                 saea.RemoteEndPoint = s_IPEndPointIPv6;
             }
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.ReceiveFromAsync(this, cancellationToken);
+            return await saea.ReceiveFromAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -409,7 +409,7 @@ namespace System.Net.Sockets
         /// <param name="receivedAddress">An <see cref="SocketAddress"/>, that will be updated with value of the remote peer.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveFromResult"/> containing the number of bytes received and the endpoint of the sending host.</returns>
-        public ValueTask<int> ReceiveFromAsync(Memory<byte> buffer, SocketFlags socketFlags, SocketAddress receivedAddress, CancellationToken cancellationToken = default)
+        public async ValueTask<int> ReceiveFromAsync(Memory<byte> buffer, SocketFlags socketFlags, SocketAddress receivedAddress, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(receivedAddress);
@@ -421,7 +421,7 @@ namespace System.Net.Sockets
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -434,7 +434,7 @@ namespace System.Net.Sockets
             saea.RemoteEndPoint = null;
             saea._socketAddress = receivedAddress;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.ReceiveFromSocketAddressAsync(this, cancellationToken);
+            return await saea.ReceiveFromSocketAddressAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -443,8 +443,8 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the received data.</param>
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveMessageFromResult"/> containing the number of bytes received and additional information about the sending host.</returns>
-        public Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(ArraySegment<byte> buffer, EndPoint remoteEndPoint) =>
-            ReceiveMessageFromAsync(buffer, SocketFlags.None, remoteEndPoint);
+        public async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(ArraySegment<byte> buffer, EndPoint remoteEndPoint) =>
+            await ReceiveMessageFromAsync(buffer, SocketFlags.None, remoteEndPoint).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data and returns additional information about the sender of the message.
@@ -453,10 +453,10 @@ namespace System.Net.Sockets
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when receiving the data.</param>
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveMessageFromResult"/> containing the number of bytes received and additional information about the sending host.</returns>
-        public Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint)
+        public async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint)
         {
             ValidateBuffer(buffer);
-            return ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint, default).AsTask();
+            return await ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -466,8 +466,8 @@ namespace System.Net.Sockets
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveMessageFromResult"/> containing the number of bytes received and additional information about the sending host.</returns>
-        public ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Memory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken = default) =>
-            ReceiveMessageFromAsync(buffer, SocketFlags.None, remoteEndPoint, cancellationToken);
+        public async ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Memory<byte> buffer, EndPoint remoteEndPoint, CancellationToken cancellationToken = default) =>
+            await ReceiveMessageFromAsync(buffer, SocketFlags.None, remoteEndPoint, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Receives data and returns additional information about the sender of the message.
@@ -477,12 +477,12 @@ namespace System.Net.Sockets
         /// <param name="remoteEndPoint">An endpoint of the same type as the endpoint of the remote host.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to signal the asynchronous operation should be canceled.</param>
         /// <returns>An asynchronous task that completes with a <see cref="SocketReceiveMessageFromResult"/> containing the number of bytes received and additional information about the sending host.</returns>
-        public ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Memory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken = default)
+        public async ValueTask<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(Memory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint, CancellationToken cancellationToken = default)
         {
             ValidateReceiveFromEndpointAndState(remoteEndPoint, nameof(remoteEndPoint));
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<SocketReceiveMessageFromResult>(cancellationToken);
+                return await ValueTask.FromCanceled<SocketReceiveMessageFromResult>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -494,7 +494,7 @@ namespace System.Net.Sockets
             saea.SocketFlags = socketFlags;
             saea.RemoteEndPoint = remoteEndPoint;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.ReceiveMessageFromAsync(this, cancellationToken);
+            return await saea.ReceiveMessageFromAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -502,8 +502,8 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffer">The buffer for the data to send.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendAsync(ArraySegment<byte> buffer) =>
-            SendAsync(buffer, SocketFlags.None);
+        public async Task<int> SendAsync(ArraySegment<byte> buffer) =>
+            await SendAsync(buffer, SocketFlags.None).ConfigureAwait(false);
 
         /// <summary>
         /// Sends data on a connected socket.
@@ -511,10 +511,10 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the data to send.</param>
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendAsync(ArraySegment<byte> buffer, SocketFlags socketFlags)
+        public async Task<int> SendAsync(ArraySegment<byte> buffer, SocketFlags socketFlags)
         {
             ValidateBuffer(buffer);
-            return SendAsync(buffer, socketFlags, default).AsTask();
+            return await SendAsync(buffer, socketFlags, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -523,8 +523,8 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the data to send.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
-            SendAsync(buffer, SocketFlags.None, cancellationToken);
+        public async ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            await SendAsync(buffer, SocketFlags.None, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends data on a connected socket.
@@ -533,11 +533,11 @@ namespace System.Net.Sockets
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default)
+        public async ValueTask<int> SendAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -548,14 +548,14 @@ namespace System.Net.Sockets
             saea.SetBuffer(MemoryMarshal.AsMemory(buffer));
             saea.SocketFlags = socketFlags;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.SendAsync(this, cancellationToken);
+            return await saea.SendAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
-        internal ValueTask SendAsyncForNetworkStream(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken)
+        internal async ValueTask SendAsyncForNetworkStream(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -566,7 +566,7 @@ namespace System.Net.Sockets
             saea.SetBuffer(MemoryMarshal.AsMemory(buffer));
             saea.SocketFlags = socketFlags;
             saea.WrapExceptionsForNetworkStream = true;
-            return saea.SendAsyncForNetworkStream(this, cancellationToken);
+            await saea.SendAsyncForNetworkStream(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -574,8 +574,8 @@ namespace System.Net.Sockets
         /// </summary>
         /// <param name="buffers">A list of buffers for the data to send.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendAsync(IList<ArraySegment<byte>> buffers) =>
-            SendAsync(buffers, SocketFlags.None);
+        public async Task<int> SendAsync(IList<ArraySegment<byte>> buffers) =>
+            await SendAsync(buffers, SocketFlags.None).ConfigureAwait(false);
 
         /// <summary>
         /// Sends data on a connected socket.
@@ -583,7 +583,7 @@ namespace System.Net.Sockets
         /// <param name="buffers">A list of buffers for the data to send.</param>
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendAsync(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags)
+        public async Task<int> SendAsync(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags)
         {
             ValidateBuffersList(buffers);
 
@@ -596,7 +596,7 @@ namespace System.Net.Sockets
 
             saea.BufferList = buffers;
             saea.SocketFlags = socketFlags;
-            return GetTaskForSendReceive(SendAsync(saea), saea, fromNetworkStream: false, isReceive: false);
+            return await GetTaskForSendReceive(SendAsync(saea), saea, fromNetworkStream: false, isReceive: false).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -605,8 +605,8 @@ namespace System.Net.Sockets
         /// <param name="buffer">The buffer for the data to send.</param>
         /// <param name="remoteEP">The remote host to which to send the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendToAsync(ArraySegment<byte> buffer, EndPoint remoteEP) =>
-            SendToAsync(buffer, SocketFlags.None, remoteEP);
+        public async Task<int> SendToAsync(ArraySegment<byte> buffer, EndPoint remoteEP) =>
+            await SendToAsync(buffer, SocketFlags.None, remoteEP).ConfigureAwait(false);
 
         /// <summary>
         /// Sends data to the specified remote host.
@@ -615,10 +615,10 @@ namespace System.Net.Sockets
         /// <param name="socketFlags">A bitwise combination of SocketFlags values that will be used when sending the data.</param>
         /// <param name="remoteEP">The remote host to which to send the data.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public Task<int> SendToAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP)
+        public async Task<int> SendToAsync(ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP)
         {
             ValidateBuffer(buffer);
-            return SendToAsync(buffer, socketFlags, remoteEP, default).AsTask();
+            return await SendToAsync(buffer, socketFlags, remoteEP, default).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -628,8 +628,8 @@ namespace System.Net.Sockets
         /// <param name="remoteEP">The remote host to which to send the data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, EndPoint remoteEP, CancellationToken cancellationToken = default) =>
-            SendToAsync(buffer, SocketFlags.None, remoteEP, cancellationToken);
+        public async ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, EndPoint remoteEP, CancellationToken cancellationToken = default) =>
+            await SendToAsync(buffer, SocketFlags.None, remoteEP, cancellationToken).ConfigureAwait(false);
 
         /// <summary>
         /// Sends data to the specified remote host.
@@ -639,13 +639,13 @@ namespace System.Net.Sockets
         /// <param name="remoteEP">The remote host to which to send the data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP, CancellationToken cancellationToken = default)
+        public async ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(remoteEP);
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -657,7 +657,7 @@ namespace System.Net.Sockets
             saea.SocketFlags = socketFlags;
             saea.RemoteEndPoint = remoteEP;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.SendToAsync(this, cancellationToken);
+            return await saea.SendToAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -668,14 +668,14 @@ namespace System.Net.Sockets
         /// <param name="socketAddress">The remote host to which to send the data.</param>
         /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
         /// <returns>An asynchronous task that completes with the number of bytes sent.</returns>
-        public ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress, CancellationToken cancellationToken = default)
+        public async ValueTask<int> SendToAsync(ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, SocketAddress socketAddress, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(socketAddress);
 
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             AwaitableSocketAsyncEventArgs saea =
@@ -690,7 +690,7 @@ namespace System.Net.Sockets
             saea.WrapExceptionsForNetworkStream = false;
             try
             {
-                return saea.SendToAsync(this, cancellationToken);
+                return await saea.SendToAsync(this, cancellationToken).ConfigureAwait(false);
             }
             finally
             {
@@ -708,9 +708,9 @@ namespace System.Net.Sockets
         /// <exception cref="NotSupportedException">The <see cref="Socket"/> object is not connected to a remote host.</exception>
         /// <exception cref="FileNotFoundException">The file <paramref name="fileName"/> was not found.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
-        public ValueTask SendFileAsync(string? fileName, CancellationToken cancellationToken = default)
+        public async ValueTask SendFileAsync(string? fileName, CancellationToken cancellationToken = default)
         {
-            return SendFileAsync(fileName, default, default, TransmitFileOptions.UseDefaultWorkerThread, cancellationToken);
+            await SendFileAsync(fileName, default, default, TransmitFileOptions.UseDefaultWorkerThread, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -726,17 +726,17 @@ namespace System.Net.Sockets
         /// <exception cref="NotSupportedException">The <see cref="Socket"/> object is not connected to a remote host.</exception>
         /// <exception cref="FileNotFoundException">The file <paramref name="fileName"/> was not found.</exception>
         /// <exception cref="SocketException">An error occurred when attempting to access the socket.</exception>
-        public ValueTask SendFileAsync(string? fileName, ReadOnlyMemory<byte> preBuffer, ReadOnlyMemory<byte> postBuffer, TransmitFileOptions flags, CancellationToken cancellationToken = default)
+        public async ValueTask SendFileAsync(string? fileName, ReadOnlyMemory<byte> preBuffer, ReadOnlyMemory<byte> postBuffer, TransmitFileOptions flags, CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             if (!IsConnectionOriented)
             {
                 var ex = ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.net_notconnected));
-                return ValueTask.FromException(ex);
+                await ValueTask.FromException(ex).ConfigureAwait(false);
             }
 
             int packetsCount = 0;
@@ -785,7 +785,7 @@ namespace System.Net.Sockets
             saea.SendPacketsFlags = flags;
             saea.SendPacketsElements = sendPacketsElements;
             saea.WrapExceptionsForNetworkStream = false;
-            return saea.SendPacketsAsync(this, cancellationToken);
+            await saea.SendPacketsAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         private static void ValidateBufferArguments(byte[] buffer, int offset, int size)

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
@@ -12,65 +12,65 @@ namespace System.Net.Sockets
     public static class SocketTaskExtensions
     {
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<Socket> AcceptAsync(this Socket socket) =>
-            socket.AcceptAsync();
+        public static async Task<Socket> AcceptAsync(this Socket socket) =>
+            await socket.AcceptAsync().ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<Socket> AcceptAsync(this Socket socket, Socket? acceptSocket) =>
-            socket.AcceptAsync(acceptSocket);
+        public static async Task<Socket> AcceptAsync(this Socket socket, Socket? acceptSocket) =>
+            await socket.AcceptAsync(acceptSocket).ConfigureAwait(false);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task ConnectAsync(this Socket socket, EndPoint remoteEP) =>
-            socket.ConnectAsync(remoteEP);
+        public static async Task ConnectAsync(this Socket socket, EndPoint remoteEP) =>
+            await socket.ConnectAsync(remoteEP).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask ConnectAsync(this Socket socket, EndPoint remoteEP, CancellationToken cancellationToken) =>
-            socket.ConnectAsync(remoteEP, cancellationToken);
+        public static async ValueTask ConnectAsync(this Socket socket, EndPoint remoteEP, CancellationToken cancellationToken) =>
+            await socket.ConnectAsync(remoteEP, cancellationToken).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task ConnectAsync(this Socket socket, IPAddress address, int port) =>
-            socket.ConnectAsync(address, port);
+        public static async Task ConnectAsync(this Socket socket, IPAddress address, int port) =>
+            await socket.ConnectAsync(address, port).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask ConnectAsync(this Socket socket, IPAddress address, int port, CancellationToken cancellationToken) =>
-            socket.ConnectAsync(address, port, cancellationToken);
+        public static async ValueTask ConnectAsync(this Socket socket, IPAddress address, int port, CancellationToken cancellationToken) =>
+            await socket.ConnectAsync(address, port, cancellationToken).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task ConnectAsync(this Socket socket, IPAddress[] addresses, int port) =>
-            socket.ConnectAsync(addresses, port);
+        public static async Task ConnectAsync(this Socket socket, IPAddress[] addresses, int port) =>
+            await socket.ConnectAsync(addresses, port).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask ConnectAsync(this Socket socket, IPAddress[] addresses, int port, CancellationToken cancellationToken) =>
-            socket.ConnectAsync(addresses, port, cancellationToken);
+        public static async ValueTask ConnectAsync(this Socket socket, IPAddress[] addresses, int port, CancellationToken cancellationToken) =>
+            await socket.ConnectAsync(addresses, port, cancellationToken).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task ConnectAsync(this Socket socket, string host, int port) =>
-            socket.ConnectAsync(host, port);
+        public static async Task ConnectAsync(this Socket socket, string host, int port) =>
+            await socket.ConnectAsync(host, port).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask ConnectAsync(this Socket socket, string host, int port, CancellationToken cancellationToken) =>
-            socket.ConnectAsync(host, port, cancellationToken);
+        public static async ValueTask ConnectAsync(this Socket socket, string host, int port, CancellationToken cancellationToken) =>
+            await socket.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<int> ReceiveAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
-            socket.ReceiveAsync(buffer, socketFlags);
+        public static async Task<int> ReceiveAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
+            await socket.ReceiveAsync(buffer, socketFlags).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
-            socket.ReceiveAsync(buffer, socketFlags, cancellationToken);
+        public static async ValueTask<int> ReceiveAsync(this Socket socket, Memory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
+            await socket.ReceiveAsync(buffer, socketFlags, cancellationToken).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<int> ReceiveAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
-            socket.ReceiveAsync(buffers, socketFlags);
+        public static async Task<int> ReceiveAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
+            await socket.ReceiveAsync(buffers, socketFlags).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<SocketReceiveFromResult> ReceiveFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint) =>
-            socket.ReceiveFromAsync(buffer, socketFlags, remoteEndPoint);
+        public static async Task<SocketReceiveFromResult> ReceiveFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint) =>
+            await socket.ReceiveFromAsync(buffer, socketFlags, remoteEndPoint).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint) =>
-            socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint);
+        public static async Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEndPoint) =>
+            await socket.ReceiveMessageFromAsync(buffer, socketFlags, remoteEndPoint).ConfigureAwait(false);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<int> SendAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
-            socket.SendAsync(buffer, socketFlags);
+        public static async Task<int> SendAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags) =>
+            await socket.SendAsync(buffer, socketFlags).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ValueTask<int> SendAsync(this Socket socket, ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
-            socket.SendAsync(buffer, socketFlags, cancellationToken);
+        public static async ValueTask<int> SendAsync(this Socket socket, ReadOnlyMemory<byte> buffer, SocketFlags socketFlags, CancellationToken cancellationToken = default) =>
+            await socket.SendAsync(buffer, socketFlags, cancellationToken).ConfigureAwait(false);
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<int> SendAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
-            socket.SendAsync(buffers, socketFlags);
+        public static async Task<int> SendAsync(this Socket socket, IList<ArraySegment<byte>> buffers, SocketFlags socketFlags) =>
+            await socket.SendAsync(buffers, socketFlags).ConfigureAwait(false);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public static Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP) =>
-            socket.SendToAsync(buffer, socketFlags, remoteEP);
+        public static async Task<int> SendToAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags, EndPoint remoteEP) =>
+            await socket.SendToAsync(buffer, socketFlags, remoteEP).ConfigureAwait(false);
     }
 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -178,22 +178,22 @@ namespace System.Net.Sockets
             _active = true;
         }
 
-        public Task ConnectAsync(IPAddress address, int port) =>
-            CompleteConnectAsync(Client.ConnectAsync(address, port));
+        public async Task ConnectAsync(IPAddress address, int port) =>
+            await CompleteConnectAsync(Client.ConnectAsync(address, port)).ConfigureAwait(false);
 
-        public Task ConnectAsync(string host, int port) =>
-            CompleteConnectAsync(Client.ConnectAsync(host, port));
+        public async Task ConnectAsync(string host, int port) =>
+            await CompleteConnectAsync(Client.ConnectAsync(host, port)).ConfigureAwait(false);
 
-        public Task ConnectAsync(IPAddress[] addresses, int port) =>
-            CompleteConnectAsync(Client.ConnectAsync(addresses, port));
+        public async Task ConnectAsync(IPAddress[] addresses, int port) =>
+            await CompleteConnectAsync(Client.ConnectAsync(addresses, port)).ConfigureAwait(false);
 
         /// <summary>
         /// Connects the client to a remote TCP host using the specified endpoint as an asynchronous operation.
         /// </summary>
         /// <param name="remoteEP">The <see cref="IPEndPoint"/> to which you intend to connect.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public Task ConnectAsync(IPEndPoint remoteEP) =>
-            CompleteConnectAsync(Client.ConnectAsync(remoteEP));
+        public async Task ConnectAsync(IPEndPoint remoteEP) =>
+            await CompleteConnectAsync(Client.ConnectAsync(remoteEP)).ConfigureAwait(false);
 
         private async Task CompleteConnectAsync(Task task)
         {
@@ -201,14 +201,14 @@ namespace System.Net.Sockets
             _active = true;
         }
 
-        public ValueTask ConnectAsync(IPAddress address, int port, CancellationToken cancellationToken) =>
-            CompleteConnectAsync(Client.ConnectAsync(address, port, cancellationToken));
+        public async ValueTask ConnectAsync(IPAddress address, int port, CancellationToken cancellationToken) =>
+            await CompleteConnectAsync(Client.ConnectAsync(address, port, cancellationToken)).ConfigureAwait(false);
 
-        public ValueTask ConnectAsync(string host, int port, CancellationToken cancellationToken) =>
-            CompleteConnectAsync(Client.ConnectAsync(host, port, cancellationToken));
+        public async ValueTask ConnectAsync(string host, int port, CancellationToken cancellationToken) =>
+            await CompleteConnectAsync(Client.ConnectAsync(host, port, cancellationToken)).ConfigureAwait(false);
 
-        public ValueTask ConnectAsync(IPAddress[] addresses, int port, CancellationToken cancellationToken) =>
-            CompleteConnectAsync(Client.ConnectAsync(addresses, port, cancellationToken));
+        public async ValueTask ConnectAsync(IPAddress[] addresses, int port, CancellationToken cancellationToken) =>
+            await CompleteConnectAsync(Client.ConnectAsync(addresses, port, cancellationToken)).ConfigureAwait(false);
 
         /// <summary>
         /// Connects the client to a remote TCP host using the specified endpoint as an asynchronous operation.
@@ -216,8 +216,8 @@ namespace System.Net.Sockets
         /// <param name="remoteEP">The <see cref="IPEndPoint"/> to which you intend to connect.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification that this operation should be canceled.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
-        public ValueTask ConnectAsync(IPEndPoint remoteEP, CancellationToken cancellationToken) =>
-            CompleteConnectAsync(Client.ConnectAsync(remoteEP, cancellationToken));
+        public async ValueTask ConnectAsync(IPEndPoint remoteEP, CancellationToken cancellationToken) =>
+            await CompleteConnectAsync(Client.ConnectAsync(remoteEP, cancellationToken)).ConfigureAwait(false);
 
         private async ValueTask CompleteConnectAsync(ValueTask task)
         {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -218,23 +218,23 @@ namespace System.Net.Sockets
         public TcpClient EndAcceptTcpClient(IAsyncResult asyncResult) =>
             EndAcceptCore<TcpClient>(asyncResult);
 
-        public Task<Socket> AcceptSocketAsync() => AcceptSocketAsync(CancellationToken.None).AsTask();
+        public async Task<Socket> AcceptSocketAsync() => await AcceptSocketAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public ValueTask<Socket> AcceptSocketAsync(CancellationToken cancellationToken)
+        public async ValueTask<Socket> AcceptSocketAsync(CancellationToken cancellationToken)
         {
             if (!_active)
             {
                 throw new InvalidOperationException(SR.net_stopped);
             }
 
-            return _serverSocket!.AcceptAsync(cancellationToken);
+            return await _serverSocket!.AcceptAsync(cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<TcpClient> AcceptTcpClientAsync() => AcceptTcpClientAsync(CancellationToken.None).AsTask();
+        public async Task<TcpClient> AcceptTcpClientAsync() => await AcceptTcpClientAsync(CancellationToken.None).ConfigureAwait(false);
 
-        public ValueTask<TcpClient> AcceptTcpClientAsync(CancellationToken cancellationToken)
+        public async ValueTask<TcpClient> AcceptTcpClientAsync(CancellationToken cancellationToken)
         {
-            return WaitAndWrap(AcceptSocketAsync(cancellationToken));
+            return await WaitAndWrap(AcceptSocketAsync(cancellationToken)).ConfigureAwait(false);
 
             static async ValueTask<TcpClient> WaitAndWrap(ValueTask<Socket> task) =>
                 new TcpClient(await task.ConfigureAwait(false));

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -526,8 +526,8 @@ namespace System.Net.Sockets
                 new IPv6MulticastOption(multicastAddr, ifindex));
         }
 
-        public Task<int> SendAsync(byte[] datagram, int bytes) =>
-            SendAsync(datagram, bytes, null);
+        public async Task<int> SendAsync(byte[] datagram, int bytes) =>
+            await SendAsync(datagram, bytes, null).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a UDP datagram asynchronously to a remote host.
@@ -541,11 +541,11 @@ namespace System.Net.Sockets
         /// <returns>A <see cref="ValueTask{T}"/> that represents the asynchronous send operation. The value of its Result property contains the number of bytes sent.</returns>
         /// <exception cref="ObjectDisposedException">The <see cref="UdpClient"/> is closed.</exception>
         /// <exception cref="SocketException">An error occurred when accessing the socket.</exception>
-        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken = default) =>
-            SendAsync(datagram, null, cancellationToken);
+        public async ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, CancellationToken cancellationToken = default) =>
+            await SendAsync(datagram, null, cancellationToken).ConfigureAwait(false);
 
-        public Task<int> SendAsync(byte[] datagram, int bytes, string? hostname, int port) =>
-            SendAsync(datagram, bytes, GetEndpoint(hostname, port));
+        public async Task<int> SendAsync(byte[] datagram, int bytes, string? hostname, int port) =>
+            await SendAsync(datagram, bytes, GetEndpoint(hostname, port)).ConfigureAwait(false);
 
         /// <summary>
         /// Sends a UDP datagram asynchronously to a remote host.
@@ -566,21 +566,21 @@ namespace System.Net.Sockets
         /// <exception cref="InvalidOperationException">The <see cref="UdpClient"/> has already established a default remote host.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="UdpClient"/> is closed.</exception>
         /// <exception cref="SocketException">An error occurred when accessing the socket.</exception>
-        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, string? hostname, int port, CancellationToken cancellationToken = default) =>
-            SendAsync(datagram, GetEndpoint(hostname, port), cancellationToken);
+        public async ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, string? hostname, int port, CancellationToken cancellationToken = default) =>
+            await SendAsync(datagram, GetEndpoint(hostname, port), cancellationToken).ConfigureAwait(false);
 
-        public Task<int> SendAsync(byte[] datagram, int bytes, IPEndPoint? endPoint)
+        public async Task<int> SendAsync(byte[] datagram, int bytes, IPEndPoint? endPoint)
         {
             ValidateDatagram(datagram, bytes, endPoint);
 
             if (endPoint is null)
             {
-                return _clientSocket.SendAsync(new ArraySegment<byte>(datagram, 0, bytes), SocketFlags.None);
+                return await _clientSocket.SendAsync(new ArraySegment<byte>(datagram, 0, bytes), SocketFlags.None).ConfigureAwait(false);
             }
             else
             {
                 CheckForBroadcast(endPoint.Address);
-                return _clientSocket.SendToAsync(new ArraySegment<byte>(datagram, 0, bytes), SocketFlags.None, endPoint);
+                return await _clientSocket.SendToAsync(new ArraySegment<byte>(datagram, 0, bytes), SocketFlags.None, endPoint).ConfigureAwait(false);
             }
         }
 
@@ -600,13 +600,13 @@ namespace System.Net.Sockets
         /// <exception cref="InvalidOperationException"><see cref="UdpClient"/> has already established a default remote host and <paramref name="endPoint"/> is not <see langword="null"/>.</exception>
         /// <exception cref="ObjectDisposedException">The <see cref="UdpClient"/> is closed.</exception>
         /// <exception cref="SocketException">An error occurred when accessing the socket.</exception>
-        public ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, IPEndPoint? endPoint, CancellationToken cancellationToken = default)
+        public async ValueTask<int> SendAsync(ReadOnlyMemory<byte> datagram, IPEndPoint? endPoint, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
 
             if (endPoint is null)
             {
-                return _clientSocket.SendAsync(datagram, SocketFlags.None, cancellationToken);
+                return await _clientSocket.SendAsync(datagram, SocketFlags.None, cancellationToken).ConfigureAwait(false);
             }
             if (_active)
             {
@@ -614,17 +614,17 @@ namespace System.Net.Sockets
                 throw new InvalidOperationException(SR.net_udpconnected);
             }
             CheckForBroadcast(endPoint.Address);
-            return _clientSocket.SendToAsync(datagram, SocketFlags.None, endPoint, cancellationToken);
+            return await _clientSocket.SendToAsync(datagram, SocketFlags.None, endPoint, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task<UdpReceiveResult> ReceiveAsync()
+        public async Task<UdpReceiveResult> ReceiveAsync()
         {
             ThrowIfDisposed();
 
-            return WaitAndWrap(_clientSocket.ReceiveFromAsync(
+            return await WaitAndWrap(_clientSocket.ReceiveFromAsync(
                 new ArraySegment<byte>(_buffer, 0, MaxUDPSize),
                 SocketFlags.None,
-                _family == AddressFamily.InterNetwork ? IPEndPointStatics.Any : IPEndPointStatics.IPv6Any));
+                _family == AddressFamily.InterNetwork ? IPEndPointStatics.Any : IPEndPointStatics.IPv6Any)).ConfigureAwait(false);
 
             async Task<UdpReceiveResult> WaitAndWrap(Task<SocketReceiveFromResult> task)
             {
@@ -643,14 +643,14 @@ namespace System.Net.Sockets
         /// <returns>A <see cref="ValueTask{TResult}"/> representing the asynchronous operation.</returns>
         /// <exception cref="ObjectDisposedException">The underlying <see cref="Socket"/> has been closed.</exception>
         /// <exception cref="SocketException">An error occurred when accessing the socket.</exception>
-        public ValueTask<UdpReceiveResult> ReceiveAsync(CancellationToken cancellationToken)
+        public async ValueTask<UdpReceiveResult> ReceiveAsync(CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
 
-            return WaitAndWrap(_clientSocket.ReceiveFromAsync(
+            return await WaitAndWrap(_clientSocket.ReceiveFromAsync(
                 _buffer,
                 SocketFlags.None,
-                _family == AddressFamily.InterNetwork ? IPEndPointStatics.Any : IPEndPointStatics.IPv6Any, cancellationToken));
+                _family == AddressFamily.InterNetwork ? IPEndPointStatics.Any : IPEndPointStatics.IPv6Any, cancellationToken)).ConfigureAwait(false);
 
             async ValueTask<UdpReceiveResult> WaitAndWrap(ValueTask<SocketReceiveFromResult> task)
             {

--- a/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
+++ b/src/libraries/System.Net.WebClient/src/System/Net/WebClient.cs
@@ -1533,8 +1533,8 @@ namespace System.Net
             AbortRequest(request);
         }
 
-        public Task<string> DownloadStringTaskAsync(string address) =>
-            DownloadStringTaskAsync(GetUri(address));
+        public async Task<string> DownloadStringTaskAsync(string address) =>
+            await DownloadStringTaskAsync(GetUri(address)).ConfigureAwait(false);
 
         public Task<string> DownloadStringTaskAsync(Uri address)
         {
@@ -1557,8 +1557,8 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<Stream> OpenReadTaskAsync(string address) =>
-            OpenReadTaskAsync(GetUri(address));
+        public async Task<Stream> OpenReadTaskAsync(string address) =>
+            await OpenReadTaskAsync(GetUri(address)).ConfigureAwait(false);
 
         public Task<Stream> OpenReadTaskAsync(Uri address)
         {
@@ -1582,14 +1582,14 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<Stream> OpenWriteTaskAsync(string address) =>
-            OpenWriteTaskAsync(GetUri(address), null);
+        public async Task<Stream> OpenWriteTaskAsync(string address) =>
+            await OpenWriteTaskAsync(GetUri(address), null).ConfigureAwait(false);
 
-        public Task<Stream> OpenWriteTaskAsync(Uri address) =>
-            OpenWriteTaskAsync(address, null);
+        public async Task<Stream> OpenWriteTaskAsync(Uri address) =>
+            await OpenWriteTaskAsync(address, null).ConfigureAwait(false);
 
-        public Task<Stream> OpenWriteTaskAsync(string address, string? method) =>
-            OpenWriteTaskAsync(GetUri(address), method);
+        public async Task<Stream> OpenWriteTaskAsync(string address, string? method) =>
+            await OpenWriteTaskAsync(GetUri(address), method).ConfigureAwait(false);
 
         public Task<Stream> OpenWriteTaskAsync(Uri address, string? method)
         {
@@ -1613,14 +1613,14 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<string> UploadStringTaskAsync(string address, string data) =>
-            UploadStringTaskAsync(address, null, data);
+        public async Task<string> UploadStringTaskAsync(string address, string data) =>
+            await UploadStringTaskAsync(address, null, data).ConfigureAwait(false);
 
-        public Task<string> UploadStringTaskAsync(Uri address, string data) =>
-            UploadStringTaskAsync(address, null, data);
+        public async Task<string> UploadStringTaskAsync(Uri address, string data) =>
+            await UploadStringTaskAsync(address, null, data).ConfigureAwait(false);
 
-        public Task<string> UploadStringTaskAsync(string address, string? method, string data) =>
-            UploadStringTaskAsync(GetUri(address), method, data);
+        public async Task<string> UploadStringTaskAsync(string address, string? method, string data) =>
+            await UploadStringTaskAsync(GetUri(address), method, data).ConfigureAwait(false);
 
         public Task<string> UploadStringTaskAsync(Uri address, string? method, string data)
         {
@@ -1644,8 +1644,8 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<byte[]> DownloadDataTaskAsync(string address) =>
-            DownloadDataTaskAsync(GetUri(address));
+        public async Task<byte[]> DownloadDataTaskAsync(string address) =>
+            await DownloadDataTaskAsync(GetUri(address)).ConfigureAwait(false);
 
         public Task<byte[]> DownloadDataTaskAsync(Uri address)
         {
@@ -1669,8 +1669,8 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task DownloadFileTaskAsync(string address, string fileName) =>
-            DownloadFileTaskAsync(GetUri(address), fileName);
+        public async Task DownloadFileTaskAsync(string address, string fileName) =>
+            await DownloadFileTaskAsync(GetUri(address), fileName).ConfigureAwait(false);
 
         public Task DownloadFileTaskAsync(Uri address, string fileName)
         {
@@ -1694,14 +1694,14 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<byte[]> UploadDataTaskAsync(string address, byte[] data) =>
-            UploadDataTaskAsync(GetUri(address), null, data);
+        public async Task<byte[]> UploadDataTaskAsync(string address, byte[] data) =>
+            await UploadDataTaskAsync(GetUri(address), null, data).ConfigureAwait(false);
 
-        public Task<byte[]> UploadDataTaskAsync(Uri address, byte[] data) =>
-            UploadDataTaskAsync(address, null, data);
+        public async Task<byte[]> UploadDataTaskAsync(Uri address, byte[] data) =>
+            await UploadDataTaskAsync(address, null, data).ConfigureAwait(false);
 
-        public Task<byte[]> UploadDataTaskAsync(string address, string? method, byte[] data) =>
-            UploadDataTaskAsync(GetUri(address), method, data);
+        public async Task<byte[]> UploadDataTaskAsync(string address, string? method, byte[] data) =>
+            await UploadDataTaskAsync(GetUri(address), method, data).ConfigureAwait(false);
 
         public Task<byte[]> UploadDataTaskAsync(Uri address, string? method, byte[] data)
         {
@@ -1725,14 +1725,14 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<byte[]> UploadFileTaskAsync(string address, string fileName) =>
-            UploadFileTaskAsync(GetUri(address), null, fileName);
+        public async Task<byte[]> UploadFileTaskAsync(string address, string fileName) =>
+            await UploadFileTaskAsync(GetUri(address), null, fileName).ConfigureAwait(false);
 
-        public Task<byte[]> UploadFileTaskAsync(Uri address, string fileName) =>
-            UploadFileTaskAsync(address, null, fileName);
+        public async Task<byte[]> UploadFileTaskAsync(Uri address, string fileName) =>
+            await UploadFileTaskAsync(address, null, fileName).ConfigureAwait(false);
 
-        public Task<byte[]> UploadFileTaskAsync(string address, string? method, string fileName) =>
-            UploadFileTaskAsync(GetUri(address), method, fileName);
+        public async Task<byte[]> UploadFileTaskAsync(string address, string? method, string fileName) =>
+            await UploadFileTaskAsync(GetUri(address), method, fileName).ConfigureAwait(false);
 
         public Task<byte[]> UploadFileTaskAsync(Uri address, string? method, string fileName)
         {
@@ -1756,14 +1756,14 @@ namespace System.Net
             return tcs.Task;
         }
 
-        public Task<byte[]> UploadValuesTaskAsync(string address, NameValueCollection data) =>
-            UploadValuesTaskAsync(GetUri(address), null, data);
+        public async Task<byte[]> UploadValuesTaskAsync(string address, NameValueCollection data) =>
+            await UploadValuesTaskAsync(GetUri(address), null, data).ConfigureAwait(false);
 
-        public Task<byte[]> UploadValuesTaskAsync(string address, string? method, NameValueCollection data) =>
-            UploadValuesTaskAsync(GetUri(address), method, data);
+        public async Task<byte[]> UploadValuesTaskAsync(string address, string? method, NameValueCollection data) =>
+            await UploadValuesTaskAsync(GetUri(address), method, data).ConfigureAwait(false);
 
-        public Task<byte[]> UploadValuesTaskAsync(Uri address, NameValueCollection data) =>
-            UploadValuesTaskAsync(address, null, data);
+        public async Task<byte[]> UploadValuesTaskAsync(Uri address, NameValueCollection data) =>
+            await UploadValuesTaskAsync(address, null, data).ConfigureAwait(false);
 
         public Task<byte[]> UploadValuesTaskAsync(Uri address, string? method, NameValueCollection data)
         {

--- a/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets.Client/src/System/Net/WebSockets/ClientWebSocket.cs
@@ -75,9 +75,9 @@ namespace System.Net.WebSockets
         /// <param name="uri">The URI of the WebSocket server to connect to.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification that the operation should be canceled.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
+        public async Task ConnectAsync(Uri uri, CancellationToken cancellationToken)
         {
-            return ConnectAsync(uri, null, cancellationToken);
+            await ConnectAsync(uri, null, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace System.Net.WebSockets
         /// <param name="invoker">The <see cref="HttpMessageInvoker" /> instance to use for connecting.</param>
         /// <param name="cancellationToken">A cancellation token used to propagate notification that the operation should be canceled.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
-        public Task ConnectAsync(Uri uri, HttpMessageInvoker? invoker, CancellationToken cancellationToken)
+        public async Task ConnectAsync(Uri uri, HttpMessageInvoker? invoker, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(uri);
 
@@ -114,7 +114,7 @@ namespace System.Net.WebSockets
             }
 
             Options.SetToReadOnly();
-            return ConnectAsyncCore(uri, invoker, cancellationToken);
+            await ConnectAsyncCore(uri, invoker, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task ConnectAsyncCore(Uri uri, HttpMessageInvoker? invoker, CancellationToken cancellationToken)
@@ -138,26 +138,26 @@ namespace System.Net.WebSockets
             }
         }
 
-        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+        public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
 
-        public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken);
+        public override async ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.SendAsync(buffer, messageType, endOfMessage, cancellationToken).ConfigureAwait(false);
 
-        public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.SendAsync(buffer, messageType, messageFlags, cancellationToken);
+        public override async ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.SendAsync(buffer, messageType, messageFlags, cancellationToken).ConfigureAwait(false);
 
-        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.ReceiveAsync(buffer, cancellationToken);
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-        public override ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.ReceiveAsync(buffer, cancellationToken);
+        public override async ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
 
-        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.CloseAsync(closeStatus, statusDescription, cancellationToken);
+        public override async Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.CloseAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
 
-        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) =>
-            ConnectedWebSocket.CloseOutputAsync(closeStatus, statusDescription, cancellationToken);
+        public override async Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken) =>
+            await ConnectedWebSocket.CloseOutputAsync(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
 
         private WebSocket ConnectedWebSocket
         {

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -294,7 +294,7 @@ namespace System.Net.WebSockets
 
         public override string? SubProtocol => _subprotocol;
 
-        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
+        public override async Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
@@ -302,11 +302,11 @@ namespace System.Net.WebSockets
 
             WebSocketValidate.ValidateArraySegment(buffer, nameof(buffer));
 
-            return SendAsync(buffer, messageType, endOfMessage ? WebSocketMessageFlags.EndOfMessage : default, cancellationToken).AsTask();
+            await SendAsync(buffer, messageType, endOfMessage ? WebSocketMessageFlags.EndOfMessage : default, cancellationToken).ConfigureAwait(false);
         }
 
-        public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
-            SendAsync(buffer, messageType, endOfMessage ? WebSocketMessageFlags.EndOfMessage : default, cancellationToken);
+        public override async ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
+            await SendAsync(buffer, messageType, endOfMessage ? WebSocketMessageFlags.EndOfMessage : default, cancellationToken).ConfigureAwait(false);
 
         public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken)
         {
@@ -348,7 +348,7 @@ namespace System.Net.WebSockets
             return t;
         }
 
-        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
+        public override async Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
@@ -358,16 +358,16 @@ namespace System.Net.WebSockets
             {
                 ThrowIfInvalidState(WebSocketStateHelper.ValidReceiveStates);
 
-                return ReceiveAsyncPrivate<WebSocketReceiveResult>(buffer, cancellationToken).AsTask();
+                return await ReceiveAsyncPrivate<WebSocketReceiveResult>(buffer, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exc)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
-                return Task.FromException<WebSocketReceiveResult>(exc);
+                throw exc;
             }
         }
 
-        public override ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
+        public override async ValueTask<ValueWebSocketReceiveResult> ReceiveAsync(Memory<byte> buffer, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
@@ -375,16 +375,16 @@ namespace System.Net.WebSockets
             {
                 ThrowIfInvalidState(WebSocketStateHelper.ValidReceiveStates);
 
-                return ReceiveAsyncPrivate<ValueWebSocketReceiveResult>(buffer, cancellationToken);
+                return await ReceiveAsyncPrivate<ValueWebSocketReceiveResult>(buffer, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception exc)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
-                return ValueTask.FromException<ValueWebSocketReceiveResult>(exc);
+                throw exc;
             }
         }
 
-        public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+        public override async Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
@@ -397,18 +397,18 @@ namespace System.Net.WebSockets
             catch (Exception exc)
             {
                 if (NetEventSource.Log.IsEnabled()) NetEventSource.TraceException(this, exc);
-                return Task.FromException(exc);
+                throw exc;
             }
 
-            return CloseAsyncPrivate(closeStatus, statusDescription, cancellationToken);
+            await CloseAsyncPrivate(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
         }
 
-        public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
+        public override async Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)
         {
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Trace(this);
 
             WebSocketValidate.ValidateCloseStatus(closeStatus, statusDescription);
-            return CloseOutputAsyncCore(closeStatus, statusDescription, cancellationToken);
+            await CloseOutputAsyncCore(closeStatus, statusDescription, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task CloseOutputAsyncCore(WebSocketCloseStatus closeStatus, string? statusDescription, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocket.cs
@@ -58,9 +58,9 @@ namespace System.Net.WebSockets
                 new ValueTask(SendAsync(arraySegment, messageType, endOfMessage, cancellationToken)) :
                 SendWithArrayPoolAsync(buffer, messageType, endOfMessage, cancellationToken);
 
-        public virtual ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken = default)
+        public virtual async ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType, WebSocketMessageFlags messageFlags, CancellationToken cancellationToken = default)
         {
-            return SendAsync(buffer, messageType, (messageFlags & WebSocketMessageFlags.EndOfMessage) != 0, cancellationToken);
+            await SendAsync(buffer, messageType, (messageFlags & WebSocketMessageFlags.EndOfMessage) != 0, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask SendWithArrayPoolAsync(

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketStream.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketStream.cs
@@ -122,16 +122,16 @@ namespace System.Net.WebSockets
             Task.CompletedTask;
 
         /// <inheritdoc />
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
 
-            return ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            return await ReadAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
-            ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException()));
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
+            await ValueTask.FromException<int>(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException())).ConfigureAwait(false);
 
         /// <inheritdoc />
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
@@ -142,16 +142,16 @@ namespace System.Net.WebSockets
             TaskToAsyncResult.End<int>(asyncResult);
 
         /// <inheritdoc />
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
 
-            return WriteAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            await WriteAsync(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
-            ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException()));
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) =>
+            await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException())).ConfigureAwait(false);
 
         /// <inheritdoc />
         public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state) =>
@@ -192,24 +192,24 @@ namespace System.Net.WebSockets
             private readonly TimeSpan? _closeTimeout = closeTimeout;
 
             /// <inheritdoc />
-            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {
                 if (_disposed)
                 {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(GetType().FullName)));
+                    await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(GetType().FullName))).ConfigureAwait(false);
                 }
 
                 if (!CanWrite)
                 {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.NotWriteableStream)));
+                    await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.NotWriteableStream))).ConfigureAwait(false);
                 }
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    return ValueTask.FromCanceled(cancellationToken);
+                    await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
                 }
 
-                return WebSocket.SendAsync(buffer, _messageType, endOfMessage: true, cancellationToken);
+                await WebSocket.SendAsync(buffer, _messageType, endOfMessage: true, cancellationToken).ConfigureAwait(false);
             }
 
             /// <inheritdoc />
@@ -294,24 +294,24 @@ namespace System.Net.WebSockets
             public override bool CanRead => false;
 
             /// <inheritdoc />
-            public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+            public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             {
                 if (_disposed)
                 {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(GetType().FullName)));
+                    await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new ObjectDisposedException(GetType().FullName))).ConfigureAwait(false);
                 }
 
                 if (!CanWrite)
                 {
-                    return ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.NotWriteableStream)));
+                    await ValueTask.FromException(ExceptionDispatchInfo.SetCurrentStackTrace(new NotSupportedException(SR.NotWriteableStream))).ConfigureAwait(false);
                 }
 
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    return ValueTask.FromCanceled(cancellationToken);
+                    await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
                 }
 
-                return WebSocket.SendAsync(buffer, _messageType, endOfMessage: false, cancellationToken);
+                await WebSocket.SendAsync(buffer, _messageType, endOfMessage: false, cancellationToken).ConfigureAwait(false);
             }
 
             public override ValueTask DisposeAsync()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -32,8 +32,6 @@ namespace System.IO
         private readonly bool _exposable;   // Whether the array can be returned to the user.
         private bool _isOpen;      // Is this stream open or closed?
 
-        private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
-
         private static int MemStreamMaxLength => Array.MaxLength;
 
         public MemoryStream()
@@ -122,7 +120,6 @@ namespace System.IO
                 _writable = false;
                 _expandable = false;
                 // Don't set buffer to null - allow TryGetBuffer, GetBuffer & ToArray to work.
-                _lastReadTask = default;
             }
         }
 
@@ -365,27 +362,15 @@ namespace System.IO
             return n;
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             ValidateBufferArguments(buffer, offset, count);
 
             // If cancellation was requested, bail early
-            if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<int>(cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
-            try
-            {
-                int n = Read(buffer, offset, count);
-                return _lastReadTask.GetTask(n);
-            }
-            catch (OperationCanceledException oce)
-            {
-                return Task.FromCanceled<int>(oce);
-            }
-            catch (Exception exception)
-            {
-                return Task.FromException<int>(exception);
-            }
+            int n = Read(buffer, offset, count);
+            return n;
         }
 
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -299,7 +299,9 @@ namespace System.IO
             }
         }
 
-        public Task<int> ReadAsync(byte[] buffer, int offset, int count) => ReadAsync(buffer, offset, count, CancellationToken.None);
+#pragma warning disable CA1835 // This 3-arg overload must call the 4-arg Task<int> overload, not the Memory<byte> one
+        public async Task<int> ReadAsync(byte[] buffer, int offset, int count) => await ReadAsync(buffer, offset, count, CancellationToken.None).ConfigureAwait(false);
+#pragma warning restore CA1835
 
         public virtual Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken) =>
             cancellationToken.IsCancellationRequested ?

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBaseWriter.cs
@@ -72,12 +72,12 @@ namespace System.Xml
             _writer.Flush();
         }
 
-        public override Task FlushAsync()
+        public override async Task FlushAsync()
         {
             if (IsClosed)
                 ThrowClosed();
 
-            return _writer.FlushAsync();
+            await _writer.FlushAsync().ConfigureAwait(false);
         }
 
         public override void Close()
@@ -361,7 +361,7 @@ namespace System.Xml
             }
         }
 
-        protected override Task WriteEndAttributeAsync()
+        protected override async Task WriteEndAttributeAsync()
         {
             if (IsClosed)
                 ThrowClosed();
@@ -369,7 +369,7 @@ namespace System.Xml
             if (_writeState != WriteState.Attribute)
                 throw new InvalidOperationException(SR.Format(SR.XmlInvalidWriteState, "WriteEndAttribute", WriteState.ToString()));
 
-            return WriteEndAttributeAsyncImpl();
+            await WriteEndAttributeAsyncImpl().ConfigureAwait(false);
         }
 
         private async Task WriteEndAttributeAsyncImpl()
@@ -588,10 +588,10 @@ namespace System.Xml
             _writer.WriteStartElement(prefix, localName);
         }
 
-        public override Task WriteStartElementAsync(string? prefix, string localName, string? namespaceUri)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? namespaceUri)
         {
             PreStartElementAsyncCheck(localName);
-            return StartElementAndWriteStartElementAsync(prefix, localName, namespaceUri);
+            await StartElementAndWriteStartElementAsync(prefix, localName, namespaceUri).ConfigureAwait(false);
         }
 
         public override void WriteStartElement(string? prefix, XmlDictionaryString localName, XmlDictionaryString? namespaceUri)
@@ -627,7 +627,7 @@ namespace System.Xml
             _writeState = WriteState.Content;
         }
 
-        public override Task WriteEndElementAsync()
+        public override async Task WriteEndElementAsync()
         {
             if (IsClosed)
                 ThrowClosed();
@@ -635,7 +635,7 @@ namespace System.Xml
             if (_depth == 0)
                 throw new InvalidOperationException(SR.Format(SR.XmlInvalidDepth, "WriteEndElement", _depth.ToString(CultureInfo.InvariantCulture)));
 
-            return WriteEndElementAsyncImpl();
+            await WriteEndElementAsyncImpl().ConfigureAwait(false);
         }
 
         private async Task WriteEndElementAsyncImpl()
@@ -794,10 +794,10 @@ namespace System.Xml
             _writer.WriteEndStartElement(false);
         }
 
-        private Task EndStartElementAsync()
+        private async Task EndStartElementAsync()
         {
             _nsMgr.DeclareNamespaces(_writer);
-            return _writer.WriteEndStartElementAsync(false);
+            await _writer.WriteEndStartElementAsync(false).ConfigureAwait(false);
         }
 
         public override string? LookupPrefix(string ns)
@@ -1509,14 +1509,14 @@ namespace System.Xml
             }
         }
 
-        public override Task WriteBase64Async(byte[] buffer, int offset, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int offset, int count)
         {
             if (IsClosed)
                 ThrowClosed();
 
             EnsureBufferBounds(buffer, offset, count);
 
-            return WriteBase64AsyncImpl(buffer, offset, count);
+            await WriteBase64AsyncImpl(buffer, offset, count).ConfigureAwait(false);
         }
 
         private async Task WriteBase64AsyncImpl(byte[] buffer, int offset, int count)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryAsyncCheckWriter.cs
@@ -88,10 +88,10 @@ namespace System.Xml
             CoreWriter.Flush();
         }
 
-        public override Task FlushAsync()
+        public override async Task FlushAsync()
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.FlushAsync());
+            await SetLastTask(CoreWriter.FlushAsync()).ConfigureAwait(false);
         }
 
         public override string? LookupPrefix(string ns)
@@ -106,10 +106,10 @@ namespace System.Xml
             CoreWriter.WriteAttributes(reader, defattr);
         }
 
-        public override Task WriteAttributesAsync(XmlReader reader, bool defattr)
+        public override async Task WriteAttributesAsync(XmlReader reader, bool defattr)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteAttributesAsync(reader, defattr));
+            await SetLastTask(CoreWriter.WriteAttributesAsync(reader, defattr)).ConfigureAwait(false);
         }
 
         public override void WriteBase64(byte[] buffer, int index, int count)
@@ -118,10 +118,10 @@ namespace System.Xml
             CoreWriter.WriteBase64(buffer, index, count);
         }
 
-        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteBase64Async(buffer, index, count));
+            await SetLastTask(CoreWriter.WriteBase64Async(buffer, index, count)).ConfigureAwait(false);
         }
 
         public override void WriteBinHex(byte[] buffer, int index, int count)
@@ -130,10 +130,10 @@ namespace System.Xml
             CoreWriter.WriteBinHex(buffer, index, count);
         }
 
-        public override Task WriteBinHexAsync(byte[] buffer, int index, int count)
+        public override async Task WriteBinHexAsync(byte[] buffer, int index, int count)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteBinHexAsync(buffer, index, count));
+            await SetLastTask(CoreWriter.WriteBinHexAsync(buffer, index, count)).ConfigureAwait(false);
         }
 
         public override void WriteCData(string? text)
@@ -142,10 +142,10 @@ namespace System.Xml
             CoreWriter.WriteCData(text);
         }
 
-        public override Task WriteCDataAsync(string? text)
+        public override async Task WriteCDataAsync(string? text)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteCDataAsync(text));
+            await SetLastTask(CoreWriter.WriteCDataAsync(text)).ConfigureAwait(false);
         }
 
         public override void WriteCharEntity(char ch)
@@ -154,10 +154,10 @@ namespace System.Xml
             CoreWriter.WriteCharEntity(ch);
         }
 
-        public override Task WriteCharEntityAsync(char ch)
+        public override async Task WriteCharEntityAsync(char ch)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteCharEntityAsync(ch));
+            await SetLastTask(CoreWriter.WriteCharEntityAsync(ch)).ConfigureAwait(false);
         }
 
         public override void WriteChars(char[] buffer, int index, int count)
@@ -166,10 +166,10 @@ namespace System.Xml
             CoreWriter.WriteChars(buffer, index, count);
         }
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteCharsAsync(buffer, index, count));
+            await SetLastTask(CoreWriter.WriteCharsAsync(buffer, index, count)).ConfigureAwait(false);
         }
 
         public override void WriteComment(string? text)
@@ -178,10 +178,10 @@ namespace System.Xml
             CoreWriter.WriteComment(text);
         }
 
-        public override Task WriteCommentAsync(string? text)
+        public override async Task WriteCommentAsync(string? text)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteCommentAsync(text));
+            await SetLastTask(CoreWriter.WriteCommentAsync(text)).ConfigureAwait(false);
         }
 
         public override void WriteDocType(string name, string? pubid, string? sysid, string? subset)
@@ -190,10 +190,10 @@ namespace System.Xml
             CoreWriter.WriteDocType(name, pubid, sysid, subset);
         }
 
-        public override Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteDocTypeAsync(name, pubid, sysid, subset));
+            await SetLastTask(CoreWriter.WriteDocTypeAsync(name, pubid, sysid, subset)).ConfigureAwait(false);
         }
 
         public override void WriteEndAttribute()
@@ -208,10 +208,10 @@ namespace System.Xml
             CoreWriter.WriteEndDocument();
         }
 
-        public override Task WriteEndDocumentAsync()
+        public override async Task WriteEndDocumentAsync()
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteEndDocumentAsync());
+            await SetLastTask(CoreWriter.WriteEndDocumentAsync()).ConfigureAwait(false);
         }
 
         public override void WriteEndElement()
@@ -220,10 +220,10 @@ namespace System.Xml
             CoreWriter.WriteEndElement();
         }
 
-        public override Task WriteEndElementAsync()
+        public override async Task WriteEndElementAsync()
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteEndElementAsync());
+            await SetLastTask(CoreWriter.WriteEndElementAsync()).ConfigureAwait(false);
         }
 
         public override void WriteEntityRef(string name)
@@ -232,10 +232,10 @@ namespace System.Xml
             CoreWriter.WriteEntityRef(name);
         }
 
-        public override Task WriteEntityRefAsync(string name)
+        public override async Task WriteEntityRefAsync(string name)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteEntityRefAsync(name));
+            await SetLastTask(CoreWriter.WriteEntityRefAsync(name)).ConfigureAwait(false);
         }
 
         public override void WriteFullEndElement()
@@ -244,10 +244,10 @@ namespace System.Xml
             CoreWriter.WriteFullEndElement();
         }
 
-        public override Task WriteFullEndElementAsync()
+        public override async Task WriteFullEndElementAsync()
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteFullEndElementAsync());
+            await SetLastTask(CoreWriter.WriteFullEndElementAsync()).ConfigureAwait(false);
         }
 
         public override void WriteName(string name)
@@ -256,10 +256,10 @@ namespace System.Xml
             CoreWriter.WriteName(name);
         }
 
-        public override Task WriteNameAsync(string name)
+        public override async Task WriteNameAsync(string name)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteNameAsync(name));
+            await SetLastTask(CoreWriter.WriteNameAsync(name)).ConfigureAwait(false);
         }
 
         public override void WriteNmToken(string name)
@@ -268,10 +268,10 @@ namespace System.Xml
             CoreWriter.WriteNmToken(name);
         }
 
-        public override Task WriteNmTokenAsync(string name)
+        public override async Task WriteNmTokenAsync(string name)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteNmTokenAsync(name));
+            await SetLastTask(CoreWriter.WriteNmTokenAsync(name)).ConfigureAwait(false);
         }
 
         public override void WriteNode(XmlReader reader, bool defattr)
@@ -280,10 +280,10 @@ namespace System.Xml
             CoreWriter.WriteNode(reader, defattr);
         }
 
-        public override Task WriteNodeAsync(XmlReader reader, bool defattr)
+        public override async Task WriteNodeAsync(XmlReader reader, bool defattr)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteNodeAsync(reader, defattr));
+            await SetLastTask(CoreWriter.WriteNodeAsync(reader, defattr)).ConfigureAwait(false);
         }
 
         public override void WriteProcessingInstruction(string name, string? text)
@@ -292,10 +292,10 @@ namespace System.Xml
             CoreWriter.WriteProcessingInstruction(name, text);
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string? text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteProcessingInstructionAsync(name, text));
+            await SetLastTask(CoreWriter.WriteProcessingInstructionAsync(name, text)).ConfigureAwait(false);
         }
 
         public override void WriteQualifiedName(string localName, string? ns)
@@ -304,10 +304,10 @@ namespace System.Xml
             CoreWriter.WriteQualifiedName(localName, ns);
         }
 
-        public override Task WriteQualifiedNameAsync(string localName, string? ns)
+        public override async Task WriteQualifiedNameAsync(string localName, string? ns)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteQualifiedNameAsync(localName, ns));
+            await SetLastTask(CoreWriter.WriteQualifiedNameAsync(localName, ns)).ConfigureAwait(false);
         }
 
         public override void WriteRaw(string data)
@@ -322,16 +322,16 @@ namespace System.Xml
             CoreWriter.WriteRaw(buffer, index, count);
         }
 
-        public override Task WriteRawAsync(string data)
+        public override async Task WriteRawAsync(string data)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteRawAsync(data));
+            await SetLastTask(CoreWriter.WriteRawAsync(data)).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        public override async Task WriteRawAsync(char[] buffer, int index, int count)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteRawAsync(buffer, index, count));
+            await SetLastTask(CoreWriter.WriteRawAsync(buffer, index, count)).ConfigureAwait(false);
         }
 
         public override void WriteStartAttribute(string? prefix, string localName, string? ns)
@@ -352,16 +352,16 @@ namespace System.Xml
             CoreWriter.WriteStartDocument(standalone);
         }
 
-        public override Task WriteStartDocumentAsync()
+        public override async Task WriteStartDocumentAsync()
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteStartDocumentAsync());
+            await SetLastTask(CoreWriter.WriteStartDocumentAsync()).ConfigureAwait(false);
         }
 
-        public override Task WriteStartDocumentAsync(bool standalone)
+        public override async Task WriteStartDocumentAsync(bool standalone)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteStartDocumentAsync(standalone));
+            await SetLastTask(CoreWriter.WriteStartDocumentAsync(standalone)).ConfigureAwait(false);
         }
 
         public override void WriteStartElement(string? prefix, string localName, string? ns)
@@ -370,10 +370,10 @@ namespace System.Xml
             CoreWriter.WriteStartElement(prefix, localName, ns);
         }
 
-        public override Task WriteStartElementAsync(string? prefix, string localName, string? ns)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteStartElementAsync(prefix, localName, ns));
+            await SetLastTask(CoreWriter.WriteStartElementAsync(prefix, localName, ns)).ConfigureAwait(false);
         }
 
         public override void WriteString(string? text)
@@ -382,10 +382,10 @@ namespace System.Xml
             CoreWriter.WriteString(text);
         }
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteStringAsync(text));
+            await SetLastTask(CoreWriter.WriteStringAsync(text)).ConfigureAwait(false);
         }
 
         public override void WriteSurrogateCharEntity(char lowChar, char highChar)
@@ -394,10 +394,10 @@ namespace System.Xml
             CoreWriter.WriteSurrogateCharEntity(lowChar, highChar);
         }
 
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteSurrogateCharEntityAsync(lowChar, highChar));
+            await SetLastTask(CoreWriter.WriteSurrogateCharEntityAsync(lowChar, highChar)).ConfigureAwait(false);
         }
 
         public override void WriteValue(string? value)
@@ -460,10 +460,10 @@ namespace System.Xml
             CoreWriter.WriteWhitespace(ws);
         }
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsync();
-            return SetLastTask(CoreWriter.WriteWhitespaceAsync(ws));
+            await SetLastTask(CoreWriter.WriteWhitespaceAsync(ws)).ConfigureAwait(false);
         }
 
         public override void WriteStartElement(string? prefix, XmlDictionaryString localName, XmlDictionaryString? namespaceUri)

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -156,10 +156,10 @@ namespace System.Xml
             WriteByte((byte)ch);
         }
 
-        protected Task WriteByteAsync(char ch)
+        protected async Task WriteByteAsync(char ch)
         {
             Debug.Assert(ch < 0x80);
-            return WriteByteAsync((byte)ch);
+            await WriteByteAsync((byte)ch).ConfigureAwait(false);
         }
 
         protected void WriteBytes(byte b1, byte b2)
@@ -203,10 +203,10 @@ namespace System.Xml
             WriteBytes((byte)ch1, (byte)ch2);
         }
 
-        protected Task WriteBytesAsync(char ch1, char ch2)
+        protected async Task WriteBytesAsync(char ch1, char ch2)
         {
             Debug.Assert(ch1 < 0x80 && ch2 < 0x80);
-            return WriteBytesAsync((byte)ch1, (byte)ch2);
+            await WriteBytesAsync((byte)ch1, (byte)ch2).ConfigureAwait(false);
         }
 
         public void WriteBytes(byte[] byteBuffer, int byteOffset, int byteCount)

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XCData.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XCData.cs
@@ -64,13 +64,13 @@ namespace System.Xml.Linq
         /// <returns>
         /// A Task that represents the eventual completion of the operation.
         /// </returns>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return writer.WriteCDataAsync(text);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await writer.WriteCDataAsync(text).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XComment.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XComment.cs
@@ -105,13 +105,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlWriter"/> to write this <see cref="XComment"/> to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return writer.WriteCommentAsync(value);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await writer.WriteCommentAsync(value).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocument.cs
@@ -456,13 +456,13 @@ namespace System.Xml.Linq
         /// A new <see cref="XDocument"/> containing the contents of the passed
         /// in <see cref="XmlReader"/>.
         /// </returns>
-        public static Task<XDocument> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
+        public static async Task<XDocument> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(reader);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<XDocument>(cancellationToken);
-            return LoadAsyncInternal(reader, options, cancellationToken);
+                return await Task.FromCanceled<XDocument>(cancellationToken).ConfigureAwait(false);
+            return await LoadAsyncInternal(reader, options, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<XDocument> LoadAsyncInternal(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
@@ -756,9 +756,9 @@ namespace System.Xml.Linq
         /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
-        public Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public async Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
-            return WriteToAsync(writer, cancellationToken);
+            await WriteToAsync(writer, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -830,13 +830,13 @@ namespace System.Xml.Linq
         /// <see cref="XDocument"/>.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return WriteToAsyncInternal(writer, cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await WriteToAsyncInternal(writer, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task WriteToAsyncInternal(XmlWriter writer, CancellationToken cancellationToken)

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocumentType.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XDocumentType.cs
@@ -157,13 +157,13 @@ namespace System.Xml.Linq
         /// <param name="cancellationToken">
         /// A cancellation token.
         /// </param>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return writer.WriteDocTypeAsync(_name, _publicId, _systemId, _internalSubset);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await writer.WriteDocTypeAsync(_name, _publicId, _systemId, _internalSubset).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XElement.cs
@@ -832,13 +832,13 @@ namespace System.Xml.Linq
         /// A new <see cref="XElement"/> containing the contents of the passed
         /// in <see cref="XmlReader"/>.
         /// </returns>
-        public static Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
+        public static async Task<XElement> LoadAsync(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(reader);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<XElement>(cancellationToken);
-            return LoadAsyncInternal(reader, options, cancellationToken);
+                return await Task.FromCanceled<XElement>(cancellationToken).ConfigureAwait(false);
+            return await LoadAsyncInternal(reader, options, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<XElement> LoadAsyncInternal(XmlReader reader, LoadOptions options, CancellationToken cancellationToken)
@@ -1174,13 +1174,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlWriter"/> to output the XML to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public async Task SaveAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return SaveAsyncInternal(writer, cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await SaveAsyncInternal(writer, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task SaveAsyncInternal(XmlWriter writer, CancellationToken cancellationToken)
@@ -1312,13 +1312,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlTextWriter"/> to write this <see cref="XElement"/> to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return new ElementWriter(writer).WriteElementAsync(this, cancellationToken);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await new ElementWriter(writer).WriteElementAsync(this, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XNode.cs
@@ -458,13 +458,13 @@ namespace System.Xml.Linq
         /// <exception cref="InvalidOperationException">
         /// Thrown if the <see cref="XmlReader"/> is not positioned on a recognized node type.
         /// </exception>
-        public static Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
+        public static async Task<XNode> ReadFromAsync(XmlReader reader, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(reader);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<XNode>(cancellationToken);
-            return ReadFromAsyncInternal(reader, cancellationToken);
+                return await Task.FromCanceled<XNode>(cancellationToken).ConfigureAwait(false);
+            return await ReadFromAsyncInternal(reader, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<XNode> ReadFromAsyncInternal(XmlReader reader, CancellationToken cancellationToken)

--- a/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XProcessingInstruction.cs
+++ b/src/libraries/System.Private.Xml.Linq/src/System/Xml/Linq/XProcessingInstruction.cs
@@ -131,13 +131,13 @@ namespace System.Xml.Linq
         /// The <see cref="XmlWriter"/> to write this <see cref="XProcessingInstruction"/> to.
         /// </param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public override Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteToAsync(XmlWriter writer, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(writer);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
-            return writer.WriteProcessingInstructionAsync(target, data);
+                await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            await writer.WriteProcessingInstructionAsync(target, data).ConfigureAwait(false);
         }
 
         internal override XNode CloneNode()

--- a/src/libraries/System.Private.Xml/src/System/Xml/Base64EncoderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Base64EncoderAsync.cs
@@ -11,14 +11,14 @@ namespace System.Xml
     {
         internal abstract Task WriteCharsAsync(char[] chars, int index, int count);
 
-        internal Task EncodeAsync(byte[] buffer, int index, int count)
+        internal async Task EncodeAsync(byte[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             if (index < 0 || (uint)count > buffer.Length - index)
             {
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count));
             }
-            return Core(buffer, index, count);
+            await Core(buffer, index, count).ConfigureAwait(false);
 
             async Task Core(byte[] buffer, int index, int count)
             {
@@ -94,9 +94,9 @@ namespace System.Xml
 
     internal sealed partial class XmlRawWriterBase64Encoder : Base64Encoder
     {
-        internal override Task WriteCharsAsync(char[] chars, int index, int count)
+        internal override async Task WriteCharsAsync(char[] chars, int index, int count)
         {
-            return _rawWriter.WriteRawAsync(chars, index, count);
+            await _rawWriter.WriteRawAsync(chars, index, count).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinHexEncoderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinHexEncoderAsync.cs
@@ -7,14 +7,14 @@ namespace System.Xml
 {
     internal static partial class BinHexEncoder
     {
-        internal static Task EncodeAsync(byte[] buffer, int index, int count, XmlWriter writer)
+        internal static async Task EncodeAsync(byte[] buffer, int index, int count, XmlWriter writer)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             if (index < 0 || (uint)count > buffer.Length - index)
             {
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count));
             }
-            return Core(buffer, index, count, writer);
+            await Core(buffer, index, count, writer).ConfigureAwait(false);
 
             static async Task Core(byte[] buffer, int index, int count, XmlWriter writer)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlAsyncCheckWriter.cs
@@ -576,10 +576,10 @@ namespace System.Xml
             return task;
         }
 
-        protected override ValueTask DisposeAsyncCore()
+        protected override async ValueTask DisposeAsyncCore()
         {
             CheckAsync();
-            return _coreWriter.DisposeAsync();
+            await _coreWriter.DisposeAsync().ConfigureAwait(false);
         }
 
         #endregion

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReaderAsync.cs
@@ -302,7 +302,7 @@ namespace System.Xml
             return readCount;
         }
 
-        public override Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count)
+        public override async Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             if (index < 0 || (uint)count > buffer.Length - index)
@@ -312,10 +312,10 @@ namespace System.Xml
 
             if (ReadState != ReadState.Interactive)
             {
-                return Task.FromResult(0);
+                return 0;
             }
 
-            return Core(buffer, index, count);
+            return await Core(buffer, index, count).ConfigureAwait(false);
 
             async Task<int> Core(byte[] buffer, int index, int count)
             {
@@ -356,7 +356,7 @@ namespace System.Xml
             }
         }
 
-        public override Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count)
+        public override async Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
             if (index < 0 || (uint)count > buffer.Length - index)
@@ -366,10 +366,10 @@ namespace System.Xml
 
             if (ReadState != ReadState.Interactive)
             {
-                return Task.FromResult(0);
+                return 0;
             }
 
-            return Core(buffer, index, count);
+            return await Core(buffer, index, count).ConfigureAwait(false);
 
             async Task<int> Core(byte[] buffer, int index, int count)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingWriterAsync.cs
@@ -16,7 +16,7 @@ namespace System.Xml
     //
     internal sealed partial class XmlCharCheckingWriter : XmlWrappingWriter
     {
-        public override Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
             if (_checkNames)
             {
@@ -52,10 +52,10 @@ namespace System.Xml
                 subset = ReplaceNewLines(subset);
             }
 
-            return writer.WriteDocTypeAsync(name, pubid, sysid, subset);
+            await writer.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
         }
 
-        public override Task WriteStartElementAsync(string? prefix, string localName, string? ns)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
             if (_checkNames)
             {
@@ -68,10 +68,10 @@ namespace System.Xml
                     ValidateNCName(prefix);
                 }
             }
-            return writer.WriteStartElementAsync(prefix, localName, ns);
+            await writer.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
-        protected internal override Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
+        protected internal override async Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
             if (_checkNames)
             {
@@ -85,7 +85,7 @@ namespace System.Xml
                 }
             }
 
-            return writer.WriteStartAttributeAsync(prefix, localName, ns);
+            await writer.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
         public override async Task WriteCDataAsync(string? text)
@@ -113,7 +113,7 @@ namespace System.Xml
             await writer.WriteCDataAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteCommentAsync(string? text)
+        public override async Task WriteCommentAsync(string? text)
         {
             if (text != null)
             {
@@ -127,10 +127,10 @@ namespace System.Xml
                     text = ReplaceNewLines(text);
                 }
             }
-            return writer.WriteCommentAsync(text);
+            await writer.WriteCommentAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string? text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
             if (_checkNames)
             {
@@ -150,19 +150,19 @@ namespace System.Xml
                 }
             }
 
-            return writer.WriteProcessingInstructionAsync(name, text!);
+            await writer.WriteProcessingInstructionAsync(name, text!).ConfigureAwait(false);
         }
 
-        public override Task WriteEntityRefAsync(string name)
+        public override async Task WriteEntityRefAsync(string name)
         {
             if (_checkNames)
             {
                 ValidateQName(name);
             }
-            return writer.WriteEntityRefAsync(name);
+            await writer.WriteEntityRefAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             ws ??= string.Empty;
 
@@ -181,10 +181,10 @@ namespace System.Xml
                 ws = ReplaceNewLines(ws);
             }
 
-            return writer.WriteWhitespaceAsync(ws);
+            await writer.WriteWhitespaceAsync(ws).ConfigureAwait(false);
         }
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             if (text != null)
             {
@@ -199,15 +199,15 @@ namespace System.Xml
                 }
             }
 
-            return writer.WriteStringAsync(text);
+            await writer.WriteStringAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
-            return writer.WriteSurrogateCharEntityAsync(lowChar, highChar);
+            await writer.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(false);
         }
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
@@ -225,40 +225,40 @@ namespace System.Xml
                 string? text = ReplaceNewLines(buffer, index, count);
                 if (text != null)
                 {
-                    return WriteStringAsync(text);
+                    await WriteStringAsync(text).ConfigureAwait(false);
                 }
             }
 
-            return writer.WriteCharsAsync(buffer, index, count);
+            await writer.WriteCharsAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteNmTokenAsync(string name)
+        public override async Task WriteNmTokenAsync(string name)
         {
             if (_checkNames)
             {
                 ArgumentException.ThrowIfNullOrEmpty(name);
                 XmlConvert.VerifyNMTOKEN(name);
             }
-            return writer.WriteNmTokenAsync(name);
+            await writer.WriteNmTokenAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteNameAsync(string name)
+        public override async Task WriteNameAsync(string name)
         {
             if (_checkNames)
             {
                 XmlConvert.VerifyQName(name, ExceptionType.XmlException);
             }
-            return writer.WriteNameAsync(name);
+            await writer.WriteNameAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteQualifiedNameAsync(string localName, string? ns)
+        public override async Task WriteQualifiedNameAsync(string localName, string? ns)
         {
             if (_checkNames)
             {
                 ValidateNCName(localName);
             }
 
-            return writer.WriteQualifiedNameAsync(localName, ns);
+            await writer.WriteQualifiedNameAsync(localName, ns).ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlEncodedRawTextWriterAsync.cs
@@ -234,7 +234,7 @@ namespace System.Xml
         }
 
         // Serialize a full element end tag: "</prefix:localName>"
-        internal override Task WriteFullEndElementAsync(string prefix, string localName, string ns)
+        internal override async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -247,11 +247,11 @@ namespace System.Xml
 
             if (!string.IsNullOrEmpty(prefix))
             {
-                return RawTextAsync(prefix, ":", localName, ">");
+                await RawTextAsync(prefix, ":", localName, ">").ConfigureAwait(false);
             }
             else
             {
-                return RawTextAsync(localName, ">");
+                await RawTextAsync(localName, ">").ConfigureAwait(false);
             }
         }
 
@@ -486,7 +486,7 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             Debug.Assert(ws != null);
@@ -495,17 +495,17 @@ namespace System.Xml
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(ws);
+                await WriteAttributeTextBlockAsync(ws).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(ws);
+                await WriteElementTextBlockAsync(ws).ConfigureAwait(false);
             }
         }
 
         // Serialize either attribute or element text using XML rules.
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
@@ -514,11 +514,11 @@ namespace System.Xml
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(text);
+                await WriteAttributeTextBlockAsync(text).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(text);
+                await WriteElementTextBlockAsync(text).ConfigureAwait(false);
             }
         }
 
@@ -542,7 +542,7 @@ namespace System.Xml
         // Serialize either attribute or element text using XML rules.
         // Arguments are validated in the XmlWellformedWriter layer.
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             Debug.Assert(buffer != null);
@@ -553,11 +553,11 @@ namespace System.Xml
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(buffer, index, count);
+                await WriteAttributeTextBlockAsync(buffer, index, count).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(buffer, index, count);
+                await WriteElementTextBlockAsync(buffer, index, count).ConfigureAwait(false);
             }
         }
 
@@ -1991,11 +1991,11 @@ namespace System.Xml
             await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
         }
 
-        public override Task WriteCDataAsync(string? text)
+        public override async Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCDataAsync(text);
+            await base.WriteCDataAsync(text).ConfigureAwait(false);
         }
 
         public override async Task WriteCommentAsync(string? text)
@@ -2020,67 +2020,67 @@ namespace System.Xml
             await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(false);
         }
 
-        public override Task WriteEntityRefAsync(string name)
+        public override async Task WriteEntityRefAsync(string name)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteEntityRefAsync(name);
+            await base.WriteEntityRefAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteCharEntityAsync(char ch)
+        public override async Task WriteCharEntityAsync(char ch)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCharEntityAsync(ch);
+            await base.WriteCharEntityAsync(ch).ConfigureAwait(false);
         }
 
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
+            await base.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(false);
         }
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteWhitespaceAsync(ws);
+            await base.WriteWhitespaceAsync(ws).ConfigureAwait(false);
         }
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteStringAsync(text);
+            await base.WriteStringAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCharsAsync(buffer, index, count);
+            await base.WriteCharsAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        public override async Task WriteRawAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteRawAsync(buffer, index, count);
+            await base.WriteRawAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(string data)
+        public override async Task WriteRawAsync(string data)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteRawAsync(data);
+            await base.WriteRawAsync(data).ConfigureAwait(false);
         }
 
-        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteBase64Async(buffer, index, count);
+            await base.WriteBase64Async(buffer, index, count).ConfigureAwait(false);
         }
 
         // Add indentation to output.  Write newline and then repeat IndentChars for each indent level.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlRawWriterAsync.cs
@@ -76,12 +76,12 @@ namespace System.Xml
         }
 
         // By default, convert base64 value to string and call WriteString.
-        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             _base64Encoder ??= new XmlRawWriterBase64Encoder(this);
 
             // Encode will call WriteRaw to write out the encoded characters
-            return _base64Encoder.EncodeAsync(buffer, index, count);
+            await _base64Encoder.EncodeAsync(buffer, index, count).ConfigureAwait(false);
         }
 
         // Raw writers do not have to verify NmToken values.
@@ -103,45 +103,45 @@ namespace System.Xml
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteCDataAsync(string? text)
+        public override async Task WriteCDataAsync(string? text)
         {
-            return WriteStringAsync(text);
+            await WriteStringAsync(text).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteCharEntityAsync(char ch)
+        public override async Task WriteCharEntityAsync(char ch)
         {
-            return WriteStringAsync(char.ToString(ch));
+            await WriteStringAsync(char.ToString(ch)).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
-            return WriteStringAsync(new string([lowChar, highChar]));
+            await WriteStringAsync(new string([lowChar, highChar])).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
-            return WriteStringAsync(ws);
+            await WriteStringAsync(ws).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
-            return WriteStringAsync(new string(buffer, index, count));
+            await WriteStringAsync(new string(buffer, index, count)).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        public override async Task WriteRawAsync(char[] buffer, int index, int count)
         {
-            return WriteStringAsync(new string(buffer, index, count));
+            await WriteStringAsync(new string(buffer, index, count)).ConfigureAwait(false);
         }
 
         // Forward call to WriteString(string).
-        public override Task WriteRawAsync(string data)
+        public override async Task WriteRawAsync(string data)
         {
-            return WriteStringAsync(data);
+            await WriteStringAsync(data).ConfigureAwait(false);
         }
 
         // Copying to XmlRawWriter is not currently supported.
@@ -183,9 +183,9 @@ namespace System.Xml
             throw new NotImplementedException();
         }
 
-        internal virtual Task WriteFullEndElementAsync(string prefix, string localName, string ns)
+        internal virtual async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
         {
-            return WriteEndElementAsync(prefix, localName, ns);
+            await WriteEndElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
         internal virtual async Task WriteQualifiedNameAsync(string prefix, string localName, string? ns)
@@ -217,16 +217,16 @@ namespace System.Xml
         }
 
         // This is called when the remainder of a base64 value should be output.
-        internal virtual Task WriteEndBase64Async()
+        internal virtual async Task WriteEndBase64Async()
         {
             // The Flush will call WriteRaw to write out the rest of the encoded characters
             Debug.Assert(_base64Encoder != null);
-            return _base64Encoder.FlushAsync();
+            await _base64Encoder.FlushAsync().ConfigureAwait(false);
         }
 
-        internal virtual ValueTask DisposeAsyncCore(WriteState currentState)
+        internal virtual async ValueTask DisposeAsyncCore(WriteState currentState)
         {
-            return DisposeAsyncCore();
+            await DisposeAsyncCore().ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
@@ -32,13 +32,13 @@ namespace System.Xml
 
         // Concatenates values of textual nodes of the current content, ignoring comments and PIs, expanding entity references,
         // and returns the content as a string. Stops at start tags and end tags.
-        public virtual Task<string> ReadContentAsStringAsync()
+        public virtual async Task<string> ReadContentAsStringAsync()
         {
             if (!CanReadContentAs())
             {
                 throw CreateReadContentAsException(nameof(ReadContentAsString));
             }
-            return InternalReadContentAsStringAsync();
+            return await InternalReadContentAsStringAsync().ConfigureAwait(false);
         }
 
         // Concatenates values of textual nodes of the current content, ignoring comments and PIs, expanding entity references,
@@ -395,13 +395,13 @@ namespace System.Xml
             return true;
         }
 
-        private Task<bool> FinishReadElementContentAsXxxAsync()
+        private async Task<bool> FinishReadElementContentAsXxxAsync()
         {
             if (NodeType != XmlNodeType.EndElement)
             {
                 throw new XmlException(SR.Xml_InvalidNodeType, NodeType.ToString());
             }
-            return ReadAsync();
+            return await ReadAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlSubtreeReaderAsync.cs
@@ -13,15 +13,15 @@ namespace System.Xml
 {
     internal sealed partial class XmlSubtreeReader : XmlWrappingReader, IXmlLineInfo, IXmlNamespaceResolver
     {
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
             if (_useCurNode)
             {
-                return Task.FromResult(_curNode.value);
+                return _curNode.value;
             }
             else
             {
-                return reader.GetValueAsync();
+                return await reader.GetValueAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -27,14 +27,14 @@ namespace System.Xml
             }
         }
 
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
             CheckAsyncCall();
             if (_parsingFunction >= ParsingFunction.PartialTextValue)
             {
-                return _GetValueAsync();
+                return await _GetValueAsync().ConfigureAwait(false);
             }
-            return Task.FromResult(_curNode.StringValue);
+            return _curNode.StringValue;
         }
 
         private async Task<string> _GetValueAsync()
@@ -158,7 +158,7 @@ namespace System.Xml
 
             if (_laterInitParam != null)
             {
-                return FinishInitAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                return FinishInitAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
             }
 
             while (true)
@@ -253,13 +253,13 @@ namespace System.Xml
                         ThrowWithoutLineInfo(SR.Xml_MissingRoot);
                         return AsyncHelper.DoneTaskFalse;
                     case ParsingFunction.PartialTextValue:
-                        return SkipPartialTextValueAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                        return SkipPartialTextValueAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
                     case ParsingFunction.InReadValueChunk:
-                        return FinishReadValueChunkAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                        return FinishReadValueChunkAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
                     case ParsingFunction.InReadContentAsBinary:
-                        return FinishReadContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                        return FinishReadContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
                     case ParsingFunction.InReadElementContentAsBinary:
-                        return FinishReadElementContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                        return FinishReadElementContentAsBinaryAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
                     default:
                         Debug.Fail($"Unexpected parsing function {_parsingFunction}");
                         break;
@@ -720,10 +720,10 @@ namespace System.Xml
             return readCount;
         }
 
-        internal Task<int> DtdParserProxy_ReadDataAsync()
+        internal async Task<int> DtdParserProxy_ReadDataAsync()
         {
             CheckAsyncCall();
-            return this.ReadDataAsync();
+            return await this.ReadDataAsync().ConfigureAwait(false);
         }
 
         internal async Task<int> DtdParserProxy_ParseNumericCharRefAsync(StringBuilder? internalSubsetBuilder)
@@ -734,10 +734,10 @@ namespace System.Xml
             return tuple_1.Item2;
         }
 
-        internal Task<int> DtdParserProxy_ParseNamedCharRefAsync(bool expand, StringBuilder? internalSubsetBuilder)
+        internal async Task<int> DtdParserProxy_ParseNamedCharRefAsync(bool expand, StringBuilder? internalSubsetBuilder)
         {
             CheckAsyncCall();
-            return this.ParseNamedCharRefAsync(expand, internalSubsetBuilder);
+            return await this.ParseNamedCharRefAsync(expand, internalSubsetBuilder).ConfigureAwait(false);
         }
 
         internal async Task DtdParserProxy_ParsePIAsync(StringBuilder? sb)
@@ -857,10 +857,10 @@ namespace System.Xml
             return true;
         }
 
-        private Task InitStreamInputAsync(Uri baseUri, Stream stream, Encoding? encoding)
+        private async Task InitStreamInputAsync(Uri baseUri, Stream stream, Encoding? encoding)
         {
             Debug.Assert(baseUri != null);
-            return InitStreamInputAsync(baseUri, baseUri.ToString(), stream, null, 0, encoding);
+            await InitStreamInputAsync(baseUri, baseUri.ToString(), stream, null, 0, encoding).ConfigureAwait(false);
         }
 
         private async Task InitStreamInputAsync(Uri? baseUri, string baseUriStr, Stream stream, byte[]? bytes, int byteCount, Encoding? encoding)
@@ -934,12 +934,12 @@ namespace System.Xml
             _ps.appendMode = true;
             await ReadDataAsync().ConfigureAwait(false);
         }
-        private Task<int> InitTextReaderInputAsync(string baseUriStr, TextReader input)
+        private async Task<int> InitTextReaderInputAsync(string baseUriStr, TextReader input)
         {
-            return InitTextReaderInputAsync(baseUriStr, null, input);
+            return await InitTextReaderInputAsync(baseUriStr, null, input).ConfigureAwait(false);
         }
 
-        private Task<int> InitTextReaderInputAsync(string baseUriStr, Uri? baseUri, TextReader input)
+        private async Task<int> InitTextReaderInputAsync(string baseUriStr, Uri? baseUri, TextReader input)
         {
             Debug.Assert(_ps.charPos == 0 && _ps.charsUsed == 0 && _ps.stream == null);
             Debug.Assert(baseUriStr != null);
@@ -969,7 +969,7 @@ namespace System.Xml
 
             // read first characters
             _ps.appendMode = true;
-            return ReadDataAsync();
+            return await ReadDataAsync().ConfigureAwait(false);
         }
 
         private Task ProcessDtdFromParserContextAsync(XmlParserContext context)
@@ -1010,9 +1010,9 @@ namespace System.Xml
             return Task.CompletedTask;
         }
 
-        private Task SwitchEncodingToUTF8Async()
+        private async Task SwitchEncodingToUTF8Async()
         {
-            return SwitchEncodingAsync(new UTF8Encoding(true, true));
+            await SwitchEncodingAsync(new UTF8Encoding(true, true)).ConfigureAwait(false);
         }
 
         // Reads more data to the character buffer, discarding already parsed chars / decoded bytes.
@@ -1466,7 +1466,7 @@ namespace System.Xml
 
 
         // Parses the document content, no async keyword for perf optimize
-        private Task<bool> ParseDocumentContentAsync()
+        private async Task<bool> ParseDocumentContentAsync()
         {
             while (true)
             {
@@ -1479,25 +1479,25 @@ namespace System.Xml
                 {
                     needMoreChars = true;
                     if (_ps.charsUsed - pos < 4) // minimum  "<a/>"
-                        return ParseDocumentContentAsync_ReadData(needMoreChars);
+                        return await ParseDocumentContentAsync_ReadData(needMoreChars).ConfigureAwait(false);
                     pos++;
                     switch (chars[pos])
                     {
                         // processing instruction
                         case '?':
                             _ps.charPos = pos + 1;
-                            return ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
+                            return await ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseDocumentContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                         case '!':
                             pos++;
                             if (_ps.charsUsed - pos < 2) // minimum characters expected "--"
-                                return ParseDocumentContentAsync_ReadData(needMoreChars);
+                                return await ParseDocumentContentAsync_ReadData(needMoreChars).ConfigureAwait(false);
                             // comment
                             if (chars[pos] == '-')
                             {
                                 if (chars[pos + 1] == '-')
                                 {
                                     _ps.charPos = pos + 2;
-                                    return ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
+                                    return await ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseDocumentContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                                 }
                                 else
                                 {
@@ -1512,12 +1512,12 @@ namespace System.Xml
                                     pos++;
                                     if (_ps.charsUsed - pos < 6)
                                     {
-                                        return ParseDocumentContentAsync_ReadData(needMoreChars);
+                                        return await ParseDocumentContentAsync_ReadData(needMoreChars).ConfigureAwait(false);
                                     }
                                     if (chars.AsSpan(pos).StartsWith("CDATA["))
                                     {
                                         _ps.charPos = pos + 6;
-                                        return ParseCDataAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ParseDocumentContentAsync_CData(), this);
+                                        return await ParseCDataAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ParseDocumentContentAsync_CData().ConfigureAwait(false), this).ConfigureAwait(false);
                                     }
                                     else
                                     {
@@ -1536,7 +1536,7 @@ namespace System.Xml
                                 {
                                     _fragmentType = XmlNodeType.Document;
                                     _ps.charPos = pos;
-                                    return ParseDoctypeDeclAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
+                                    return await ParseDoctypeDeclAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseDocumentContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                                 }
                                 else
                                 {
@@ -1569,28 +1569,28 @@ namespace System.Xml
                             }
                             _ps.charPos = pos;
                             _rootElementParsed = true;
-                            return ParseElementAsync().ReturnTrueTaskWhenFinishAsync();
+                            return await ParseElementAsync().ReturnTrueTaskWhenFinishAsync().ConfigureAwait(false);
                     }
                 }
                 else if (chars[pos] == '&')
                 {
-                    return ParseDocumentContentAsync_ParseEntity();
+                    return await ParseDocumentContentAsync_ParseEntity().ConfigureAwait(false);
                 }
                 // end of buffer
                 else if (pos == _ps.charsUsed || (_v1Compat && chars[pos] == 0x0))
                 {
-                    return ParseDocumentContentAsync_ReadData(needMoreChars);
+                    return await ParseDocumentContentAsync_ReadData(needMoreChars).ConfigureAwait(false);
                 }
                 // something else -> root level whitespace
                 else
                 {
                     if (_fragmentType == XmlNodeType.Document)
                     {
-                        return ParseRootLevelWhitespaceAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseDocumentContentAsync(), this);
+                        return await ParseRootLevelWhitespaceAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseDocumentContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                     }
                     else
                     {
-                        return ParseDocumentContentAsync_WhiteSpace();
+                        return await ParseDocumentContentAsync_WhiteSpace().ConfigureAwait(false);
                     }
                 }
 
@@ -1726,7 +1726,7 @@ namespace System.Xml
 
 
         // Parses element content
-        private Task<bool> ParseElementContentAsync()
+        private async Task<bool> ParseElementContentAsync()
         {
             while (true)
             {
@@ -1742,18 +1742,18 @@ namespace System.Xml
                             // processing instruction
                             case '?':
                                 _ps.charPos = pos + 2;
-                                return ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
+                                return await ParsePIAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseElementContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                             case '!':
                                 pos += 2;
                                 if (_ps.charsUsed - pos < 2)
-                                    return ParseElementContent_ReadData();
+                                    return await ParseElementContent_ReadData().ConfigureAwait(false);
                                 // comment
                                 if (chars[pos] == '-')
                                 {
                                     if (chars[pos + 1] == '-')
                                     {
                                         _ps.charPos = pos + 2;
-                                        return ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
+                                        return await ParseCommentAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseElementContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                                     }
                                     else
                                     {
@@ -1766,12 +1766,12 @@ namespace System.Xml
                                     pos++;
                                     if (_ps.charsUsed - pos < 6)
                                     {
-                                        return ParseElementContent_ReadData();
+                                        return await ParseElementContent_ReadData().ConfigureAwait(false);
                                     }
                                     if (chars.AsSpan(pos).StartsWith("CDATA["))
                                     {
                                         _ps.charPos = pos + 6;
-                                        return ParseCDataAsync().ReturnTrueTaskWhenFinishAsync();
+                                        return await ParseCDataAsync().ReturnTrueTaskWhenFinishAsync().ConfigureAwait(false);
                                     }
                                     else
                                     {
@@ -1793,33 +1793,33 @@ namespace System.Xml
                             // element end tag
                             case '/':
                                 _ps.charPos = pos + 2;
-                                return ParseEndElementAsync().ReturnTrueTaskWhenFinishAsync();
+                                return await ParseEndElementAsync().ReturnTrueTaskWhenFinishAsync().ConfigureAwait(false);
                             default:
                                 // end of buffer
                                 if (pos + 1 == _ps.charsUsed)
                                 {
-                                    return ParseElementContent_ReadData();
+                                    return await ParseElementContent_ReadData().ConfigureAwait(false);
                                 }
                                 else
                                 {
                                     // element start tag
                                     _ps.charPos = pos + 1;
-                                    return ParseElementAsync().ReturnTrueTaskWhenFinishAsync();
+                                    return await ParseElementAsync().ReturnTrueTaskWhenFinishAsync().ConfigureAwait(false);
                                 }
                         }
                         break;
                     case '&':
-                        return ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
+                        return await ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseElementContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                     default:
                         // end of buffer
                         if (pos == _ps.charsUsed)
                         {
-                            return ParseElementContent_ReadData();
+                            return await ParseElementContent_ReadData().ConfigureAwait(false);
                         }
                         else
                         {
                             // text node, whitespace or entity reference
-                            return ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(thisRef => thisRef.ParseElementContentAsync(), this);
+                            return await ParseTextAsync().ContinueBoolTaskFuncWhenFalseAsync(async thisRef => await thisRef.ParseElementContentAsync().ConfigureAwait(false), this).ConfigureAwait(false);
                         }
                 }
             }
@@ -1923,18 +1923,18 @@ namespace System.Xml
             return ParseElementAsync_SetElement(colonPos, pos);
         }
 
-        private Task ParseElementAsync_ContinueWithSetElement(Task<(int, int)> task)
+        private async Task ParseElementAsync_ContinueWithSetElement(Task<(int, int)> task)
         {
             if (task.IsSuccess())
             {
                 var tuple_4 = task.Result;
                 int colonPos = tuple_4.Item1;
                 int pos = tuple_4.Item2;
-                return ParseElementAsync_SetElement(colonPos, pos);
+                await ParseElementAsync_SetElement(colonPos, pos).ConfigureAwait(false);
             }
             else
             {
-                return _ParseElementAsync_ContinueWithSetElement(task);
+                await _ParseElementAsync_ContinueWithSetElement(task).ConfigureAwait(false);
             }
         }
 
@@ -1946,7 +1946,7 @@ namespace System.Xml
             await ParseElementAsync_SetElement(colonPos, pos).ConfigureAwait(false);
         }
 
-        private Task ParseElementAsync_SetElement(int colonPos, int pos)
+        private async Task ParseElementAsync_SetElement(int colonPos, int pos)
         {
             char[] chars = _ps.chars;
 
@@ -1989,12 +1989,12 @@ namespace System.Xml
             _ps.charPos = pos;
             if (isWs)
             {
-                return ParseAttributesAsync();
+                await ParseAttributesAsync().ConfigureAwait(false);
             }
             // no attributes
             else
             {
-                return ParseElementAsync_NoAttributes();
+                await ParseElementAsync_NoAttributes().ConfigureAwait(false);
             }
         }
 
@@ -2057,7 +2057,7 @@ namespace System.Xml
             await ParseElementAsync_NoAttributes().ConfigureAwait(false);
         }
 
-        private Task ParseEndElementAsync()
+        private async Task ParseEndElementAsync()
         {
             NodeData startTagNode = _nodes[_index - 1];
 
@@ -2066,10 +2066,10 @@ namespace System.Xml
 
             if (_ps.charsUsed - _ps.charPos < prefLen + locLen + 1)
             {
-                return _ParseEndElmentAsync();
+                await _ParseEndElmentAsync().ConfigureAwait(false);
             }
 
-            return ParseEndElementAsync_CheckNameAndParse();
+            await ParseEndElementAsync_CheckNameAndParse().ConfigureAwait(false);
         }
 
         private async Task _ParseEndElmentAsync()
@@ -2095,7 +2095,7 @@ namespace System.Xml
             }
         }
 
-        private Task ParseEndElementAsync_CheckNameAndParse()
+        private async Task ParseEndElementAsync_CheckNameAndParse()
         {
             NodeData startTagNode = _nodes[_index - 1];
             int prefLen = startTagNode.prefix.Length;
@@ -2107,7 +2107,7 @@ namespace System.Xml
             {
                 if (!chars.AsSpan(_ps.charPos).StartsWith(startTagNode.localName))
                 {
-                    return ThrowTagMismatchAsync(startTagNode);
+                    await ThrowTagMismatchAsync(startTagNode).ConfigureAwait(false);
                 }
                 nameLen = locLen;
             }
@@ -2118,12 +2118,12 @@ namespace System.Xml
                         chars[colonPos] != ':' ||
                         !chars.AsSpan(colonPos + 1).StartsWith(startTagNode.localName))
                 {
-                    return ThrowTagMismatchAsync(startTagNode);
+                    await ThrowTagMismatchAsync(startTagNode).ConfigureAwait(false);
                 }
                 nameLen = locLen + prefLen + 1;
             }
             LineInfo endTagLineInfo = new LineInfo(_ps.lineNo, _ps.LinePos);
-            return ParseEndElementAsync_Finish(nameLen, startTagNode, endTagLineInfo);
+            await ParseEndElementAsync_Finish(nameLen, startTagNode, endTagLineInfo).ConfigureAwait(false);
         }
 
         private enum ParseEndElementParseFunction
@@ -3891,9 +3891,9 @@ namespace System.Xml
             }
         }
 
-        private Task<bool> ParsePIAsync()
+        private async Task<bool> ParsePIAsync()
         {
-            return ParsePIAsync(null);
+            return await ParsePIAsync(null).ConfigureAwait(false);
         }
 
         // Parses processing instruction; if piInDtdStringBuilder != null, the processing instruction is in DTD and
@@ -4186,9 +4186,9 @@ namespace System.Xml
             }
         }
 
-        private Task ParseCDataAsync()
+        private async Task ParseCDataAsync()
         {
-            return ParseCDataOrCommentAsync(XmlNodeType.CDATA);
+            await ParseCDataOrCommentAsync(XmlNodeType.CDATA).ConfigureAwait(false);
         }
 
         // Parses CDATA section or comment
@@ -4588,7 +4588,7 @@ namespace System.Xml
             _ps.charPos++;
         }
 
-        private Task SkipPublicOrSystemIdLiteralAsync()
+        private async Task SkipPublicOrSystemIdLiteralAsync()
         {
             // check quote char
             char quoteChar = _ps.chars[_ps.charPos];
@@ -4598,7 +4598,7 @@ namespace System.Xml
             }
 
             _ps.charPos++;
-            return SkipUntilAsync(quoteChar, false);
+            await SkipUntilAsync(quoteChar, false).ConfigureAwait(false);
         }
 
         private async Task SkipUntilAsync(char stopChar, bool recognizeLiterals)
@@ -4969,9 +4969,9 @@ namespace System.Xml
             return tuple_25.Item2;
         }
 
-        private Task<(int, int)> ParseQNameAsync()
+        private async Task<(int, int)> ParseQNameAsync()
         {
-            return ParseQNameAsync(true, 0);
+            return await ParseQNameAsync(true, 0).ConfigureAwait(false);
         }
 
         private async Task<(int, int)> ParseQNameAsync(bool isQName, int startOffset)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpersAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpersAsync.cs
@@ -22,39 +22,45 @@ namespace System.Xml
         //
         internal sealed partial class DtdParserProxy : IDtdParserAdapterV1
         {
-            Task<int> IDtdParserAdapter.ReadDataAsync()
+            async Task<int> IDtdParserAdapter.ReadDataAsync()
             {
-                return _reader.DtdParserProxy_ReadDataAsync();
+                return await _reader.DtdParserProxy_ReadDataAsync().ConfigureAwait(false);
             }
 
-            Task<int> IDtdParserAdapter.ParseNumericCharRefAsync(StringBuilder? internalSubsetBuilder)
+            async
+                        Task<int> IDtdParserAdapter.ParseNumericCharRefAsync(StringBuilder? internalSubsetBuilder)
             {
-                return _reader.DtdParserProxy_ParseNumericCharRefAsync(internalSubsetBuilder);
+                return await _reader.DtdParserProxy_ParseNumericCharRefAsync(internalSubsetBuilder).ConfigureAwait(false);
             }
 
-            Task<int> IDtdParserAdapter.ParseNamedCharRefAsync(bool expand, StringBuilder? internalSubsetBuilder)
+            async
+                        Task<int> IDtdParserAdapter.ParseNamedCharRefAsync(bool expand, StringBuilder? internalSubsetBuilder)
             {
-                return _reader.DtdParserProxy_ParseNamedCharRefAsync(expand, internalSubsetBuilder);
+                return await _reader.DtdParserProxy_ParseNamedCharRefAsync(expand, internalSubsetBuilder).ConfigureAwait(false);
             }
 
-            Task IDtdParserAdapter.ParsePIAsync(StringBuilder? sb)
+            async
+                        Task IDtdParserAdapter.ParsePIAsync(StringBuilder? sb)
             {
-                return _reader.DtdParserProxy_ParsePIAsync(sb);
+                await _reader.DtdParserProxy_ParsePIAsync(sb).ConfigureAwait(false);
             }
 
-            Task IDtdParserAdapter.ParseCommentAsync(StringBuilder? sb)
+            async
+                        Task IDtdParserAdapter.ParseCommentAsync(StringBuilder? sb)
             {
-                return _reader.DtdParserProxy_ParseCommentAsync(sb);
+                await _reader.DtdParserProxy_ParseCommentAsync(sb).ConfigureAwait(false);
             }
 
-            Task<(int, bool)> IDtdParserAdapter.PushEntityAsync(IDtdEntityInfo entity)
+            async
+                        Task<(int, bool)> IDtdParserAdapter.PushEntityAsync(IDtdEntityInfo entity)
             {
-                return _reader.DtdParserProxy_PushEntityAsync(entity);
+                return await _reader.DtdParserProxy_PushEntityAsync(entity).ConfigureAwait(false);
             }
 
-            Task<bool> IDtdParserAdapter.PushExternalSubsetAsync(string? systemId, string? publicId)
+            async
+                        Task<bool> IDtdParserAdapter.PushExternalSubsetAsync(string? systemId, string? publicId)
             {
-                return _reader.DtdParserProxy_PushExternalSubsetAsync(systemId, publicId);
+                return await _reader.DtdParserProxy_PushExternalSubsetAsync(systemId, publicId).ConfigureAwait(false);
             }
         }
     }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlUtf8RawTextWriterAsync.cs
@@ -206,7 +206,7 @@ namespace System.Xml
         }
 
         // Serialize a full element end tag: "</prefix:localName>"
-        internal override Task WriteFullEndElementAsync(string prefix, string localName, string ns)
+        internal override async Task WriteFullEndElementAsync(string prefix, string localName, string ns)
         {
             CheckAsyncCall();
             Debug.Assert(localName != null && localName.Length > 0);
@@ -217,11 +217,11 @@ namespace System.Xml
 
             if (!string.IsNullOrEmpty(prefix))
             {
-                return RawTextAsync(prefix, ":", localName, ">");
+                await RawTextAsync(prefix, ":", localName, ">").ConfigureAwait(false);
             }
             else
             {
-                return RawTextAsync(localName, ">");
+                await RawTextAsync(localName, ">").ConfigureAwait(false);
             }
         }
 
@@ -436,35 +436,35 @@ namespace System.Xml
 
         // Serialize a whitespace node.
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             Debug.Assert(ws != null);
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(ws);
+                await WriteAttributeTextBlockAsync(ws).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(ws);
+                await WriteElementTextBlockAsync(ws).ConfigureAwait(false);
             }
         }
 
         // Serialize either attribute or element text using XML rules.
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             Debug.Assert(text != null);
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(text);
+                await WriteAttributeTextBlockAsync(text).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(text);
+                await WriteElementTextBlockAsync(text).ConfigureAwait(false);
             }
         }
 
@@ -486,7 +486,7 @@ namespace System.Xml
         // Serialize either attribute or element text using XML rules.
         // Arguments are validated in the XmlWellformedWriter layer.
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             Debug.Assert(buffer != null);
@@ -495,11 +495,11 @@ namespace System.Xml
 
             if (_inAttributeValue)
             {
-                return WriteAttributeTextBlockAsync(buffer, index, count);
+                await WriteAttributeTextBlockAsync(buffer, index, count).ConfigureAwait(false);
             }
             else
             {
-                return WriteElementTextBlockAsync(buffer, index, count);
+                await WriteElementTextBlockAsync(buffer, index, count).ConfigureAwait(false);
             }
         }
 
@@ -1859,11 +1859,11 @@ namespace System.Xml
             await base.WriteStartNamespaceDeclarationAsync(prefix).ConfigureAwait(false);
         }
 
-        public override Task WriteCDataAsync(string? text)
+        public override async Task WriteCDataAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCDataAsync(text);
+            await base.WriteCDataAsync(text).ConfigureAwait(false);
         }
 
         public override async Task WriteCommentAsync(string? text)
@@ -1888,67 +1888,67 @@ namespace System.Xml
             await base.WriteProcessingInstructionAsync(target, text).ConfigureAwait(false);
         }
 
-        public override Task WriteEntityRefAsync(string name)
+        public override async Task WriteEntityRefAsync(string name)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteEntityRefAsync(name);
+            await base.WriteEntityRefAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteCharEntityAsync(char ch)
+        public override async Task WriteCharEntityAsync(char ch)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCharEntityAsync(ch);
+            await base.WriteCharEntityAsync(ch).ConfigureAwait(false);
         }
 
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteSurrogateCharEntityAsync(lowChar, highChar);
+            await base.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(false);
         }
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteWhitespaceAsync(ws);
+            await base.WriteWhitespaceAsync(ws).ConfigureAwait(false);
         }
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteStringAsync(text);
+            await base.WriteStringAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteCharsAsync(buffer, index, count);
+            await base.WriteCharsAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        public override async Task WriteRawAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteRawAsync(buffer, index, count);
+            await base.WriteRawAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(string data)
+        public override async Task WriteRawAsync(string data)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteRawAsync(data);
+            await base.WriteRawAsync(data).ConfigureAwait(false);
         }
 
-        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
             _mixedContent = true;
-            return base.WriteBase64Async(buffer, index, count);
+            await base.WriteBase64Async(buffer, index, count).ConfigureAwait(false);
         }
 
         // Add indentation to output.  Write newline and then repeat IndentChars for each indent level.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlValidatingReaderImplAsync.cs
@@ -17,9 +17,9 @@ namespace System.Xml
     internal sealed partial class XmlValidatingReaderImpl : XmlReader, IXmlLineInfo, IXmlNamespaceResolver
     {
         // Returns the text value of the current node.
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
-            return _coreReader.GetValueAsync();
+            return await _coreReader.GetValueAsync().ConfigureAwait(false);
         }
 
         // Reads and validated next node from the input data

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterAsync.cs
@@ -18,14 +18,14 @@ namespace System.Xml
 {
     internal sealed partial class XmlWellFormedWriter : XmlWriter
     {
-        public override Task WriteStartDocumentAsync()
+        public override async Task WriteStartDocumentAsync()
         {
-            return WriteStartDocumentImplAsync(XmlStandalone.Omit);
+            await WriteStartDocumentImplAsync(XmlStandalone.Omit).ConfigureAwait(false);
         }
 
-        public override Task WriteStartDocumentAsync(bool standalone)
+        public override async Task WriteStartDocumentAsync(bool standalone)
         {
-            return WriteStartDocumentImplAsync(standalone ? XmlStandalone.Yes : XmlStandalone.No);
+            await WriteStartDocumentImplAsync(standalone ? XmlStandalone.Yes : XmlStandalone.No).ConfigureAwait(false);
         }
 
         public override async Task WriteEndDocumentAsync()
@@ -148,15 +148,15 @@ namespace System.Xml
         }
 
         //call nextTaskFun after task finish. Check exception.
-        private Task SequenceRun<TArg>(Task task, Func<TArg, Task> nextTaskFun, TArg arg)
+        private async Task SequenceRun<TArg>(Task task, Func<TArg, Task> nextTaskFun, TArg arg)
         {
             if (task.IsSuccess())
             {
-                return TryReturnTask(nextTaskFun(arg));
+                await TryReturnTask(nextTaskFun(arg)).ConfigureAwait(false);
             }
             else
             {
-                return _SequenceRun(task, nextTaskFun, arg);
+                await _SequenceRun(task, nextTaskFun, arg).ConfigureAwait(false);
             }
         }
 
@@ -319,7 +319,7 @@ namespace System.Xml
             {
                 Task task = AdvanceStateAsync(Token.EndElement);
 
-                return SequenceRun(task, thisRef => thisRef.WriteEndElementAsync_NoAdvanceState(), this);
+                return SequenceRun(task, async thisRef => await thisRef.WriteEndElementAsync_NoAdvanceState().ConfigureAwait(false), this);
             }
             catch
             {
@@ -348,7 +348,7 @@ namespace System.Xml
                     task = _writer.WriteEndElementAsync();
                 }
 
-                return SequenceRun(task, thisRef => thisRef.WriteEndElementAsync_FinishWrite(), this);
+                return SequenceRun(task, async thisRef => await thisRef.WriteEndElementAsync_FinishWrite().ConfigureAwait(false), this);
             }
             catch
             {
@@ -398,7 +398,7 @@ namespace System.Xml
             {
                 Task task = AdvanceStateAsync(Token.EndElement);
 
-                return SequenceRun(task, thisRef => thisRef.WriteFullEndElementAsync_NoAdvanceState(), this);
+                return SequenceRun(task, async thisRef => await thisRef.WriteFullEndElementAsync_NoAdvanceState().ConfigureAwait(false), this);
             }
             catch
             {
@@ -427,7 +427,7 @@ namespace System.Xml
                     task = _writer.WriteFullEndElementAsync();
                 }
 
-                return SequenceRun(task, thisRef => thisRef.WriteEndElementAsync_FinishWrite(), this);
+                return SequenceRun(task, async thisRef => await thisRef.WriteEndElementAsync_FinishWrite().ConfigureAwait(false), this);
             }
             catch
             {
@@ -611,7 +611,7 @@ namespace System.Xml
             try
             {
                 Task task = AdvanceStateAsync(Token.EndAttribute);
-                return SequenceRun(task, thisRef => thisRef.WriteEndAttributeAsync_NoAdvance(), this);
+                return SequenceRun(task, async thisRef => await thisRef.WriteEndAttributeAsync_NoAdvance().ConfigureAwait(false), this);
             }
             catch
             {
@@ -620,17 +620,17 @@ namespace System.Xml
             }
         }
 
-        private Task WriteEndAttributeAsync_NoAdvance()
+        private async Task WriteEndAttributeAsync_NoAdvance()
         {
             try
             {
                 if (_specAttr != SpecialAttribute.No)
                 {
-                    return WriteEndAttributeAsync_SepcialAtt();
+                    await WriteEndAttributeAsync_SepcialAtt().ConfigureAwait(false);
                 }
                 else
                 {
-                    return TryReturnTask(_writer.WriteEndAttributeAsync());
+                    await TryReturnTask(_writer.WriteEndAttributeAsync()).ConfigureAwait(false);
                 }
             }
             catch
@@ -1245,16 +1245,16 @@ namespace System.Xml
             _currentState = newState;
         }
 
-        private Task AdvanceStateAsync_ContinueWhenFinish(Task task, State newState, Token token)
+        private async Task AdvanceStateAsync_ContinueWhenFinish(Task task, State newState, Token token)
         {
             if (task.IsSuccess())
             {
                 _currentState = newState;
-                return AdvanceStateAsync(token);
+                await AdvanceStateAsync(token).ConfigureAwait(false);
             }
             else
             {
-                return _AdvanceStateAsync_ContinueWhenFinish(task, newState, token);
+                await _AdvanceStateAsync_ContinueWhenFinish(task, newState, token).ConfigureAwait(false);
             }
         }
 
@@ -1308,14 +1308,14 @@ namespace System.Xml
                         return AdvanceStateAsync_ReturnWhenFinish(WriteStartDocumentAsync(), State.Element);
 
                     case State.EndAttrSEle:
-                        task = SequenceRun(WriteEndAttributeAsync(), thisRef => thisRef.StartElementContentAsync(), this);
+                        task = SequenceRun(WriteEndAttributeAsync(), async thisRef => await thisRef.StartElementContentAsync().ConfigureAwait(false), this);
                         return AdvanceStateAsync_ReturnWhenFinish(task, State.Element);
 
                     case State.EndAttrEEle:
-                        task = SequenceRun(WriteEndAttributeAsync(), thisRef => thisRef.StartElementContentAsync(), this);
+                        task = SequenceRun(WriteEndAttributeAsync(), async thisRef => await thisRef.StartElementContentAsync().ConfigureAwait(false), this);
                         return AdvanceStateAsync_ReturnWhenFinish(task, State.Content);
                     case State.EndAttrSCont:
-                        task = SequenceRun(WriteEndAttributeAsync(), thisRef => thisRef.StartElementContentAsync(), this);
+                        task = SequenceRun(WriteEndAttributeAsync(), async thisRef => await thisRef.StartElementContentAsync().ConfigureAwait(false), this);
                         return AdvanceStateAsync_ReturnWhenFinish(task, State.Content);
 
                     case State.EndAttrSAttr:

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpersAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWellFormedWriterHelpersAsync.cs
@@ -13,14 +13,14 @@ namespace System.Xml
     {
         private partial struct ElementScope
         {
-            internal Task WriteEndElementAsync(XmlRawWriter rawWriter)
+            internal async Task WriteEndElementAsync(XmlRawWriter rawWriter)
             {
-                return rawWriter.WriteEndElementAsync(prefix, localName, namespaceUri);
+                await rawWriter.WriteEndElementAsync(prefix, localName, namespaceUri).ConfigureAwait(false);
             }
 
-            internal Task WriteFullEndElementAsync(XmlRawWriter rawWriter)
+            internal async Task WriteFullEndElementAsync(XmlRawWriter rawWriter)
             {
-                return rawWriter.WriteFullEndElementAsync(prefix, localName, namespaceUri);
+                await rawWriter.WriteFullEndElementAsync(prefix, localName, namespaceUri).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingReaderAsync.cs
@@ -12,19 +12,19 @@ namespace System.Xml
 {
     internal partial class XmlWrappingReader : XmlReader, IXmlLineInfo
     {
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
-            return reader.GetValueAsync();
+            return await reader.GetValueAsync().ConfigureAwait(false);
         }
 
-        public override Task<bool> ReadAsync()
+        public override async Task<bool> ReadAsync()
         {
-            return reader.ReadAsync();
+            return await reader.ReadAsync().ConfigureAwait(false);
         }
 
-        public override Task SkipAsync()
+        public override async Task SkipAsync()
         {
-            return reader.SkipAsync();
+            await reader.SkipAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWrappingWriterAsync.cs
@@ -12,114 +12,114 @@ namespace System.Xml
 {
     internal partial class XmlWrappingWriter : XmlWriter
     {
-        public override Task WriteStartDocumentAsync()
+        public override async Task WriteStartDocumentAsync()
         {
-            return writer.WriteStartDocumentAsync();
+            await writer.WriteStartDocumentAsync().ConfigureAwait(false);
         }
 
-        public override Task WriteStartDocumentAsync(bool standalone)
+        public override async Task WriteStartDocumentAsync(bool standalone)
         {
-            return writer.WriteStartDocumentAsync(standalone);
+            await writer.WriteStartDocumentAsync(standalone).ConfigureAwait(false);
         }
 
-        public override Task WriteEndDocumentAsync()
+        public override async Task WriteEndDocumentAsync()
         {
-            return writer.WriteEndDocumentAsync();
+            await writer.WriteEndDocumentAsync().ConfigureAwait(false);
         }
 
-        public override Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
+        public override async Task WriteDocTypeAsync(string name, string? pubid, string? sysid, string? subset)
         {
-            return writer.WriteDocTypeAsync(name, pubid, sysid, subset);
+            await writer.WriteDocTypeAsync(name, pubid, sysid, subset).ConfigureAwait(false);
         }
 
-        public override Task WriteStartElementAsync(string? prefix, string localName, string? ns)
+        public override async Task WriteStartElementAsync(string? prefix, string localName, string? ns)
         {
-            return writer.WriteStartElementAsync(prefix, localName, ns);
+            await writer.WriteStartElementAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
-        public override Task WriteEndElementAsync()
+        public override async Task WriteEndElementAsync()
         {
-            return writer.WriteEndElementAsync();
+            await writer.WriteEndElementAsync().ConfigureAwait(false);
         }
 
-        public override Task WriteFullEndElementAsync()
+        public override async Task WriteFullEndElementAsync()
         {
-            return writer.WriteFullEndElementAsync();
+            await writer.WriteFullEndElementAsync().ConfigureAwait(false);
         }
 
-        protected internal override Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
+        protected internal override async Task WriteStartAttributeAsync(string? prefix, string localName, string? ns)
         {
-            return writer.WriteStartAttributeAsync(prefix, localName, ns);
+            await writer.WriteStartAttributeAsync(prefix, localName, ns).ConfigureAwait(false);
         }
 
-        protected internal override Task WriteEndAttributeAsync()
+        protected internal override async Task WriteEndAttributeAsync()
         {
-            return writer.WriteEndAttributeAsync();
+            await writer.WriteEndAttributeAsync().ConfigureAwait(false);
         }
 
-        public override Task WriteCDataAsync(string? text)
+        public override async Task WriteCDataAsync(string? text)
         {
-            return writer.WriteCDataAsync(text);
+            await writer.WriteCDataAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteCommentAsync(string? text)
+        public override async Task WriteCommentAsync(string? text)
         {
-            return writer.WriteCommentAsync(text);
+            await writer.WriteCommentAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteProcessingInstructionAsync(string name, string? text)
+        public override async Task WriteProcessingInstructionAsync(string name, string? text)
         {
-            return writer.WriteProcessingInstructionAsync(name, text);
+            await writer.WriteProcessingInstructionAsync(name, text).ConfigureAwait(false);
         }
 
-        public override Task WriteEntityRefAsync(string name)
+        public override async Task WriteEntityRefAsync(string name)
         {
-            return writer.WriteEntityRefAsync(name);
+            await writer.WriteEntityRefAsync(name).ConfigureAwait(false);
         }
 
-        public override Task WriteCharEntityAsync(char ch)
+        public override async Task WriteCharEntityAsync(char ch)
         {
-            return writer.WriteCharEntityAsync(ch);
+            await writer.WriteCharEntityAsync(ch).ConfigureAwait(false);
         }
 
-        public override Task WriteWhitespaceAsync(string? ws)
+        public override async Task WriteWhitespaceAsync(string? ws)
         {
-            return writer.WriteWhitespaceAsync(ws);
+            await writer.WriteWhitespaceAsync(ws).ConfigureAwait(false);
         }
 
-        public override Task WriteStringAsync(string? text)
+        public override async Task WriteStringAsync(string? text)
         {
-            return writer.WriteStringAsync(text);
+            await writer.WriteStringAsync(text).ConfigureAwait(false);
         }
 
-        public override Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
+        public override async Task WriteSurrogateCharEntityAsync(char lowChar, char highChar)
         {
-            return writer.WriteSurrogateCharEntityAsync(lowChar, highChar);
+            await writer.WriteSurrogateCharEntityAsync(lowChar, highChar).ConfigureAwait(false);
         }
 
-        public override Task WriteCharsAsync(char[] buffer, int index, int count)
+        public override async Task WriteCharsAsync(char[] buffer, int index, int count)
         {
-            return writer.WriteCharsAsync(buffer, index, count);
+            await writer.WriteCharsAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(char[] buffer, int index, int count)
+        public override async Task WriteRawAsync(char[] buffer, int index, int count)
         {
-            return writer.WriteRawAsync(buffer, index, count);
+            await writer.WriteRawAsync(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task WriteRawAsync(string data)
+        public override async Task WriteRawAsync(string data)
         {
-            return writer.WriteRawAsync(data);
+            await writer.WriteRawAsync(data).ConfigureAwait(false);
         }
 
-        public override Task WriteBase64Async(byte[] buffer, int index, int count)
+        public override async Task WriteBase64Async(byte[] buffer, int index, int count)
         {
-            return writer.WriteBase64Async(buffer, index, count);
+            await writer.WriteBase64Async(buffer, index, count).ConfigureAwait(false);
         }
 
-        public override Task FlushAsync()
+        public override async Task FlushAsync()
         {
-            return writer.FlushAsync();
+            await writer.FlushAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -68,7 +68,7 @@ namespace System.Xml
             Task task = WriteStartAttributeAsync(prefix, localName, ns);
             if (task.IsSuccess())
             {
-                return WriteStringAsync(value).CallTaskFuncWhenFinishAsync(thisRef => thisRef.WriteEndAttributeAsync(), this);
+                return WriteStringAsync(value).CallTaskFuncWhenFinishAsync(async thisRef => await thisRef.WriteEndAttributeAsync().ConfigureAwait(false), this);
             }
 
             return WriteAttributeStringAsyncHelper(task, value);
@@ -180,9 +180,9 @@ namespace System.Xml
         }
 
         // Encodes the specified binary bytes as bin hex and writes out the resulting text.
-        public virtual Task WriteBinHexAsync(byte[] buffer, int index, int count)
+        public virtual async Task WriteBinHexAsync(byte[] buffer, int index, int count)
         {
-            return BinHexEncoder.EncodeAsync(buffer, index, count, this);
+            await BinHexEncoder.EncodeAsync(buffer, index, count, this).ConfigureAwait(false);
         }
 
         // Flushes data that is in the internal buffers into the underlying streams/TextReader and flushes the stream/TextReader.
@@ -196,17 +196,17 @@ namespace System.Xml
 
         // Writes out the specified name, ensuring it is a valid NmToken according to the XML specification
         // (http://www.w3.org/TR/1998/REC-xml-19980210#NT-Name).
-        public virtual Task WriteNmTokenAsync(string name)
+        public virtual async Task WriteNmTokenAsync(string name)
         {
             ArgumentException.ThrowIfNullOrEmpty(name);
-            return WriteStringAsync(XmlConvert.VerifyNMTOKEN(name, ExceptionType.ArgumentException));
+            await WriteStringAsync(XmlConvert.VerifyNMTOKEN(name, ExceptionType.ArgumentException)).ConfigureAwait(false);
         }
 
         // Writes out the specified name, ensuring it is a valid Name according to the XML specification
         // (http://www.w3.org/TR/1998/REC-xml-19980210#NT-Name).
-        public virtual Task WriteNameAsync(string name)
+        public virtual async Task WriteNameAsync(string name)
         {
-            return WriteStringAsync(XmlConvert.VerifyQName(name, ExceptionType.ArgumentException));
+            await WriteStringAsync(XmlConvert.VerifyQName(name, ExceptionType.ArgumentException)).ConfigureAwait(false);
         }
 
         // Writes out the specified namespace-qualified name by looking up the prefix that is in scope for the given namespace.
@@ -228,10 +228,10 @@ namespace System.Xml
         // XmlReader Helper Methods
 
         // Writes out all the attributes found at the current position in the specified XmlReader.
-        public virtual Task WriteAttributesAsync(XmlReader reader, bool defattr)
+        public virtual async Task WriteAttributesAsync(XmlReader reader, bool defattr)
         {
             ArgumentNullException.ThrowIfNull(reader);
-            return Core(reader, defattr);
+            await Core(reader, defattr).ConfigureAwait(false);
 
             async Task Core(XmlReader reader, bool defattr)
             {
@@ -277,16 +277,16 @@ namespace System.Xml
 
         // Copies the current node from the given reader to the writer (including child nodes), and if called on an element moves the XmlReader
         // to the corresponding end element.
-        public virtual Task WriteNodeAsync(XmlReader reader, bool defattr)
+        public virtual async Task WriteNodeAsync(XmlReader reader, bool defattr)
         {
             ArgumentNullException.ThrowIfNull(reader);
 
             if (reader.Settings is { Async: true })
             {
-                return WriteNodeAsync_CallAsyncReader(reader, defattr);
+                await WriteNodeAsync_CallAsyncReader(reader, defattr).ConfigureAwait(false);
             }
 
-            return WriteNodeAsync_CallSyncReader(reader, defattr);
+            await WriteNodeAsync_CallSyncReader(reader, defattr).ConfigureAwait(false);
         }
 
 
@@ -416,10 +416,10 @@ namespace System.Xml
         }
 
         // Copies the current node from the given XPathNavigator to the writer (including child nodes).
-        public virtual Task WriteNodeAsync(XPathNavigator navigator, bool defattr)
+        public virtual async Task WriteNodeAsync(XPathNavigator navigator, bool defattr)
         {
             ArgumentNullException.ThrowIfNull(navigator);
-            return Core(navigator, defattr);
+            await Core(navigator, defattr).ConfigureAwait(false);
 
             async Task Core(XPathNavigator navigator, bool defattr)
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdCachingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdCachingReaderAsync.cs
@@ -15,15 +15,15 @@ namespace System.Xml
     internal sealed partial class XsdCachingReader : XmlReader, IXmlLineInfo
     {
         // Gets the text value of the current node.
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
             if (_returnOriginalStringValues)
             {
-                return Task.FromResult(_cachedNode!.OriginalStringValue!);
+                return _cachedNode!.OriginalStringValue!;
             }
             else
             {
-                return Task.FromResult(_cachedNode!.RawValue);
+                return _cachedNode!.RawValue;
             }
         }
 
@@ -131,12 +131,12 @@ namespace System.Xml
         }
 
         //Private methods
-        internal Task SetToReplayModeAsync()
+        internal async Task SetToReplayModeAsync()
         {
             _cacheState = CachingReaderState.Replay;
             _currentContentIndex = 0;
             _currentAttrIndex = -1;
-            return ReadAsync(); //Position on first node recorded to begin replaying
+            await ReadAsync().ConfigureAwait(false); //Position on first node recorded to begin replaying
         }
     }
 }

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReaderAsync.cs
@@ -17,25 +17,25 @@ namespace System.Xml
     internal sealed partial class XsdValidatingReader : XmlReader, IXmlSchemaInfo, IXmlLineInfo, IXmlNamespaceResolver
     {
         // Gets the text value of the current node.
-        public override Task<string> GetValueAsync()
+        public override async Task<string> GetValueAsync()
         {
             if ((int)_validationState < 0)
             {
                 Debug.Assert(_cachedNode != null);
-                return Task.FromResult(_cachedNode.RawValue);
+                return _cachedNode.RawValue;
             }
 
-            return _coreReader.GetValueAsync();
+            return await _coreReader.GetValueAsync().ConfigureAwait(false);
         }
 
-        public override Task<object> ReadContentAsObjectAsync()
+        public override async Task<object> ReadContentAsObjectAsync()
         {
             if (!CanReadContentAs(this.NodeType))
             {
                 throw CreateReadContentAsException(nameof(ReadContentAsObject));
             }
 
-            return InternalReadContentAsObjectAsync(true);
+            return await InternalReadContentAsObjectAsync(true).ConfigureAwait(false);
         }
 
         public override async Task<string> ReadContentAsStringAsync()
@@ -319,7 +319,7 @@ namespace System.Xml
                 case ValidatingReaderState.OnReadBinaryContent:
                     _validationState = _savedState;
                     Debug.Assert(_readBinaryHelper != null);
-                    return _readBinaryHelper.FinishAsync().CallBoolTaskFuncWhenFinishAsync(thisRef => thisRef.ReadAsync(), this);
+                    return _readBinaryHelper.FinishAsync().CallBoolTaskFuncWhenFinishAsync(async thisRef => await thisRef.ReadAsync().ConfigureAwait(false), this);
 
                 case ValidatingReaderState.Init:
                     _validationState = ValidatingReaderState.Read;
@@ -674,9 +674,9 @@ namespace System.Xml
             }
         }
 
-        private Task<object> InternalReadContentAsObjectAsync()
+        private async Task<object> InternalReadContentAsObjectAsync()
         {
-            return InternalReadContentAsObjectAsync(false);
+            return await InternalReadContentAsObjectAsync(false).ConfigureAwait(false);
         }
 
         private async Task<object> InternalReadContentAsObjectAsync(bool unwrapTypedValue)
@@ -756,9 +756,9 @@ namespace System.Xml
             }
         }
 
-        private Task<(XmlSchemaType, object)> InternalReadElementContentAsObjectAsync()
+        private async Task<(XmlSchemaType, object)> InternalReadElementContentAsObjectAsync()
         {
-            return InternalReadElementContentAsObjectAsync(false);
+            return await InternalReadElementContentAsObjectAsync(false).ConfigureAwait(false);
         }
 
         private async Task<(XmlSchemaType, object)> InternalReadElementContentAsObjectAsync(bool unwrapTypedValue)

--- a/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
@@ -14,7 +14,7 @@ namespace System.Xml.Resolvers
     //
     public partial class XmlPreloadedResolver : XmlResolver
     {
-        public override Task<object> GetEntityAsync(Uri absoluteUri,
+        public override async Task<object> GetEntityAsync(Uri absoluteUri,
                                              string? role,
                                              Type? ofObjectToReturn)
         {
@@ -25,18 +25,18 @@ namespace System.Xml.Resolvers
             {
                 if (_fallbackResolver != null)
                 {
-                    return _fallbackResolver.GetEntityAsync(absoluteUri, role, ofObjectToReturn);
+                    return await _fallbackResolver.GetEntityAsync(absoluteUri, role, ofObjectToReturn).ConfigureAwait(false);
                 }
                 throw new XmlException(SR.Format(SR.Xml_CannotResolveUrl, absoluteUri));
             }
 
             if (ofObjectToReturn == null || ofObjectToReturn == typeof(Stream) || ofObjectToReturn == typeof(object))
             {
-                return Task.FromResult<object>(data.AsStream());
+                return data.AsStream();
             }
             else if (ofObjectToReturn == typeof(TextReader))
             {
-                return Task.FromResult<object>(data.AsTextReader());
+                return data.AsTextReader();
             }
             else
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DtdParserAsync.cs
@@ -131,10 +131,10 @@ namespace System.Xml
             }
         }
 
-        private Task ParseInternalSubsetAsync()
+        private async Task ParseInternalSubsetAsync()
         {
             Debug.Assert(ParsingInternalSubset);
-            return ParseSubsetAsync();
+            await ParseSubsetAsync().ConfigureAwait(false);
         }
 
         private async Task ParseExternalSubsetAsync()
@@ -2377,14 +2377,14 @@ namespace System.Xml
             }
         }
 
-        private Task ScanNameAsync()
+        private async Task ScanNameAsync()
         {
-            return ScanQNameAsync(false);
+            await ScanQNameAsync(false).ConfigureAwait(false);
         }
 
-        private Task ScanQNameAsync()
+        private async Task ScanQNameAsync()
         {
-            return ScanQNameAsync(SupportNamespaces);
+            await ScanQNameAsync(SupportNamespaces).ConfigureAwait(false);
         }
 
         private async Task ScanQNameAsync(bool isQName)
@@ -2569,12 +2569,12 @@ namespace System.Xml
         //
         // Entity handling
         //
-        private Task<bool> HandleEntityReferenceAsync(bool paramEntity, bool inLiteral, bool inAttribute)
+        private async Task<bool> HandleEntityReferenceAsync(bool paramEntity, bool inLiteral, bool inAttribute)
         {
             Debug.Assert(_chars[_curPos] == '&' || _chars[_curPos] == '%');
             _curPos++;
 
-            return HandleEntityReferenceAsync(ScanEntityName(), paramEntity, inLiteral, inAttribute);
+            return await HandleEntityReferenceAsync(ScanEntityName(), paramEntity, inLiteral, inAttribute).ConfigureAwait(false);
         }
 
         private async Task<bool> HandleEntityReferenceAsync(XmlQualifiedName entityName, bool paramEntity, bool inLiteral, bool inAttribute)

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlDownloadManager.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlDownloadManager.cs
@@ -24,16 +24,16 @@ namespace System.Xml
             }
         }
 
-        internal static Task<Stream> GetStreamAsync(Uri uri, ICredentials? credentials, IWebProxy? proxy)
+        internal static async Task<Stream> GetStreamAsync(Uri uri, ICredentials? credentials, IWebProxy? proxy)
         {
             if (uri.Scheme == "file")
             {
                 Uri fileUri = uri;
-                return Task.FromResult<Stream>(new FileStream(fileUri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1, useAsync: true));
+                return new FileStream(fileUri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1, useAsync: true);
             }
             else
             {
-                return GetNonFileStreamAsync(uri, credentials, proxy);
+                return await GetNonFileStreamAsync(uri, credentials, proxy).ConfigureAwait(false);
             }
         }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
@@ -37,13 +37,13 @@ namespace System.Xml
                 throw new XmlException(SR.Xml_UnsupportedClass, string.Empty);
             }
 
-            public override Task<object> GetEntityAsync(Uri absoluteUri, string? role, Type? ofObjectToReturn)
+            public override async Task<object> GetEntityAsync(Uri absoluteUri, string? role, Type? ofObjectToReturn)
             {
                 if (ofObjectToReturn == null || ofObjectToReturn == typeof(Stream) || ofObjectToReturn == typeof(object))
                 {
                     if (absoluteUri.Scheme == "file")
                     {
-                        return Task.FromResult<object>(new FileStream(absoluteUri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1, useAsync: true));
+                        return new FileStream(absoluteUri.LocalPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1, useAsync: true);
                     }
                 }
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlSecureResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlSecureResolver.cs
@@ -24,7 +24,7 @@ namespace System.Xml
         public override object? GetEntity(Uri absoluteUri, string? role, Type? ofObjectToReturn) => XmlResolver.ThrowingResolver.GetEntity(absoluteUri, role, ofObjectToReturn);
 
         // Forward to ThrowingResolver to get its exception message
-        public override Task<object> GetEntityAsync(Uri absoluteUri, string? role, Type? ofObjectToReturn) => XmlResolver.ThrowingResolver.GetEntityAsync(absoluteUri, role, ofObjectToReturn);
+        public override async Task<object> GetEntityAsync(Uri absoluteUri, string? role, Type? ofObjectToReturn) => await XmlResolver.ThrowingResolver.GetEntityAsync(absoluteUri, role, ofObjectToReturn).ConfigureAwait(false);
 
         // An earlier implementation of this type overrode this method, so we'll continue to do so
         // to preserve binary compatibility.

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMultiSignMessage.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseMultiSignMessage.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -245,7 +245,7 @@ namespace System.Security.Cryptography.Cose
         ///     One or more of the labels specified in a <see cref="CoseHeaderLabel.CriticalHeaders"/> header is missing.
         ///   </para>
         /// </exception>
-        public static Task<byte[]> SignDetachedAsync(
+        public static async Task<byte[]> SignDetachedAsync(
             Stream detachedContent,
             CoseSigner signer,
             CoseHeaderMap? protectedHeaders = null,
@@ -265,7 +265,7 @@ namespace System.Security.Cryptography.Cose
             ValidateBeforeSign(signer, protectedHeaders, unprotectedHeaders);
 
             int expectedSize = ComputeEncodedSize(signer, protectedHeaders, unprotectedHeaders, contentLength: 0, isDetached: true);
-            return SignAsyncCore(expectedSize, detachedContent, signer, protectedHeaders, unprotectedHeaders, associatedData, cancellationToken);
+            return await SignAsyncCore(expectedSize, detachedContent, signer, protectedHeaders, unprotectedHeaders, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<byte[]> SignAsyncCore(
@@ -824,7 +824,7 @@ namespace System.Security.Cryptography.Cose
         ///   </para>
         /// </exception>
         /// <exception cref="InvalidOperationException">The content is embedded on this message, use an overload that uses embedded content.</exception>
-        public Task AddSignatureForDetachedAsync(Stream detachedContent, CoseSigner signer, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public async Task AddSignatureForDetachedAsync(Stream detachedContent, CoseSigner signer, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(detachedContent);
 
@@ -833,7 +833,7 @@ namespace System.Security.Cryptography.Cose
                 throw new InvalidOperationException(SR.ContentWasEmbedded);
             }
 
-            return AddSignatureCoreAsync(detachedContent, signer, associatedData, cancellationToken);
+            await AddSignatureCoreAsync(detachedContent, signer, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task AddSignatureCoreAsync(Stream content, CoseSigner signer, ReadOnlyMemory<byte> associatedData, CancellationToken cancellationToken)

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSign1Message.cs
@@ -201,7 +201,7 @@ namespace System.Security.Cryptography.Cose
         ///     One or more of the labels specified in a <see cref="CoseHeaderLabel.CriticalHeaders"/> header is missing.
         ///   </para>
         /// </exception>
-        public static Task<byte[]> SignDetachedAsync(Stream detachedContent, CoseSigner signer, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public static async Task<byte[]> SignDetachedAsync(Stream detachedContent, CoseSigner signer, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(detachedContent);
             ArgumentNullException.ThrowIfNull(signer);
@@ -215,7 +215,7 @@ namespace System.Security.Cryptography.Cose
             ValidateBeforeSign(signer);
 
             int expectedSize = ComputeEncodedSize(signer, contentLength: 0, isDetached: true);
-            return SignAsyncCore(expectedSize, detachedContent, signer, associatedData, cancellationToken);
+            return await SignAsyncCore(expectedSize, detachedContent, signer, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<byte[]> SignAsyncCore(int expectedSize, Stream content, CoseSigner signer, ReadOnlyMemory<byte> associatedData, CancellationToken cancellationToken)
@@ -850,7 +850,7 @@ namespace System.Security.Cryptography.Cose
         /// </exception>
         /// <seealso cref="VerifyDetached(AsymmetricAlgorithm, Stream, ReadOnlySpan{byte})"/>
         /// <seealso cref="CoseMessage.Content"/>
-        public Task<bool> VerifyDetachedAsync(AsymmetricAlgorithm key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public async Task<bool> VerifyDetachedAsync(AsymmetricAlgorithm key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(detachedContent);
@@ -872,7 +872,7 @@ namespace System.Security.Cryptography.Cose
 
             CoseAlgorithm coseAlgorithm = GetCoseAlgorithmFromProtectedHeaders();
             CoseKey coseKey = CoseKey.FromUntrustedAlgorithmAndKey(coseAlgorithm, key);
-            return VerifyAsyncCore(coseKey, detachedContent, associatedData, cancellationToken);
+            return await VerifyAsyncCore(coseKey, detachedContent, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -912,7 +912,7 @@ namespace System.Security.Cryptography.Cose
         ///   </para>
         /// </exception>
         /// <seealso cref="CoseMessage.Content"/>
-        public Task<bool> VerifyDetachedAsync(CoseKey key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public async Task<bool> VerifyDetachedAsync(CoseKey key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(detachedContent);
@@ -932,7 +932,7 @@ namespace System.Security.Cryptography.Cose
                 throw new InvalidOperationException(SR.ContentWasEmbedded);
             }
 
-            return VerifyAsyncCore(key, detachedContent, associatedData, cancellationToken);
+            return await VerifyAsyncCore(key, detachedContent, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<bool> VerifyAsyncCore(CoseKey key, Stream content, ReadOnlyMemory<byte> associatedData, CancellationToken cancellationToken)

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSignature.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseSignature.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
@@ -524,7 +524,7 @@ namespace System.Security.Cryptography.Cose
         /// </exception>
         /// <seealso cref="VerifyDetached(AsymmetricAlgorithm, Stream, ReadOnlySpan{byte})"/>
         /// <seealso cref="CoseMessage.Content"/>
-        public Task<bool> VerifyDetachedAsync(AsymmetricAlgorithm key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public async Task<bool> VerifyDetachedAsync(AsymmetricAlgorithm key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(detachedContent);
@@ -547,7 +547,7 @@ namespace System.Security.Cryptography.Cose
             CoseAlgorithm coseAlgorithm = GetCoseAlgorithmFromProtectedHeaders();
             CoseKey coseKey = CoseKey.FromUntrustedAlgorithmAndKey(coseAlgorithm, key);
 
-            return VerifyAsyncCore(coseKey, detachedContent, associatedData, cancellationToken);
+            return await VerifyAsyncCore(coseKey, detachedContent, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -588,7 +588,7 @@ namespace System.Security.Cryptography.Cose
         /// </exception>
         /// <seealso cref="VerifyDetached(CoseKey, Stream, ReadOnlySpan{byte})"/>
         /// <seealso cref="CoseMessage.Content"/>
-        public Task<bool> VerifyDetachedAsync(CoseKey key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
+        public async Task<bool> VerifyDetachedAsync(CoseKey key, Stream detachedContent, ReadOnlyMemory<byte> associatedData = default, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(detachedContent);
@@ -608,7 +608,7 @@ namespace System.Security.Cryptography.Cose
                 throw new InvalidOperationException(SR.ContentWasEmbedded);
             }
 
-            return VerifyAsyncCore(key, detachedContent, associatedData, cancellationToken);
+            return await VerifyAsyncCore(key, detachedContent, associatedData, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<bool> VerifyAsyncCore(CoseKey key, Stream content, ReadOnlyMemory<byte> associatedData, CancellationToken cancellationToken)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoStream.cs
@@ -124,12 +124,12 @@ namespace System.Security.Cryptography
         /// </summary>
         /// <param name="cancellationToken">The token to monitor for cancellation requests. The default value is <see cref="CancellationToken.None"/>.</param>
         /// <returns>A task that represents the asynchronous flush operation.</returns>
-        public ValueTask FlushFinalBlockAsync(CancellationToken cancellationToken = default)
+        public async ValueTask FlushFinalBlockAsync(CancellationToken cancellationToken = default)
         {
             if (cancellationToken.IsCancellationRequested)
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
 
-            return FlushFinalBlockAsync(useAsync: true, cancellationToken);
+            await FlushFinalBlockAsync(useAsync: true, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask FlushFinalBlockAsync(bool useAsync, CancellationToken cancellationToken)
@@ -214,19 +214,19 @@ namespace System.Security.Cryptography
             throw new NotSupportedException(SR.NotSupported_UnseekableStream);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckReadArguments(buffer, offset, count);
-            return ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            return await ReadAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (!CanRead)
-                return ValueTask.FromException<int>(new NotSupportedException(SR.NotSupported_UnreadableStream));
+                return await ValueTask.FromException<int>(new NotSupportedException(SR.NotSupported_UnreadableStream)).ConfigureAwait(false);
 
-            return ReadAsyncInternal(buffer, cancellationToken);
+            return await ReadAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask<int> ReadAsyncInternal(Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -453,19 +453,19 @@ namespace System.Security.Cryptography
             }
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             CheckWriteArguments(buffer, offset, count);
-            return WriteAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+            await WriteAsyncInternal(buffer.AsMemory(offset, count), cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             if (!CanWrite)
-                return ValueTask.FromException(new NotSupportedException(SR.NotSupported_UnwritableStream));
+                await ValueTask.FromException(new NotSupportedException(SR.NotSupported_UnwritableStream)).ConfigureAwait(false);
 
-            return WriteAsyncInternal(buffer, cancellationToken);
+            await WriteAsyncInternal(buffer, cancellationToken).ConfigureAwait(false);
         }
 
         private async ValueTask WriteAsyncInternal(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
@@ -710,10 +710,10 @@ namespace System.Security.Cryptography
         }
 
         /// <inheritdoc/>
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
             CheckCopyToArguments(destination, bufferSize);
-            return CopyToAsyncInternal(destination, bufferSize, cancellationToken);
+            await CopyToAsyncInternal(destination, bufferSize, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task CopyToAsyncInternal(Stream destination, int bufferSize, CancellationToken cancellationToken)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptographicOperations.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptographicOperations.cs
@@ -305,7 +305,7 @@ namespace System.Security.Cryptography
         /// <exception cref="OperationCanceledException">
         ///   <paramref name="cancellationToken"/> has been canceled.
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             HashAlgorithmName hashAlgorithm,
             Stream source,
             Memory<byte> destination,
@@ -316,11 +316,11 @@ namespace System.Security.Cryptography
             Debug.Assert(hashAlgorithm.Name is not null);
             CheckDestinationSize(hashSizeInBytes, destination.Length);
 
-            return LiteHashProvider.HashStreamAsync(
+            return await LiteHashProvider.HashStreamAsync(
                 hashAlgorithm.Name,
                 source,
                 destination,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -354,7 +354,7 @@ namespace System.Security.Cryptography
         /// <exception cref="OperationCanceledException">
         ///   <paramref name="cancellationToken"/> has been canceled.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             HashAlgorithmName hashAlgorithm,
             Stream source,
             CancellationToken cancellationToken = default)
@@ -363,7 +363,7 @@ namespace System.Security.Cryptography
             CheckStream(source);
             Debug.Assert(hashAlgorithm.Name is not null);
 
-            return LiteHashProvider.HashStreamAsync(hashAlgorithm.Name, source, cancellationToken);
+            return await LiteHashProvider.HashStreamAsync(hashAlgorithm.Name, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -651,14 +651,14 @@ namespace System.Security.Cryptography
         /// <exception cref="OperationCanceledException">
         ///   <paramref name="cancellationToken"/> has been canceled.
         /// </exception>
-        public static ValueTask<byte[]> HmacDataAsync(
+        public static async ValueTask<byte[]> HmacDataAsync(
             HashAlgorithmName hashAlgorithm,
             byte[] key,
             Stream source,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(key);
-            return HmacDataAsync(hashAlgorithm, new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return await HmacDataAsync(hashAlgorithm, new ReadOnlyMemory<byte>(key), source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -696,7 +696,7 @@ namespace System.Security.Cryptography
         /// <exception cref="OperationCanceledException">
         ///   <paramref name="cancellationToken"/> has been canceled.
         /// </exception>
-        public static ValueTask<int> HmacDataAsync(
+        public static async ValueTask<int> HmacDataAsync(
             HashAlgorithmName hashAlgorithm,
             ReadOnlyMemory<byte> key,
             Stream source,
@@ -708,7 +708,7 @@ namespace System.Security.Cryptography
             Debug.Assert(hashAlgorithm.Name is not null);
             CheckDestinationSize(hashSizeInBytes, destination.Length);
 
-            return LiteHashProvider.HmacStreamAsync(hashAlgorithm.Name, key.Span, source, destination, cancellationToken);
+            return await LiteHashProvider.HmacStreamAsync(hashAlgorithm.Name, key.Span, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -743,7 +743,7 @@ namespace System.Security.Cryptography
         /// <exception cref="OperationCanceledException">
         ///   <paramref name="cancellationToken"/> has been canceled.
         /// </exception>
-        public static ValueTask<byte[]> HmacDataAsync(
+        public static async ValueTask<byte[]> HmacDataAsync(
             HashAlgorithmName hashAlgorithm,
             ReadOnlyMemory<byte> key,
             Stream source,
@@ -753,7 +753,7 @@ namespace System.Security.Cryptography
             CheckStream(source);
             Debug.Assert(hashAlgorithm.Name is not null);
 
-            return LiteHashProvider.HmacStreamAsync(hashAlgorithm.Name, key.Span, source, cancellationToken);
+            return await LiteHashProvider.HmacStreamAsync(hashAlgorithm.Name, key.Span, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -971,7 +971,7 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyHmacAsync(
+        public static async ValueTask<bool> VerifyHmacAsync(
             HashAlgorithmName hashAlgorithm,
             ReadOnlyMemory<byte> key,
             Stream source,
@@ -988,7 +988,7 @@ namespace System.Security.Cryptography
             CheckStream(source);
             Debug.Assert(hashAlgorithm.Name is not null);
 
-            return VerifyHmacAsyncInner(hashAlgorithm.Name, key, source, hash, cancellationToken);
+            return await VerifyHmacAsyncInner(hashAlgorithm.Name, key, source, hash, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> VerifyHmacAsyncInner(
                 string hashAlgorithm,
@@ -1025,7 +1025,7 @@ namespace System.Security.Cryptography
         ///   </para>
         /// </exception>
         /// <inheritdoc cref="VerifyHmacAsync(HashAlgorithmName, ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyHmacAsync(
+        public static async ValueTask<bool> VerifyHmacAsync(
             HashAlgorithmName hashAlgorithm,
             byte[] key,
             Stream source,
@@ -1035,12 +1035,12 @@ namespace System.Security.Cryptography
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(hash);
 
-            return VerifyHmacAsync(
+            return await VerifyHmacAsync(
                 hashAlgorithm,
                 new ReadOnlyMemory<byte>(key),
                 source,
                 new ReadOnlyMemory<byte>(hash),
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private static void CheckStream([NotNull] Stream source)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACMD5.cs
@@ -228,9 +228,9 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -250,9 +250,9 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -280,13 +280,13 @@ namespace System.Security.Cryptography
         ///   </p>
         /// </exception>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -387,13 +387,13 @@ namespace System.Security.Cryptography
         ///   timing information.
         /// </remarks>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
@@ -401,13 +401,13 @@ namespace System.Security.Cryptography
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA1.cs
@@ -223,9 +223,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -244,9 +244,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -273,13 +273,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -375,26 +375,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA256.cs
@@ -215,9 +215,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -236,9 +236,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -265,13 +265,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -367,26 +367,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA384.cs
@@ -232,9 +232,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -253,9 +253,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -282,13 +282,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -384,26 +384,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_256.cs
@@ -251,9 +251,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -272,9 +272,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,13 +301,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </para>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -412,26 +412,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_384.cs
@@ -251,9 +251,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -272,9 +272,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,13 +301,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </para>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -412,26 +412,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA3_512.cs
@@ -251,9 +251,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -272,9 +272,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -301,13 +301,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </para>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -412,26 +412,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACSHA512.cs
@@ -229,9 +229,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(ReadOnlyMemory<byte> key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -250,9 +250,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -279,13 +279,13 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken);
+            return await HMACStatic<HMACTrait>.HashDataAsync(key, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -381,26 +381,26 @@ namespace System.Security.Cryptography
         ///   This API performs a fixed-time comparison of the derived HMAC against a known HMAC to prevent leaking
         ///   timing information.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
         /// <inheritdoc cref="VerifyAsync(ReadOnlyMemory{byte}, Stream, ReadOnlyMemory{byte}, CancellationToken)" />
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             CancellationToken cancellationToken = default)
         {
-            return HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken);
+            return await HMACStatic<HMACTrait>.VerifyAsync(key, source, hash, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACStatic.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HMACStatic.cs
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography
             return HashData(new ReadOnlySpan<byte>(key), source);
         }
 
-        internal static ValueTask<byte[]> HashDataAsync(
+        internal static async ValueTask<byte[]> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             CancellationToken cancellationToken)
@@ -125,17 +125,17 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
 
             CheckPlatformSupport();
-            return LiteHashProvider.HmacStreamAsync(THMAC.HashAlgorithmName, key.Span, source, cancellationToken);
+            return await LiteHashProvider.HmacStreamAsync(THMAC.HashAlgorithmName, key.Span, source, cancellationToken).ConfigureAwait(false);
         }
 
-        internal static ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken)
+        internal static async ValueTask<byte[]> HashDataAsync(byte[] key, Stream source, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(key);
 
-            return HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken);
+            return await HashDataAsync(new ReadOnlyMemory<byte>(key), source, cancellationToken).ConfigureAwait(false);
         }
 
-        internal static ValueTask<int> HashDataAsync(
+        internal static async ValueTask<int> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
@@ -150,12 +150,12 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
 
             CheckPlatformSupport();
-            return LiteHashProvider.HmacStreamAsync(
+            return await LiteHashProvider.HmacStreamAsync(
                 THMAC.HashAlgorithmName,
                 key.Span,
                 source,
                 destination,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         internal static bool Verify(byte[] key, byte[] source, byte[] hash)
@@ -196,7 +196,7 @@ namespace System.Security.Cryptography
             return Verify(new ReadOnlySpan<byte>(key), source, new ReadOnlySpan<byte>(hash));
         }
 
-        internal static ValueTask<bool> VerifyAsync(
+        internal static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
@@ -211,7 +211,7 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
 
             CheckPlatformSupport();
-            return VerifyAsyncInner(key, source, hash, cancellationToken);
+            return await VerifyAsyncInner(key, source, hash, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> VerifyAsyncInner(
                 ReadOnlyMemory<byte> key,
@@ -236,7 +236,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        internal static ValueTask<bool> VerifyAsync(
+        internal static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
@@ -246,7 +246,7 @@ namespace System.Security.Cryptography
             ArgumentNullException.ThrowIfNull(hash);
             // source parameter check is done in called overload.
 
-            return VerifyAsync(new ReadOnlyMemory<byte>(key), source, new ReadOnlyMemory<byte>(hash), cancellationToken);
+            return await VerifyAsync(new ReadOnlyMemory<byte>(key), source, new ReadOnlyMemory<byte>(hash), cancellationToken).ConfigureAwait(false);
         }
 
         internal static void CheckPlatformSupport()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithm.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashAlgorithm.cs
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography
             return CaptureHashCodeAndReinitialize();
         }
 
-        public Task<byte[]> ComputeHashAsync(
+        public async Task<byte[]> ComputeHashAsync(
             Stream inputStream,
             CancellationToken cancellationToken = default)
         {
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography
 
             ObjectDisposedException.ThrowIf(_disposed, this);
 
-            return ComputeHashAsyncCore(inputStream, cancellationToken);
+            return await ComputeHashAsyncCore(inputStream, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<byte[]> ComputeHashAsyncCore(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashStatic.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/HashStatic.cs
@@ -87,7 +87,7 @@ namespace System.Security.Cryptography
             return LiteHashProvider.HashStream(THash.HashAlgorithmName, THash.HashSizeInBytes, source);
         }
 
-        internal static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken)
+        internal static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(source);
 
@@ -95,10 +95,10 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
 
             CheckPlatformSupport();
-            return LiteHashProvider.HashStreamAsync(THash.HashAlgorithmName, source, cancellationToken);
+            return await LiteHashProvider.HashStreamAsync(THash.HashAlgorithmName, source, cancellationToken).ConfigureAwait(false);
         }
 
-        internal static ValueTask<int> HashDataAsync(
+        internal static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken)
@@ -112,11 +112,11 @@ namespace System.Security.Cryptography
                 throw new ArgumentException(SR.Argument_StreamNotReadable, nameof(source));
 
             CheckPlatformSupport();
-            return LiteHashProvider.HashStreamAsync(
+            return await LiteHashProvider.HashStreamAsync(
                 THash.HashAlgorithmName,
                 source,
                 destination,
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         internal static void CheckPlatformSupport()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Kmac128.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Kmac128.cs
@@ -497,7 +497,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC128.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             byte[] key,
             Stream source,
             int outputLength,
@@ -510,7 +510,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key, source, xof: false, outputLength, customizationString, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key, source, xof: false, outputLength, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -544,7 +544,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC128.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             int outputLength,
@@ -556,7 +556,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: false, outputLength, customizationString.Span, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: false, outputLength, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC128.
         /// </exception>
-        public static ValueTask HashDataAsync(
+        public static async ValueTask HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
@@ -596,7 +596,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: false, destination, customizationString.Span, cancellationToken);
+            await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: false, destination, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -688,14 +688,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             byte[]? customizationString = null,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -733,14 +733,14 @@ namespace System.Security.Cryptography
         ///   The length of the hash to produce and verify is determined by the length of <paramref name="hash" />.
         ///   Callers should ensure the length of the hash meets the desired security requirements.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             ReadOnlyMemory<byte> customizationString = default,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Kmac256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Kmac256.cs
@@ -497,7 +497,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             byte[] key,
             Stream source,
             int outputLength,
@@ -510,7 +510,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key, source, xof: false, outputLength, customizationString, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key, source, xof: false, outputLength, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -544,7 +544,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             int outputLength,
@@ -556,7 +556,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: false, outputLength, customizationString.Span, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: false, outputLength, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMAC256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMAC256.
         /// </exception>
-        public static ValueTask HashDataAsync(
+        public static async ValueTask HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
@@ -596,7 +596,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: false, destination, customizationString.Span, cancellationToken);
+            await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: false, destination, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -688,14 +688,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             byte[]? customizationString = null,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -733,14 +733,14 @@ namespace System.Security.Cryptography
         ///   The length of the hash to produce and verify is determined by the length of <paramref name="hash" />.
         ///   Callers should ensure the length of the hash meets the desired security requirements.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             ReadOnlyMemory<byte> customizationString = default,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacStatic.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacStatic.cs
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography
                 new ReadOnlySpan<byte>(customizationString)); // null to empty conversion is expected.
         }
 
-        internal static ValueTask<bool> VerifyAsync(
+        internal static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography
             ThrowIfStreamUnreadable(source);
             ThrowIfNotSupported();
 
-            return VerifyAsyncInner(key, source, hash, customizationString, cancellationToken);
+            return await VerifyAsyncInner(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
 
             static async ValueTask<bool> VerifyAsyncInner(
                 ReadOnlyMemory<byte> key,
@@ -139,7 +139,7 @@ namespace System.Security.Cryptography
             }
         }
 
-        internal static ValueTask<bool> VerifyAsync(
+        internal static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
@@ -149,12 +149,12 @@ namespace System.Security.Cryptography
             ArgumentNullException.ThrowIfNull(key);
             ArgumentNullException.ThrowIfNull(hash);
 
-            return VerifyAsync(
+            return await VerifyAsync(
                 new ReadOnlyMemory<byte>(key),
                 source,
                 new ReadOnlyMemory<byte>(hash),
                 new ReadOnlyMemory<byte>(customizationString), // null to empty conversion is expected.
-                cancellationToken);
+                cancellationToken).ConfigureAwait(false);
         }
 
         private static bool VerifyCore<TSource>(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacXof128.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacXof128.cs
@@ -497,7 +497,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF128.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             byte[] key,
             Stream source,
             int outputLength,
@@ -510,7 +510,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key, source, xof: true, outputLength, customizationString, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key, source, xof: true, outputLength, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -544,7 +544,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF128.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             int outputLength,
@@ -556,7 +556,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: true, outputLength, customizationString.Span, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: true, outputLength, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF128.
         /// </exception>
-        public static ValueTask HashDataAsync(
+        public static async ValueTask HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
@@ -596,7 +596,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: true, destination, customizationString.Span, cancellationToken);
+            await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC128, key.Span, source, xof: true, destination, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -688,14 +688,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             byte[]? customizationString = null,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -733,14 +733,14 @@ namespace System.Security.Cryptography
         ///   The length of the hash to produce and verify is determined by the length of <paramref name="hash" />.
         ///   Callers should ensure the length of the hash meets the desired security requirements.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             ReadOnlyMemory<byte> customizationString = default,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacXof256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/KmacXof256.cs
@@ -497,7 +497,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             byte[] key,
             Stream source,
             int outputLength,
@@ -510,7 +510,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key, source, xof: true, outputLength, customizationString, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key, source, xof: true, outputLength, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -544,7 +544,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(
+        public static async ValueTask<byte[]> HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             int outputLength,
@@ -556,7 +556,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: true, outputLength, customizationString.Span, cancellationToken);
+            return await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: true, outputLength, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -585,7 +585,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support KMACXOF256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports KMACXOF256.
         /// </exception>
-        public static ValueTask HashDataAsync(
+        public static async ValueTask HashDataAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             Memory<byte> destination,
@@ -596,7 +596,7 @@ namespace System.Security.Cryptography
 
             CheckStreamCanRead(source);
             CheckPlatformSupport();
-            return LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: true, destination, customizationString.Span, cancellationToken);
+            await LiteHashProvider.KmacStreamAsync(HashAlgorithmNames.KMAC256, key.Span, source, xof: true, destination, customizationString.Span, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -688,14 +688,14 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentNullException">
         ///   <paramref name="key" />, <paramref name="source" />, or <paramref name="hash" /> is <see langword="null" />.
         /// </exception>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             byte[] key,
             Stream source,
             byte[] hash,
             byte[]? customizationString = null,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -733,14 +733,14 @@ namespace System.Security.Cryptography
         ///   The length of the hash to produce and verify is determined by the length of <paramref name="hash" />.
         ///   Callers should ensure the length of the hash meets the desired security requirements.
         /// </remarks>
-        public static ValueTask<bool> VerifyAsync(
+        public static async ValueTask<bool> VerifyAsync(
             ReadOnlyMemory<byte> key,
             Stream source,
             ReadOnlyMemory<byte> hash,
             ReadOnlyMemory<byte> customizationString = default,
             CancellationToken cancellationToken = default)
         {
-            return KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken);
+            return await KmacStatic<KmacTrait>.VerifyAsync(key, source, hash, customizationString, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.Xof.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.Xof.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography
             return result;
         }
 
-        internal static ValueTask XofStreamAsync(
+        internal static async ValueTask XofStreamAsync(
             string hashAlgorithmId,
             Stream source,
             Memory<byte> destination,
@@ -62,14 +62,14 @@ namespace System.Security.Cryptography
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled(cancellationToken);
+                await ValueTask.FromCanceled(cancellationToken).ConfigureAwait(false);
             }
 
             LiteXof hash = CreateXof(hashAlgorithmId);
-            return ProcessStreamIndefiniteAsync(hash, source, destination, cancellationToken);
+            await ProcessStreamIndefiniteAsync(hash, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
-        internal static ValueTask<byte[]> XofStreamAsync(
+        internal static async ValueTask<byte[]> XofStreamAsync(
             string hashAlgorithmId,
             int outputLength,
             Stream source,
@@ -77,11 +77,11 @@ namespace System.Security.Cryptography
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<byte[]>(cancellationToken);
+                return await ValueTask.FromCanceled<byte[]>(cancellationToken).ConfigureAwait(false);
             }
 
             LiteXof hash = CreateXof(hashAlgorithmId);
-            return ProcessStreamAsync(hash, outputLength, source, cancellationToken);
+            return await ProcessStreamAsync(hash, outputLength, source, cancellationToken).ConfigureAwait(false);
         }
 
         internal static ValueTask KmacStreamAsync(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHashProvider.cs
@@ -25,7 +25,7 @@ namespace System.Security.Cryptography
             return result;
         }
 
-        internal static ValueTask<int> HashStreamAsync(
+        internal static async ValueTask<int> HashStreamAsync(
             string hashAlgorithmId,
             Stream source,
             Memory<byte> destination,
@@ -33,25 +33,25 @@ namespace System.Security.Cryptography
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<int>(cancellationToken);
+                return await ValueTask.FromCanceled<int>(cancellationToken).ConfigureAwait(false);
             }
 
             LiteHash hash = CreateHash(hashAlgorithmId);
-            return ProcessStreamAsync(hash, source, destination, cancellationToken);
+            return await ProcessStreamAsync(hash, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
-        internal static ValueTask<byte[]> HashStreamAsync(
+        internal static async ValueTask<byte[]> HashStreamAsync(
             string hashAlgorithmId,
             Stream source,
             CancellationToken cancellationToken)
         {
             if (cancellationToken.IsCancellationRequested)
             {
-                return ValueTask.FromCanceled<byte[]>(cancellationToken);
+                return await ValueTask.FromCanceled<byte[]>(cancellationToken).ConfigureAwait(false);
             }
 
             LiteHash hash = CreateHash(hashAlgorithmId);
-            return ProcessStreamAsync(hash, hash.HashSizeInBytes, source, cancellationToken);
+            return await ProcessStreamAsync(hash, hash.HashSizeInBytes, source, cancellationToken).ConfigureAwait(false);
         }
 
         internal static int HmacStream(

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MD5.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/MD5.cs
@@ -159,9 +159,9 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -188,12 +188,12 @@ namespace System.Security.Cryptography
         ///   </p>
         /// </exception>
         [UnsupportedOSPlatform("browser")]
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : MD5

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA1.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA1.cs
@@ -148,9 +148,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -176,12 +176,12 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA1

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA256.cs
@@ -148,9 +148,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -176,12 +176,12 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA256

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA384.cs
@@ -147,9 +147,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -175,12 +175,12 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA384

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_256.cs
@@ -188,9 +188,9 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,12 +219,12 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-256.
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA3_256

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_384.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_384.cs
@@ -189,9 +189,9 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-384.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -220,12 +220,12 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-384.
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA3_384

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA3_512.cs
@@ -188,9 +188,9 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-512.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,12 +219,12 @@ namespace System.Security.Cryptography
         /// <exception cref="PlatformNotSupportedException">
         /// The platform does not support SHA3-512.
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA3_512

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA512.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SHA512.cs
@@ -147,9 +147,9 @@ namespace System.Security.Cryptography
         /// <exception cref="ArgumentException">
         ///   <paramref name="source" /> does not support reading.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -175,12 +175,12 @@ namespace System.Security.Cryptography
         ///   <paramref name="source" /> does not support reading.
         ///   </p>
         /// </exception>
-        public static ValueTask<int> HashDataAsync(
+        public static async ValueTask<int> HashDataAsync(
             Stream source,
             Memory<byte> destination,
             CancellationToken cancellationToken = default)
         {
-            return HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken);
+            return await HashStatic<HashTrait>.HashDataAsync(source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         private sealed class Implementation : SHA512

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Shake128.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Shake128.cs
@@ -412,7 +412,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support SHAKE128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports SHAKE128.
         /// </exception>
-        public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default)
+        public static async ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
@@ -422,7 +422,7 @@ namespace System.Security.Cryptography
             }
 
             CheckPlatformSupport();
-            return LiteHashProvider.XofStreamAsync(HashAlgorithmId, source, destination, cancellationToken);
+            await LiteHashProvider.XofStreamAsync(HashAlgorithmId, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support SHAKE128. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports SHAKE128.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentOutOfRangeException.ThrowIfNegative(outputLength);
@@ -464,7 +464,7 @@ namespace System.Security.Cryptography
             }
 
             CheckPlatformSupport();
-            return LiteHashProvider.XofStreamAsync(HashAlgorithmId, outputLength, source, cancellationToken);
+            return await LiteHashProvider.XofStreamAsync(HashAlgorithmId, outputLength, source, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(ReadOnlySpan<byte> source, Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Shake256.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Shake256.cs
@@ -412,7 +412,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support SHAKE256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports SHAKE256.
         /// </exception>
-        public static ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default)
+        public static async ValueTask HashDataAsync(Stream source, Memory<byte> destination, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
 
@@ -422,7 +422,7 @@ namespace System.Security.Cryptography
             }
 
             CheckPlatformSupport();
-            return LiteHashProvider.XofStreamAsync(HashAlgorithmId, source, destination, cancellationToken);
+            await LiteHashProvider.XofStreamAsync(HashAlgorithmId, source, destination, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -453,7 +453,7 @@ namespace System.Security.Cryptography
         ///   The platform does not support SHAKE256. Callers can use the <see cref="IsSupported" /> property
         ///   to determine if the platform supports SHAKE256.
         /// </exception>
-        public static ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default)
+        public static async ValueTask<byte[]> HashDataAsync(Stream source, int outputLength, CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentOutOfRangeException.ThrowIfNegative(outputLength);
@@ -464,7 +464,7 @@ namespace System.Security.Cryptography
             }
 
             CheckPlatformSupport();
-            return LiteHashProvider.XofStreamAsync(HashAlgorithmId, outputLength, source, cancellationToken);
+            return await LiteHashProvider.XofStreamAsync(HashAlgorithmId, outputLength, source, cancellationToken).ConfigureAwait(false);
         }
 
         private static void HashDataCore(ReadOnlySpan<byte> source, Span<byte> destination)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Document/JsonDocument.Parse.cs
@@ -205,14 +205,14 @@ namespace System.Text.Json
         /// <exception cref="ArgumentException">
         ///   <paramref name="options"/> contains unsupported options.
         /// </exception>
-        public static Task<JsonDocument> ParseAsync(
+        public static async Task<JsonDocument> ParseAsync(
             Stream utf8Json,
             JsonDocumentOptions options = default,
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(utf8Json);
 
-            return ParseAsyncCore(utf8Json, options, cancellationToken);
+            return await ParseAsyncCore(utf8Json, options, cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<JsonDocument> ParseAsyncCore(

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Pipe.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Pipe.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static ValueTask<TValue?> DeserializeAsync<TValue>(
+        public static async ValueTask<TValue?> DeserializeAsync<TValue>(
             PipeReader utf8Json,
             JsonSerializerOptions? options = null,
             CancellationToken cancellationToken = default)
@@ -48,7 +48,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(utf8Json, nameof(utf8Json));
 
             JsonTypeInfo<TValue> jsonTypeInfo = GetTypeInfo<TValue>(options);
-            return jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace System.Text.Json
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the PipeReader.
         /// </exception>
-        public static ValueTask<TValue?> DeserializeAsync<TValue>(
+        public static async ValueTask<TValue?> DeserializeAsync<TValue>(
                 PipeReader utf8Json,
                 JsonTypeInfo<TValue> jsonTypeInfo,
                 CancellationToken cancellationToken = default)
@@ -79,7 +79,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo, nameof(jsonTypeInfo));
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace System.Text.Json
         /// The JSON is invalid,
         /// or when there is remaining data in the PipeReader.
         /// </exception>
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
                 PipeReader utf8Json,
                 JsonTypeInfo jsonTypeInfo,
                 CancellationToken cancellationToken = default)
@@ -108,7 +108,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo, nameof(jsonTypeInfo));
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ namespace System.Text.Json
         /// The <see cref="JsonSerializerContext.GetTypeInfo(Type)"/> method on the provided <paramref name="context"/>
         /// did not return a compatible <see cref="JsonTypeInfo"/> for <paramref name="returnType"/>.
         /// </exception>
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
                 PipeReader utf8Json,
                 Type returnType,
                 JsonSerializerContext context,
@@ -149,7 +149,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(context, nameof(context));
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -177,7 +177,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
                PipeReader utf8Json,
                Type returnType,
                JsonSerializerOptions? options = null,
@@ -187,7 +187,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(returnType, nameof(returnType));
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Read.Stream.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static ValueTask<TValue?> DeserializeAsync<TValue>(
+        public static async ValueTask<TValue?> DeserializeAsync<TValue>(
             Stream utf8Json,
             JsonSerializerOptions? options = null,
             CancellationToken cancellationToken = default)
@@ -48,7 +48,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(utf8Json);
 
             JsonTypeInfo<TValue> jsonTypeInfo = GetTypeInfo<TValue>(options);
-            return jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
             Stream utf8Json,
             Type returnType,
             JsonSerializerOptions? options = null,
@@ -118,7 +118,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(returnType);
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, returnType);
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace System.Text.Json
         /// <typeparamref name="TValue"/> is not compatible with the JSON,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<TValue?> DeserializeAsync<TValue>(
+        public static async ValueTask<TValue?> DeserializeAsync<TValue>(
             Stream utf8Json,
             JsonTypeInfo<TValue> jsonTypeInfo,
             CancellationToken cancellationToken = default)
@@ -183,7 +183,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -203,7 +203,7 @@ namespace System.Text.Json
         /// The JSON is invalid,
         /// or when there is remaining data in the Stream.
         /// </exception>
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
             Stream utf8Json,
             JsonTypeInfo jsonTypeInfo,
             CancellationToken cancellationToken = default)
@@ -212,7 +212,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace System.Text.Json
         /// The <see cref="JsonSerializerContext.GetTypeInfo(Type)"/> method on the provided <paramref name="context"/>
         /// did not return a compatible <see cref="JsonTypeInfo"/> for <paramref name="returnType"/>.
         /// </exception>
-        public static ValueTask<object?> DeserializeAsync(
+        public static async ValueTask<object?> DeserializeAsync(
             Stream utf8Json,
             Type returnType,
             JsonSerializerContext context,
@@ -305,7 +305,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(context);
 
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, returnType);
-            return jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken);
+            return await jsonTypeInfo.DeserializeAsObjectAsync(utf8Json, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Pipe.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Pipe.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -26,7 +26,7 @@ namespace System.Text.Json
         /// <exception cref="ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
-        public static Task SerializeAsync<TValue>(
+        public static async Task SerializeAsync<TValue>(
             PipeWriter utf8Json,
             TValue value,
             JsonTypeInfo<TValue> jsonTypeInfo,
@@ -36,7 +36,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static Task SerializeAsync<TValue>(
+        public static async Task SerializeAsync<TValue>(
             PipeWriter utf8Json,
             TValue value,
             JsonSerializerOptions? options = null,
@@ -66,7 +66,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(utf8Json);
 
             JsonTypeInfo<TValue> jsonTypeInfo = GetTypeInfo<TValue>(options);
-            return jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace System.Text.Json
         /// <exception cref="InvalidCastException">
         /// <paramref name="value"/> does not match the type of <paramref name="jsonTypeInfo"/>.
         /// </exception>
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
             PipeWriter utf8Json,
             object? value,
             JsonTypeInfo jsonTypeInfo,
@@ -93,7 +93,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace System.Text.Json
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>
         /// for <paramref name="inputType"/>  or its serializable members.
         /// </exception>
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
                 PipeWriter utf8Json,
                 object? value,
                 Type inputType,
@@ -128,7 +128,7 @@ namespace System.Text.Json
             ValidateInputType(value, inputType);
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, inputType);
 
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
                 PipeWriter utf8Json,
                 object? value,
                 Type inputType,
@@ -164,7 +164,7 @@ namespace System.Text.Json
             ValidateInputType(value, inputType);
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
 
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonSerializer.Write.Stream.cs
@@ -40,7 +40,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static Task SerializeAsync<TValue>(
+        public static async Task SerializeAsync<TValue>(
             Stream utf8Json,
             TValue value,
             JsonSerializerOptions? options = null,
@@ -49,7 +49,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(utf8Json);
 
             JsonTypeInfo<TValue> jsonTypeInfo = GetTypeInfo<TValue>(options);
-            return jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ namespace System.Text.Json
         /// </exception>
         [RequiresUnreferencedCode(SerializationUnreferencedCodeMessage)]
         [RequiresDynamicCode(SerializationRequiresDynamicCodeMessage)]
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
             Stream utf8Json,
             object? value,
             Type inputType,
@@ -111,7 +111,7 @@ namespace System.Text.Json
 
             ValidateInputType(value, inputType);
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(options, inputType);
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,7 +158,7 @@ namespace System.Text.Json
         /// <exception cref="ArgumentNullException">
         /// <paramref name="utf8Json"/> is <see langword="null"/>.
         /// </exception>
-        public static Task SerializeAsync<TValue>(
+        public static async Task SerializeAsync<TValue>(
             Stream utf8Json,
             TValue value,
             JsonTypeInfo<TValue> jsonTypeInfo,
@@ -168,7 +168,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace System.Text.Json
         /// <exception cref="InvalidCastException">
         /// <paramref name="value"/> does not match the type of <paramref name="jsonTypeInfo"/>.
         /// </exception>
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
             Stream utf8Json,
             object? value,
             JsonTypeInfo jsonTypeInfo,
@@ -217,7 +217,7 @@ namespace System.Text.Json
             ArgumentNullException.ThrowIfNull(jsonTypeInfo);
 
             jsonTypeInfo.EnsureConfigured();
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -263,7 +263,7 @@ namespace System.Text.Json
         /// There is no compatible <see cref="System.Text.Json.Serialization.JsonConverter"/>
         /// for <paramref name="inputType"/>  or its serializable members.
         /// </exception>
-        public static Task SerializeAsync(
+        public static async Task SerializeAsync(
             Stream utf8Json,
             object? value,
             Type inputType,
@@ -275,7 +275,7 @@ namespace System.Text.Json
 
             ValidateInputType(value, inputType);
             JsonTypeInfo jsonTypeInfo = GetTypeInfo(context, inputType);
-            return jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken);
+            await jsonTypeInfo.SerializeAsObjectAsync(utf8Json, value, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.ReadHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -55,17 +55,17 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        internal ValueTask<T?> DeserializeAsync(Stream utf8Json, CancellationToken cancellationToken)
+        internal async ValueTask<T?> DeserializeAsync(Stream utf8Json, CancellationToken cancellationToken)
         {
             // Note: The ReadBufferState ctor rents pooled buffers.
             StreamReadBufferState bufferState = new StreamReadBufferState(Options.DefaultBufferSize);
-            return DeserializeAsync(utf8Json, bufferState, cancellationToken);
+            return await DeserializeAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
         }
 
-        internal ValueTask<T?> DeserializeAsync(PipeReader utf8Json, CancellationToken cancellationToken)
+        internal async ValueTask<T?> DeserializeAsync(PipeReader utf8Json, CancellationToken cancellationToken)
         {
             PipeReadBufferState bufferState = new(utf8Json);
-            return DeserializeAsync(utf8Json, bufferState, cancellationToken);
+            return await DeserializeAsync(utf8Json, bufferState, cancellationToken).ConfigureAwait(false);
         }
 
         internal T? Deserialize(Stream utf8Json)

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Metadata/JsonTypeInfoOfT.WriteHelpers.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -59,7 +59,7 @@ namespace System.Text.Json.Serialization.Metadata
             }
         }
 
-        internal Task SerializeAsync(Stream utf8Json,
+        internal async Task SerializeAsync(Stream utf8Json,
             T? rootValue,
             CancellationToken cancellationToken,
             object? rootValueBoxed = null)
@@ -68,17 +68,17 @@ namespace System.Text.Json.Serialization.Metadata
             // Value chosen as 90% of the default buffer used in PooledByteBufferWriter.
             // This is a tradeoff between likelihood of needing to grow the array vs. utilizing most of the buffer
             int flushThreshold = (int)(writer.Capacity * JsonSerializer.FlushThreshold);
-            return SerializeAsync(writer, rootValue, flushThreshold, cancellationToken, rootValueBoxed);
+            await SerializeAsync(writer, rootValue, flushThreshold, cancellationToken, rootValueBoxed).ConfigureAwait(false);
         }
 
-        internal Task SerializeAsync(PipeWriter utf8Json,
+        internal async Task SerializeAsync(PipeWriter utf8Json,
             T? rootValue,
             CancellationToken cancellationToken,
             object? rootValueBoxed = null)
         {
             // Value chosen as 90% of 4 buffer segments in Pipes. This is semi-arbitrarily chosen and may be changed in future iterations.
             int flushThreshold = (int)(4 * PipeOptions.Default.MinimumSegmentSize * JsonSerializer.FlushThreshold);
-            return SerializeAsync(utf8Json, rootValue, flushThreshold, cancellationToken, rootValueBoxed);
+            await SerializeAsync(utf8Json, rootValue, flushThreshold, cancellationToken, rootValueBoxed).ConfigureAwait(false);
         }
 
         // Root serialization method for async streaming serialization.
@@ -340,14 +340,14 @@ namespace System.Text.Json.Serialization.Metadata
         internal sealed override void SerializeAsObject(Utf8JsonWriter writer, object? rootValue)
             => Serialize(writer, JsonSerializer.UnboxOnWrite<T>(rootValue), rootValue);
 
-        internal sealed override Task SerializeAsObjectAsync(PipeWriter pipeWriter, object? rootValue, int flushThreshold, CancellationToken cancellationToken)
-            => SerializeAsync(pipeWriter, JsonSerializer.UnboxOnWrite<T>(rootValue), flushThreshold, cancellationToken, rootValue);
+        internal sealed override async Task SerializeAsObjectAsync(PipeWriter pipeWriter, object? rootValue, int flushThreshold, CancellationToken cancellationToken)
+            => await SerializeAsync(pipeWriter, JsonSerializer.UnboxOnWrite<T>(rootValue), flushThreshold, cancellationToken, rootValue).ConfigureAwait(false);
 
-        internal sealed override Task SerializeAsObjectAsync(Stream utf8Json, object? rootValue, CancellationToken cancellationToken)
-            => SerializeAsync(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), cancellationToken, rootValue);
+        internal sealed override async Task SerializeAsObjectAsync(Stream utf8Json, object? rootValue, CancellationToken cancellationToken)
+            => await SerializeAsync(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), cancellationToken, rootValue).ConfigureAwait(false);
 
-        internal sealed override Task SerializeAsObjectAsync(PipeWriter utf8Json, object? rootValue, CancellationToken cancellationToken)
-            => SerializeAsync(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), cancellationToken, rootValue);
+        internal sealed override async Task SerializeAsObjectAsync(PipeWriter utf8Json, object? rootValue, CancellationToken cancellationToken)
+            => await SerializeAsync(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), cancellationToken, rootValue).ConfigureAwait(false);
 
         internal sealed override void SerializeAsObject(Stream utf8Json, object? rootValue)
             => Serialize(utf8Json, JsonSerializer.UnboxOnWrite<T>(rootValue), rootValue);

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -79,9 +79,9 @@ namespace System.Threading.RateLimiting
             return GetRateLimiter(resource).AttemptAcquire(permitCount);
         }
 
-        protected override ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
         {
-            return GetRateLimiter(resource).AcquireAsync(permitCount, cancellationToken);
+            return await GetRateLimiter(resource).AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
         }
 
         private RateLimiter GetRateLimiter(TResource resource)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/TranslatingLimiter.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Threading.Tasks;
@@ -34,11 +34,11 @@ namespace System.Threading.RateLimiting
             return _innerRateLimiter.AttemptAcquire(key, permitCount);
         }
 
-        protected override ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(TResource resource, int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDispose();
             TInner key = _keyAdapter(resource);
-            return _innerRateLimiter.AcquireAsync(key, permitCount, cancellationToken);
+            return await _innerRateLimiter.AcquireAsync(key, permitCount, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
+++ b/src/libraries/System.Threading.Tasks.Dataflow/src/Base/DataflowBlock.cs
@@ -256,9 +256,9 @@ namespace System.Threading.Tasks.Dataflow
         /// never attempts to consume or release the message, the returned task will never complete.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">The <paramref name="target"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<bool> SendAsync<TInput>(this ITargetBlock<TInput> target, TInput item)
+        public static async Task<bool> SendAsync<TInput>(this ITargetBlock<TInput> target, TInput item)
         {
-            return SendAsync<TInput>(target, item, CancellationToken.None);
+            return await SendAsync<TInput>(target, item, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously offers a message to the target message block, allowing for postponement.</summary>
@@ -781,11 +781,11 @@ namespace System.Threading.Tasks.Dataflow
         /// because the source is empty and completed, the returned task will be canceled.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">The <paramref name="source"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<TOutput> ReceiveAsync<TOutput>(
+        public static async Task<TOutput> ReceiveAsync<TOutput>(
             this ISourceBlock<TOutput> source)
         {
             // Argument validation handled by target method
-            return ReceiveAsync(source, Common.InfiniteTimeSpan, CancellationToken.None);
+            return await ReceiveAsync(source, Common.InfiniteTimeSpan, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously receives a value from the specified source.</summary>
@@ -798,11 +798,11 @@ namespace System.Threading.Tasks.Dataflow
         /// either because cancellation is requested or the source is empty and completed, the returned task will be canceled.
         /// </returns>
         /// <exception cref="System.ArgumentNullException">The <paramref name="source"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<TOutput> ReceiveAsync<TOutput>(
+        public static async Task<TOutput> ReceiveAsync<TOutput>(
             this ISourceBlock<TOutput> source, CancellationToken cancellationToken)
         {
             // Argument validation handled by target method
-            return ReceiveAsync(source, Common.InfiniteTimeSpan, cancellationToken);
+            return await ReceiveAsync(source, Common.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously receives a value from the specified source.</summary>
@@ -818,11 +818,11 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// timeout is a negative number other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than <see cref="int.MaxValue"/>.
         /// </exception>
-        public static Task<TOutput> ReceiveAsync<TOutput>(
+        public static async Task<TOutput> ReceiveAsync<TOutput>(
             this ISourceBlock<TOutput> source, TimeSpan timeout)
         {
             // Argument validation handled by target method
-            return ReceiveAsync(source, timeout, CancellationToken.None);
+            return await ReceiveAsync(source, timeout, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>Asynchronously receives a value from the specified source.</summary>
@@ -839,7 +839,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentOutOfRangeException">
         /// timeout is a negative number other than -1 milliseconds, which represents an infinite time-out -or- timeout is greater than <see cref="int.MaxValue"/>.
         /// </exception>
-        public static Task<TOutput> ReceiveAsync<TOutput>(
+        public static async Task<TOutput> ReceiveAsync<TOutput>(
             this ISourceBlock<TOutput> source, TimeSpan timeout, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(source);
@@ -848,7 +848,7 @@ namespace System.Threading.Tasks.Dataflow
             if (!Common.IsValidTimeout(timeout)) throw new ArgumentOutOfRangeException(nameof(timeout), SR.ArgumentOutOfRange_NeedNonNegOrNegative1);
 
             // Return the task representing the core receive operation
-            return ReceiveCore(source, true, timeout, cancellationToken);
+            return await ReceiveCore(source, true, timeout, cancellationToken).ConfigureAwait(false);
         }
         #endregion
 
@@ -968,7 +968,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <param name="timeout">A <see cref="System.TimeSpan"/> that represents the number of milliseconds to wait, or a TimeSpan that represents -1 milliseconds to wait indefinitely.</param>
         /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> which may be used to cancel the receive operation.</param>
         /// <returns>A Task for the receive operation.</returns>
-        private static Task<TOutput> ReceiveCore<TOutput>(
+        private static async Task<TOutput> ReceiveCore<TOutput>(
             this ISourceBlock<TOutput> source, bool attemptTryReceive, TimeSpan timeout, CancellationToken cancellationToken)
         {
             Debug.Assert(source != null, "Need a source from which to receive.");
@@ -976,7 +976,7 @@ namespace System.Threading.Tasks.Dataflow
             // If cancellation has been requested, we're done before we've even started, cancel this receive.
             if (cancellationToken.IsCancellationRequested)
             {
-                return Common.CreateTaskFromCancellation<TOutput>(cancellationToken);
+                return await Common.CreateTaskFromCancellation<TOutput>(cancellationToken).ConfigureAwait(false);
             }
 
             if (attemptTryReceive)
@@ -990,12 +990,12 @@ namespace System.Threading.Tasks.Dataflow
                         TOutput? fastCheckedItem;
                         if (receivableSource.TryReceive(null, out fastCheckedItem))
                         {
-                            return Task.FromResult<TOutput>(fastCheckedItem);
+                            return fastCheckedItem;
                         }
                     }
                     catch (Exception exc)
                     {
-                        return Common.CreateTaskFromException<TOutput>(exc);
+                        return await Common.CreateTaskFromException<TOutput>(exc).ConfigureAwait(false);
                     }
                 }
             }
@@ -1003,10 +1003,10 @@ namespace System.Threading.Tasks.Dataflow
             int millisecondsTimeout = (int)timeout.TotalMilliseconds;
             if (millisecondsTimeout == 0)
             {
-                return Common.CreateTaskFromException<TOutput>(ReceiveTarget<TOutput>.CreateExceptionForTimeout());
+                return await Common.CreateTaskFromException<TOutput>(ReceiveTarget<TOutput>.CreateExceptionForTimeout()).ConfigureAwait(false);
             }
 
-            return ReceiveCoreByLinking<TOutput>(source, millisecondsTimeout, cancellationToken);
+            return await ReceiveCoreByLinking<TOutput>(source, millisecondsTimeout, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>The reason for a ReceiveCoreByLinking call failing.</summary>
@@ -1379,9 +1379,9 @@ namespace System.Threading.Tasks.Dataflow
         /// If it returns false, more output is not and will never be available, due to the source
         /// completing prior to output being available.
         /// </returns>
-        public static Task<bool> OutputAvailableAsync<TOutput>(this ISourceBlock<TOutput> source)
+        public static async Task<bool> OutputAvailableAsync<TOutput>(this ISourceBlock<TOutput> source)
         {
-            return OutputAvailableAsync<TOutput>(source, CancellationToken.None);
+            return await OutputAvailableAsync<TOutput>(source, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1658,12 +1658,12 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentNullException">The <paramref name="action1"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="source2"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="action2"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<int> Choose<T1, T2>(
+        public static async Task<int> Choose<T1, T2>(
             ISourceBlock<T1> source1, Action<T1> action1,
             ISourceBlock<T2> source2, Action<T2> action2)
         {
             // All argument validation is handled by the delegated method
-            return Choose(source1, action1, source2, action2, DataflowBlockOptions.Default);
+            return await Choose(source1, action1, source2, action2, DataflowBlockOptions.Default).ConfigureAwait(false);
         }
 
         /// <summary>Monitors two dataflow sources, invoking the provided handler for whichever source makes data available first.</summary>
@@ -1696,7 +1696,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentNullException">The <paramref name="source2"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="action2"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="dataflowBlockOptions"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<int> Choose<T1, T2>(
+        public static async Task<int> Choose<T1, T2>(
             ISourceBlock<T1> source1, Action<T1> action1,
             ISourceBlock<T2> source2, Action<T2> action2,
             DataflowBlockOptions dataflowBlockOptions)
@@ -1708,7 +1708,7 @@ namespace System.Threading.Tasks.Dataflow
             ArgumentNullException.ThrowIfNull(dataflowBlockOptions);
 
             // Delegate to the shared implementation
-            return ChooseCore<T1, T2, VoidResult>(source1, action1, source2, action2, null, null, dataflowBlockOptions);
+            return await ChooseCore<T1, T2, VoidResult>(source1, action1, source2, action2, null, null, dataflowBlockOptions).ConfigureAwait(false);
         }
         #endregion
 
@@ -1742,13 +1742,13 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentNullException">The <paramref name="action2"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="source3"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="action3"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<int> Choose<T1, T2, T3>(
+        public static async Task<int> Choose<T1, T2, T3>(
             ISourceBlock<T1> source1, Action<T1> action1,
             ISourceBlock<T2> source2, Action<T2> action2,
             ISourceBlock<T3> source3, Action<T3> action3)
         {
             // All argument validation is handled by the delegated method
-            return Choose(source1, action1, source2, action2, source3, action3, DataflowBlockOptions.Default);
+            return await Choose(source1, action1, source2, action2, source3, action3, DataflowBlockOptions.Default).ConfigureAwait(false);
         }
 
         /// <summary>Monitors three dataflow sources, invoking the provided handler for whichever source makes data available first.</summary>
@@ -1785,7 +1785,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <exception cref="System.ArgumentNullException">The <paramref name="source3"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="action3"/> is null (Nothing in Visual Basic).</exception>
         /// <exception cref="System.ArgumentNullException">The <paramref name="dataflowBlockOptions"/> is null (Nothing in Visual Basic).</exception>
-        public static Task<int> Choose<T1, T2, T3>(
+        public static async Task<int> Choose<T1, T2, T3>(
             ISourceBlock<T1> source1, Action<T1> action1,
             ISourceBlock<T2> source2, Action<T2> action2,
             ISourceBlock<T3> source3, Action<T3> action3,
@@ -1800,7 +1800,7 @@ namespace System.Threading.Tasks.Dataflow
             ArgumentNullException.ThrowIfNull(dataflowBlockOptions);
 
             // Delegate to the shared implementation
-            return ChooseCore<T1, T2, T3>(source1, action1, source2, action2, source3, action3, dataflowBlockOptions);
+            return await ChooseCore<T1, T2, T3>(source1, action1, source2, action2, source3, action3, dataflowBlockOptions).ConfigureAwait(false);
         }
         #endregion
 
@@ -1998,7 +1998,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <param name="source">The source with which this branch is associated.</param>
         /// <param name="action">The action to run for a single element received from the source.</param>
         /// <returns>A task representing the branch.</returns>
-        private static Task<int> CreateChooseBranch<T>(
+        private static async Task<int> CreateChooseBranch<T>(
             StrongBox<Task> boxedCompleted, CancellationTokenSource cts,
             TaskScheduler scheduler,
             int branchId, ISourceBlock<T> source, Action<T> action)
@@ -2006,7 +2006,7 @@ namespace System.Threading.Tasks.Dataflow
             // If the cancellation token is already canceled, there is no need to create and link a target.
             // Instead, directly return a canceled task.
             if (cts.IsCancellationRequested)
-                return Common.CreateTaskFromCancellation<int>(cts.Token);
+                return await Common.CreateTaskFromCancellation<int>(cts.Token).ConfigureAwait(false);
 
             // Proceed with creating and linking a hidden target. Also get the source's completion task,
             // as we need it to know when the source completes.  Both of these operations
@@ -2020,14 +2020,14 @@ namespace System.Threading.Tasks.Dataflow
             catch (Exception exc)
             {
                 cts.Cancel();
-                return Common.CreateTaskFromException<int>(exc);
+                return await Common.CreateTaskFromException<int>(exc).ConfigureAwait(false);
             }
 
             // The continuation task below is implicitly capturing the right execution context,
             // as CreateChooseBranch is called synchronously from Choose, so we
             // don't need to additionally capture and marshal an ExecutionContext.
 
-            return target.Task.ContinueWith(completed =>
+            return await target.Task.ContinueWith(completed =>
             {
                 try
                 {
@@ -2054,7 +2054,7 @@ namespace System.Threading.Tasks.Dataflow
                     // original action's exception if there was one.
                     unlink.Dispose();
                 }
-            }, CancellationToken.None, Common.GetContinuationOptions(), scheduler);
+            }, CancellationToken.None, Common.GetContinuationOptions(), scheduler).ConfigureAwait(false);
         }
 
         /// <summary>Provides a dataflow target used by Choose to receive data from a single source.</summary>
@@ -2567,9 +2567,9 @@ namespace System.Threading.Tasks.Dataflow
             /// <summary>Sends a value to the underlying target asynchronously.</summary>
             /// <param name="value">The value to send.</param>
             /// <returns>A Task{bool} to wait on.</returns>
-            internal Task<bool> SendAsyncToTarget(TInput value)
+            internal async Task<bool> SendAsyncToTarget(TInput value)
             {
-                return _target.SendAsync(value);
+                return await _target.SendAsync(value).ConfigureAwait(false);
             }
 
             /// <summary>The data to display in the debugger display attribute.</summary>

--- a/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
+++ b/src/libraries/System.Threading.Tasks.Parallel/src/System/Threading/Tasks/Parallel.ForEachAsync.cs
@@ -17,14 +17,14 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForAsync<T>(T fromInclusive, T toExclusive, Func<T, CancellationToken, ValueTask> body)
+        public static async Task ForAsync<T>(T fromInclusive, T toExclusive, Func<T, CancellationToken, ValueTask> body)
             where T : notnull, IBinaryInteger<T>
         {
             ArgumentNullException.ThrowIfNull(fromInclusive);
             ArgumentNullException.ThrowIfNull(toExclusive);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForAsync(fromInclusive, toExclusive, DefaultDegreeOfParallelism, TaskScheduler.Default, default, body);
+            await ForAsync(fromInclusive, toExclusive, DefaultDegreeOfParallelism, TaskScheduler.Default, default, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for loop in which iterations may run in parallel.</summary>
@@ -35,14 +35,14 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForAsync<T>(T fromInclusive, T toExclusive, CancellationToken cancellationToken, Func<T, CancellationToken, ValueTask> body)
+        public static async Task ForAsync<T>(T fromInclusive, T toExclusive, CancellationToken cancellationToken, Func<T, CancellationToken, ValueTask> body)
             where T : notnull, IBinaryInteger<T>
         {
             ArgumentNullException.ThrowIfNull(fromInclusive);
             ArgumentNullException.ThrowIfNull(toExclusive);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForAsync(fromInclusive, toExclusive, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body);
+            await ForAsync(fromInclusive, toExclusive, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for loop in which iterations may run in parallel.</summary>
@@ -53,7 +53,7 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForAsync<T>(T fromInclusive, T toExclusive, ParallelOptions parallelOptions, Func<T, CancellationToken, ValueTask> body)
+        public static async Task ForAsync<T>(T fromInclusive, T toExclusive, ParallelOptions parallelOptions, Func<T, CancellationToken, ValueTask> body)
             where T : notnull, IBinaryInteger<T>
         {
             ArgumentNullException.ThrowIfNull(fromInclusive);
@@ -61,7 +61,7 @@ namespace System.Threading.Tasks
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForAsync(fromInclusive, toExclusive, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body);
+            await ForAsync(fromInclusive, toExclusive, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -195,12 +195,12 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForEachAsync<TSource>(IEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, default(CancellationToken), body);
+            await ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, default(CancellationToken), body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -211,12 +211,12 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForEachAsync<TSource>(IEnumerable<TSource> source, CancellationToken cancellationToken, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IEnumerable<TSource> source, CancellationToken cancellationToken, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body);
+            await ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -226,13 +226,13 @@ namespace System.Threading.Tasks
         /// <param name="body">An asynchronous delegate that is invoked once per element in the data source.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
-        public static Task ForEachAsync<TSource>(IEnumerable<TSource> source, ParallelOptions parallelOptions, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IEnumerable<TSource> source, ParallelOptions parallelOptions, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body);
+            await ForEachAsync(source, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -350,12 +350,12 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, default(CancellationToken), body);
+            await ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, default(CancellationToken), body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IAsyncEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -366,12 +366,12 @@ namespace System.Threading.Tasks
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
         /// <remarks>The operation will execute at most <see cref="Environment.ProcessorCount"/> operations in parallel.</remarks>
-        public static Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, CancellationToken cancellationToken, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body);
+            await ForEachAsync(source, DefaultDegreeOfParallelism, TaskScheduler.Default, cancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IAsyncEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -381,13 +381,13 @@ namespace System.Threading.Tasks
         /// <param name="body">An asynchronous delegate that is invoked once per element in the data source.</param>
         /// <exception cref="ArgumentNullException">The <paramref name="source"/> argument or <paramref name="body"/> argument is <see langword="null"/>.</exception>
         /// <returns>A task that represents the entire for each operation.</returns>
-        public static Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, ParallelOptions parallelOptions, Func<TSource, CancellationToken, ValueTask> body)
+        public static async Task ForEachAsync<TSource>(IAsyncEnumerable<TSource> source, ParallelOptions parallelOptions, Func<TSource, CancellationToken, ValueTask> body)
         {
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(parallelOptions);
             ArgumentNullException.ThrowIfNull(body);
 
-            return ForEachAsync(source, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body);
+            await ForEachAsync(source, parallelOptions.EffectiveMaxConcurrencyLevel, parallelOptions.EffectiveTaskScheduler, parallelOptions.CancellationToken, body).ConfigureAwait(false);
         }
 
         /// <summary>Executes a for each operation on an <see cref="IAsyncEnumerable{TSource}"/> in which iterations may run in parallel.</summary>
@@ -588,7 +588,7 @@ namespace System.Threading.Tasks
             public bool SignalWorkerCompletedIterating() => Interlocked.Decrement(ref _completionRefCount) == 0;
 
             /// <summary>Asynchronously acquires exclusive access to the enumerator.</summary>
-            public Task AcquireLock()
+            public async Task AcquireLock()
             {
                 // We explicitly don't pass this.Cancellation to WaitAsync.  Doing so adds overhead, and it isn't actually
                 // necessary. All of the operations that monitor the lock are part of the same ForEachAsync operation, and the Task
@@ -599,7 +599,7 @@ namespace System.Threading.Tasks
                 // not being requested.  We want to optimize for the latter.  This also then avoids an exception throw / catch when
                 // cancellation is requested.
                 Debug.Assert(_lock is not null, "Should only be invoked when _lock is non-null");
-                return _lock.WaitAsync(CancellationToken.None);
+                await _lock.WaitAsync(CancellationToken.None).ConfigureAwait(false);
             }
 
             /// <summary>Relinquishes exclusive access to the enumerator.</summary>
@@ -718,10 +718,10 @@ namespace System.Threading.Tasks
                 Enumerator = source.GetAsyncEnumerator(Cancellation.Token) ?? throw new InvalidOperationException(SR.Parallel_ForEach_NullEnumerator);
             }
 
-            public ValueTask DisposeAsync()
+            public async ValueTask DisposeAsync()
             {
                 _registration.Dispose();
-                return Enumerator.DisposeAsync();
+                await Enumerator.DisposeAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/tools/PreferAsyncAwait/PreferAsyncAwait.csproj
+++ b/src/tools/PreferAsyncAwait/PreferAsyncAwait.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <EnableDefaultItems>false</EnableDefaultItems>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="PreferAsyncAwaitAnalyzer.cs" />
+    <Compile Include="PreferAsyncAwaitCodeFixProvider.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/PreferAsyncAwait/PreferAsyncAwaitAnalyzer.cs
+++ b/src/tools/PreferAsyncAwait/PreferAsyncAwaitAnalyzer.cs
@@ -1,0 +1,342 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable RS2008 // Not a shipping analyzer, so we don't need release tracking
+
+namespace PreferAsyncAwait;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PreferAsyncAwaitAnalyzer : DiagnosticAnalyzer
+{
+    public const string DiagnosticId = "ASYNC0001";
+
+    private static readonly DiagnosticDescriptor s_rule = new(
+        id: DiagnosticId,
+        title: "Method can be converted to async",
+        messageFormat: "'{0}' returns a task from a method call and can be converted to async",
+        category: "Usage",
+        defaultSeverity: DiagnosticSeverity.Info,
+        isEnabledByDefault: true,
+        description: "Non-async methods, local functions, and lambdas that return a Task/ValueTask from a single method invocation can be converted to use async/await for improved stack traces and exception handling.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationContext =>
+        {
+            var taskType = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task");
+            var taskOfTType = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+            var valueTaskType = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask");
+            var valueTaskOfTType = compilationContext.Compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+
+            if (taskType is null && taskOfTType is null && valueTaskType is null && valueTaskOfTType is null)
+                return;
+
+            compilationContext.RegisterSyntaxNodeAction(
+                ctx => AnalyzeNode(ctx, taskType, taskOfTType, valueTaskType, valueTaskOfTType),
+                SyntaxKind.MethodDeclaration,
+                SyntaxKind.LocalFunctionStatement,
+                SyntaxKind.ParenthesizedLambdaExpression,
+                SyntaxKind.SimpleLambdaExpression);
+        });
+    }
+
+    private static void AnalyzeNode(
+        SyntaxNodeAnalysisContext context,
+        INamedTypeSymbol? taskType,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        IMethodSymbol? methodSymbol;
+        SyntaxTokenList modifiers;
+        ExpressionSyntax? expressionBody;
+        BlockSyntax? blockBody;
+        Location reportLocation;
+        string displayName;
+
+        switch (context.Node)
+        {
+            case MethodDeclarationSyntax method:
+                if (method.Modifiers.Any(SyntaxKind.AsyncKeyword))
+                    return;
+                if (method.ExpressionBody is null && method.Body is null)
+                    return;
+                methodSymbol = context.SemanticModel.GetDeclaredSymbol(method, context.CancellationToken);
+                modifiers = method.Modifiers;
+                expressionBody = method.ExpressionBody?.Expression;
+                blockBody = method.Body;
+                reportLocation = method.Identifier.GetLocation();
+                displayName = methodSymbol?.Name ?? "method";
+                break;
+
+            case LocalFunctionStatementSyntax localFunc:
+                if (localFunc.Modifiers.Any(SyntaxKind.AsyncKeyword))
+                    return;
+                if (localFunc.ExpressionBody is null && localFunc.Body is null)
+                    return;
+                methodSymbol = context.SemanticModel.GetDeclaredSymbol(localFunc, context.CancellationToken) as IMethodSymbol;
+                modifiers = localFunc.Modifiers;
+                expressionBody = localFunc.ExpressionBody?.Expression;
+                blockBody = localFunc.Body;
+                reportLocation = localFunc.Identifier.GetLocation();
+                displayName = methodSymbol?.Name ?? "local function";
+                break;
+
+            case ParenthesizedLambdaExpressionSyntax lambda:
+                if (lambda.Modifiers.Any(SyntaxKind.AsyncKeyword))
+                    return;
+                methodSymbol = context.SemanticModel.GetSymbolInfo(lambda, context.CancellationToken).Symbol as IMethodSymbol;
+                modifiers = lambda.Modifiers;
+                expressionBody = lambda.Body as ExpressionSyntax;
+                blockBody = lambda.Body as BlockSyntax;
+                if (expressionBody is null && blockBody is null)
+                    return;
+                reportLocation = lambda.ArrowToken.GetLocation();
+                displayName = "lambda";
+                break;
+
+            case SimpleLambdaExpressionSyntax lambda:
+                if (lambda.Modifiers.Any(SyntaxKind.AsyncKeyword))
+                    return;
+                methodSymbol = context.SemanticModel.GetSymbolInfo(lambda, context.CancellationToken).Symbol as IMethodSymbol;
+                modifiers = lambda.Modifiers;
+                expressionBody = lambda.Body as ExpressionSyntax;
+                blockBody = lambda.Body as BlockSyntax;
+                if (expressionBody is null && blockBody is null)
+                    return;
+                reportLocation = lambda.ArrowToken.GetLocation();
+                displayName = "lambda";
+                break;
+
+            default:
+                return;
+        }
+
+        if (methodSymbol is null)
+            return;
+
+        AnalyzeFunction(context, methodSymbol, modifiers, expressionBody, blockBody,
+            context.Node, reportLocation, displayName, taskType, taskOfTType, valueTaskType, valueTaskOfTType);
+    }
+
+    private static void AnalyzeFunction(
+        SyntaxNodeAnalysisContext context,
+        IMethodSymbol methodSymbol,
+        SyntaxTokenList modifiers,
+        ExpressionSyntax? expressionBody,
+        BlockSyntax? blockBody,
+        SyntaxNode syntaxNode,
+        Location reportLocation,
+        string displayName,
+        INamedTypeSymbol? taskType,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        if (!IsTaskLikeType(methodSymbol.ReturnType, taskType, taskOfTType, valueTaskType, valueTaskOfTType))
+            return;
+
+        // Skip functions with ref/in/out parameters (cannot be async)
+        foreach (var param in methodSymbol.Parameters)
+        {
+            if (param.RefKind is RefKind.Ref or RefKind.Out or RefKind.In)
+                return;
+        }
+
+        // Skip functions with Span/ReadOnlySpan parameters (ref structs cannot be in async methods)
+        foreach (var param in methodSymbol.Parameters)
+        {
+            if (param.Type.IsRefLikeType)
+                return;
+        }
+
+        // Skip functions with [MethodImpl(MethodImplOptions.Synchronized)]
+        foreach (var attr in methodSymbol.GetAttributes())
+        {
+            if (attr.AttributeClass?.Name == "MethodImplAttribute" &&
+                attr.ConstructorArguments.Length > 0 &&
+                attr.ConstructorArguments[0].Value is int flags &&
+                (flags & 0x0020) != 0) // MethodImplOptions.Synchronized
+                return;
+        }
+
+        // Skip functions with unsafe modifier or inside unsafe type
+        if (modifiers.Any(SyntaxKind.UnsafeKeyword))
+            return;
+        foreach (var ancestor in syntaxNode.Ancestors())
+        {
+            if (ancestor is TypeDeclarationSyntax typeDecl && typeDecl.Modifiers.Any(SyntaxKind.UnsafeKeyword))
+                return;
+        }
+
+        // Skip functions containing lock statements (cannot await in lock body)
+        if (blockBody is not null)
+        {
+            foreach (var node in blockBody.DescendantNodes(n => !IsNestedFunctionLike(n)))
+            {
+                if (node is LockStatementSyntax)
+                    return;
+            }
+        }
+
+        // Check expression body
+        if (expressionBody is not null)
+        {
+            if (IsTaskReturningInvocation(expressionBody, context.SemanticModel, taskType, taskOfTType, valueTaskType, valueTaskOfTType))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(s_rule, reportLocation, displayName));
+            }
+
+            return;
+        }
+
+        // Check block body
+        if (blockBody is not null)
+        {
+            // Skip functions that contain fire-and-forget task-returning calls (bare expression
+            // statements or assignments to variables). Making the function async would trigger
+            // CS4014 for those calls. Explicit discards (`_ = SomeAsync();`) are fine — they
+            // suppress CS4014.
+            if (HasUnawaitedTaskCalls(blockBody, context.SemanticModel, taskType, taskOfTType, valueTaskType, valueTaskOfTType))
+                return;
+
+            // Collect all return statements that belong to this function (not nested lambdas/local functions)
+            var returnStatements = blockBody.DescendantNodes(n => !IsNestedFunctionLike(n))
+                .OfType<ReturnStatementSyntax>()
+                .ToList();
+
+            // Must have at least one return statement, and all must return invocations
+            if (returnStatements.Count == 0)
+                return;
+
+            foreach (var returnStatement in returnStatements)
+            {
+                if (returnStatement.Expression is null)
+                    return;
+
+                if (!IsTaskReturningInvocation(returnStatement.Expression, context.SemanticModel, taskType, taskOfTType, valueTaskType, valueTaskOfTType))
+                    return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(s_rule, reportLocation, displayName));
+        }
+    }
+
+    private static bool HasUnawaitedTaskCalls(
+        BlockSyntax body,
+        SemanticModel semanticModel,
+        INamedTypeSymbol? taskType,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        foreach (var node in body.DescendantNodes(n => !IsNestedFunctionLike(n)))
+        {
+            if (node is not InvocationExpressionSyntax invocation)
+                continue;
+
+            var typeInfo = semanticModel.GetTypeInfo(invocation);
+            if (typeInfo.Type is null || !IsTaskLikeType(typeInfo.Type, taskType, taskOfTType, valueTaskType, valueTaskOfTType))
+                continue;
+
+            var parent = invocation.Parent;
+
+            // Bare expression statement: `SomeAsync();` — would trigger CS4014
+            if (parent is ExpressionStatementSyntax)
+                return true;
+
+            // Assigned to a variable: `var t = SomeAsync();` or `Task t = SomeAsync();`
+            if (parent is EqualsValueClauseSyntax)
+                return true;
+
+            // Simple assignment: `t = SomeAsync();` (but NOT `_ = SomeAsync();`)
+            if (parent is AssignmentExpressionSyntax assignment &&
+                assignment.Left is not IdentifierNameSyntax { Identifier.Text: "_" })
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsNestedFunctionLike(SyntaxNode node) =>
+        node is LocalFunctionStatementSyntax
+            or ParenthesizedLambdaExpressionSyntax
+            or SimpleLambdaExpressionSyntax
+            or AnonymousMethodExpressionSyntax;
+
+    private static bool IsTaskReturningInvocation(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        INamedTypeSymbol? taskType,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        if (expression is not InvocationExpressionSyntax)
+            return false;
+
+        var typeInfo = semanticModel.GetTypeInfo(expression);
+        if (typeInfo.Type is null)
+            return false;
+
+        return IsTaskLikeType(typeInfo.Type, taskType, taskOfTType, valueTaskType, valueTaskOfTType);
+    }
+
+    internal static bool IsTaskLikeType(
+        ITypeSymbol type,
+        INamedTypeSymbol? taskType,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        if (taskType is not null && SymbolEqualityComparer.Default.Equals(type, taskType))
+            return true;
+
+        if (valueTaskType is not null && SymbolEqualityComparer.Default.Equals(type, valueTaskType))
+            return true;
+
+        if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
+        {
+            var originalDef = namedType.OriginalDefinition;
+
+            if (taskOfTType is not null && SymbolEqualityComparer.Default.Equals(originalDef, taskOfTType))
+                return true;
+
+            if (valueTaskOfTType is not null && SymbolEqualityComparer.Default.Equals(originalDef, valueTaskOfTType))
+                return true;
+        }
+
+        return false;
+    }
+
+    internal static bool IsGenericTaskType(
+        ITypeSymbol type,
+        INamedTypeSymbol? taskOfTType,
+        INamedTypeSymbol? valueTaskOfTType)
+    {
+        if (type is INamedTypeSymbol namedType && namedType.IsGenericType)
+        {
+            var originalDef = namedType.OriginalDefinition;
+
+            if (taskOfTType is not null && SymbolEqualityComparer.Default.Equals(originalDef, taskOfTType))
+                return true;
+
+            if (valueTaskOfTType is not null && SymbolEqualityComparer.Default.Equals(originalDef, valueTaskOfTType))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/src/tools/PreferAsyncAwait/PreferAsyncAwaitCodeFixProvider.cs
+++ b/src/tools/PreferAsyncAwait/PreferAsyncAwaitCodeFixProvider.cs
@@ -1,0 +1,309 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace PreferAsyncAwait;
+
+[ExportCodeFixProvider(LanguageNames.CSharp), Shared]
+public sealed class PreferAsyncAwaitCodeFixProvider : CodeFixProvider
+{
+    public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(PreferAsyncAwaitAnalyzer.DiagnosticId);
+
+    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+            return;
+
+        var diagnostic = context.Diagnostics[0];
+        var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
+
+        // The diagnostic is reported on:
+        //   - Identifier token for methods and local functions (parent is the declaration)
+        //   - Arrow token for lambdas (parent is the lambda expression)
+        SyntaxNode? targetNode = token.Parent;
+        if (targetNode is not (MethodDeclarationSyntax or LocalFunctionStatementSyntax or LambdaExpressionSyntax))
+            return;
+
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Convert to async",
+                createChangedDocument: ct => ConvertToAsync(context.Document, targetNode, ct),
+                equivalenceKey: nameof(PreferAsyncAwaitCodeFixProvider)),
+            diagnostic);
+    }
+
+    private static async Task<Document> ConvertToAsync(Document document, SyntaxNode node, CancellationToken cancellationToken)
+    {
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+        if (semanticModel is null)
+            return document;
+
+        IMethodSymbol? methodSymbol = node switch
+        {
+            MethodDeclarationSyntax m => semanticModel.GetDeclaredSymbol(m, cancellationToken),
+            LocalFunctionStatementSyntax l => semanticModel.GetDeclaredSymbol(l, cancellationToken) as IMethodSymbol,
+            LambdaExpressionSyntax lambda => semanticModel.GetSymbolInfo(lambda, cancellationToken).Symbol as IMethodSymbol,
+            _ => null
+        };
+        if (methodSymbol is null)
+            return document;
+
+        var taskOfTType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+        var valueTaskOfTType = semanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+        bool isGenericReturn = PreferAsyncAwaitAnalyzer.IsGenericTaskType(methodSymbol.ReturnType, taskOfTType, valueTaskOfTType);
+
+        var editor = await DocumentEditor.CreateAsync(document, cancellationToken).ConfigureAwait(false);
+
+        SyntaxNode newNode = node switch
+        {
+            MethodDeclarationSyntax m => ConvertMethod(m, isGenericReturn),
+            LocalFunctionStatementSyntax l => ConvertLocalFunction(l, isGenericReturn),
+            ParenthesizedLambdaExpressionSyntax p => ConvertParenthesizedLambda(p, isGenericReturn),
+            SimpleLambdaExpressionSyntax s => ConvertSimpleLambda(s, isGenericReturn),
+            _ => node
+        };
+
+        editor.ReplaceNode(node, newNode);
+
+        return editor.GetChangedDocument();
+    }
+
+    private static MethodDeclarationSyntax ConvertMethod(MethodDeclarationSyntax method, bool isGenericReturn)
+    {
+        var asyncToken = SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space);
+
+        MethodDeclarationSyntax newMethod;
+        if (method.Modifiers.Count > 0)
+        {
+            var lastMod = method.Modifiers.Last();
+            var updatedLastMod = lastMod.WithTrailingTrivia(SyntaxFactory.Space);
+            newMethod = method.WithModifiers(method.Modifiers.Replace(lastMod, updatedLastMod).Add(asyncToken));
+        }
+        else
+        {
+            asyncToken = asyncToken.WithLeadingTrivia(method.ReturnType.GetLeadingTrivia());
+            newMethod = method.WithModifiers(SyntaxFactory.TokenList(asyncToken))
+                              .WithReturnType(method.ReturnType.WithoutLeadingTrivia());
+        }
+
+        if (method.ExpressionBody is { } expressionBody)
+        {
+            var newExpr = TransformExpression(expressionBody.Expression);
+            return newMethod.WithExpressionBody(expressionBody.WithExpression(newExpr));
+        }
+
+        if (method.Body is { } body)
+        {
+            return newMethod.WithBody(TransformBlockReturns(body, isGenericReturn));
+        }
+
+        return newMethod;
+    }
+
+    private static LocalFunctionStatementSyntax ConvertLocalFunction(LocalFunctionStatementSyntax localFunc, bool isGenericReturn)
+    {
+        var asyncToken = SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space);
+        var newFunc = localFunc.WithModifiers(localFunc.Modifiers.Add(asyncToken));
+
+        if (localFunc.ExpressionBody is { } expressionBody)
+        {
+            var newExpr = TransformExpression(expressionBody.Expression);
+            return newFunc.WithExpressionBody(expressionBody.WithExpression(newExpr));
+        }
+
+        if (localFunc.Body is { } body)
+        {
+            return newFunc.WithBody(TransformBlockReturns(body, isGenericReturn));
+        }
+
+        return newFunc;
+    }
+
+    private static ParenthesizedLambdaExpressionSyntax ConvertParenthesizedLambda(
+        ParenthesizedLambdaExpressionSyntax lambda, bool isGenericReturn)
+    {
+        var asyncToken = SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space);
+        var newLambda = lambda.WithModifiers(lambda.Modifiers.Add(asyncToken));
+
+        if (lambda.Body is ExpressionSyntax expr)
+        {
+            var newExpr = TransformExpression(expr);
+            return newLambda.WithBody(newExpr);
+        }
+
+        if (lambda.Body is BlockSyntax body)
+        {
+            return newLambda.WithBody(TransformBlockReturns(body, isGenericReturn));
+        }
+
+        return newLambda;
+    }
+
+    private static SimpleLambdaExpressionSyntax ConvertSimpleLambda(
+        SimpleLambdaExpressionSyntax lambda, bool isGenericReturn)
+    {
+        var asyncToken = SyntaxFactory.Token(SyntaxKind.AsyncKeyword).WithTrailingTrivia(SyntaxFactory.Space);
+        var newLambda = lambda.WithModifiers(lambda.Modifiers.Add(asyncToken));
+
+        if (lambda.Body is ExpressionSyntax expr)
+        {
+            var newExpr = TransformExpression(expr);
+            return newLambda.WithBody(newExpr);
+        }
+
+        if (lambda.Body is BlockSyntax body)
+        {
+            return newLambda.WithBody(TransformBlockReturns(body, isGenericReturn));
+        }
+
+        return newLambda;
+    }
+
+    private static BlockSyntax TransformBlockReturns(BlockSyntax body, bool isGenericReturn) =>
+        body.ReplaceNodes(
+            body.DescendantNodes(n => !IsNestedFunctionLike(n)).OfType<ReturnStatementSyntax>(),
+            (originalReturn, _) => TransformReturn(originalReturn, isGenericReturn));
+
+    private static ExpressionSyntax TransformExpression(ExpressionSyntax expression)
+    {
+        if (TryUnwrapFromResult(expression, out var unwrapped))
+            return unwrapped!.WithTriviaFrom(expression);
+
+        var awaitExpr = SyntaxFactory.AwaitExpression(AddConfigureAwaitFalse(expression))
+            .WithTriviaFrom(expression);
+        return awaitExpr;
+    }
+
+    private static SyntaxNode TransformReturn(ReturnStatementSyntax returnStatement, bool isGenericReturn)
+    {
+        if (returnStatement.Expression is null)
+            return returnStatement;
+
+        if (TryUnwrapFromResult(returnStatement.Expression, out var unwrapped))
+        {
+            if (isGenericReturn)
+            {
+                return returnStatement.WithExpression(unwrapped!.WithLeadingTrivia(returnStatement.Expression.GetLeadingTrivia()));
+            }
+            else
+            {
+                return SyntaxFactory.ExpressionStatement(unwrapped!)
+                    .WithLeadingTrivia(returnStatement.GetLeadingTrivia())
+                    .WithTrailingTrivia(returnStatement.GetTrailingTrivia());
+            }
+        }
+
+        var awaitExpression = SyntaxFactory.AwaitExpression(AddConfigureAwaitFalse(returnStatement.Expression));
+
+        if (isGenericReturn)
+        {
+            return returnStatement.WithExpression(awaitExpression);
+        }
+        else
+        {
+            return SyntaxFactory.ExpressionStatement(awaitExpression)
+                .WithLeadingTrivia(returnStatement.GetLeadingTrivia())
+                .WithTrailingTrivia(returnStatement.GetTrailingTrivia());
+        }
+    }
+
+    private static bool TryUnwrapFromResult(
+        ExpressionSyntax expr,
+        out ExpressionSyntax? inner)
+    {
+        inner = null;
+        if (expr is not InvocationExpressionSyntax invocation)
+            return false;
+        if (invocation.ArgumentList.Arguments.Count != 1)
+            return false;
+
+        var memberName = invocation.Expression switch
+        {
+            MemberAccessExpressionSyntax { Name: var name } => name,
+            _ => null
+        };
+
+        if (memberName is null)
+            return false;
+
+        var identText = memberName switch
+        {
+            GenericNameSyntax gns => gns.Identifier.Text,
+            IdentifierNameSyntax ins => ins.Identifier.Text,
+            _ => null
+        };
+
+        if (identText != "FromResult")
+            return false;
+
+        if (invocation.Expression is MemberAccessExpressionSyntax memberAccess)
+        {
+            var receiverText = memberAccess.Expression switch
+            {
+                IdentifierNameSyntax id => id.Identifier.Text,
+                GenericNameSyntax gn => gn.Identifier.Text,
+                MemberAccessExpressionSyntax nested => nested.Name switch
+                {
+                    IdentifierNameSyntax nid => nid.Identifier.Text,
+                    GenericNameSyntax ngn => ngn.Identifier.Text,
+                    _ => null
+                },
+                _ => null
+            };
+
+            if (receiverText is not ("Task" or "ValueTask"))
+                return false;
+        }
+
+        inner = invocation.ArgumentList.Arguments[0].Expression;
+        return true;
+    }
+
+    private static InvocationExpressionSyntax AddConfigureAwaitFalse(ExpressionSyntax expression) =>
+        SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                StripAsTask(expression),
+                SyntaxFactory.IdentifierName("ConfigureAwait")),
+            SyntaxFactory.ArgumentList(
+                SyntaxFactory.SingletonSeparatedList(
+                    SyntaxFactory.Argument(
+                        SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)))));
+
+    /// <summary>
+    /// Strips a trailing <c>.AsTask()</c> call since it's unnecessary in async methods.
+    /// </summary>
+    private static ExpressionSyntax StripAsTask(ExpressionSyntax expression)
+    {
+        if (expression is InvocationExpressionSyntax
+            {
+                ArgumentList.Arguments.Count: 0,
+                Expression: MemberAccessExpressionSyntax { Name: IdentifierNameSyntax { Identifier.Text: "AsTask" } } memberAccess
+            })
+        {
+            return memberAccess.Expression.WithTriviaFrom(expression);
+        }
+
+        return expression;
+    }
+
+    private static bool IsNestedFunctionLike(SyntaxNode node) =>
+        node is LocalFunctionStatementSyntax
+            or ParenthesizedLambdaExpressionSyntax
+            or SimpleLambdaExpressionSyntax
+            or AnonymousMethodExpressionSyntax;
+}

--- a/src/tools/PreferAsyncAwait/tests/CSharpCodeFixVerifier.cs
+++ b/src/tools/PreferAsyncAwait/tests/CSharpCodeFixVerifier.cs
@@ -1,0 +1,75 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace PreferAsyncAwait.Tests;
+
+public static class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
+    where TAnalyzer : DiagnosticAnalyzer, new()
+    where TCodeFix : CodeFixProvider, new()
+{
+    public static DiagnosticResult Diagnostic(string diagnosticId)
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
+
+    public static async Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] expected)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    public static async Task VerifyCodeFixAsync(string source, string fixedSource, params DiagnosticResult[] expected)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    public static async Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+
+        test.ExpectedDiagnostics.Add(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    public static async Task VerifyCodeFixAsync(string source, DiagnosticResult[] expected, string fixedSource)
+    {
+        var test = new Test
+        {
+            TestCode = source,
+            FixedCode = fixedSource,
+        };
+
+        test.ExpectedDiagnostics.AddRange(expected);
+        await test.RunAsync(CancellationToken.None);
+    }
+
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
+    {
+        public Test()
+        {
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80;
+        }
+    }
+}

--- a/src/tools/PreferAsyncAwait/tests/PreferAsyncAwait.Tests.csproj
+++ b/src/tools/PreferAsyncAwait/tests/PreferAsyncAwait.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(CompilerPlatformTestingVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(CompilerPlatformTestingVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PreferAsyncAwait.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/tools/PreferAsyncAwait/tests/PreferAsyncAwaitAnalyzerTests.cs
+++ b/src/tools/PreferAsyncAwait/tests/PreferAsyncAwaitAnalyzerTests.cs
@@ -1,0 +1,957 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+
+using VerifyCS = PreferAsyncAwait.Tests.CSharpCodeFixVerifier<
+    PreferAsyncAwait.PreferAsyncAwaitAnalyzer,
+    PreferAsyncAwait.PreferAsyncAwaitCodeFixProvider>;
+
+namespace PreferAsyncAwait.Tests;
+
+public class PreferAsyncAwaitAnalyzerTests
+{
+    [Fact]
+    public async Task NoDiagnosticForEmptySource()
+        => await VerifyCS.VerifyAnalyzerAsync(string.Empty);
+
+    [Fact]
+    public async Task NoDiagnosticForAlreadyAsyncMethod()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M() { return await M2(); }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForNonTaskReturningMethod()
+    {
+        const string source = """
+            class C
+            {
+                int M() { return M2(); }
+                int M2() => 42;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForVoidMethod()
+    {
+        const string source = """
+            class C
+            {
+                void M() { M2(); }
+                void M2() { }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForMethodReturningNonInvocation()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> M()
+                {
+                    var t = Task.FromResult(42);
+                    return t;
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForAbstractMethod()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            abstract class C
+            {
+                public abstract Task<int> M();
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DiagnosticForGenericTaskBlockBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}() { return M2(); }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M() { return await M2().ConfigureAwait(false); }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForGenericTaskExpressionBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}() => M2();
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M() => await M2().ConfigureAwait(false);
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForNonGenericTaskBlockBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task {|#0:M|}() { return M2(); }
+                async Task M2() { }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task M() { await M2().ConfigureAwait(false); }
+                async Task M2() { }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForNonGenericTaskExpressionBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task {|#0:M|}() => M2();
+                async Task M2() { }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task M() => await M2().ConfigureAwait(false);
+                async Task M2() { }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForGenericValueTaskBlockBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                ValueTask<int> {|#0:M|}() { return M2(); }
+                async ValueTask<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async ValueTask<int> M() { return await M2().ConfigureAwait(false); }
+                async ValueTask<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForNonGenericValueTaskBlockBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                ValueTask {|#0:M|}() { return M2(); }
+                async ValueTask M2() { }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async ValueTask M() { await M2().ConfigureAwait(false); }
+                async ValueTask M2() { }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForMethodWithStatementsBeforeReturn()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}()
+                {
+                    Console.WriteLine("hello");
+                    return M2();
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M()
+                {
+                    Console.WriteLine("hello");
+                    return await M2().ConfigureAwait(false);
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForMultipleReturnStatements()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}(bool b)
+                {
+                    if (b)
+                        return M2();
+                    return M3();
+                }
+                async Task<int> M2() { return 1; }
+                async Task<int> M3() { return 2; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M(bool b)
+                {
+                    if (b)
+                        return await M2().ConfigureAwait(false);
+                    return await M3().ConfigureAwait(false);
+                }
+                async Task<int> M2() { return 1; }
+                async Task<int> M3() { return 2; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticIgnoresReturnInsideLambda()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}()
+                {
+                    Func<Task<int>> f = () {|#1:=>|} { return Task.FromResult(42); };
+                    return f();
+                }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M()
+                {
+                    Func<Task<int>> f = async () => { return 42; };
+                    return await f().ConfigureAwait(false);
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            new[]
+            {
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(1).WithArguments("lambda"),
+            },
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task FixUnwrapsTaskFromResult()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}() => Task.FromResult(42);
+
+                Task<string> {|#1:M2|}()
+                {
+                    return Task.FromResult("hello");
+                }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M() => 42;
+
+                async Task<string> M2()
+                {
+                    return "hello";
+                }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            new[]
+            {
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(1).WithArguments("M2"),
+            },
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task FixStripsAsTask()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task {|#0:M|}() => GetValueTaskAsync().AsTask();
+
+                Task<int> {|#1:M2|}()
+                {
+                    return GetValueTaskOfIntAsync().AsTask();
+                }
+
+                ValueTask GetValueTaskAsync() => default;
+                ValueTask<int> GetValueTaskOfIntAsync() => default;
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task M() => await GetValueTaskAsync().ConfigureAwait(false);
+
+                async Task<int> M2()
+                {
+                    return await GetValueTaskOfIntAsync().ConfigureAwait(false);
+                }
+
+                ValueTask GetValueTaskAsync() => default;
+                ValueTask<int> GetValueTaskOfIntAsync() => default;
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            new[]
+            {
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+                VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(1).WithArguments("M2"),
+            },
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticWhenMixedReturnTypes()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> M(bool b)
+                {
+                    if (b)
+                        return M2();
+                    var t = Task.FromResult(42);
+                    return t;
+                }
+                async Task<int> M2() { return 1; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForBareFireAndForgetCall()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> M()
+                {
+                    FireAndForget();
+                    return M2();
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForAssignedTaskCall()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> M()
+                {
+                    Task t = FireAndForget();
+                    return M2();
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DiagnosticAllowedWithExplicitDiscard()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}()
+                {
+                    _ = FireAndForget();
+                    return M2();
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M()
+                {
+                    _ = FireAndForget();
+                    return await M2().ConfigureAwait(false);
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForReassignedTaskVariable()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> M()
+                {
+                    Task t;
+                    t = FireAndForget();
+                    return M2();
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task FireAndForgetInsideLambdaDoesNotBlockDiagnostic()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> {|#0:M|}()
+                {
+                    Action a = () => { FireAndForget(); };
+                    return M2();
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                async Task<int> M()
+                {
+                    Action a = () => { FireAndForget(); };
+                    return await M2().ConfigureAwait(false);
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("M"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForLocalFunctionBlockBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Task<int> {|#0:Local|}() { return M2(); }
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    async Task<int> Local() { return await M2().ConfigureAwait(false); }
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("Local"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForLocalFunctionExpressionBody()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Task<int> {|#0:Local|}() => M2();
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    async Task<int> Local() => await M2().ConfigureAwait(false);
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("Local"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForParenthesizedLambdaExpressionBody()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = () {|#0:=>|} M2();
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = async () => await M2().ConfigureAwait(false);
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("lambda"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForParenthesizedLambdaBlockBody()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = () {|#0:=>|}
+                    {
+                        return M2();
+                    };
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = async () =>
+                    {
+                        return await M2().ConfigureAwait(false);
+                    };
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("lambda"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task DiagnosticForSimpleLambdaExpressionBody()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<int, Task<int>> f = x {|#0:=>|} M2(x);
+                }
+                async Task<int> M2(int x) { return x; }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<int, Task<int>> f = async x => await M2(x).ConfigureAwait(false);
+                }
+                async Task<int> M2(int x) { return x; }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("lambda"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForAlreadyAsyncLocalFunction()
+    {
+        const string source = """
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    async Task<int> Local() { return await M2(); }
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForAlreadyAsyncLambda()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = async () => await M2();
+                }
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task DiagnosticForNonGenericTaskLambda()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task> f = () {|#0:=>|} M2();
+                }
+                async Task M2() { }
+            }
+            """;
+
+        const string fixedSource = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task> f = async () => await M2().ConfigureAwait(false);
+                }
+                async Task M2() { }
+            }
+            """;
+
+        await VerifyCS.VerifyCodeFixAsync(
+            source,
+            VerifyCS.Diagnostic(PreferAsyncAwaitAnalyzer.DiagnosticId).WithLocation(0).WithArguments("lambda"),
+            fixedSource);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForLambdaWithFireAndForget()
+    {
+        const string source = """
+            using System;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                void M()
+                {
+                    Func<Task<int>> f = () =>
+                    {
+                        FireAndForget();
+                        return M2();
+                    };
+                }
+                Task FireAndForget() => Task.CompletedTask;
+                async Task<int> M2() { return 42; }
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoDiagnosticForConditionalTaskReturn()
+    {
+        const string source = """
+            using System;
+            using System.Threading;
+            using System.Threading.Tasks;
+
+            class C
+            {
+                Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+                {
+                    return cancellationToken.IsCancellationRequested ?
+                        Task.FromCanceled<int>(cancellationToken) :
+                        Task.FromResult(Read(buffer, offset, count));
+                }
+                int Read(byte[] buffer, int offset, int count) => count;
+            }
+            """;
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
+}


### PR DESCRIPTION
This PR adds an analyzer that turns Task-returning sync methods into async methods. For example,

```C#
Task M() => M2();
```

would become

```C#
async Task M() => await M2();
```

The reason is because this is a de-optimization in async2 (vs. an optimization in async1). In async2, Task objects are not reified if they're immediately behind an await. This lets an entire chain of async calls be wrapped together. However, if sync methods are introduced into the chain, they force reification of the Task, allocation, and de-optimization.

This is such a common pattern that we might need to directly introduce a JIT optimization to handle it automatically. However, even if we do that, I think this optimization makes sense in the runtime repo. The optimization will take additional time in the JIT. If we make these methods async, the JIT doesn't need to do any extra work. Therefore, it's still a win if we introduce the optimization.