### PR TITLE
[mobile] Disable RoundTrip_AllWindowLogs on iOS / tvOS / MacCatalyst / Android

### DIFF
--- a/src/libraries/Common/tests/System/IO/Compression/EncoderDecoderTestBase.cs
+++ b/src/libraries/Common/tests/System/IO/Compression/EncoderDecoderTestBase.cs
@@ -688,6 +688,7 @@ namespace System.IO.Compression
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/127563", TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst | TestPlatforms.Android)]
         public void RoundTrip_AllWindowLogs()
         {
             byte[] input = CreateTestData();


### PR DESCRIPTION
## Description

`EncoderDecoderTestBase.RoundTrip_AllWindowLogs` (Deflate / ZLib / GZip variants) deterministically returns `OperationStatus.DestinationTooSmall` on every Apple-mobile and Android architecture regardless of runtime flavor tracked in #127563.