### PR TITLE
[mobile] Skip NonRandomizedToRandomizedUpgrade on aggressive trimming

### DIFF
--- a/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionary.Generic.Tests.cs
+++ b/src/libraries/System.Collections.Concurrent/tests/ConcurrentDictionary/ConcurrentDictionary.Generic.Tests.cs
@@ -47,6 +47,7 @@ namespace System.Collections.Concurrent.Tests
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/81945", typeof(PlatformDetection), nameof(PlatformDetection.IsBuiltWithAggressiveTrimming))]
         public void NonRandomizedToRandomizedUpgrade_FunctionsCorrectly(bool ignoreCase)
         {
             List<string> strings = GenerateCollidingStrings(110); // higher than the collisions threshold


### PR DESCRIPTION
## Description

`ConcurrentDictionary_Generic_Tests<TKey,TValue>.NonRandomizedToRandomizedUpgrade_FunctionsCorrectly` reflects on the internal nested `ConcurrentDictionary<,>+Tables` type via `Type.GetType(throwOnError: true)`, whose metadata is trimmed away on aggressive-trimming configurations (NativeAOT and Apple mobile), so the test throws `TypeLoadException` deterministically on every run (tracked at #81945).

This recovers the `System.Collections.Concurrent.Tests` work item on the tvos-arm64 Mono leg by gating the `[Theory]` on `PlatformDetection.IsBuiltWithAggressiveTrimming` (`IsNativeAot || IsAppleMobile`).
