### PR TITLE
Handle minimal MethodTables in dotnet-pgo trace processing

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -416,14 +416,6 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             dependsOnKnownNonLoadableType = true;
                             return null;
                         }
-                        int typeDefRowCount = ecmaModule.MetadataReader.GetTableRowCount(TableIndex.TypeDef);
-                        if (typedefRow > typeDefRowCount)
-                        {
-                            Program.PrintWarning($"TypeDef rid 0x{typedefRow:X} in module '{ecmaModule}' is out of range (max {typeDefRowCount}). " +
-                                "The trace and reference assembly may be mismatched.");
-                            dependsOnKnownNonLoadableType = true;
-                            return null;
-                        }
                         TypeDefinitionHandle typedef = MetadataTokens.TypeDefinitionHandle(typedefRow);
                         MetadataType uninstantiatedType = (MetadataType)ecmaModule.GetType(typedef);
                         // Instantiate the type if requested

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -405,7 +405,20 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                             throw new Exception($"Invalid typedef {tinfo.TypeValue.TypeNameID:4x}");
                         }
 
-                        TypeDefinitionHandle typedef = MetadataTokens.TypeDefinitionHandle(tinfo.TypeValue.TypeNameID & 0xFFFFFF);
+                        int typedefRow = tinfo.TypeValue.TypeNameID & 0xFFFFFF;
+                        // The runtime emits BulkType events for "minimal" MethodTables created by
+                        // CreateMinimalMethodTable in coreclr (used for Reflection.Emit DynamicMethod
+                        // hosts and the IL stub cache). These MTs have no typedef token and surface
+                        // here as TypeNameID == 0x02000000 (rid 0). Treat them as unresolvable
+                        // dynamic types so trace processing can continue. Out-of-range rids (which
+                        // would happen if the trace and reference assembly are mismatched) are
+                        // handled the same way.
+                        if (typedefRow == 0 || typedefRow > ecmaModule.MetadataReader.GetTableRowCount(TableIndex.TypeDef))
+                        {
+                            dependsOnKnownNonLoadableType = true;
+                            return null;
+                        }
+                        TypeDefinitionHandle typedef = MetadataTokens.TypeDefinitionHandle(typedefRow);
                         MetadataType uninstantiatedType = (MetadataType)ecmaModule.GetType(typedef);
                         // Instantiate the type if requested
                         if ((tinfo.TypeValue.TypeParameters.Length != 0) && uninstantiatedType != null)

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -410,11 +410,17 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         // CreateMinimalMethodTable in coreclr (used for Reflection.Emit DynamicMethod
                         // hosts and the IL stub cache). These MTs have no typedef token and surface
                         // here as TypeNameID == 0x02000000 (rid 0). Treat them as unresolvable
-                        // dynamic types so trace processing can continue. Out-of-range rids (which
-                        // would happen if the trace and reference assembly are mismatched) are
-                        // handled the same way.
-                        if (typedefRow == 0 || typedefRow > ecmaModule.MetadataReader.GetTableRowCount(TableIndex.TypeDef))
+                        // dynamic types so trace processing can continue.
+                        if (typedefRow == 0)
                         {
+                            dependsOnKnownNonLoadableType = true;
+                            return null;
+                        }
+                        int typeDefRowCount = ecmaModule.MetadataReader.GetTableRowCount(TableIndex.TypeDef);
+                        if (typedefRow > typeDefRowCount)
+                        {
+                            Program.PrintWarning($"TypeDef rid 0x{typedefRow:X} in module '{ecmaModule}' is out of range (max {typeDefRowCount}). " +
+                                "The trace and reference assembly may be mismatched.");
                             dependsOnKnownNonLoadableType = true;
                             return null;
                         }


### PR DESCRIPTION
BulkType ETW events emit `TypeNameID = th.GetCl()` (eventtrace_bulktype.cpp). For "minimal" MethodTables created by `CreateMinimalMethodTable` (used for Reflection.Emit DynamicMethod hosts in dynamicmethod.cpp and the IL stub cache in ilstubcache.cpp), `SetCl` is never called, so `GetCl` returns `mdTypeDefNil` (0x02000000, rid 0).

dotnet-pgo previously treated this as a valid TypeDef token, and the lazy `EcmaType.Name` access would throw `BadImageFormatException: Read out of bounds` because rid 0 is before the typedef table.

Validate the typedef row before constructing the `TypeDefinitionHandle` and treat out-of-range rids (rid 0, or rid greater than the typedef table size) as unresolvable dynamic types so trace processing can continue.

This started failing on the SDK training pipeline after #126330 (Migrate CLR to COM stubs to be IL stubs) and #125352 (Move struct marshaling to transient IL) flowed through, which routed new categories of stubs through the minimal-MT path and added their BulkType events to the trace.