### PR TITLE
Set per-target compile PDB for cDAC descriptor object libraries

### DIFF
--- a/src/coreclr/clrdatadescriptors.cmake
+++ b/src/coreclr/clrdatadescriptors.cmake
@@ -88,4 +88,16 @@ function(generate_data_descriptors)
   # Set include directories for the data descriptor targets, now that they are created.
   target_include_directories(${LIBRARY} PUBLIC ${DATA_DESCRIPTOR_SHARED_INCLUDE_DIR})
   target_include_directories(${LIBRARY} PRIVATE ${GENERATED_CDAC_DESCRIPTOR_DIR})
+
+  if(MSVC)
+    # Give this OBJECT library a deterministic, per-target compile PDB. Without this,
+    # MSVC writes debug info to the default `vc140.pdb`, which does not travel with
+    # the .obj files when they are archived into a static library (e.g.
+    # Runtime.ServerGC.lib). Downstream linkers - notably the NativeAOT publish
+    # of ILCompiler/crossgen2/ilasm - then emit LNK4099 ("PDB 'vc140.pdb' was not
+    # found"), which is fatal under /WX.
+    set_target_properties(${LIBRARY} PROPERTIES
+        COMPILE_PDB_NAME "${LIBRARY}"
+        COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
 endfunction(generate_data_descriptors)

--- a/src/coreclr/clrdatadescriptors.cmake
+++ b/src/coreclr/clrdatadescriptors.cmake
@@ -98,6 +98,6 @@ function(generate_data_descriptors)
     # found"), which is fatal under /WX.
     set_target_properties(${LIBRARY} PROPERTIES
         COMPILE_PDB_NAME "${LIBRARY}"
-        COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+        COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>")
   endif()
 endfunction(generate_data_descriptors)

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -599,7 +599,7 @@ size_t emitter::emitOutputULEB128(uint8_t* destination, uint64_t value)
 size_t emitter::emitOutputULEB128Padded(uint8_t* destination, uint64_t value)
 {
     uint8_t* buffer = destination + writeableOffset;
-    int      i      = 0;
+    unsigned i      = 0;
 
     for (; i < PADDED_RELOC_SIZE - 1; i++)
     {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

## Problem

The OBJECT libraries created by `generate_data_descriptors()` in `src/coreclr/clrdatadescriptors.cmake` compile `contract-descriptor.c` and `contractpointerdata.cpp` with MSVC defaults, which routes debug info into the compiler-default `vc140.pdb`. That PDB does not travel with the `.obj` files when they are archived into a static library such as `Runtime.ServerGC.lib`.

Downstream linkers — in particular the NativeAOT publish of `ILCompiler`, `crossgen2`, and `ilasm` on Windows — then emit `LNK4099` ("PDB 'vc140.pdb' was not found") for each affected object, which is fatal under `/WX`.

## Symptom

The `dotnet/runtime` → `dotnet/dotnet` codeflow PR [dotnet/dotnet#6423](https://github.com/dotnet/dotnet/pull/6423) is blocked: the **VMR Vertical Build Windows_x64** and **VMR Vertical Build Windows_x86** legs both fail with 22 `LNK4099` errors apiece, e.g.:

```
Runtime.ServerGC.lib(contract-descriptor.c.obj) : error LNK4099:
  PDB 'vc140.pdb' was not found with 'Runtime.ServerGC.lib(contract-descriptor.c.obj)'
  or at '...\artifacts\bin\ILCompiler_publish\x64\Release\native\vc140.pdb';
  linking object as if no debug info
   [src\coreclr\tools\aot\ILCompiler\ILCompiler_publish.csproj]
Runtime.ServerGC.lib(contractpointerdata.cpp.obj) : error LNK4099: ...
```

repeated for `crossgen2_publish.csproj` and `ilasm.csproj`. Linux/macOS/WASM/iOS/Android verticals all pass — `LNK4099` is MSVC-specific.

The regression was introduced by #126972 ("[NativeAOT] Add cDAC data descriptor infrastructure"), which wired the new descriptor `OBJECT` libraries into the NativeAOT runtime so they end up archived inside `Runtime.ServerGC.lib`.

## Fix

Set `COMPILE_PDB_NAME` and `COMPILE_PDB_OUTPUT_DIRECTORY` on `${LIBRARY}` so each descriptor library produces its own deterministic PDB that the consuming linker can locate. This matches the convention already used by `install_static_library` in `eng/native/functions.cmake`.

## Validation

- CMake reconfigures cleanly.
- Ninja built `nativeaot_gc_svr_descriptor`, `nativeaot_gc_wks_descriptor`, `nativeaot_cdac_contract_descriptor`, and `cdac_contract_descriptor` without errors on linux-x64.
- The actual `LNK4099` resolution can only be verified on a Windows NativeAOT publish leg in CI; please pay particular attention to the Windows legs and to the next forward-flow into `dotnet/dotnet`.

cc @max-charlamb (author of #126972)
