### PR TITLE
Add interpreter SOS leg to runtime-diagnostics pipeline

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -41,6 +41,7 @@ parameters:
   noFallback: false
   classFilter: ''
   methodFilter: ''
+  testInterpreter: false
 
 jobs:
 - template: /eng/common/${{ parameters.templatePath }}/job/job.yml
@@ -94,6 +95,7 @@ jobs:
       - _NoFallbackArgs: ''
       - _ClassFilterArgs: ''
       - _MethodFilterArgs: ''
+      - _TestInterpreterArgs: ''
 
       - _buildScript: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
 
@@ -117,6 +119,9 @@ jobs:
 
       - ${{ if ne(parameters.methodFilter, '') }}:
         - _MethodFilterArgs: '-methodfilter ${{ parameters.methodFilter }}'
+
+      - ${{ if eq(parameters.testInterpreter, 'true') }}:
+        - _TestInterpreterArgs: '-testInterpreter'
 
       # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
       - _InternalInstallArgs: ''
@@ -212,6 +217,7 @@ jobs:
           -privatebuild
           $(_CdacArgs)
           $(_NoFallbackArgs)
+          $(_TestInterpreterArgs)
           -liveRuntimeDir ${{ parameters.liveRuntimeDir }}
           $(_TestArgs)
           $(_Cross)

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -86,6 +86,34 @@ extends:
                 tarCompression: $(tarCompression)
                 artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr
                 displayName: Build Assets
+      # Build leg producing a Checked CoreCLR (libs/SDK stay Release). Consumed by the
+      # Interpreter test job below; FEATURE_INTERPRETER is only compiled into Debug/Checked
+      # CoreCLR drops, so the existing Release leg cannot exercise interpreter frames.
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - windows_x64
+          jobParameters:
+            buildArgs: -s clr+libs+tools.cdac+host+packs -c Debug -rc Checked -lc $(_BuildConfig)
+            nameSuffix: AllSubsets_CoreCLR_Checked
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            timeoutInMinutes: 360
+            postBuildSteps:
+            - powershell: |
+                $versionDir = Get-ChildItem -Directory -Path "$(Build.SourcesDirectory)\artifacts\bin\testhost\net*\shared\Microsoft.NETCore.App" | Select-Object -ExpandProperty FullName
+                Write-Host "##vso[task.setvariable variable=versionDir]$versionDir"
+              displayName: 'Set Path to Shared Framework Artifacts'
+            - template: /eng/pipelines/common/upload-artifact-step.yml
+              parameters:
+                rootFolder: $(versionDir)
+                includeRootFolder: false
+                archiveType: $(archiveType)
+                archiveExtension: $(archiveExtension)
+                tarCompression: $(tarCompression)
+                artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr_Checked
+                displayName: Build Assets (Checked)
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
           jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -245,6 +273,64 @@ extends:
               inputs:
                 targetPath: '$(Build.SourcesDirectory)/artifacts/TestResults'
                 artifactName: 'TestResults_DAC_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
+              displayName: 'Publish Test Results and SOS Logs'
+              continueOnError: true
+              condition: failed()
+      # Interpreter SOS test leg. Runs against the Checked CoreCLR build (which has
+      # FEATURE_INTERPRETER compiled in) and is the only job that sets
+      # testInterpreter: true; the cDAC / cDAC_no_fallback / DAC jobs above stay on the
+      # Release build and are unaffected.
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/diagnostics/runtime-diag-job.yml
+          buildConfig: release
+          platforms:
+          - windows_x64
+          # Workaround: microsoft/azure-pipelines-tasks#21871
+          variables:
+            - name: AllowPtrToDetectTestRunRetryFiles
+              value: false
+          jobParameters:
+            name: Interpreter
+            useCdac: true
+            testInterpreter: true
+            methodFilter: SOSInterpreter*
+            isOfficialBuild: ${{ variables.isOfficialBuild }}
+            liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
+            timeoutInMinutes: 360
+            dependsOn:
+            - build_windows_x64_release_AllSubsets_CoreCLR_Checked
+            preBuildSteps:
+              - template: /eng/pipelines/common/download-artifact-step.yml
+                parameters:
+                  artifactName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr_Checked
+                  artifactFileName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_coreclr_Checked$(archiveExtension)
+                  unpackFolder: $(Build.SourcesDirectory)/artifacts/runtime
+                  displayName: 'Runtime Build Artifacts (Checked)'
+            postBuildSteps:
+            - task: PublishTestResults@2
+              inputs:
+                testResultsFormat: xUnit
+                testResultsFiles: '**/*.xml'
+                searchFolder: '$(Build.SourcesDirectory)/artifacts/TestResults'
+                testRunTitle: 'Tests $(_PhaseName)'
+                failTaskOnFailedTests: true
+                publishRunAttachments: true
+                mergeTestResults: true
+                buildConfiguration: $(_BuildConfig)
+              continueOnError: true
+              condition: always()
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Build.SourcesDirectory)/artifacts/tmp/$(_BuildConfig)/dumps'
+                artifactName: 'Dumps_Interpreter_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
+              displayName: 'Publish Crash Dumps'
+              continueOnError: true
+              condition: failed()
+            - task: PublishPipelineArtifact@1
+              inputs:
+                targetPath: '$(Build.SourcesDirectory)/artifacts/TestResults'
+                artifactName: 'TestResults_Interpreter_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)_Attempt$(System.JobAttempt)'
               displayName: 'Publish Test Results and SOS Logs'
               continueOnError: true
               condition: failed()


### PR DESCRIPTION
## Summary

Adds an opt-in **Interpreter** SOS test leg to `runtime-diagnostics.yml` that exercises the diagnostics-side `SOSInterpreterTests.InterpreterStackTest` against a **Checked** CoreCLR drop. `FEATURE_INTERPRETER` is only compiled into Debug/Checked CoreCLR, so the existing Release build leg cannot run this test.

Companion diagnostics PR: dotnet/diagnostics#5829.

## Changes

### `eng/pipelines/diagnostics/runtime-diag-job.yml`
- New `testInterpreter` parameter (default **false**).
- New `_TestInterpreterArgs` derived variable, set to `-testInterpreter` when the parameter is true.
- Forwarded to the diagnostics build script alongside the existing `-useCdac` / `-noFallback` flags.
- Default-false invocation is identical to today; existing test legs are unaffected.

### `eng/pipelines/runtime-diagnostics.yml`
- New build leg that produces a **Checked** CoreCLR (libs/SDK stay Release: `-c Debug -rc Checked -lc $(_BuildConfig)`). Distinct artifact name (`..._coreclr_Checked`) so it does not collide with the existing Release leg.
- New `Interpreter` test job modelled on the existing `cDAC` job:
  - Depends on the new Checked build leg.
  - Downloads the Checked artifact into `$(Build.SourcesDirectory)/artifacts/runtime`.
  - **Only this job** sets `testInterpreter: true`.
  - Keeps `useCdac: true`, `classFilter: SOS`.

The existing cDAC / cDAC_no_fallback / DAC test jobs and the existing Release build leg are unchanged.

## Activation flow

When the new leg runs, `runtime-diag-job.yml` invokes the diagnostics build script with `-testInterpreter`, which exports `SOS_TEST_INTERPRETER=true`. `SOSRunner` (in the diagnostics PR) sees `config.TestInterpreter == true` and sets `DOTNET_Interpreter=InterpTestMethod*` on the debuggee process. The debuggee csproj declares `<InterpreterTest>true</InterpreterTest>`; the rest of the wiring is in the diagnostics PR.

## Validation

Manually queued the `runtime-diagnostics` pipeline in dnceng-public/public against this branch with parameter `diagnosticsBranch=dev/max-charlamb/sos-interpreter-tests` so the pipeline checks out the companion diagnostics PR.

Expected:
- New `Interpreter_windows_x64_release` job runs and passes.
- Existing cDAC / cDAC_no_fallback / DAC jobs continue passing — they do not set `testInterpreter` and produce the same script invocation as today.
