### PR TITLE
Add Azure Linux 4 to libraries Helix extra-platforms (linux_x64)

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -61,6 +61,7 @@ jobs:
         # CoreCLR path
           - ${{ if and(eq(parameters.jobParameters.isExtraPlatformsBuild, true), ne(parameters.jobParameters.testScope, 'outerloop'))}}:
             # extra-platforms CoreCLR (inner loop only)
+            - (AzureLinux.4.0.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-4.0-helix-amd64@sha256:d86d3499ccba1cc92ad045fbd3e055fdde21ed5c757f25d1245fea978711b3a6
             - (Debian.13.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:debian-13-helix-amd64@sha256:4bf6a0a32b1e4dbe3e0cc0b453d0bea775d9898336cdb3c92c84862c05d822ea
             - (Fedora.44.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:fedora-44-helix-amd64@sha256:d61f2b7f64797109f37109b55183751847b62eb23734698c9b056cb25194577e
             - (openSUSE.16.0.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:opensuse-16.0-helix-amd64@sha256:010211f9ab9e8238ffb0656edee4c8a411e5a4a9fb4718037614c8c94350e45c


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

Adds Azure Linux 4 to the libraries Helix extra-platforms queue set for `linux_x64` (CoreCLR inner-loop) in `eng/pipelines/libraries/helix-queues-setup.yml`.

Replaces #127613, which got tangled up in merge history. This is a clean, single-commit version with the digest refreshed to the current `azurelinux-4.0-helix-amd64` image (`sha256:d86d3499…`).

## Change

| File | Distro | Slot | Action |
|------|--------|------|--------|
| `eng/pipelines/libraries/helix-queues-setup.yml` | AzureLinux 4.0 | extra-platforms `linux_x64` | Added |

Queue entry:

```
(AzureLinux.4.0.Amd64.Open)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-4.0-helix-amd64@sha256:d86d3499ccba1cc92ad045fbd3e055fdde21ed5c757f25d1245fea978711b3a6
```

Host queue is `AzureLinux.3.Amd64.Open`, matching the other container-backed entries in the same section (Debian 13, Fedora 44, openSUSE 16.0).

## Scope

`helix-platforms.yml` is intentionally **not** updated — those values are reserved for GA releases, and Azure Linux 4 has not yet GA'd. This change only adds opt-in coverage via the extra-platforms pipeline.

## CI

```
/azp run runtime-extra-platforms
```

## References

- #127613 (previous attempt)
- [OS onboarding guide](https://github.com/dotnet/runtime/blob/main/docs/project/os-onboarding.md)
- [.NET OS Support Tracking](https://github.com/dotnet/core/issues/9638)
