### PR TITLE
Fix iOS arm64 CoreCLR crash from shared MethodDesc::CalliCookie slot

### DIFF
--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11500,8 +11500,9 @@ LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* sz
 
     // When compiling a calli inside an IL stub for a P/Invoke, pass the target
     // P/Invoke MethodDesc so ComputeCallStub can detect the Swift calling convention.
-    // Do not cache the cookie on pContextMD: MethodDesc::CalliCookie is shared with
-    // other writers that key on different signatures.
+    // Do not cache the cookie on pContextMD: MethodDesc::CalliCookie is for
+    // calling the target via managed calling convention. The stub we are about
+    // to generate calls the target via unmanaged calling convention.
     MethodDesc* pContextMD = nullptr;
     if (m_pMethodBeingCompiled != nullptr && m_pMethodBeingCompiled->IsILStub())
     {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11501,8 +11501,7 @@ LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* sz
     // When compiling a calli inside an IL stub for a P/Invoke, pass the target
     // P/Invoke MethodDesc so ComputeCallStub can detect the Swift calling convention.
     // Do not cache the cookie on pContextMD: MethodDesc::CalliCookie is shared with
-    // other writers that key on different signatures, which caused null PCODE
-    // dispatch on iOS arm64 (dotnet/runtime#127869).
+    // other writers that key on different signatures.
     MethodDesc* pContextMD = nullptr;
     if (m_pMethodBeingCompiled != nullptr && m_pMethodBeingCompiled->IsILStub())
     {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11500,6 +11500,9 @@ LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* sz
 
     // When compiling a calli inside an IL stub for a P/Invoke, pass the target
     // P/Invoke MethodDesc so ComputeCallStub can detect the Swift calling convention.
+    // Do not cache the cookie on pContextMD: MethodDesc::CalliCookie is shared with
+    // other writers that key on different signatures, which caused null PCODE
+    // dispatch on iOS arm64 (dotnet/runtime#127869).
     MethodDesc* pContextMD = nullptr;
     if (m_pMethodBeingCompiled != nullptr && m_pMethodBeingCompiled->IsILStub())
     {
@@ -11507,32 +11510,22 @@ LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* sz
         if (pTargetMD != nullptr)
         {
             pContextMD = pTargetMD;
-            result = pTargetMD->GetCalliCookie();
         }
     }
 
-    if (result == NULL)
-    {
-        Instantiation classInst = Instantiation((TypeHandle*) szMetaSig->sigInst.classInst, szMetaSig->sigInst.classInstCount);
-        Instantiation methodInst = Instantiation((TypeHandle*) szMetaSig->sigInst.methInst, szMetaSig->sigInst.methInstCount);
-        SigTypeContext typeContext = SigTypeContext(classInst, methodInst);
-        Module* mod = GetModule(szMetaSig->scope);
+    Instantiation classInst = Instantiation((TypeHandle*) szMetaSig->sigInst.classInst, szMetaSig->sigInst.classInstCount);
+    Instantiation methodInst = Instantiation((TypeHandle*) szMetaSig->sigInst.methInst, szMetaSig->sigInst.methInstCount);
+    SigTypeContext typeContext = SigTypeContext(classInst, methodInst);
+    Module* mod = GetModule(szMetaSig->scope);
 
-        MetaSig sig(szMetaSig->pSig, szMetaSig->cbSig, mod, &typeContext);
+    MetaSig sig(szMetaSig->pSig, szMetaSig->cbSig, mod, &typeContext);
 
-        if (szMetaSig->isAsyncCall())
-            sig.SetIsAsyncCall();
+    if (szMetaSig->isAsyncCall())
+        sig.SetIsAsyncCall();
 
-        _ASSERTE(szMetaSig->isAsyncCall() == sig.IsAsyncCall());
+    _ASSERTE(szMetaSig->isAsyncCall() == sig.IsAsyncCall());
 
-        result = GetCookieForCalliSig(sig, pContextMD);
-
-        if (pContextMD != nullptr)
-        {
-            pContextMD->SetCalliCookie(result);
-            result = pContextMD->GetCalliCookie();
-        }
-    }
+    result = GetCookieForCalliSig(sig, pContextMD);
 
     EE_TO_JIT_TRANSITION();
     return (void*)result;


### PR DESCRIPTION
## Problem

 PR #127016 added a small "calli cookie" cache. Each managed method has one slot where this cookie is stored. The problem is that two different parts of the runtime now write to that one slot:
 - The interpreter-to-native call path stores a helper that's set up for the method's own signature
 - The new code in #127016 stores a helper that's set up for the signature of a `calli` instruction inside an IL stub.
 
 On iOS, when an app tries to execute address 0 the kernel does not give us a normal crash. It assumes the page is unsigned/tampered and kills the process with `SIGKILL` and a `CODESIGNING / Invalid Page` reason.

## Proposed fix

Drop the new `pContextMD->{Set,Get}CalliCookie` cache reads/writes in `CInterpreterJitInfo::GetCookieForInterpreterCalliSig`. The function now always computes the cookie via `GetCookieForCalliSig(sig, pContextMD)`, matching pre-#127016 behavior.

Fixes #127869 #127863 #127867