### PR TITLE
[cDAC] Switch runtime-diagnostics SOS test filter to -method for wildcard support

### DIFF
--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -40,6 +40,7 @@ parameters:
   useCdac: false
   noFallback: false
   classFilter: ''
+  methodFilter: ''
 
 jobs:
 - template: /eng/common/${{ parameters.templatePath }}/job/job.yml
@@ -92,6 +93,7 @@ jobs:
       - _CdacArgs: ''
       - _NoFallbackArgs: ''
       - _ClassFilterArgs: ''
+      - _MethodFilterArgs: ''
 
       - _buildScript: $(Build.SourcesDirectory)$(dir)build$(scriptExt)
 
@@ -112,6 +114,9 @@ jobs:
 
       - ${{ if ne(parameters.classFilter, '') }}:
         - _ClassFilterArgs: '-classfilter ${{ parameters.classFilter }}'
+
+      - ${{ if ne(parameters.methodFilter, '') }}:
+        - _MethodFilterArgs: '-methodfilter ${{ parameters.methodFilter }}'
 
       # For testing msrc's and service releases. The RuntimeSourceVersion is either "default" or the service release version to test
       - _InternalInstallArgs: ''
@@ -212,6 +217,7 @@ jobs:
           $(_Cross)
           $(_InternalInstallArgs)
           $(_ClassFilterArgs)
+          $(_MethodFilterArgs)
           /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
       ${{ if eq(parameters.testOnly, 'true') }}:
         displayName: Test

--- a/eng/pipelines/runtime-diagnostics.yml
+++ b/eng/pipelines/runtime-diagnostics.yml
@@ -101,7 +101,7 @@ extends:
           jobParameters:
             name: cDAC
             useCdac: true
-            classFilter: SOS
+            methodFilter: SOS*
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
@@ -155,7 +155,7 @@ extends:
             name: cDAC_no_fallback
             useCdac: true
             noFallback: true
-            classFilter: SOS
+            methodFilter: SOS*
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360
@@ -208,7 +208,7 @@ extends:
           jobParameters:
             name: DAC
             useCdac: false
-            classFilter: SOS
+            methodFilter: SOS*
             isOfficialBuild: ${{ variables.isOfficialBuild }}
             liveRuntimeDir: $(Build.SourcesDirectory)/artifacts/runtime
             timeoutInMinutes: 360


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of GitHub Copilot (AI-generated content).

## Problem

[dotnet/diagnostics PR #5821](https://github.com/dotnet/diagnostics/pull/5821) split the single ``SOS`` test class into 11 ``SOS``-prefixed classes (``SOSStackTraceTests``, ``SOSExceptionTests``, ``SOSGCTests``, ``SOSDumpTests``, etc.) to enable parallelism. The existing ``classFilter: SOS`` in ``runtime-diagnostics.yml`` no longer matches any class, so the cDAC, cDAC_no_fallback, and DAC test legs are now silently running **zero** tests.

A naïve fix to ``classFilter: SOS*`` does not work either: xunit v2's ``-class`` filter is a ``HashSet<string>`` with exact-match ``Contains()`` only; it has no wildcard support. I verified this by directly invoking ``XunitFilters.Filter()`` against ``xunit.runner.utility`` 2.9.2:

| Filter | Matches ``SOSStackTraceTests.TestMethod1`` |
|--------|--------------------------------------------|
| ``-class SOS*`` | ❌ No (literal HashSet contains) |
| **``-method SOS*``** | ✅ **Yes** |
| Multiple ``-class`` entries | ✅ Yes (would require enumerating all 11) |

## Fix

xunit v2's ``-method`` filter is regex-based and operates on the fully qualified ``ClassName.MethodName``, so ``SOS*`` matches every method on any SOS-prefixed class.

This PR:

1. Adds a ``methodFilter`` parameter to ``eng/pipelines/diagnostics/runtime-diag-job.yml`` (parallel to the existing ``classFilter``), wiring it through to the diagnostics ``build.ps1``'s already-supported ``-methodfilter`` argument.
2. Switches the three SOS test legs in ``eng/pipelines/runtime-diagnostics.yml`` (cDAC, cDAC_no_fallback, DAC) to ``methodFilter: SOS*``.

The existing ``classFilter`` parameter is left in place for any other consumer that needs exact-match class filtering.