### PR TITLE
Enable sccache for linux-x64 coreclr PR builds

### DIFF
--- a/eng/pipelines/coreclr/templates/sccache-stats.yml
+++ b/eng/pipelines/coreclr/templates/sccache-stats.yml
@@ -12,7 +12,7 @@ parameters:
   osSubgroup: ''
 
 steps:
-  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x64')) }}:
-    - script: sccache --show-stats
+  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, ''), eq(parameters.archType, 'x64')) }}:
+    - script: sccache --show-stats || true
       displayName: Sccache stats
       condition: always()

--- a/eng/pipelines/coreclr/templates/sccache-stats.yml
+++ b/eng/pipelines/coreclr/templates/sccache-stats.yml
@@ -1,0 +1,18 @@
+parameters:
+  archType: 'x64'
+  osGroup: 'linux'
+  buildConfig: ''
+  runtimeFlavor: ''
+  runtimeVariant: ''
+  helixQueues: ''
+  targetRid: ''
+  nameSuffix: ''
+  platform: ''
+  shouldContinueOnError: false
+  osSubgroup: ''
+
+steps:
+  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x64')) }}:
+    - script: sccache --show-stats
+      displayName: Sccache stats
+      condition: always()

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -11,13 +11,18 @@ parameters:
   shouldContinueOnError: false
   osSubgroup: ''
 
+  # sccache NuGet package version — keep in sync with runtime-prereqs.proj
+  sccacheVersion: '0.15.0'
+
 steps:
-  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x64')) }}:
-    # Set up the Azure Pipeline Cache for sccache's local cache directory
+  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, ''), eq(parameters.archType, 'x64')) }}:
+    # Set up the Azure Pipeline Cache for sccache's local cache directory.
+    # Use a rolling key so each build can update the cache; restoreKeys
+    # falls back to the most recent saved entry.
     - task: Cache@2
       displayName: Sccache cache
       inputs:
-        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}
+        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | $(Build.BuildNumber)
         path: $(Pipeline.Workspace)/.sccache
         restoreKeys: |
           sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}
@@ -25,9 +30,11 @@ steps:
     # Configure sccache environment and add binary to PATH.
     # The sccache package is restored by runtime-prereqs.proj during the build.
     - script: |
-        sccacheDir="$(Build.SourcesDirectory)/.packages/sccache/0.15.0/tools"
+        sccacheVersion="${{ parameters.sccacheVersion }}"
+        sccacheDir="$(Build.SourcesDirectory)/.packages/sccache/${sccacheVersion}/tools"
         mkdir -p "$sccacheDir"
         echo "##vso[task.prependpath]$sccacheDir"
         echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
+        echo "##vso[task.setvariable variable=SCCACHE_IDLE_TIMEOUT]0"
         echo "##vso[task.setvariable variable=USE_SCCACHE]true"
       displayName: Configure sccache

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -22,7 +22,7 @@ steps:
     - task: Cache@2
       displayName: Sccache cache
       inputs:
-        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | $(Build.BuildNumber)
+        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | "$(Build.BuildId)"
         path: $(Pipeline.Workspace)/.sccache
         restoreKeys: |
           sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -22,10 +22,10 @@ steps:
     - task: Cache@2
       displayName: Sccache cache
       inputs:
-        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | "$(Build.BuildId)"
+        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | ${{ parameters.buildConfig }} | "$(Build.BuildId)"
         path: $(Pipeline.Workspace)/.sccache
         restoreKeys: |
-          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}
+          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | ${{ parameters.buildConfig }}
 
     # Configure sccache environment and add binary to PATH.
     # The sccache package is restored by runtime-prereqs.proj during the build.

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -1,0 +1,33 @@
+parameters:
+  archType: 'x64'
+  osGroup: 'linux'
+  buildConfig: ''
+  runtimeFlavor: ''
+  runtimeVariant: ''
+  helixQueues: ''
+  targetRid: ''
+  nameSuffix: ''
+  platform: ''
+  shouldContinueOnError: false
+  osSubgroup: ''
+
+steps:
+  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.archType, 'x64')) }}:
+    # Set up the Azure Pipeline Cache for sccache's local cache directory
+    - task: Cache@2
+      displayName: Sccache cache
+      inputs:
+        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}
+        path: $(Pipeline.Workspace)/.sccache
+        restoreKeys: |
+          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }}
+
+    # Configure sccache environment and add binary to PATH.
+    # The sccache package is restored by runtime-prereqs.proj during the build.
+    - script: |
+        sccacheDir="$(Build.SourcesDirectory)/.packages/sccache/0.15.0/tools"
+        mkdir -p "$sccacheDir"
+        echo "##vso[task.prependpath]$sccacheDir"
+        echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
+        echo "##vso[task.setvariable variable=USE_SCCACHE]true"
+      displayName: Configure sccache

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -254,7 +254,10 @@ extends:
             nameSuffix: CoreCLR_Libraries
             buildArgs: -s clr+libs+libs.tests -rc Release -c $(_BuildConfig) /p:ArchiveTests=true
             timeoutInMinutes: 120
+            preBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/setup-sccache.yml
             postBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/sccache-stats.yml
               - template: /eng/pipelines/common/upload-artifact-step.yml
                 parameters:
                   rootFolder: $(Build.SourcesDirectory)/artifacts/bin
@@ -399,7 +402,10 @@ extends:
             nameSuffix: Libraries_CheckedCoreCLR
             buildArgs: -s clr+clr.wasmjit+libs -c $(_BuildConfig) -rc Checked
             timeoutInMinutes: 120
+            preBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/setup-sccache.yml
             postBuildSteps:
+              - template: /eng/pipelines/coreclr/templates/sccache-stats.yml
               - template: /eng/pipelines/coreclr/templates/build-native-test-assets-step.yml
               - template: /eng/pipelines/common/upload-artifact-step.yml
                 parameters:

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -174,6 +174,7 @@ if [[ "$__TargetArch" != "$__HostArch" ]]; then
 fi
 
 if [[ "$USE_SCCACHE" == "true" ]]; then
+    chmod +x "$(command -v sccache)" 2>/dev/null || true
     __CMakeArgs="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache $__CMakeArgs"
 fi
 

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -174,7 +174,13 @@ if [[ "$__TargetArch" != "$__HostArch" ]]; then
 fi
 
 if [[ "$USE_SCCACHE" == "true" ]]; then
-    chmod +x "$(command -v sccache)" 2>/dev/null || true
+    # NuGet strips execute permissions; restore them using the known package path.
+    # Try the CI-local packages dir first, then fall back to the global NuGet cache.
+    for sccacheBin in "$__RepoRootDir/.packages/sccache"/*/tools/sccache "$HOME/.nuget/packages/sccache"/*/tools/sccache; do
+        if [[ -f "$sccacheBin" ]]; then
+            chmod +x "$sccacheBin"
+        fi
+    done
     __CMakeArgs="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache $__CMakeArgs"
 fi
 

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -10,6 +10,10 @@
     <AssemblyName>.NET Runtime</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup Condition="$([MSBuild]::IsOsPlatform(Linux)) and '$(ContinuousIntegrationBuild)' == 'true'">
+    <PackageDownload Include="sccache" Version="[0.15.0]" />
+  </ItemGroup>
+
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

Wire up sccache as a compiler cache for linux-x64 coreclr native builds in PR pipelines using the Azure Pipeline Cache task. This can likely be expanded to more runs/platforms in the future, but this is a good place to start.

## Changes

- **`src/coreclr/runtime-prereqs.proj`**: Add `PackageDownload` for `sccache` 0.15.0 (Linux CI only), piggybacking on the existing restore
- **`eng/pipelines/coreclr/templates/setup-sccache.yml`**: Pre-build template that configures the Pipeline Cache for sccache storage, sets `USE_SCCACHE`/`SCCACHE_DIR` env vars, and prepends sccache to `PATH`
- **`eng/pipelines/coreclr/templates/sccache-stats.yml`**: Post-build template that prints `sccache --show-stats`
- **`eng/pipelines/runtime.yml`**: Wires both templates into the `CoreCLR_Libraries` and `Libraries_CheckedCoreCLR` jobs
- **`src/coreclr/build-runtime.sh`**: `chmod +x` the sccache binary before use (NuGet strips execute permissions)

## How it works

1. **Pre-build**: Pipeline Cache restores the sccache storage dir → env vars configured (`PATH`, `SCCACHE_DIR`, `USE_SCCACHE`)
2. **Build**: `build.sh` restores `runtime-prereqs.proj` (downloads sccache binary) → native build uses sccache as cmake compiler launcher
3. **Post-build**: Stats printed for observability; Pipeline Cache saves storage dir for next run

Templates use compile-time `${{ if }}` conditions so they are no-ops for non-linux-x64 platforms in multi-platform matrix jobs.