### PR TITLE
perf: reuse counter snapshot buffer in CounterGroup.OnTimer

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -147,6 +147,7 @@ namespace System.Diagnostics.Tracing
         private TimeSpan _timeSinceCollectionStarted;
         private TimeSpan _pollingInterval;
         private TimeSpan _nextPollingOffset;
+        private DiagnosticCounter[] _onTimerCounters = [];
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
@@ -232,21 +233,28 @@ namespace System.Diagnostics.Tracing
                 TimeSpan nowOffset;
                 TimeSpan elapsed;
                 TimeSpan pollingInterval;
-                DiagnosticCounter[] counters;
+                int counterCount;
                 lock (s_counterGroupLock)
                 {
                     nowOffset = Stopwatch.GetElapsedTime(_baseTimestamp);
                     elapsed = nowOffset - _timeSinceCollectionStarted;
                     pollingInterval = _pollingInterval;
-                    counters = new DiagnosticCounter[_counters.Count];
-                    _counters.CopyTo(counters);
+
+                    counterCount = _counters.Count;
+                    if (_onTimerCounters.Length < counterCount)
+                    {
+                        _onTimerCounters = new DiagnosticCounter[counterCount];
+                    }
+
+                    _counters.CopyTo(_onTimerCounters);
+                    Array.Clear(_onTimerCounters, counterCount, _onTimerCounters.Length - counterCount);
                 }
 
                 // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
                 // callback can be re-entrant to CounterGroup (i.e. it's possible it calls back into EnableTimer()
                 // above, since WritePayload callback can contain user code that can invoke EventSource constructor
                 // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
-                foreach (DiagnosticCounter counter in counters)
+                foreach (DiagnosticCounter counter in _onTimerCounters.AsSpan(0, counterCount))
                 {
                     // NOTE: It is still possible for a race condition to occur here. An example is if the session
                     // that subscribed to these batch of counters was disabled and it was immediately enabled in

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -247,7 +247,6 @@ namespace System.Diagnostics.Tracing
                     }
 
                     _counters.CopyTo(_onTimerCounters);
-                    Array.Clear(_onTimerCounters, counterCount, _onTimerCounters.Length - counterCount);
                 }
 
                 // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
@@ -267,6 +266,8 @@ namespace System.Diagnostics.Tracing
                     // be an actual issue.
                     counter.WritePayload((float)elapsed.TotalSeconds, (int)pollingInterval.TotalMilliseconds);
                 }
+
+                Array.Clear(_onTimerCounters);
 
                 lock (s_counterGroupLock)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -3,8 +3,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 
@@ -149,17 +147,7 @@ namespace System.Diagnostics.Tracing
         private TimeSpan _timeSinceCollectionStarted;
         private TimeSpan _pollingInterval;
         private TimeSpan _nextPollingOffset;
-
-        /// <summary>
-        /// Stack scratch sized for the largest counter set known to the BCL today (RuntimeEventSource).
-        /// This is used to avoid heap allocations in the hot path of polling for counter values.
-        /// Extra buffer is left, in case if more counters are added in the future
-        /// </summary>
-        [InlineArray(32)]
-        private struct CounterScratch
-        {
-            private DiagnosticCounter? _element0;
-        }
+        private DiagnosticCounter[] _onTimerCounters = [];
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
@@ -245,25 +233,27 @@ namespace System.Diagnostics.Tracing
                 TimeSpan nowOffset;
                 TimeSpan elapsed;
                 TimeSpan pollingInterval;
-
-                CounterScratch scratch = default;
-                using var builder = new ValueListBuilder<DiagnosticCounter>(scratch);
-
+                int counterCount;
                 lock (s_counterGroupLock)
                 {
                     nowOffset = Stopwatch.GetElapsedTime(_baseTimestamp);
                     elapsed = nowOffset - _timeSinceCollectionStarted;
                     pollingInterval = _pollingInterval;
 
-                    Span<DiagnosticCounter> dst = builder.AppendSpan(_counters.Count);
-                    CollectionsMarshal.AsSpan(_counters).CopyTo(dst);
+                    counterCount = _counters.Count;
+                    if (_onTimerCounters.Length < counterCount)
+                    {
+                        _onTimerCounters = new DiagnosticCounter[counterCount];
+                    }
+
+                    _counters.CopyTo(_onTimerCounters);
                 }
 
                 // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
                 // callback can be re-entrant to CounterGroup (i.e. it's possible it calls back into EnableTimer()
                 // above, since WritePayload callback can contain user code that can invoke EventSource constructor
                 // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
-                foreach (DiagnosticCounter counter in builder.AsSpan())
+                foreach (DiagnosticCounter counter in _onTimerCounters.AsSpan(0, counterCount))
                 {
                     // NOTE: It is still possible for a race condition to occur here. An example is if the session
                     // that subscribed to these batch of counters was disabled and it was immediately enabled in
@@ -276,6 +266,8 @@ namespace System.Diagnostics.Tracing
                     // be an actual issue.
                     counter.WritePayload((float)elapsed.TotalSeconds, (int)pollingInterval.TotalMilliseconds);
                 }
+
+                Array.Clear(_onTimerCounters);
 
                 lock (s_counterGroupLock)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -151,7 +151,7 @@ namespace System.Diagnostics.Tracing
         private TimeSpan _nextPollingOffset;
 
         /// <summary>
-        /// Stack scratch sized for the largest counter set known to the BCL today <see cref="RuntimeEventSource"/>
+        /// Stack scratch sized for the largest counter set known to the BCL today (RuntimeEventSource).
         /// This is used to avoid heap allocations in the hot path of polling for counter values.
         /// Extra buffer is left, in case if more counters are added in the future
         /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -242,6 +242,8 @@ namespace System.Diagnostics.Tracing
                     elapsed = nowOffset - _timeSinceCollectionStarted;
                     pollingInterval = _pollingInterval;
 
+                    // Safe to reuse _onTimerCounters: OnTimer is the only reader/writer,
+                    // and runs only on the single s_pollingThread (see PollForValues).
                     counterCount = _counters.Count;
                     if (_onTimerCounters.Length < counterCount)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Threading;
 
@@ -147,7 +149,17 @@ namespace System.Diagnostics.Tracing
         private TimeSpan _timeSinceCollectionStarted;
         private TimeSpan _pollingInterval;
         private TimeSpan _nextPollingOffset;
-        private DiagnosticCounter[] _onTimerCounters = [];
+
+        /// <summary>
+        /// Stack scratch sized for the largest counter set known to the BCL today <see cref="RuntimeEventSource"/>
+        /// This is used to avoid heap allocations in the hot path of polling for counter values.
+        /// Extra buffer is left, in case if more counters are added in the future
+        /// </summary>
+        [InlineArray(32)]
+        private struct CounterScratch
+        {
+            private DiagnosticCounter? _element0;
+        }
 
         private void EnableTimer(float pollingIntervalInSeconds)
         {
@@ -233,27 +245,25 @@ namespace System.Diagnostics.Tracing
                 TimeSpan nowOffset;
                 TimeSpan elapsed;
                 TimeSpan pollingInterval;
-                int counterCount;
+
+                CounterScratch scratch = default;
+                using var builder = new ValueListBuilder<DiagnosticCounter>(scratch);
+
                 lock (s_counterGroupLock)
                 {
                     nowOffset = Stopwatch.GetElapsedTime(_baseTimestamp);
                     elapsed = nowOffset - _timeSinceCollectionStarted;
                     pollingInterval = _pollingInterval;
 
-                    counterCount = _counters.Count;
-                    if (_onTimerCounters.Length < counterCount)
-                    {
-                        _onTimerCounters = new DiagnosticCounter[counterCount];
-                    }
-
-                    _counters.CopyTo(_onTimerCounters);
+                    Span<DiagnosticCounter> dst = builder.AppendSpan(_counters.Count);
+                    CollectionsMarshal.AsSpan(_counters).CopyTo(dst);
                 }
 
                 // MUST keep out of the scope of s_counterGroupLock because this will cause WritePayload
                 // callback can be re-entrant to CounterGroup (i.e. it's possible it calls back into EnableTimer()
                 // above, since WritePayload callback can contain user code that can invoke EventSource constructor
                 // and lead to a deadlock. (See https://github.com/dotnet/runtime/issues/40190 for details)
-                foreach (DiagnosticCounter counter in _onTimerCounters.AsSpan(0, counterCount))
+                foreach (DiagnosticCounter counter in builder.AsSpan())
                 {
                     // NOTE: It is still possible for a race condition to occur here. An example is if the session
                     // that subscribed to these batch of counters was disabled and it was immediately enabled in
@@ -266,8 +276,6 @@ namespace System.Diagnostics.Tracing
                     // be an actual issue.
                     counter.WritePayload((float)elapsed.TotalSeconds, (int)pollingInterval.TotalMilliseconds);
                 }
-
-                Array.Clear(_onTimerCounters);
 
                 lock (s_counterGroupLock)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/CounterGroup.cs
@@ -147,6 +147,8 @@ namespace System.Diagnostics.Tracing
         private TimeSpan _timeSinceCollectionStarted;
         private TimeSpan _pollingInterval;
         private TimeSpan _nextPollingOffset;
+
+        // Accessed only from OnTimer, which runs only on the single s_pollingThread.
         private DiagnosticCounter[] _onTimerCounters = [];
 
         private void EnableTimer(float pollingIntervalInSeconds)


### PR DESCRIPTION
`CounterGroup.OnTimer` allocates a fresh `DiagnosticCounter[]` snapshot every poll to copy the counter list. In practice the counter set is fixed at `EventSource` construction and rarely changes. Reuse a per-instance buffer instead, grow on demand, and clear trailing slots for disposed counters.