### PR TITLE
Reuse a per-thread last-thrown-object handle

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -900,9 +900,9 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
     // which has the same dereference semantics as a real GC handle.
     {
         OBJECTHANDLE ohException = thread->GetThrowableAsPseudoHandle();
-        if (ohException == (OBJECTHANDLE)NULL)
+        if (ohException == (OBJECTHANDLE)NULL && !thread->IsLastThrownObjectNull())
         {
-            ohException = thread->m_LastThrownObjectHandle;
+            ohException = thread->LastThrownObjectHandle();
         }
         threadData->lastThrownObjectHandle = TO_CDADDR(ohException);
     }

--- a/src/coreclr/debug/daccess/task.cpp
+++ b/src/coreclr/debug/daccess/task.cpp
@@ -521,7 +521,7 @@ ClrDataTask::GetLastExceptionState(
 
     EX_TRY
     {
-        if (m_thread->m_LastThrownObjectHandle)
+        if (!m_thread->IsLastThrownObjectNull())
         {
             *exception = new (nothrow)
                 ClrDataExceptionState(m_dac,
@@ -529,7 +529,7 @@ ClrDataTask::GetLastExceptionState(
                                       m_thread,
                                       CLRDATA_EXCEPTION_PARTIAL,
                                       NULL,
-                                      m_thread->m_LastThrownObjectHandle,
+                                      m_thread->LastThrownObjectHandle(),
                                       NULL);
             status = *exception ? S_OK : E_OUTOFMEMORY;
         }

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -7449,7 +7449,7 @@ HRESULT Debugger::SendException(Thread *pThread,
             (fFirstChance && (!pExState->GetFlags()->SentDebugFirstChance() || !pExState->GetFlags()->SentDebugUserFirstChance())));
 
     // There must be a managed exception object to send a managed exception event
-    if (g_pEEInterface->IsThreadExceptionNull(pThread) && (pThread->LastThrownObjectHandle() == NULL))
+    if (pThread->IsThrowableNull() && pThread->IsLastThrownObjectNull())
     {
         managedEventNeeded = FALSE;
     }
@@ -7736,7 +7736,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
 {
     CONTRACTL
     {
-        if ((GetThreadNULLOk() == NULL) || g_pEEInterface->IsThreadExceptionNull(GetThread()))
+        if ((GetThreadNULLOk() == NULL) || GetThread()->IsThrowableNull())
         {
             NOTHROW;
             GC_NOTRIGGER;
@@ -7766,7 +7766,7 @@ LONG Debugger::NotifyOfCHFFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID p
     // useful information for the debugger and, in fact, it may be a completely
     // internally handled runtime exception, so we should do nothing.
     //
-    if ((GetThreadNULLOk() == NULL) || g_pEEInterface->IsThreadExceptionNull(GetThread()))
+    if ((GetThreadNULLOk() == NULL) || GetThread()->IsThrowableNull())
     {
         return EXCEPTION_CONTINUE_SEARCH;
     }
@@ -12336,7 +12336,7 @@ bool Debugger::IsThreadAtSafePlace(Thread *thread)
     // NOTE: don't check for thread->IsExceptionInProgress(), SO has special handling
     // that directly sets the last thrown object without ever creating a tracker.
     // (Tracker is what thread->IsExceptionInProgress() checks for)
-    if (g_pEEInterface->GetThreadException(thread) == CLRException::GetPreallocatedStackOverflowExceptionHandle())
+    if (thread->IsLastThrownObjectStackOverflowException())
     {
         return false;
     }

--- a/src/coreclr/vm/eedbginterface.h
+++ b/src/coreclr/vm/eedbginterface.h
@@ -100,8 +100,6 @@ public:
 
     virtual OBJECTHANDLE GetThreadException(Thread *pThread) = 0;
 
-    virtual bool IsThreadExceptionNull(Thread *pThread) = 0;
-
     virtual void ClearThreadException(Thread *pThread) = 0;
 
     virtual bool StartSuspendForDebug(AppDomain *pAppDomain,

--- a/src/coreclr/vm/eedbginterfaceimpl.cpp
+++ b/src/coreclr/vm/eedbginterfaceimpl.cpp
@@ -248,20 +248,12 @@ OBJECTHANDLE EEDbgInterfaceImpl::GetThreadException(Thread *pThread)
 
     // Return the last thrown object if there's no current throwable.
     // This logic is similar to UpdateCurrentThrowable().
-    return pThread->m_LastThrownObjectHandle;
-}
-
-bool EEDbgInterfaceImpl::IsThreadExceptionNull(Thread *pThread)
-{
-    CONTRACTL
+    if (!pThread->IsLastThrownObjectNull())
     {
-        NOTHROW;
-        GC_NOTRIGGER;
-        PRECONDITION(CheckPointer(pThread));
+        return pThread->LastThrownObjectHandle();
     }
-    CONTRACTL_END;
 
-    return pThread->IsThrowableNull();
+    return NULL;
 }
 
 void EEDbgInterfaceImpl::ClearThreadException(Thread *pThread)

--- a/src/coreclr/vm/eedbginterfaceimpl.h
+++ b/src/coreclr/vm/eedbginterfaceimpl.h
@@ -88,8 +88,6 @@ public:
 
     OBJECTHANDLE GetThreadException(Thread *pThread);
 
-    bool IsThreadExceptionNull(Thread *pThread);
-
     void ClearThreadException(Thread *pThread);
 
     bool StartSuspendForDebug(AppDomain *pAppDomain,

--- a/src/coreclr/vm/excep.cpp
+++ b/src/coreclr/vm/excep.cpp
@@ -2020,11 +2020,7 @@ VOID DECLSPEC_NORETURN RaiseTheExceptionInternalOnly(OBJECTREF throwable)
 
     // Always save the current object in the handle so on rethrow we can reuse it. This is important as it
     // contains stack trace info.
-    //
-    // Note: we use SafeSetLastThrownObject, which will try to set the throwable and if there are any problems,
-    // it will set the throwable to something appropriate (like OOM exception) and return the new
-    // exception. Thus, the user's exception object can be replaced here.
-    throwable = pThread->SafeSetLastThrownObject(throwable);
+    pThread->SetLastThrownObject(throwable);
 
     ULONG_PTR hr = GetHRFromThrowable(throwable);
 
@@ -4007,7 +4003,7 @@ LONG InternalUnhandledExceptionFilter_Worker(
             OBJECTREF oThrowable = pParam->pThread->GetThrowable();
             if ((oThrowable != NULL) && (pParam->pThread->LastThrownObject() != oThrowable))
             {
-                pParam->pThread->SafeSetLastThrownObject(oThrowable);
+                pParam->pThread->SetLastThrownObject(oThrowable);
                 LOG((LF_EH, LL_INFO100, "InternalUnhandledExceptionFilter_Worker: Resetting the LastThrownObject as it appears to have changed.\n"));
             }
 
@@ -8194,10 +8190,10 @@ void SetupInitialThrowBucketDetails(UINT_PTR adjustedIp)
         if (fAreBucketingDetailsPresent)
         {
 #ifdef _DEBUG
-            // Under OOM scenarios, its possible that when we are raising a threadabort,
-            // the throwable may get converted to preallocated OOM object when RaiseTheExceptionInternalOnly
-            // invokes Thread::SafeSetLastThrownObject. We check if this is the current case and use it in
-            // our validation below.
+            // It's possible that the throwable is the preallocated OOM object even when the
+            // bucket tracker captured the buckets for a thread abort (e.g., OOM was thrown
+            // directly while a thread abort was in flight). Account for that case in our
+            // validation below.
             BOOL fIsPreallocatedOOMExceptionForTA = FALSE;
             if ((!fIsThreadAbortException) && pUEWatsonBucketTracker->CapturedForThreadAbort())
             {

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3186,7 +3186,7 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
 
     if (!pThread->GetExceptionState()->IsExceptionInProgress())
     {
-        pThread->SafeSetLastThrownObject(NULL);
+        pThread->SetLastThrownObject(NULL);
     }
 
     // Sync managed exception state, for the managed thread, based upon any active exception tracker

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10543,9 +10543,7 @@ void CEEInfo::HandleException(struct _EXCEPTION_POINTERS *pExceptionPointers)
             if (_gc.oCurrentThrowable != _gc.oLastThrownObject)
             {
                 // Update the LTO.
-                //
-                // Note: Incase of OOM, this will get set to OOM instance.
-                pCurThread->SafeSetLastThrownObject(_gc.oCurrentThrowable);
+                pCurThread->SetLastThrownObject(_gc.oCurrentThrowable);
             }
 
             GCPROTECT_END();

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1933,9 +1933,8 @@ extern "C" PCODE STDCALL PreStubWorker(TransitionBlock* pTransitionBlock, Method
         }
         EX_CATCH
         {
-            OBJECTHANDLE ohThrowable = CURRENT_THREAD->LastThrownObjectHandle();
-            _ASSERTE(ohThrowable);
-            StackTraceInfo::AppendElement(ObjectFromHandle(ohThrowable), 0, (UINT_PTR)pTransitionBlock, pMD, NULL);
+            _ASSERTE(!CURRENT_THREAD->IsLastThrownObjectNull());
+            StackTraceInfo::AppendElement(CURRENT_THREAD->LastThrownObject(), 0, (UINT_PTR)pTransitionBlock, pMD, NULL);
             EX_RETHROW;
         }
         EX_END_CATCH
@@ -2136,11 +2135,10 @@ void ExecuteInterpretedMethodWithArgs_PortableEntryPoint_Complex(PCODE portableE
         }
         EX_CATCH
         {
-            OBJECTHANDLE ohThrowable = CURRENT_THREAD->LastThrownObjectHandle();
-            _ASSERTE(ohThrowable);
+            _ASSERTE(!CURRENT_THREAD->IsLastThrownObjectNull());
             if (finishedPrestubPortion)
             {
-                StackTraceInfo::AppendElement(ObjectFromHandle(ohThrowable), 0, (UINT_PTR)block, pMethod, NULL);
+                StackTraceInfo::AppendElement(CURRENT_THREAD->LastThrownObject(), 0, (UINT_PTR)block, pMethod, NULL);
             }
             EX_RETHROW;
         }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1242,7 +1242,9 @@ Thread::Thread()
     m_StrongHndToExposedObject = CreateGlobalStrongHandle(NULL);
     GlobalStrongHandleHolder strongHndToExposedObjectHolder(m_StrongHndToExposedObject);
 
-    m_LastThrownObjectHandle = NULL;
+    m_LastThrownObjectHandle = CreateGlobalStrongHandle(NULL);
+    GlobalStrongHandleHolder lastThrownObjectHandleHolder(m_LastThrownObjectHandle);
+
     m_ltoIsUnhandled = FALSE;
 
     m_debuggerFilterContext = NULL;
@@ -1364,6 +1366,7 @@ Thread::Thread()
     exposedObjectHolder.SuppressRelease();
     strongHndToExposedObjectHolder.SuppressRelease();
     contextHolder.SuppressRelease();
+    lastThrownObjectHandleHolder.SuppressRelease();
 
 #ifdef FEATURE_COMINTEROP
     m_uliInitializeSpyCookie.QuadPart = 0ul;
@@ -2270,11 +2273,13 @@ Thread::~Thread()
 
     if (!IsAtProcessExit())
     {
-        // Destroy any handles that we're using to hold onto exception objects
-        SafeSetThrowables(NULL);
-
         DestroyShortWeakHandle(m_ExposedObject);
         DestroyStrongHandle(m_StrongHndToExposedObject);
+
+        if (m_LastThrownObjectHandle != g_pPreallocatedStackOverflowException)
+        {
+            DestroyStrongHandle(m_LastThrownObjectHandle);
+        }
     }
 
     g_pThinLockThreadIdDispenser->DisposeId(GetThreadId());
@@ -3111,7 +3116,7 @@ void Thread::SetLastThrownObject(OBJECTREF throwable, BOOL isUnhandled)
 {
     CONTRACTL
     {
-        if ((throwable == NULL) || CLRException::IsPreallocatedExceptionObject(throwable)) NOTHROW; else THROWS; // From CreateHandle
+        NOTHROW;
         GC_NOTRIGGER;
         if (throwable == NULL) MODE_ANY; else MODE_COOPERATIVE;
     }
@@ -3125,44 +3130,22 @@ void Thread::SetLastThrownObject(OBJECTREF throwable, BOOL isUnhandled)
     // you can't have a NULL unhandled exception
     _ASSERTE(!(throwable == NULL && isUnhandled));
 
-    if (m_LastThrownObjectHandle != NULL)
-    {
-        // We'll sometimes use a handle for a preallocated exception object. We should never, ever destroy one of
-        // these handles... they'll be destroyed when the Runtime shuts down.
-        if (!CLRException::IsPreallocatedExceptionHandle(m_LastThrownObjectHandle))
-        {
-            DestroyHandle(m_LastThrownObjectHandle);
-        }
-
-        m_LastThrownObjectHandle = NULL; // Make sure to set this to NULL here just in case we throw trying to make
-                                         // a new handle below.
-    }
+    // Each Thread owns a per-thread strong handle for the LastThrownObject slot
+    // (allocated in the Thread ctor, destroyed in ~Thread). Setting LTO is just
+    // a payload write; no handle allocation or destruction is needed.
+    _ASSERTE(m_LastThrownObjectHandle != NULL);
+    _ASSERTE(throwable == NULL || this == GetThread());
+    _ASSERTE(throwable == NULL || IsException(throwable->GetMethodTable()));
 
     if (throwable != NULL)
     {
-        _ASSERTE(this == GetThread());
-
-        // Non-compliant exceptions are always wrapped.
-        // The use of the ExceptionNative:: helper here (rather than the global ::IsException helper)
-        // is hokey, but we need a GC_NOTRIGGER version and it's only for an ASSERT.
-        _ASSERTE(IsException(throwable->GetMethodTable()));
-
-        // If we're tracking one of the preallocated exception objects, then just use the global handle that
-        // matches it rather than creating a new one.
-        if (CLRException::IsPreallocatedExceptionObject(throwable))
-        {
-            m_LastThrownObjectHandle = CLRException::GetPreallocatedHandleForObject(throwable);
-        }
-        else
-        {
-            m_LastThrownObjectHandle = AppDomain::GetCurrentDomain()->CreateHandle(throwable);
-        }
-
-        _ASSERTE(m_LastThrownObjectHandle != NULL);
+        StoreObjectInHandle(m_LastThrownObjectHandle, throwable);
         m_ltoIsUnhandled = isUnhandled;
+
     }
     else
     {
+        ResetOBJECTHANDLE(m_LastThrownObjectHandle);
         m_ltoIsUnhandled = FALSE;
     }
 }
@@ -3183,41 +3166,6 @@ void Thread::SetSOForLastThrownObject()
     // The current domain is going to be unloaded or the process is going to be killed, so
     // we will not leak a handle.
     m_LastThrownObjectHandle = CLRException::GetPreallocatedStackOverflowExceptionHandle();
-}
-
-//
-// This is a nice wrapper for SetLastThrownObject which catches any exceptions caused by not being able to create
-// the handle for the throwable, and setting the last thrown object to the preallocated out of memory exception
-// instead.
-//
-OBJECTREF Thread::SafeSetLastThrownObject(OBJECTREF throwable)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        if (throwable == NULL) MODE_ANY; else MODE_COOPERATIVE;
-    }
-    CONTRACTL_END;
-
-    // We return the original throwable if nothing goes wrong.
-    OBJECTREF ret = throwable;
-
-    EX_TRY
-    {
-        // Try to set the throwable.
-        SetLastThrownObject(throwable);
-    }
-    EX_CATCH
-    {
-        // If it didn't work, then set the last thrown object to the preallocated OOM exception, and return that
-        // object instead of the original throwable.
-        ret = CLRException::GetPreallocatedOutOfMemoryException();
-        SetLastThrownObject(ret);
-    }
-    EX_END_CATCH
-
-    return ret;
 }
 
 //
@@ -3283,34 +3231,15 @@ void Thread::SyncManagedExceptionState(bool fIsDebuggerThread)
         GCX_COOP();
 
         // Syncup the LastThrownObject on the managed thread
-        SafeUpdateLastThrownObject();
+        UpdateLastThrownObject();
     }
-}
-
-void Thread::SetLastThrownObjectHandle(OBJECTHANDLE h)
-{
-    CONTRACTL
-    {
-        NOTHROW;
-        GC_NOTRIGGER;
-        MODE_COOPERATIVE;
-    }
-    CONTRACTL_END;
-
-    if (m_LastThrownObjectHandle != NULL &&
-        !CLRException::IsPreallocatedExceptionHandle(m_LastThrownObjectHandle))
-    {
-        DestroyHandle(m_LastThrownObjectHandle);
-    }
-
-    m_LastThrownObjectHandle = h;
 }
 
 //
 // Create a duplicate handle of the current throwable and set the last thrown object to that. This ensures that the
 // last thrown object and the current throwable have handles that are in the same app domain.
 //
-void Thread::SafeUpdateLastThrownObject(void)
+void Thread::UpdateLastThrownObject(void)
 {
     CONTRACTL
     {
@@ -3324,16 +3253,7 @@ void Thread::SafeUpdateLastThrownObject(void)
 
     if (throwable != NULL)
     {
-        EX_TRY
-        {
-            SetLastThrownObject(throwable);
-        }
-        EX_CATCH
-        {
-            // If we can't create a handle, set the last thrown object to the preallocated OOM exception.
-            SafeSetThrowables(CLRException::GetPreallocatedOutOfMemoryException());
-        }
-        EX_END_CATCH
+        SetLastThrownObject(throwable);
     }
 }
 
@@ -6690,9 +6610,8 @@ extern "C" InterpThreadContext* STDCALL GetInterpThreadContextWithPossiblyMissin
         }
         EX_CATCH
         {
-            OBJECTHANDLE ohThrowable = CURRENT_THREAD->LastThrownObjectHandle();
-            _ASSERTE(ohThrowable);
-            StackTraceInfo::AppendElement(ObjectFromHandle(ohThrowable), 0, (UINT_PTR)pTransitionBlock, pByteCodeStart->Method->methodHnd, NULL);
+            _ASSERTE(!CURRENT_THREAD->IsLastThrownObjectNull());
+            StackTraceInfo::AppendElement(CURRENT_THREAD->LastThrownObject(), 0, (UINT_PTR)pTransitionBlock, pByteCodeStart->Method->methodHnd, NULL);
             EX_RETHROW;
         }
         EX_END_CATCH

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2619,7 +2619,7 @@ private:
     // Differs from m_pThrowable in that it doesn't stack on nested exceptions.
     OBJECTHANDLE m_LastThrownObjectHandle;      // Unsafe to use directly.  Use accessors instead.
 
-    // Indicates that the throwable in m_lastThrownObjectHandle should be treated as
+    // Indicates that the throwable in m_LastThrownObjectHandle should be treated as
     // unhandled. This occurs during fatal error and a few other early error conditions
     // before EH is fully set up.
     BOOL m_ltoIsUnhandled;
@@ -2628,22 +2628,18 @@ private:
 
 public:
 
-    BOOL IsLastThrownObjectNull() { WRAPPER_NO_CONTRACT; return (m_LastThrownObjectHandle == (OBJECTHANDLE)0); }
+    BOOL IsLastThrownObjectNull()
+    {
+        WRAPPER_NO_CONTRACT;
+        _ASSERTE(m_LastThrownObjectHandle != NULL);
+        return ObjectHandleIsNull(m_LastThrownObjectHandle);
+    }
 
     OBJECTREF LastThrownObject()
     {
         WRAPPER_NO_CONTRACT;
-
-        if (m_LastThrownObjectHandle == (OBJECTHANDLE)0)
-        {
-            return NULL;
-        }
-        else
-        {
-            // We only have a handle if we have an object to keep in it.
-            _ASSERTE(ObjectFromHandle(m_LastThrownObjectHandle) != NULL);
-            return ObjectFromHandle(m_LastThrownObjectHandle);
-        }
+        _ASSERTE(m_LastThrownObjectHandle != NULL);
+        return ObjectFromHandle(m_LastThrownObjectHandle);
     }
 
     OBJECTHANDLE LastThrownObjectHandle()
@@ -2655,7 +2651,6 @@ public:
 
     void SetLastThrownObject(OBJECTREF throwable, BOOL isUnhandled = FALSE);
     void SetSOForLastThrownObject();
-    OBJECTREF SafeSetLastThrownObject(OBJECTREF throwable);
 
     // Inidcates that the last thrown object is now treated as unhandled
     void MarkLastThrownObjectUnhandled()
@@ -2671,7 +2666,7 @@ public:
         return m_ltoIsUnhandled;
     }
 
-    void SafeUpdateLastThrownObject(void);
+    void UpdateLastThrownObject(void);
     OBJECTREF SafeSetThrowables(OBJECTREF pThrowable,
                                 BOOL isUnhandled = FALSE);
 
@@ -2693,8 +2688,6 @@ public:
     void ClearThreadCurrNotification();
 
 private:
-    void SetLastThrownObjectHandle(OBJECTHANDLE h);
-
     ThreadExceptionState  m_ExceptionState;
 
 private:


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI-generated with GitHub Copilot CLI.

## Summary

Each `Thread` previously allocated and destroyed an `OBJECTHANDLE` for its last-thrown-object on every `Thread::SetLastThrownObject` transition. This is hot during exception throw/unwind (and especially nested throws). This PR allocates one strong handle per thread once at construction and updates the referent in-place via `StoreObjectInHandle` for the lifetime of the thread.

This is the same pattern NativeAOT uses for its per-thread last-thrown-object slot.

## Behavior change

- `Thread::SetLastThrownObject` collapses to a single `StoreObjectInHandle` call and becomes `NOTHROW`.
- `Thread::SafeSetLastThrownObject` and `Thread::SetLastThrownObjectHandle` are removed (no longer needed with a permanent handle).
- `Thread::SafeUpdateLastThrownObject` is renamed to `Thread::UpdateLastThrownObject` and simplified — the per-thread handle cannot fail to allocate, so the OOM fallback is dead code.
- `Thread::SetSOForLastThrownObject` clobbers `m_LastThrownObjectHandle` to point at the global preallocated SO handle (`g_pPreallocatedStackOverflowException`), preserving the cheap pointer-compare in `IsLastThrownObjectStackOverflowException`. Stack overflow is process-fatal, so the leaked per-thread handle is inconsequential; `~Thread` guards against destroying the global singleton.
- `IsLastThrownObjectNull` uses `ObjectHandleIsNull` instead of comparing the handle pointer to NULL — the handle is now always allocated, so the old `m_LastThrownObjectHandle == NULL` test would always be false. `ObjectHandleIsNull` is MODE_ANY-safe (no `VALIDATEOBJECTREF`).

## Audit / migration

Every site that compared the LTO `OBJECTHANDLE` directly was migrated:

- `Debugger::IsAtSafePlace` uses `Thread::IsLastThrownObjectStackOverflowException()` (handle pointer compare against the global SO handle) instead of calling through `EEDbgInterface`.
- The `EX_CATCH` paths in `DoPrestub`, `DoInterpreterMethodPrestub`, and `GetInterpThreadContextWithPossiblyMissingThreadOrCallStub` no longer read `LastThrownObjectHandle()` for a now-trivial non-NULL assert; they assert via `IsLastThrownObjectNull()` and consume the throwable through `LastThrownObject()`.
- DAC paths in `ClrDataTask::GetLastExceptionThrown` and `ClrDataAccess::GetThreadData` are guarded by `IsLastThrownObjectNull()` before reading the handle, since the handle is now always non-NULL but may have a NULL payload.
- `EEDbgInterfaceImpl::GetThreadException` LTO fallback is guarded by `IsLastThrownObjectNull()` to preserve the NULL-handle-means-no-exception contract for debugger IPC callers.
- `EEDbgInterface::IsThreadExceptionNull` is removed; callers use `Thread::IsThrowableNull()` directly.

## Validation

- Windows x64 Checked build clean.
- `Exceptions/Exceptions` (incl. ForeignThreadExceptions): exit 100.
- `baseservices/exceptions`: exit 100 (only the two intentional process-death testers fail by design).
- `tools.cdactests`: pass.
- `JIT/Methodical/eh`: 164/164 real tests pass.

CI will exercise broader matrices.