### PR TITLE
Replace `GetOsPageSize()` with `minipal_getpagesize()` in CoreCLR

### DIFF
--- a/src/coreclr/debug/createdump/createdumpunix.cpp
+++ b/src/coreclr/debug/createdump/createdumpunix.cpp
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "createdump.h"
+#include <minipal/ospagesize.h>
 
 #if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64) || defined(__riscv)
 long g_pageSize = 0;
@@ -20,7 +21,7 @@ CreateDump(const CreateDumpOptions& options)
 
     // Initialize PAGE_SIZE
 #if defined(__arm__) || defined(__aarch64__) || defined(__loongarch64) || defined(__riscv)
-    g_pageSize = sysconf(_SC_PAGESIZE);
+    g_pageSize = minipal_getpagesize();
 #endif
     TRACE("PAGE_SIZE %d\n", PAGE_SIZE);
 

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -99,7 +99,7 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                     ulSize = assembly->GetLoadedLayout()->GetSize();
                 }
 
-                // memory are mapped in GetOsPageSize() size.
+                // memory are mapped in minipal_getpagesize() size.
                 // Some memory are mapped in but some are not. You cannot
                 // write all in one block. So iterating through page size
                 //
@@ -112,7 +112,7 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                     // MethodHeader MethodDesc::GetILHeader. Without this RVA,
                     // all locals are broken. In case, you are asked about this question again.
                     //
-                    ulSizeBlock = ulSize > GetOsPageSize() ? GetOsPageSize() : ulSize;
+                    ulSizeBlock = ulSize > (uint32_t)minipal_getpagesize() ? (uint32_t)minipal_getpagesize() : ulSize;
                     ReportMem(pStartAddr, ulSizeBlock, false);
                     pStartAddr += ulSizeBlock;
                     ulSize -= ulSizeBlock;

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -112,7 +112,7 @@ HRESULT ClrDataAccess::EnumMemCollectImages()
                     // MethodHeader MethodDesc::GetILHeader. Without this RVA,
                     // all locals are broken. In case, you are asked about this question again.
                     //
-                    ulSizeBlock = ulSize > (uint32_t)minipal_getpagesize() ? (uint32_t)minipal_getpagesize() : ulSize;
+                    ulSizeBlock = ulSize > minipal_getpagesize() ? minipal_getpagesize() : ulSize;
                     ReportMem(pStartAddr, ulSizeBlock, false);
                     pStartAddr += ulSizeBlock;
                     ulSize -= ulSizeBlock;

--- a/src/coreclr/debug/di/shimlocaldatatarget.cpp
+++ b/src/coreclr/debug/di/shimlocaldatatarget.cpp
@@ -321,7 +321,7 @@ ShimLocalDataTarget::ReadVirtual(
     {
         // Calculate bytes to read and don't let read cross
         // a page boundary.
-        readSize = GetOsPageSize() - (ULONG32)(address & (GetOsPageSize() - 1));
+        readSize = (uint32_t)minipal_getpagesize() - (ULONG32)(address & ((uint32_t)minipal_getpagesize() - 1));
         readSize = min(cbRequestSize, readSize);
 
         if (!ReadProcessMemory(m_hProcess, (PVOID)(ULONG_PTR)address,

--- a/src/coreclr/debug/di/shimlocaldatatarget.cpp
+++ b/src/coreclr/debug/di/shimlocaldatatarget.cpp
@@ -321,7 +321,7 @@ ShimLocalDataTarget::ReadVirtual(
     {
         // Calculate bytes to read and don't let read cross
         // a page boundary.
-        readSize = (uint32_t)minipal_getpagesize() - (ULONG32)(address & ((uint32_t)minipal_getpagesize() - 1));
+        readSize = minipal_getpagesize() - (ULONG32)(address & (minipal_getpagesize() - 1));
         readSize = min(cbRequestSize, readSize);
 
         if (!ReadProcessMemory(m_hProcess, (PVOID)(ULONG_PTR)address,

--- a/src/coreclr/debug/di/shimremotedatatarget.cpp
+++ b/src/coreclr/debug/di/shimremotedatatarget.cpp
@@ -14,6 +14,8 @@
 #include "dbgtransportsession.h"
 #include "dbgtransportmanager.h"
 
+#include <minipal/ospagesize.h>
+
 #ifdef __APPLE__
 #include <mach/mach.h>
 #else
@@ -299,7 +301,7 @@ ShimRemoteDataTarget::ReadVirtual(
 #ifdef __APPLE__
         // vm_read_overwrite usually requires the address be page-aligned and the size be a multiple
         // of the page size, so we always page-align ourselves and copy out the relevant slice.
-        const size_t pageSize = (size_t)sysconf(_SC_PAGESIZE);
+        const size_t pageSize = minipal_getpagesize();
         vm_address_t addressAligned = (vm_address_t)(address & ~(ULONG64)(pageSize - 1));
         ssize_t offset = (ssize_t)(address & (pageSize - 1));
         ssize_t bytesLeft = (ssize_t)cbRequestSize;

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -1084,7 +1084,7 @@ uint64_t GetAvailablePhysicalMemory()
     sz = sizeof(free_count);
     sysctlbyname("vm.stats.vm.v_free_count", &free_count, &sz, NULL, 0);
 
-    available = (inactive_count + laundry_count + free_count) * sysconf(_SC_PAGESIZE);
+    available = (inactive_count + laundry_count + free_count) * minipal_getpagesize();
 #elif defined(__HAIKU__)
     system_info info;
     if (get_system_info(&info) == B_OK)
@@ -1140,7 +1140,7 @@ uint64_t GetAvailablePageFile()
     rc = sysctlnametomib("vm.swap_info", mib, &length);
     if (rc == 0)
     {
-        int pagesize = getpagesize();
+        uint32_t pagesize = minipal_getpagesize();
         // Aggregate the information for all swap files on the system
         for (mib[2] = 0; ; mib[2]++)
         {
@@ -1161,7 +1161,7 @@ uint64_t GetAvailablePageFile()
     struct anoninfo ai;
     if (swapctl(SC_AINFO, &ai) != -1)
     {
-        int pagesize = getpagesize();
+        uint32_t pagesize = minipal_getpagesize();
         available = ai.ani_free * pagesize;
     }
 #elif HAVE_SYSINFO

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -160,7 +160,7 @@ struct LoaderHeapEvent;
 inline UINT32 GetStubCodePageSize()
 {
 #if (defined(TARGET_ARM64) && defined(TARGET_UNIX)) || defined(TARGET_WASM)
-    return max(16*1024u, GetOsPageSize());
+    return max(16*1024u, (uint32_t)minipal_getpagesize());
 #elif defined(TARGET_ARM)
     return 4096; // ARM is special as the 32bit instruction set does not easily permit a 16KB offset
 #else

--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -160,7 +160,7 @@ struct LoaderHeapEvent;
 inline UINT32 GetStubCodePageSize()
 {
 #if (defined(TARGET_ARM64) && defined(TARGET_UNIX)) || defined(TARGET_WASM)
-    return max(16*1024u, (uint32_t)minipal_getpagesize());
+    return max(16*1024u, minipal_getpagesize());
 #elif defined(TARGET_ARM)
     return 4096; // ARM is special as the 32bit instruction set does not easily permit a 16KB offset
 #else

--- a/src/coreclr/inc/pedecoder.inl
+++ b/src/coreclr/inc/pedecoder.inl
@@ -109,7 +109,7 @@ inline PEDecoder::PEDecoder(PTR_VOID mappedBase, bool fixedUp /*= FALSE*/)
     CONTRACTL_END;
 
     // Temporarily set the size to 2 pages, so we can get the headers.
-    m_size = GetOsPageSize()*2;
+    m_size = (uint32_t)minipal_getpagesize()*2;
 
     m_pNTHeaders = PTR_IMAGE_NT_HEADERS(FindNTHeaders());
     if (!m_pNTHeaders)
@@ -182,7 +182,7 @@ inline HRESULT PEDecoder::Init(void *mappedBase, bool fixedUp /*= FALSE*/)
         m_flags |= FLAG_RELOCATED;
 
     // Temporarily set the size to 2 pages, so we can get the headers.
-    m_size = GetOsPageSize()*2;
+    m_size = (uint32_t)minipal_getpagesize()*2;
 
     m_pNTHeaders = FindNTHeaders();
     if (!m_pNTHeaders)

--- a/src/coreclr/inc/pedecoder.inl
+++ b/src/coreclr/inc/pedecoder.inl
@@ -109,7 +109,7 @@ inline PEDecoder::PEDecoder(PTR_VOID mappedBase, bool fixedUp /*= FALSE*/)
     CONTRACTL_END;
 
     // Temporarily set the size to 2 pages, so we can get the headers.
-    m_size = (uint32_t)minipal_getpagesize()*2;
+    m_size = minipal_getpagesize()*2;
 
     m_pNTHeaders = PTR_IMAGE_NT_HEADERS(FindNTHeaders());
     if (!m_pNTHeaders)
@@ -182,7 +182,7 @@ inline HRESULT PEDecoder::Init(void *mappedBase, bool fixedUp /*= FALSE*/)
         m_flags |= FLAG_RELOCATED;
 
     // Temporarily set the size to 2 pages, so we can get the headers.
-    m_size = (uint32_t)minipal_getpagesize()*2;
+    m_size = minipal_getpagesize()*2;
 
     m_pNTHeaders = FindNTHeaders();
     if (!m_pNTHeaders)

--- a/src/coreclr/inc/utilcode.h
+++ b/src/coreclr/inc/utilcode.h
@@ -38,6 +38,7 @@ using std::nothrow;
 #include <stddef.h>
 #include <minipal/guid.h>
 #include <minipal/log.h>
+#include <minipal/ospagesize.h>
 #include <dn-u16.h>
 
 #include "clrnt.h"
@@ -576,8 +577,6 @@ int GetTotalProcessorCount();
 // Returns the number of processors that a process has been configured to run on
 //******************************************************************************
 int GetCurrentProcessCpuCount();
-
-uint32_t GetOsPageSize();
 
 
 //*****************************************************************************

--- a/src/coreclr/pal/src/exception/machexception.cpp
+++ b/src/coreclr/pal/src/exception/machexception.cpp
@@ -32,6 +32,7 @@ SET_DEFAULT_DEBUG_CHANNEL(EXCEPT); // some headers have code with asserts, so do
 
 #include <minipal/debugger.h>
 #include <minipal/utils.h>
+#include <minipal/ospagesize.h>
 
 #include "machmessage.h"
 
@@ -751,7 +752,7 @@ HijackFaultingThread(
     if (exceptionRecord.ExceptionCode == EXCEPTION_ACCESS_VIOLATION)
     {
         // Calculate the page base addresses for the fault and the faulting thread's SP.
-        int cbPage = getpagesize();
+        int cbPage = minipal_getpagesize();
         char *pFaultPage = (char*)(exceptionRecord.ExceptionInformation[1] & ~(cbPage - 1));
         char *pStackTopPage = (char*)((size_t)targetSP & ~(cbPage - 1));
 

--- a/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test2/test2.cpp
@@ -15,6 +15,7 @@
 **=========================================================*/
 
 #include <palsuite.h>
+#include <minipal/ospagesize.h>
 
 PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscellaneous/IsBadWritePtr/test2/paltest_isbadwriteptr_test2")
 {
@@ -31,7 +32,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     */
     
     PageOne = VirtualAlloc(NULL, 
-			   GetOsPageSize()*4,
+			   (uint32_t)minipal_getpagesize()*4,
 			   MEM_RESERVE, 
 			   PAGE_NOACCESS);
 
@@ -43,7 +44,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     /* Set the first Page to PAGE_NOACCESS */
     
     PageOne = VirtualAlloc(PageOne,
-			   GetOsPageSize(),
+			   (uint32_t)minipal_getpagesize(),
 			   MEM_COMMIT,
 			   PAGE_NOACCESS);
 
@@ -57,8 +58,8 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Set the second Page to PAGE_READWRITE */
 
-    PageTwo = VirtualAlloc(((BYTE*)PageOne)+GetOsPageSize(),
-			   GetOsPageSize(),
+    PageTwo = VirtualAlloc(((BYTE*)PageOne)+(uint32_t)minipal_getpagesize(),
+			   (uint32_t)minipal_getpagesize(),
 			   MEM_COMMIT,
 			   PAGE_READWRITE);
     if(PageTwo == NULL)
@@ -71,8 +72,8 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     
     /* Set the third Page to PAGE_NOACCESS */
 
-    PageThree = VirtualAlloc(((BYTE*)PageTwo) + (2 * GetOsPageSize()),
-			     GetOsPageSize(),
+    PageThree = VirtualAlloc(((BYTE*)PageTwo) + (2 * (uint32_t)minipal_getpagesize()),
+			     (uint32_t)minipal_getpagesize(),
 			     MEM_COMMIT,
 			     PAGE_NOACCESS);
       
@@ -87,7 +88,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     
 /* Check that calling IsBadWritePtr on the first page returns non-zero */
     
-    if(IsBadWritePtr(PageThree,GetOsPageSize()) == 0)
+    if(IsBadWritePtr(PageThree,(uint32_t)minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 
@@ -98,7 +99,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Check that calling IsBadWritePtr on the middle page returns 0 */
 
-    if(IsBadWritePtr(PageTwo,GetOsPageSize()) != 0)
+    if(IsBadWritePtr(PageTwo,(uint32_t)minipal_getpagesize()) != 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 
@@ -108,7 +109,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Check that calling IsBadWritePtr on the third page returns non-zero */
     
-    if(IsBadWritePtr(PageThree,GetOsPageSize()) == 0)
+    if(IsBadWritePtr(PageThree,(uint32_t)minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 

--- a/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test2/test2.cpp
+++ b/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test2/test2.cpp
@@ -32,7 +32,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     */
     
     PageOne = VirtualAlloc(NULL, 
-			   (uint32_t)minipal_getpagesize()*4,
+			   minipal_getpagesize()*4,
 			   MEM_RESERVE, 
 			   PAGE_NOACCESS);
 
@@ -44,7 +44,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     /* Set the first Page to PAGE_NOACCESS */
     
     PageOne = VirtualAlloc(PageOne,
-			   (uint32_t)minipal_getpagesize(),
+			   minipal_getpagesize(),
 			   MEM_COMMIT,
 			   PAGE_NOACCESS);
 
@@ -58,8 +58,8 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Set the second Page to PAGE_READWRITE */
 
-    PageTwo = VirtualAlloc(((BYTE*)PageOne)+(uint32_t)minipal_getpagesize(),
-			   (uint32_t)minipal_getpagesize(),
+    PageTwo = VirtualAlloc(((BYTE*)PageOne)+minipal_getpagesize(),
+			   minipal_getpagesize(),
 			   MEM_COMMIT,
 			   PAGE_READWRITE);
     if(PageTwo == NULL)
@@ -72,8 +72,8 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     
     /* Set the third Page to PAGE_NOACCESS */
 
-    PageThree = VirtualAlloc(((BYTE*)PageTwo) + (2 * (uint32_t)minipal_getpagesize()),
-			     (uint32_t)minipal_getpagesize(),
+    PageThree = VirtualAlloc(((BYTE*)PageTwo) + (2 * minipal_getpagesize()),
+			     minipal_getpagesize(),
 			     MEM_COMMIT,
 			     PAGE_NOACCESS);
       
@@ -88,7 +88,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
     
 /* Check that calling IsBadWritePtr on the first page returns non-zero */
     
-    if(IsBadWritePtr(PageThree,(uint32_t)minipal_getpagesize()) == 0)
+    if(IsBadWritePtr(PageThree,minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 
@@ -99,7 +99,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Check that calling IsBadWritePtr on the middle page returns 0 */
 
-    if(IsBadWritePtr(PageTwo,(uint32_t)minipal_getpagesize()) != 0)
+    if(IsBadWritePtr(PageTwo,minipal_getpagesize()) != 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 
@@ -109,7 +109,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test2_paltest_isbadwriteptr_test2, "miscella
 
     /* Check that calling IsBadWritePtr on the third page returns non-zero */
     
-    if(IsBadWritePtr(PageThree,(uint32_t)minipal_getpagesize()) == 0)
+    if(IsBadWritePtr(PageThree,minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 

--- a/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test3/test3.cpp
@@ -12,6 +12,7 @@
 **=========================================================*/
 
 #include <palsuite.h>
+#include <minipal/ospagesize.h>
 
 PALTEST(miscellaneous_IsBadWritePtr_test3_paltest_isbadwriteptr_test3, "miscellaneous/IsBadWritePtr/test3/paltest_isbadwriteptr_test3")
 {
@@ -28,7 +29,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test3_paltest_isbadwriteptr_test3, "miscella
     */
     
     PageOne = VirtualAlloc(NULL, 
-			   GetOsPageSize(), 
+			   (uint32_t)minipal_getpagesize(), 
 			   MEM_COMMIT, 
 			   PAGE_READONLY);
 
@@ -37,7 +38,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test3_paltest_isbadwriteptr_test3, "miscella
 	Fail("ERROR: VirtualAlloc failed to commit the required memory.\n");
     }
 
-    if(IsBadWritePtr(PageOne,GetOsPageSize()) == 0)
+    if(IsBadWritePtr(PageOne,(uint32_t)minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 

--- a/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test3/test3.cpp
+++ b/src/coreclr/pal/tests/palsuite/miscellaneous/IsBadWritePtr/test3/test3.cpp
@@ -29,7 +29,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test3_paltest_isbadwriteptr_test3, "miscella
     */
     
     PageOne = VirtualAlloc(NULL, 
-			   (uint32_t)minipal_getpagesize(), 
+			   minipal_getpagesize(), 
 			   MEM_COMMIT, 
 			   PAGE_READONLY);
 
@@ -38,7 +38,7 @@ PALTEST(miscellaneous_IsBadWritePtr_test3_paltest_isbadwriteptr_test3, "miscella
 	Fail("ERROR: VirtualAlloc failed to commit the required memory.\n");
     }
 
-    if(IsBadWritePtr(PageOne,(uint32_t)minipal_getpagesize()) == 0)
+    if(IsBadWritePtr(PageOne,minipal_getpagesize()) == 0)
     {
 	VirtualFree(PageOne,0,MEM_RELEASE);
 

--- a/src/coreclr/utilcode/clrhost_nodependencies.cpp
+++ b/src/coreclr/utilcode/clrhost_nodependencies.cpp
@@ -173,8 +173,8 @@ BOOL DbgIsExecutable(LPVOID lpMem, SIZE_T length)
     // No NX support on PAL
     return TRUE;
 #else // !(TARGET_UNIX)
-    BYTE *regionStart = (BYTE*) ALIGN_DOWN((BYTE*)lpMem, GetOsPageSize());
-    BYTE *regionEnd = (BYTE*) ALIGN_UP((BYTE*)lpMem+length, GetOsPageSize());
+    BYTE *regionStart = (BYTE*) ALIGN_DOWN((BYTE*)lpMem, minipal_getpagesize());
+    BYTE *regionEnd = (BYTE*) ALIGN_UP((BYTE*)lpMem+length, minipal_getpagesize());
     _ASSERTE(length > 0);
     _ASSERTE(regionStart < regionEnd);
 

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -140,7 +140,7 @@ LiveProcDataTarget::ReadVirtual(
     {
         // Calculate bytes to read and don't let read cross
         // a page boundary.
-        readSize = GetOsPageSize() - (ULONG32)(address & (GetOsPageSize() - 1));
+        readSize = (uint32_t)minipal_getpagesize() - (ULONG32)(address & ((uint32_t)minipal_getpagesize() - 1));
         readSize = min(request, readSize);
 
         if (!ReadProcessMemory(m_process, (PVOID)(ULONG_PTR)address,

--- a/src/coreclr/utilcode/dacutil.cpp
+++ b/src/coreclr/utilcode/dacutil.cpp
@@ -140,7 +140,7 @@ LiveProcDataTarget::ReadVirtual(
     {
         // Calculate bytes to read and don't let read cross
         // a page boundary.
-        readSize = (uint32_t)minipal_getpagesize() - (ULONG32)(address & ((uint32_t)minipal_getpagesize() - 1));
+        readSize = minipal_getpagesize() - (ULONG32)(address & (minipal_getpagesize() - 1));
         readSize = min(request, readSize);
 
         if (!ReadProcessMemory(m_process, (PVOID)(ULONG_PTR)address,

--- a/src/coreclr/utilcode/executableallocator.cpp
+++ b/src/coreclr/utilcode/executableallocator.cpp
@@ -190,7 +190,7 @@ void ExecutableAllocator::InitLazyPreferredRange(size_t base, size_t size, int r
     }
 
     // Randomize the address space
-    pStart += GetOsPageSize() * randomPageOffset;
+    pStart += minipal_getpagesize() * randomPageOffset;
 
     g_lazyPreferredRangeStart = pStart;
     g_lazyPreferredRangeHint = pStart;

--- a/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
+++ b/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
@@ -64,7 +64,7 @@ ExplicitControlLoaderHeap::ExplicitControlLoaderHeap(bool fMakeExecutable) :
     m_pEndReservedRegion         = NULL;
     m_pAllocPtr                  = NULL;
 
-    m_dwCommitBlockSize          = GetOsPageSize();
+    m_dwCommitBlockSize          = (uint32_t)minipal_getpagesize();
 
 #ifdef _DEBUG
     m_dwDebugWastedBytes         = 0;
@@ -165,7 +165,7 @@ BOOL ExplicitControlLoaderHeap::ReservePages(size_t dwSizeToCommit)
     size_t dwSizeToReserve;
 
     // Round to page size again
-    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
+    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, minipal_getpagesize());
 
     ReservedMemoryHolder pData = NULL;
     BOOL fReleaseMemory = TRUE;
@@ -266,7 +266,7 @@ BOOL ExplicitControlLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
             dwSizeToCommit = min((SIZE_T)(m_pEndReservedRegion - m_pPtrToEndOfCommittedRegion), (SIZE_T)m_dwCommitBlockSize);
 
         // Round to page size
-        dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
+        dwSizeToCommit = ALIGN_UP(dwSizeToCommit, minipal_getpagesize());
 
         size_t dwSizeToCommitPart = dwSizeToCommit;
 

--- a/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
+++ b/src/coreclr/utilcode/explicitcontrolloaderheap.cpp
@@ -64,7 +64,7 @@ ExplicitControlLoaderHeap::ExplicitControlLoaderHeap(bool fMakeExecutable) :
     m_pEndReservedRegion         = NULL;
     m_pAllocPtr                  = NULL;
 
-    m_dwCommitBlockSize          = (uint32_t)minipal_getpagesize();
+    m_dwCommitBlockSize          = minipal_getpagesize();
 
 #ifdef _DEBUG
     m_dwDebugWastedBytes         = 0;

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -49,7 +49,7 @@ UnlockedInterleavedLoaderHeap::UnlockedInterleavedLoaderHeap(
     }
     CONTRACTL_END;
 
-    _ASSERTE((GetStubCodePageSize() % GetOsPageSize()) == 0); // Stub code page size MUST be in increments of the page size. (Really it must be a power of 2 as well, but this is good enough)
+    _ASSERTE((GetStubCodePageSize() % (uint32_t)minipal_getpagesize()) == 0); // Stub code page size MUST be in increments of the page size. (Really it must be a power of 2 as well, but this is good enough)
 }
 
 UnlockedInterleavedLoaderHeap::~UnlockedInterleavedLoaderHeap()
@@ -151,7 +151,7 @@ BOOL UnlockedInterleavedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
     size_t dwSizeToReserve;
 
     // Round to page size again
-    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
+    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, minipal_getpagesize());
 
     ReservedMemoryHolder pData = NULL;
 

--- a/src/coreclr/utilcode/interleavedloaderheap.cpp
+++ b/src/coreclr/utilcode/interleavedloaderheap.cpp
@@ -49,7 +49,7 @@ UnlockedInterleavedLoaderHeap::UnlockedInterleavedLoaderHeap(
     }
     CONTRACTL_END;
 
-    _ASSERTE((GetStubCodePageSize() % (uint32_t)minipal_getpagesize()) == 0); // Stub code page size MUST be in increments of the page size. (Really it must be a power of 2 as well, but this is good enough)
+    _ASSERTE((GetStubCodePageSize() % minipal_getpagesize()) == 0); // Stub code page size MUST be in increments of the page size. (Really it must be a power of 2 as well, but this is good enough)
 }
 
 UnlockedInterleavedLoaderHeap::~UnlockedInterleavedLoaderHeap()

--- a/src/coreclr/utilcode/loaderheap.cpp
+++ b/src/coreclr/utilcode/loaderheap.cpp
@@ -172,7 +172,7 @@ BOOL UnlockedLoaderHeap::UnlockedReservePages(size_t dwSizeToCommit)
     size_t dwSizeToReserve;
 
     // Round to page size again
-    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
+    dwSizeToCommit = ALIGN_UP(dwSizeToCommit, minipal_getpagesize());
 
     ReservedMemoryHolder pData = NULL;
     BOOL fReleaseMemory = TRUE;
@@ -307,7 +307,7 @@ BOOL UnlockedLoaderHeap::GetMoreCommittedPages(size_t dwMinSize)
             dwSizeToCommit = min((SIZE_T)(m_pEndReservedRegion - m_pPtrToEndOfCommittedRegion), (SIZE_T)m_dwCommitBlockSize);
 
         // Round to page size
-        dwSizeToCommit = ALIGN_UP(dwSizeToCommit, GetOsPageSize());
+        dwSizeToCommit = ALIGN_UP(dwSizeToCommit, minipal_getpagesize());
 
         size_t dwSizeToCommitPart = dwSizeToCommit;
 

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -1085,36 +1085,6 @@ DWORD_PTR GetCurrentProcessCpuMask()
 }
 #endif // HOST_WINDOWS
 
-uint32_t GetOsPageSizeUncached()
-{
-    SYSTEM_INFO sysInfo;
-    ::GetSystemInfo(&sysInfo);
-    return sysInfo.dwAllocationGranularity ? sysInfo.dwAllocationGranularity : 0x1000;
-}
-
-namespace
-{
-    Volatile<uint32_t> g_pageSize = 0;
-}
-
-uint32_t GetOsPageSize()
-{
-#ifdef HOST_UNIX
-    size_t result = g_pageSize.LoadWithoutBarrier();
-
-    if(!result)
-    {
-        result = GetOsPageSizeUncached();
-
-        g_pageSize.StoreWithoutBarrier(result);
-    }
-
-    return result;
-#else
-    return 0x1000;
-#endif
-}
-
 //=============================================================================
 // AssemblyNamesList
 //=============================================================================

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -202,17 +202,17 @@ FORCEINLINE  void PinnedHeapHandleBlockHolder__StaticFree(PinnedHeapHandleBlockH
 // set) and being able to specify specific versions.
 //
 
-#define LOW_FREQUENCY_HEAP_RESERVE_SIZE        (3 * GetOsPageSize())
-#define LOW_FREQUENCY_HEAP_COMMIT_SIZE         (1 * GetOsPageSize())
+#define LOW_FREQUENCY_HEAP_RESERVE_SIZE        (3 * (uint32_t)minipal_getpagesize())
+#define LOW_FREQUENCY_HEAP_COMMIT_SIZE         (1 * (uint32_t)minipal_getpagesize())
 
-#define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (8 * GetOsPageSize())
-#define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * GetOsPageSize())
+#define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (8 * (uint32_t)minipal_getpagesize())
+#define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * (uint32_t)minipal_getpagesize())
 
-#define STUB_HEAP_RESERVE_SIZE                 (3 * GetOsPageSize())
-#define STUB_HEAP_COMMIT_SIZE                  (1 * GetOsPageSize())
+#define STUB_HEAP_RESERVE_SIZE                 (3 * (uint32_t)minipal_getpagesize())
+#define STUB_HEAP_COMMIT_SIZE                  (1 * (uint32_t)minipal_getpagesize())
 
-#define STATIC_FIELD_HEAP_RESERVE_SIZE         (2 * GetOsPageSize())
-#define STATIC_FIELD_HEAP_COMMIT_SIZE          (1 * GetOsPageSize())
+#define STATIC_FIELD_HEAP_RESERVE_SIZE         (2 * (uint32_t)minipal_getpagesize())
+#define STATIC_FIELD_HEAP_COMMIT_SIZE          (1 * (uint32_t)minipal_getpagesize())
 
 // --------------------------------------------------------------------------------
 // PE File List lock - for creating list locks on PE files

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -202,17 +202,17 @@ FORCEINLINE  void PinnedHeapHandleBlockHolder__StaticFree(PinnedHeapHandleBlockH
 // set) and being able to specify specific versions.
 //
 
-#define LOW_FREQUENCY_HEAP_RESERVE_SIZE        (3 * (uint32_t)minipal_getpagesize())
-#define LOW_FREQUENCY_HEAP_COMMIT_SIZE         (1 * (uint32_t)minipal_getpagesize())
+#define LOW_FREQUENCY_HEAP_RESERVE_SIZE        (3 * minipal_getpagesize())
+#define LOW_FREQUENCY_HEAP_COMMIT_SIZE         (1 * minipal_getpagesize())
 
-#define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (8 * (uint32_t)minipal_getpagesize())
-#define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * (uint32_t)minipal_getpagesize())
+#define HIGH_FREQUENCY_HEAP_RESERVE_SIZE       (8 * minipal_getpagesize())
+#define HIGH_FREQUENCY_HEAP_COMMIT_SIZE        (1 * minipal_getpagesize())
 
-#define STUB_HEAP_RESERVE_SIZE                 (3 * (uint32_t)minipal_getpagesize())
-#define STUB_HEAP_COMMIT_SIZE                  (1 * (uint32_t)minipal_getpagesize())
+#define STUB_HEAP_RESERVE_SIZE                 (3 * minipal_getpagesize())
+#define STUB_HEAP_COMMIT_SIZE                  (1 * minipal_getpagesize())
 
-#define STATIC_FIELD_HEAP_RESERVE_SIZE         (2 * (uint32_t)minipal_getpagesize())
-#define STATIC_FIELD_HEAP_COMMIT_SIZE          (1 * (uint32_t)minipal_getpagesize())
+#define STATIC_FIELD_HEAP_RESERVE_SIZE         (2 * minipal_getpagesize())
+#define STATIC_FIELD_HEAP_COMMIT_SIZE          (1 * minipal_getpagesize())
 
 // --------------------------------------------------------------------------------
 // PE File List lock - for creating list locks on PE files

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -1011,8 +1011,8 @@ void EEStartupHelper()
 #ifdef FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
         // retrieve configured max size for the mini-metadata buffer (defaults to 64KB)
         g_MiniMetaDataBuffMaxSize = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_MiniMdBufferCapacity);
-        // align up to GetOsPageSize(), with a maximum of 1 MB
-        g_MiniMetaDataBuffMaxSize = (DWORD) min(ALIGN_UP(g_MiniMetaDataBuffMaxSize, GetOsPageSize()), (DWORD)(1024 * 1024));
+        // align up to minipal_getpagesize(), with a maximum of 1 MB
+        g_MiniMetaDataBuffMaxSize = (DWORD) min(ALIGN_UP(g_MiniMetaDataBuffMaxSize, minipal_getpagesize()), (DWORD)(1024 * 1024));
         // allocate the buffer. this is never touched while the process is running, so it doesn't
         // contribute to the process' working set. it is needed only as a "shadow" for a mini-metadata
         // buffer that will be set up and reported / updated in the Watson process (the

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -89,8 +89,8 @@ typedef struct
 } EH_CLAUSE_ENUMERATOR;
 class EECodeInfo;
 
-#define ROUND_DOWN_TO_PAGE(x)   ( (size_t) (x)                        & ~((size_t)GetOsPageSize()-1))
-#define ROUND_UP_TO_PAGE(x)     (((size_t) (x) + (GetOsPageSize()-1)) & ~((size_t)GetOsPageSize()-1))
+#define ROUND_DOWN_TO_PAGE(x)   ( (size_t) (x)                        & ~(minipal_getpagesize()-1))
+#define ROUND_UP_TO_PAGE(x)     (((size_t) (x) + (minipal_getpagesize()-1)) & ~(minipal_getpagesize()-1))
 
 
 enum StubCodeBlockKind : int
@@ -528,7 +528,7 @@ struct HeapList
     TADDR               startAddress;
     TADDR               endAddress;     // the current end of the used portion of the Heap
 
-    TADDR               mapBase;        // "startAddress" rounded down to GetOsPageSize(). pHdrMap is relative to this address
+    TADDR               mapBase;        // "startAddress" rounded down to minipal_getpagesize(). pHdrMap is relative to this address
     PTR_DWORD           pHdrMap;        // bit array used to find the start of methods
 
     size_t              maxCodeHeapSize;// Size of the entire contiguous block of memory

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -89,8 +89,8 @@ typedef struct
 } EH_CLAUSE_ENUMERATOR;
 class EECodeInfo;
 
-#define ROUND_DOWN_TO_PAGE(x)   ( (size_t) (x)                        & ~(minipal_getpagesize()-1))
-#define ROUND_UP_TO_PAGE(x)     (((size_t) (x) + (minipal_getpagesize()-1)) & ~(minipal_getpagesize()-1))
+#define ROUND_DOWN_TO_PAGE(x)   ( (size_t) (x)                        & ~((size_t)minipal_getpagesize()-1))
+#define ROUND_UP_TO_PAGE(x)     (((size_t) (x) + (minipal_getpagesize()-1)) & ~((size_t)minipal_getpagesize()-1))
 
 
 enum StubCodeBlockKind : int

--- a/src/coreclr/vm/debughelp.cpp
+++ b/src/coreclr/vm/debughelp.cpp
@@ -71,10 +71,10 @@ BOOL isMemoryReadable(const TADDR start, unsigned len)
     // Now we have to loop thru each and every page in between and touch them.
     //
     location = start;
-    while (len > GetOsPageSize())
+    while (len > (uint32_t)minipal_getpagesize())
     {
-        location += GetOsPageSize();
-        len -= GetOsPageSize();
+        location += (uint32_t)minipal_getpagesize();
+        len -= (uint32_t)minipal_getpagesize();
 
 #ifdef DACCESS_COMPILE
         if (DacReadAll(location, &buff, 1, false) != S_OK)

--- a/src/coreclr/vm/debughelp.cpp
+++ b/src/coreclr/vm/debughelp.cpp
@@ -71,10 +71,10 @@ BOOL isMemoryReadable(const TADDR start, unsigned len)
     // Now we have to loop thru each and every page in between and touch them.
     //
     location = start;
-    while (len > (uint32_t)minipal_getpagesize())
+    while (len > minipal_getpagesize())
     {
-        location += (uint32_t)minipal_getpagesize();
-        len -= (uint32_t)minipal_getpagesize();
+        location += minipal_getpagesize();
+        len -= minipal_getpagesize();
 
 #ifdef DACCESS_COMPILE
         if (DacReadAll(location, &buff, 1, false) != S_OK)

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -45,7 +45,7 @@ enum LFH {
 // Windows uses 64kB as the null-reference area
 #define NULL_AREA_SIZE   (64 * 1024)
 #else // !TARGET_UNIX
-#define NULL_AREA_SIZE   GetOsPageSize()
+#define NULL_AREA_SIZE   (uint32_t)minipal_getpagesize()
 #endif // !TARGET_UNIX
 
 class IJitManager;

--- a/src/coreclr/vm/excep.h
+++ b/src/coreclr/vm/excep.h
@@ -45,7 +45,7 @@ enum LFH {
 // Windows uses 64kB as the null-reference area
 #define NULL_AREA_SIZE   (64 * 1024)
 #else // !TARGET_UNIX
-#define NULL_AREA_SIZE   (uint32_t)minipal_getpagesize()
+#define NULL_AREA_SIZE   minipal_getpagesize()
 #endif // !TARGET_UNIX
 
 class IJitManager;

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -554,14 +554,14 @@ VOID Frame::Push(Thread *pThread)
 
     m_Next = pThread->GetFrame();
 
-    // GetOsPageSize() is used to relax the assert for cases where two Frames are
+    // minipal_getpagesize() is used to relax the assert for cases where two Frames are
     // declared in the same source function. We cannot predict the order
     // in which the C compiler will lay them out in the stack frame.
-    // So GetOsPageSize() is a guess of the maximum stack frame size of any method
+    // So minipal_getpagesize() is a guess of the maximum stack frame size of any method
     // with multiple Frames in coreclr.dll
     _ASSERTE((pThread->IsExecutingOnAltStack() ||
              (m_Next == FRAME_TOP) ||
-             (PBYTE(m_Next) + (2 * GetOsPageSize())) > PBYTE(this)) &&
+             (PBYTE(m_Next) + (2 * minipal_getpagesize())) > PBYTE(this)) &&
              "Pushing a frame out of order ?");
 
     _ASSERTE(// If AssertOnFailFast is set, the test expects to do stack overrun
@@ -1214,13 +1214,13 @@ void GCFrame::Push(Thread* pThread)
     m_Next = pThread->GetGCFrame();
     m_pCurThread = pThread;
 
-    // GetOsPageSize() is used to relax the assert for cases where two Frames are
+    // minipal_getpagesize() is used to relax the assert for cases where two Frames are
     // declared in the same source function. We cannot predict the order
     // in which the compiler will lay them out in the stack frame.
-    // So GetOsPageSize() is a guess of the maximum stack frame size of any method
+    // So minipal_getpagesize() is a guess of the maximum stack frame size of any method
     // with multiple GCFrames in coreclr.dll
     _ASSERTE(((m_Next == GCFRAME_TOP) ||
-              (PBYTE(m_Next->GetOSStackLocation()) + (2 * GetOsPageSize())) > PBYTE(this->GetOSStackLocation())) &&
+              (PBYTE(m_Next->GetOSStackLocation()) + (2 * minipal_getpagesize())) > PBYTE(this->GetOSStackLocation())) &&
              "Pushing a GCFrame out of order ?");
 
     pThread->SetGCFrame(this);

--- a/src/coreclr/vm/hosting.cpp
+++ b/src/coreclr/vm/hosting.cpp
@@ -165,9 +165,9 @@ BOOL ClrVirtualProtect(LPVOID lpAddress, SIZE_T dwSize, DWORD flNewProtect, PDWO
                 //
                 // because the section following UEF will also be included in the region size
                 // if it has the same protection as the UEF section.
-                DWORD dwUEFSectionPageCount = ((pUEFSection->Misc.VirtualSize + GetOsPageSize() - 1) / GetOsPageSize());
+                DWORD dwUEFSectionPageCount = (DWORD)((pUEFSection->Misc.VirtualSize + minipal_getpagesize() - 1) / minipal_getpagesize());
 
-                BYTE* pAddressOfFollowingSection = pStartOfUEFSection + (GetOsPageSize() * dwUEFSectionPageCount);
+                BYTE* pAddressOfFollowingSection = pStartOfUEFSection + (minipal_getpagesize() * dwUEFSectionPageCount);
 
                 // Ensure that the section following us is having different memory protection
                 MEMORY_BASIC_INFORMATION nextSectionInfo;

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -120,8 +120,8 @@ void InitJITWriteBarrierHelpers()
 
     // All write barrier helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < (ptrdiff_t)GetOsPageSize());
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < (ptrdiff_t)GetOsPageSize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
 
     // Copy the write barriers to their final resting place.
     if (IsWriteBarrierCopyEnabled())

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -120,8 +120,8 @@ void InitJITWriteBarrierHelpers()
 
     // All write barrier helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < minipal_getpagesize());
 
     // Copy the write barriers to their final resting place.
     if (IsWriteBarrierCopyEnabled())

--- a/src/coreclr/vm/i386/jitinterfacex86.cpp
+++ b/src/coreclr/vm/i386/jitinterfacex86.cpp
@@ -120,8 +120,8 @@ void InitJITWriteBarrierHelpers()
 
     // All write barrier helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < minipal_getpagesize());
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_WriteBarrierGroup_End - (BYTE*)JIT_WriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedWriteBarrierGroup_End - (BYTE*)JIT_PatchedWriteBarrierGroup < (ptrdiff_t)minipal_getpagesize());
 
     // Copy the write barriers to their final resting place.
     if (IsWriteBarrierCopyEnabled())

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -10355,7 +10355,7 @@ void CEEInfo::getEEInfo(CORINFO_EE_INFO *pEEInfoOut)
     _ASSERTE(sizeof(ReversePInvokeFrame) <= pEEInfoOut->sizeOfReversePInvokeFrame);
 #endif
 
-    pEEInfoOut->osPageSize = GetOsPageSize();
+    pEEInfoOut->osPageSize = minipal_getpagesize();
     pEEInfoOut->maxUncheckedOffsetForNullObject = MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT;
     pEEInfoOut->targetAbi = CORINFO_CORECLR_ABI;
     pEEInfoOut->osType = getClrVmOs();

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -15,7 +15,7 @@
 // TODO: Set this value to 0 for Wasm
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT (1024 - 1)
 #elif defined (TARGET_UNIX)
-#define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((GetOsPageSize() / 2) - 1)
+#define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT (((uint32_t)minipal_getpagesize() / 2) - 1)
 #else
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((32*1024)-1)   // when generating JIT code
 #endif

--- a/src/coreclr/vm/jitinterface.h
+++ b/src/coreclr/vm/jitinterface.h
@@ -15,7 +15,7 @@
 // TODO: Set this value to 0 for Wasm
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT (1024 - 1)
 #elif defined (TARGET_UNIX)
-#define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT (((uint32_t)minipal_getpagesize() / 2) - 1)
+#define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((minipal_getpagesize() / 2) - 1)
 #else
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((32*1024)-1)   // when generating JIT code
 #endif

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1086,7 +1086,7 @@ void LoaderAllocator::ActivateManagedTracking()
 
 // We don't actually allocate a low frequency heap for collectible types.
 // This is carefully tuned to sum up to 16 pages to reduce waste.
-#define COLLECTIBLE_LOW_FREQUENCY_HEAP_SIZE        (0 * (uint32_t)minipal_getpagesize())
+#define COLLECTIBLE_LOW_FREQUENCY_HEAP_SIZE        0
 #define COLLECTIBLE_HIGH_FREQUENCY_HEAP_SIZE       (3 * (uint32_t)minipal_getpagesize())
 #define COLLECTIBLE_STUB_HEAP_SIZE                 (uint32_t)minipal_getpagesize()
 #define COLLECTIBLE_CODEHEAP_SIZE                  (10 * (uint32_t)minipal_getpagesize())

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1086,11 +1086,11 @@ void LoaderAllocator::ActivateManagedTracking()
 
 // We don't actually allocate a low frequency heap for collectible types.
 // This is carefully tuned to sum up to 16 pages to reduce waste.
-#define COLLECTIBLE_LOW_FREQUENCY_HEAP_SIZE        (0 * GetOsPageSize())
-#define COLLECTIBLE_HIGH_FREQUENCY_HEAP_SIZE       (3 * GetOsPageSize())
-#define COLLECTIBLE_STUB_HEAP_SIZE                 GetOsPageSize()
-#define COLLECTIBLE_CODEHEAP_SIZE                  (10 * GetOsPageSize())
-#define COLLECTIBLE_VIRTUALSTUBDISPATCH_HEAP_SPACE (2 * GetOsPageSize())
+#define COLLECTIBLE_LOW_FREQUENCY_HEAP_SIZE        (0 * (uint32_t)minipal_getpagesize())
+#define COLLECTIBLE_HIGH_FREQUENCY_HEAP_SIZE       (3 * (uint32_t)minipal_getpagesize())
+#define COLLECTIBLE_STUB_HEAP_SIZE                 (uint32_t)minipal_getpagesize()
+#define COLLECTIBLE_CODEHEAP_SIZE                  (10 * (uint32_t)minipal_getpagesize())
+#define COLLECTIBLE_VIRTUALSTUBDISPATCH_HEAP_SPACE (2 * (uint32_t)minipal_getpagesize())
 
 void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
 {
@@ -1144,7 +1144,7 @@ void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
     // Take a page from the high-frequency heap for this.
     if (pExecutableHeapMemory != NULL)
     {
-        dwExecutableHeapReserveSize = GetOsPageSize();
+        dwExecutableHeapReserveSize = (uint32_t)minipal_getpagesize();
 
         _ASSERTE(dwExecutableHeapReserveSize < dwHighFrequencyHeapReserveSize);
         dwHighFrequencyHeapReserveSize -= dwExecutableHeapReserveSize;

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -1087,10 +1087,10 @@ void LoaderAllocator::ActivateManagedTracking()
 // We don't actually allocate a low frequency heap for collectible types.
 // This is carefully tuned to sum up to 16 pages to reduce waste.
 #define COLLECTIBLE_LOW_FREQUENCY_HEAP_SIZE        0
-#define COLLECTIBLE_HIGH_FREQUENCY_HEAP_SIZE       (3 * (uint32_t)minipal_getpagesize())
-#define COLLECTIBLE_STUB_HEAP_SIZE                 (uint32_t)minipal_getpagesize()
-#define COLLECTIBLE_CODEHEAP_SIZE                  (10 * (uint32_t)minipal_getpagesize())
-#define COLLECTIBLE_VIRTUALSTUBDISPATCH_HEAP_SPACE (2 * (uint32_t)minipal_getpagesize())
+#define COLLECTIBLE_HIGH_FREQUENCY_HEAP_SIZE       (3 * minipal_getpagesize())
+#define COLLECTIBLE_STUB_HEAP_SIZE                 minipal_getpagesize()
+#define COLLECTIBLE_CODEHEAP_SIZE                  (10 * minipal_getpagesize())
+#define COLLECTIBLE_VIRTUALSTUBDISPATCH_HEAP_SPACE (2 * minipal_getpagesize())
 
 void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
 {
@@ -1144,7 +1144,7 @@ void LoaderAllocator::Init(BYTE *pExecutableHeapMemory)
     // Take a page from the high-frequency heap for this.
     if (pExecutableHeapMemory != NULL)
     {
-        dwExecutableHeapReserveSize = (uint32_t)minipal_getpagesize();
+        dwExecutableHeapReserveSize = minipal_getpagesize();
 
         _ASSERTE(dwExecutableHeapReserveSize < dwHighFrequencyHeapReserveSize);
         dwHighFrequencyHeapReserveSize -= dwExecutableHeapReserveSize;

--- a/src/coreclr/vm/peimagelayout.cpp
+++ b/src/coreclr/vm/peimagelayout.cpp
@@ -1135,7 +1135,7 @@ static PVOID SplitPlaceholder(
 
 static SIZE_T OffsetWithinPage(SIZE_T addr)
 {
-    return addr & (GetOsPageSize() - 1);
+    return addr & (minipal_getpagesize() - 1);
 }
 
 static SIZE_T RoundToPage(SIZE_T size, SIZE_T offset)
@@ -1169,13 +1169,13 @@ void* FlatImageLayout::LoadImageByMappingParts(SIZE_T* m_imageParts) const
     PVOID reservedEnd = NULL;
     IMAGE_NT_HEADERS* ntHeader = FindNTHeaders();
 
-    if  ((ntHeader->OptionalHeader.FileAlignment < GetOsPageSize()) &&
+    if  ((ntHeader->OptionalHeader.FileAlignment < minipal_getpagesize()) &&
          (ntHeader->OptionalHeader.FileAlignment != ntHeader->OptionalHeader.SectionAlignment))
     {
         goto UNSUPPORTED;
     }
 
-    if (this->GetSize() < GetOsPageSize() * 2)
+    if (this->GetSize() < minipal_getpagesize() * 2)
     {
         goto UNSUPPORTED;
     }
@@ -1278,7 +1278,7 @@ void* FlatImageLayout::LoadImageByMappingParts(SIZE_T* m_imageParts) const
         // then map only the aligned chunk that fits, the rest we will copy.
         while (mapEnd > offset + this->GetSize())
         {
-            mapEnd -= GetOsPageSize();
+            mapEnd -= minipal_getpagesize();
         }
 
         // if we have something to map at page granularity, map it

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -5192,7 +5192,7 @@ static void DebugLogStackRegionMBIs(UINT_PTR uLowAddress, UINT_PTR uHighAddress)
 
         UINT_PTR uRegionSize = uStartOfNextRegion - uStartOfThisRegion;
 
-        LOG((LF_EH, LL_INFO1000, "0x%p -> 0x%p (%d pg)  ", uStartOfThisRegion, uStartOfNextRegion - 1, uRegionSize / minipal_getpagesize()));
+        LOG((LF_EH, LL_INFO1000, "0x%p -> 0x%p (%d pg)  ", uStartOfThisRegion, uStartOfNextRegion - 1, (int)(uRegionSize / minipal_getpagesize())));
         DebugLogMBIFlags(meminfo.State, meminfo.Protect);
         LOG((LF_EH, LL_INFO1000, "\n"));
 
@@ -5230,7 +5230,7 @@ void Thread::DebugLogStackMBIs()
     UINT_PTR uStackSize         = uStackBase - uStackLimit;
 
     LOG((LF_EH, LL_INFO1000, "----------------------------------------------------------------------\n"));
-    LOG((LF_EH, LL_INFO1000, "Stack Snapshot 0x%p -> 0x%p (%d pg)\n", uStackLimit, uStackBase, uStackSize / minipal_getpagesize()));
+    LOG((LF_EH, LL_INFO1000, "Stack Snapshot 0x%p -> 0x%p (%d pg)\n", uStackLimit, uStackBase, (int)(uStackSize / minipal_getpagesize())));
     if (pThread)
     {
         LOG((LF_EH, LL_INFO1000, "Last normal addr: 0x%p\n", pThread->GetLastNormalStackAddress()));

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1053,7 +1053,7 @@ void InitThreadManager()
     // All patched helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
     _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart > (ptrdiff_t)0);
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < (ptrdiff_t)GetOsPageSize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < (ptrdiff_t)minipal_getpagesize());
 
     if (IsWriteBarrierCopyEnabled())
     {
@@ -1924,11 +1924,11 @@ BOOL Thread::CreateNewOSThread(SIZE_T sizeToCommitOrReserve, LPTHREAD_START_ROUT
     }
 
 #ifndef TARGET_UNIX // the PAL does its own adjustments as necessary
-    if (sizeToCommitOrReserve != 0 && sizeToCommitOrReserve <= GetOsPageSize())
+    if (sizeToCommitOrReserve != 0 && sizeToCommitOrReserve <= minipal_getpagesize())
     {
         // On Windows, passing a value that is <= one page size bizarrely causes the OS to use the default stack size instead of
         // a minimum, which is undesirable. This adjustment fixes that issue to use a minimum stack size (typically 64 KB).
-        sizeToCommitOrReserve = GetOsPageSize() + 1;
+        sizeToCommitOrReserve = minipal_getpagesize() + 1;
     }
 #endif // !TARGET_UNIX
 
@@ -4469,7 +4469,7 @@ void Thread::HandleThreadInterrupt ()
 }
 
 #ifdef _DEBUG
-#define MAXSTACKBYTES (2 * GetOsPageSize())
+#define MAXSTACKBYTES (2 * minipal_getpagesize())
 void CleanStackForFastGCStress ()
 {
     CONTRACTL {
@@ -5045,7 +5045,7 @@ HRESULT Thread::CLRSetThreadStackGuarantee(SetThreadStackGuaranteeScope fScope)
         INDEBUG(EXTRA_PAGES += 1);
 
         int ThreadGuardPages = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_ThreadGuardPages, EXTRA_PAGES);
-        uGuardSize += (ThreadGuardPages * GetOsPageSize());
+        uGuardSize += (ThreadGuardPages * (uint32_t)minipal_getpagesize());
 
         LOG((LF_EH, LL_INFO10000, "STACKOVERFLOW: setting thread stack guarantee to 0x%x\n", uGuardSize));
 
@@ -5086,14 +5086,14 @@ UINT_PTR Thread::GetLastNormalStackAddress(UINT_PTR StackLimit)
     UINT_PTR cbStackGuarantee = GetStackGuarantee();
 
     // Here we take the "hard guard region size", the "stack guarantee" and the "fault page" and add them
-    // all together.  Note that the "fault page" is the reason for the extra GetOsPageSize() below.  The OS
+    // all together.  Note that the "fault page" is the reason for the extra minipal_getpagesize() below.  The OS
     // will guarantee us a certain amount of stack remaining after a stack overflow.  This is called the
     // "stack guarantee".  But to do this, it has to fault on the page before that region as the app is
     // allowed to fault at the very end of that page.  So, as a result, the last normal stack address is
     // one page sooner.
     return StackLimit + (cbStackGuarantee
 #ifndef TARGET_UNIX
-            + GetOsPageSize()
+            + minipal_getpagesize()
 #endif // !TARGET_UNIX
             + HARD_GUARD_REGION_SIZE);
 }
@@ -5192,7 +5192,7 @@ static void DebugLogStackRegionMBIs(UINT_PTR uLowAddress, UINT_PTR uHighAddress)
 
         UINT_PTR uRegionSize = uStartOfNextRegion - uStartOfThisRegion;
 
-        LOG((LF_EH, LL_INFO1000, "0x%p -> 0x%p (%d pg)  ", uStartOfThisRegion, uStartOfNextRegion - 1, uRegionSize / GetOsPageSize()));
+        LOG((LF_EH, LL_INFO1000, "0x%p -> 0x%p (%d pg)  ", uStartOfThisRegion, uStartOfNextRegion - 1, uRegionSize / minipal_getpagesize()));
         DebugLogMBIFlags(meminfo.State, meminfo.Protect);
         LOG((LF_EH, LL_INFO1000, "\n"));
 
@@ -5230,7 +5230,7 @@ void Thread::DebugLogStackMBIs()
     UINT_PTR uStackSize         = uStackBase - uStackLimit;
 
     LOG((LF_EH, LL_INFO1000, "----------------------------------------------------------------------\n"));
-    LOG((LF_EH, LL_INFO1000, "Stack Snapshot 0x%p -> 0x%p (%d pg)\n", uStackLimit, uStackBase, uStackSize / GetOsPageSize()));
+    LOG((LF_EH, LL_INFO1000, "Stack Snapshot 0x%p -> 0x%p (%d pg)\n", uStackLimit, uStackBase, uStackSize / minipal_getpagesize()));
     if (pThread)
     {
         LOG((LF_EH, LL_INFO1000, "Last normal addr: 0x%p\n", pThread->GetLastNormalStackAddress()));
@@ -5485,13 +5485,13 @@ VOID Thread::RestoreGuardPage()
     // to change the size of the guard region, we'll just go ahead and protect the next page down from where we are
     // now. The guard page will get pushed forward again, just like normal, until the next stack overflow.
         approxStackPointer   = (UINT_PTR)GetCurrentSP();
-        guardPageBase        = (UINT_PTR)ALIGN_DOWN(approxStackPointer, GetOsPageSize()) - GetOsPageSize();
+        guardPageBase        = (UINT_PTR)ALIGN_DOWN(approxStackPointer, minipal_getpagesize()) - minipal_getpagesize();
 
         // OS uses soft guard page to update the stack info in TEB.  If our guard page is not beyond the current stack, the TEB
         // will not be updated, and then OS's check of stack during exception will fail.
         if (approxStackPointer >= guardPageBase)
         {
-            guardPageBase -= GetOsPageSize();
+            guardPageBase -= minipal_getpagesize();
         }
     // If we're currently "too close" to the page we want to mark as a guard then the call to VirtualProtect to set
     // PAGE_GUARD will fail, but it won't return an error. Therefore, we protect the page, then query it to make
@@ -5521,7 +5521,7 @@ VOID Thread::RestoreGuardPage()
             }
             else
             {
-                guardPageBase -= GetOsPageSize();
+                guardPageBase -= minipal_getpagesize();
             }
         }
     }

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1053,7 +1053,7 @@ void InitThreadManager()
     // All patched helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
     _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart > (ptrdiff_t)0);
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < (ptrdiff_t)minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < minipal_getpagesize());
 
     if (IsWriteBarrierCopyEnabled())
     {
@@ -5045,7 +5045,7 @@ HRESULT Thread::CLRSetThreadStackGuarantee(SetThreadStackGuaranteeScope fScope)
         INDEBUG(EXTRA_PAGES += 1);
 
         int ThreadGuardPages = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_ThreadGuardPages, EXTRA_PAGES);
-        uGuardSize += (ThreadGuardPages * (uint32_t)minipal_getpagesize());
+        uGuardSize += (ThreadGuardPages * minipal_getpagesize());
 
         LOG((LF_EH, LL_INFO10000, "STACKOVERFLOW: setting thread stack guarantee to 0x%x\n", uGuardSize));
 

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1053,7 +1053,7 @@ void InitThreadManager()
     // All patched helpers should fit into one page.
     // If you hit this assert on retail build, there is most likely problem with BBT script.
     _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart > (ptrdiff_t)0);
-    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < minipal_getpagesize());
+    _ASSERTE_ALL_BUILDS((BYTE*)JIT_PatchedCodeLast - (BYTE*)JIT_PatchedCodeStart < (ptrdiff_t)minipal_getpagesize());
 
     if (IsWriteBarrierCopyEnabled())
     {

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2290,8 +2290,6 @@ private:
     UINT_PTR    m_CacheStackSufficientExecutionLimit;
     UINT_PTR    m_CacheStackStackAllocNonRiskyExecutionLimit;
 
-#define HARD_GUARD_REGION_SIZE GetOsPageSize()
-
 private:
     //
     static HRESULT CLRSetThreadStackGuarantee(SetThreadStackGuaranteeScope fScope = STSGuarantee_OnlyIfEnabled);
@@ -2304,8 +2302,8 @@ private:
 
     // Every stack has a single reserved page at its limit that we call the 'hard guard page'. This page is never
     // committed, and access to it after a stack overflow will terminate the thread.
-#define HARD_GUARD_REGION_SIZE GetOsPageSize()
-#define SIZEOF_DEFAULT_STACK_GUARANTEE 1 * GetOsPageSize()
+#define HARD_GUARD_REGION_SIZE ((uint32_t)minipal_getpagesize())
+#define SIZEOF_DEFAULT_STACK_GUARANTEE ((uint32_t)minipal_getpagesize())
 
 public:
     // This will return the last stack address that one could write to before a stack overflow.

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2302,8 +2302,8 @@ private:
 
     // Every stack has a single reserved page at its limit that we call the 'hard guard page'. This page is never
     // committed, and access to it after a stack overflow will terminate the thread.
-#define HARD_GUARD_REGION_SIZE ((uint32_t)minipal_getpagesize())
-#define SIZEOF_DEFAULT_STACK_GUARANTEE ((uint32_t)minipal_getpagesize())
+#define HARD_GUARD_REGION_SIZE (minipal_getpagesize())
+#define SIZEOF_DEFAULT_STACK_GUARANTEE (minipal_getpagesize())
 
 public:
     // This will return the last stack address that one could write to before a stack overflow.

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -495,12 +495,12 @@ void VirtualCallStubManager::Init(LoaderAllocator *pLoaderAllocator)
     //
     // Align up all of the commit and reserve sizes
     //
-    indcell_heap_reserve_size        = (DWORD) ALIGN_UP(indcell_heap_reserve_size,     GetOsPageSize());
-    indcell_heap_commit_size         = (DWORD) ALIGN_UP(indcell_heap_commit_size,      GetOsPageSize());
+    indcell_heap_reserve_size        = (DWORD) ALIGN_UP(indcell_heap_reserve_size,     minipal_getpagesize());
+    indcell_heap_commit_size         = (DWORD) ALIGN_UP(indcell_heap_commit_size,      minipal_getpagesize());
 
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-    cache_entry_heap_reserve_size    = (DWORD) ALIGN_UP(cache_entry_heap_reserve_size, GetOsPageSize());
-    cache_entry_heap_commit_size     = (DWORD) ALIGN_UP(cache_entry_heap_commit_size,  GetOsPageSize());
+    cache_entry_heap_reserve_size    = (DWORD) ALIGN_UP(cache_entry_heap_reserve_size, minipal_getpagesize());
+    cache_entry_heap_commit_size     = (DWORD) ALIGN_UP(cache_entry_heap_commit_size,  minipal_getpagesize());
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
 
     BYTE * initReservedMem = NULL;
@@ -520,17 +520,17 @@ void VirtualCallStubManager::Init(LoaderAllocator *pLoaderAllocator)
             DWORD dwWastedReserveMemSize = dwTotalReserveMemSize - dwTotalReserveMemSizeCalc;
             if (dwWastedReserveMemSize != 0)
             {
-                DWORD cWastedPages = dwWastedReserveMemSize / GetOsPageSize();
+                DWORD cWastedPages = dwWastedReserveMemSize / (uint32_t)minipal_getpagesize();
 
                 // Split the wasted pages over the 2 LoaderHeaps that we allocate as part of a VirtualCallStubManager
                 DWORD cPagesPerHeap = cWastedPages / 2;
                 DWORD cPagesRemainder = cWastedPages % 2; // We'll throw this at the cache entry heap
 
-                indcell_heap_reserve_size += cPagesPerHeap * GetOsPageSize();
+                indcell_heap_reserve_size += cPagesPerHeap * (uint32_t)minipal_getpagesize();
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-                cache_entry_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * GetOsPageSize();
+                cache_entry_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * (uint32_t)minipal_getpagesize();
 #else
-                indcell_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * GetOsPageSize();
+                indcell_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * (uint32_t)minipal_getpagesize();
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
             }
 
@@ -552,15 +552,15 @@ void VirtualCallStubManager::Init(LoaderAllocator *pLoaderAllocator)
     }
     else
     {
-        indcell_heap_reserve_size        = GetOsPageSize();
-        indcell_heap_commit_size         = GetOsPageSize();
+        indcell_heap_reserve_size        = (uint32_t)minipal_getpagesize();
+        indcell_heap_commit_size         = (uint32_t)minipal_getpagesize();
 
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-        cache_entry_heap_reserve_size    = GetOsPageSize();
-        cache_entry_heap_commit_size     = GetOsPageSize();
+        cache_entry_heap_reserve_size    = (uint32_t)minipal_getpagesize();
+        cache_entry_heap_commit_size     = (uint32_t)minipal_getpagesize();
 #else
         // If we don't support VSD, use a slightly bigger heap size to avoid wasting memory
-        indcell_heap_reserve_size        = 2 * GetOsPageSize();
+        indcell_heap_reserve_size        = 2 * (uint32_t)minipal_getpagesize();
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
 
 #ifdef _DEBUG

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -520,17 +520,17 @@ void VirtualCallStubManager::Init(LoaderAllocator *pLoaderAllocator)
             DWORD dwWastedReserveMemSize = dwTotalReserveMemSize - dwTotalReserveMemSizeCalc;
             if (dwWastedReserveMemSize != 0)
             {
-                DWORD cWastedPages = dwWastedReserveMemSize / (uint32_t)minipal_getpagesize();
+                DWORD cWastedPages = dwWastedReserveMemSize / minipal_getpagesize();
 
                 // Split the wasted pages over the 2 LoaderHeaps that we allocate as part of a VirtualCallStubManager
                 DWORD cPagesPerHeap = cWastedPages / 2;
                 DWORD cPagesRemainder = cWastedPages % 2; // We'll throw this at the cache entry heap
 
-                indcell_heap_reserve_size += cPagesPerHeap * (uint32_t)minipal_getpagesize();
+                indcell_heap_reserve_size += cPagesPerHeap * minipal_getpagesize();
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-                cache_entry_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * (uint32_t)minipal_getpagesize();
+                cache_entry_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * minipal_getpagesize();
 #else
-                indcell_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * (uint32_t)minipal_getpagesize();
+                indcell_heap_reserve_size += (cPagesPerHeap + cPagesRemainder) * minipal_getpagesize();
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
             }
 
@@ -552,15 +552,15 @@ void VirtualCallStubManager::Init(LoaderAllocator *pLoaderAllocator)
     }
     else
     {
-        indcell_heap_reserve_size        = (uint32_t)minipal_getpagesize();
-        indcell_heap_commit_size         = (uint32_t)minipal_getpagesize();
+        indcell_heap_reserve_size        = minipal_getpagesize();
+        indcell_heap_commit_size         = minipal_getpagesize();
 
 #ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-        cache_entry_heap_reserve_size    = (uint32_t)minipal_getpagesize();
-        cache_entry_heap_commit_size     = (uint32_t)minipal_getpagesize();
+        cache_entry_heap_reserve_size    = minipal_getpagesize();
+        cache_entry_heap_commit_size     = minipal_getpagesize();
 #else
         // If we don't support VSD, use a slightly bigger heap size to avoid wasting memory
-        indcell_heap_reserve_size        = 2 * (uint32_t)minipal_getpagesize();
+        indcell_heap_reserve_size        = 2 * minipal_getpagesize();
 #endif // FEATURE_VIRTUAL_STUB_DISPATCH
 
 #ifdef _DEBUG

--- a/src/native/managed/cdac/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdac/tests/PrecodeStubsTests.cs
@@ -22,7 +22,7 @@ public class PrecodeStubsTests
         public required int OffsetOfPrecodeType { get; init; }
         public required int ShiftOfPrecodeType { get; init; }
         // #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
-        //    return max(16*1024u, GetOsPageSize());
+        //    return max(16*1024u, (uint32_t)minipal_getpagesize());
         // #elif defined(TARGET_ARM)
         //    return 4096; // ARM is special as the 32bit instruction set does not easily permit a 16KB offset
         // #else

--- a/src/native/managed/cdac/tests/PrecodeStubsTests.cs
+++ b/src/native/managed/cdac/tests/PrecodeStubsTests.cs
@@ -22,7 +22,7 @@ public class PrecodeStubsTests
         public required int OffsetOfPrecodeType { get; init; }
         public required int ShiftOfPrecodeType { get; init; }
         // #if defined(TARGET_ARM64) && defined(TARGET_UNIX)
-        //    return max(16*1024u, (uint32_t)minipal_getpagesize());
+        //    return max(16*1024u, minipal_getpagesize());
         // #elif defined(TARGET_ARM)
         //    return 4096; // ARM is special as the 32bit instruction set does not easily permit a 16KB offset
         // #else

--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -16,11 +16,11 @@ set(SOURCES
     log.c
 )
 
-# ospagesize is provided inline in the header on Windows and WASM; the .c file
-# only contains the POSIX implementation. Including it on those platforms would
-# produce a redefinition error (mono builds for wasi/browser set HOST_WASM but
-# not CLR_CMAKE_TARGET_ARCH_WASM, so check both).
-if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_ARCH_WASM AND NOT HOST_WASM)
+# ospagesize is provided inline in the header on WASM; the .c file contains the
+# POSIX and Windows implementations. Including it on WASM would produce a
+# redefinition error (mono builds for wasi/browser set HOST_WASM but not
+# CLR_CMAKE_TARGET_ARCH_WASM, so check both).
+if(NOT CLR_CMAKE_TARGET_ARCH_WASM AND NOT HOST_WASM)
     list(APPEND SOURCES ospagesize.c)
 endif()
 

--- a/src/native/minipal/CMakeLists.txt
+++ b/src/native/minipal/CMakeLists.txt
@@ -16,11 +16,11 @@ set(SOURCES
     log.c
 )
 
-# ospagesize is provided inline in the header on WASM; the .c file contains the
-# POSIX and Windows implementations. Including it on WASM would produce a
-# redefinition error (mono builds for wasi/browser set HOST_WASM but not
-# CLR_CMAKE_TARGET_ARCH_WASM, so check both).
-if(NOT CLR_CMAKE_TARGET_ARCH_WASM AND NOT HOST_WASM)
+# ospagesize is provided inline in the header on Windows and WASM; the .c file
+# only contains the POSIX implementation. Including it on those platforms would
+# produce a redefinition error (mono builds for wasi/browser set HOST_WASM but
+# not CLR_CMAKE_TARGET_ARCH_WASM, so check both).
+if(NOT WIN32 AND NOT CLR_CMAKE_TARGET_ARCH_WASM AND NOT HOST_WASM)
     list(APPEND SOURCES ospagesize.c)
 endif()
 

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -8,6 +8,7 @@
 
 #include <unistd.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include "ospagesize.h"
 
 uint32_t minipal_getpagesize(void)

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -13,8 +13,8 @@
 
 uint32_t minipal_getpagesize(void)
 {
-    static uint32_t cached_page_size = 0;
-    uint32_t page_size = __atomic_load_n(&cached_page_size, __ATOMIC_RELAXED);
+    static atomic_uint cached_page_size = 0;
+    uint32_t page_size = atomic_load_explicit(&cached_page_size, memory_order_relaxed);
     if (page_size == 0)
     {
         long sc = sysconf(_SC_PAGESIZE);

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -7,18 +7,24 @@
 // src/native/minipal/CMakeLists.txt to avoid an empty translation unit.
 
 #include <unistd.h>
+#include <stdlib.h>
 #include "ospagesize.h"
 
 uint32_t minipal_getpagesize(void)
 {
-    // Process-wide constant. Any thread that races to initialize the cache writes
-    // the same value, so no synchronization is required.
     static uint32_t cached_page_size = 0;
-    uint32_t page_size = cached_page_size;
+    uint32_t page_size = __atomic_load_n(&cached_page_size, __ATOMIC_RELAXED);
     if (page_size == 0)
     {
-        page_size = (uint32_t)sysconf(_SC_PAGESIZE);
-        cached_page_size = page_size;
+        long sc = sysconf(_SC_PAGESIZE);
+        // _SC_PAGESIZE is mandatory in POSIX 2001; treat any failure as fatal
+        // rather than caching a nonsense value (e.g. (uint32_t)-1).
+        if (sc <= 0)
+        {
+            abort();
+        }
+        page_size = (uint32_t)sc;
+        __atomic_store_n(&cached_page_size, page_size, __ATOMIC_RELAXED);
     }
     return page_size;
 }

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -1,18 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Implementation of minipal_getpagesize for non-WASM platforms. On WASM the page
-// size is a compile-time constant and the function is defined inline in the
-// header; this file is excluded from the build on WASM by
+// POSIX implementation of minipal_getpagesize. On WASM and Windows the page size
+// is a compile-time constant and minipal_getpagesize is defined inline in the
+// header; this file is excluded from the build on those platforms by
 // src/native/minipal/CMakeLists.txt to avoid an empty translation unit.
 
-#include "ospagesize.h"
-
-#ifdef _WIN32
-#include <windows.h>
-#else
 #include <unistd.h>
-#endif
+#include "ospagesize.h"
 
 uint32_t minipal_getpagesize(void)
 {
@@ -22,13 +17,7 @@ uint32_t minipal_getpagesize(void)
     uint32_t page_size = cached_page_size;
     if (page_size == 0)
     {
-#ifdef _WIN32
-        SYSTEM_INFO sysInfo;
-        GetSystemInfo(&sysInfo);
-        page_size = (uint32_t)sysInfo.dwPageSize;
-#else
         page_size = (uint32_t)getpagesize();
-#endif
         cached_page_size = page_size;
     }
     return page_size;

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -17,7 +17,7 @@ uint32_t minipal_getpagesize(void)
     uint32_t page_size = cached_page_size;
     if (page_size == 0)
     {
-        page_size = (uint32_t)getpagesize();
+        page_size = (uint32_t)sysconf(_SC_PAGESIZE);
         cached_page_size = page_size;
     }
     return page_size;

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -1,23 +1,34 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// POSIX implementation of minipal_getpagesize. On WASM and Windows the page size
-// is a compile-time constant and minipal_getpagesize is defined inline in the
-// header; this file is excluded from the build on those platforms by
+// Implementation of minipal_getpagesize for non-WASM platforms. On WASM the page
+// size is a compile-time constant and the function is defined inline in the
+// header; this file is excluded from the build on WASM by
 // src/native/minipal/CMakeLists.txt to avoid an empty translation unit.
 
-#include <unistd.h>
 #include "ospagesize.h"
 
-size_t minipal_getpagesize(void)
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+uint32_t minipal_getpagesize(void)
 {
     // Process-wide constant. Any thread that races to initialize the cache writes
     // the same value, so no synchronization is required.
-    static size_t cached_page_size = 0;
-    size_t page_size = cached_page_size;
+    static uint32_t cached_page_size = 0;
+    uint32_t page_size = cached_page_size;
     if (page_size == 0)
     {
-        page_size = (size_t)getpagesize();
+#ifdef _WIN32
+        SYSTEM_INFO sysInfo;
+        GetSystemInfo(&sysInfo);
+        page_size = (uint32_t)sysInfo.dwPageSize;
+#else
+        page_size = (uint32_t)getpagesize();
+#endif
         cached_page_size = page_size;
     }
     return page_size;

--- a/src/native/minipal/ospagesize.c
+++ b/src/native/minipal/ospagesize.c
@@ -25,7 +25,7 @@ uint32_t minipal_getpagesize(void)
             abort();
         }
         page_size = (uint32_t)sc;
-        __atomic_store_n(&cached_page_size, page_size, __ATOMIC_RELAXED);
+        atomic_store_explicit(&cached_page_size, page_size, memory_order_relaxed);
     }
     return page_size;
 }

--- a/src/native/minipal/ospagesize.h
+++ b/src/native/minipal/ospagesize.h
@@ -12,9 +12,9 @@ extern "C" {
 
 // Returns the OS page size in bytes.
 //
-// On WASM the page size is a compile-time constant (16KB) and is defined inline so
-// callers see a constant. This matters for the GC, which expects GetPageSize to fold
-// into a constant for alignment math.
+// On platforms where the page size is fixed (Windows: 4KB, WASM: 16KB) this is
+// defined inline so callers see a compile-time constant. This matters for the GC,
+// which expects GetPageSize to fold into a constant for alignment math.
 //
 // On other platforms the value is queried from the OS once and cached; the
 // definition lives in ospagesize.c so there is exactly one cache per process.
@@ -25,6 +25,12 @@ static inline uint32_t minipal_getpagesize(void)
     // which is too coarse for GC alignment and thresholds. Reduce the OS page size used
     // by the runtime on WASM to 16KB.
     return 16 * 1024;
+}
+#elif defined(HOST_WINDOWS)
+static inline uint32_t minipal_getpagesize(void)
+{
+    // The page size on Windows is 4KB and is not going to change.
+    return 4 * 1024;
 }
 #else
 uint32_t minipal_getpagesize(void);

--- a/src/native/minipal/ospagesize.h
+++ b/src/native/minipal/ospagesize.h
@@ -4,7 +4,7 @@
 #ifndef HAVE_MINIPAL_OSPAGESIZE_H
 #define HAVE_MINIPAL_OSPAGESIZE_H
 
-#include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,28 +12,22 @@ extern "C" {
 
 // Returns the OS page size in bytes.
 //
-// On platforms where the page size is fixed (Windows: 4KB, WASM: 16KB) this is
-// defined inline so callers see a compile-time constant. This matters for the GC,
-// which expects GetPageSize to fold into a constant for alignment math.
+// On WASM the page size is a compile-time constant (16KB) and is defined inline so
+// callers see a constant. This matters for the GC, which expects GetPageSize to fold
+// into a constant for alignment math.
 //
 // On other platforms the value is queried from the OS once and cached; the
 // definition lives in ospagesize.c so there is exactly one cache per process.
 #if defined(HOST_WASM)
-static inline size_t minipal_getpagesize(void)
+static inline uint32_t minipal_getpagesize(void)
 {
     // WASM has no hardware pages; getpagesize() returns the 64KB memory.grow granularity,
     // which is too coarse for GC alignment and thresholds. Reduce the OS page size used
     // by the runtime on WASM to 16KB.
     return 16 * 1024;
 }
-#elif defined(HOST_WINDOWS)
-static inline size_t minipal_getpagesize(void)
-{
-    // The page size on Windows is 4KB and is not going to change.
-    return 4 * 1024;
-}
 #else
-size_t minipal_getpagesize(void);
+uint32_t minipal_getpagesize(void);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/127550

## Summary

Remove the `GetOsPageSize()` wrapper from `utilcode` and replace all call sites in CoreCLR with the new `minipal_getpagesize()` API introduced in #127328.

## Motivation

PR #127328 introduced `minipal_getpagesize()` in `src/native/minipal/ospagesize.h` as the canonical way to query the OS page size across all platforms:

- **Windows**: inline constant `4096` (no syscall)
- **WASM**: inline constant `16384` (reduced from the 64KB `memory.grow` granularity)
- **Unix**: cached `getpagesize()` result (queried once per process)

The old `GetOsPageSize()` in `src/coreclr/utilcode/util.cpp` duplicated this logic with slightly different behavior (used `GetSystemInfo().dwAllocationGranularity` on the PAL path, hardcoded `0x1000` on Windows). Consolidating on the minipal version eliminates the duplication and ensures consistent page-size semantics, particularly for WASM where the correct value is 16KB.

## Changes

### `minipal_getpagesize()` API

- Return type changed from `size_t` to `uint32_t` so the value matches the natural width used by call sites and avoids `(uint32_t)` casts at every use.
- Windows and WASM remain inline compile-time constants (the GC requires this to fold into a constant for alignment math).

### CoreCLR consumers

- **Removed** `GetOsPageSize()` and `GetOsPageSizeUncached()` definitions from `src/coreclr/utilcode/util.cpp`
- **Removed** `GetOsPageSize()` declaration from `src/coreclr/inc/utilcode.h`
- **Added** `#include <minipal/ospagesize.h>` to `utilcode.h` (covers all VM/utilcode consumers) and to the two PAL test files that don't include `utilcode.h`
- **Replaced** all `GetOsPageSize()` call sites with `minipal_getpagesize()`
- **Removed** redundant `(uint32_t)` and `(ptrdiff_t)` casts at call sites now that `minipal_getpagesize()` returns `uint32_t`
- **Fixed** `HARD_GUARD_REGION_SIZE` being defined twice in `threads.h` (removed the redundant first definition)
- **Fixed** `SIZEOF_DEFAULT_STACK_GUARANTEE` and `HARD_GUARD_REGION_SIZE` macro hygiene (wrapped in outer parentheses, removed pointless `1 *` multiplier)
- **Adjusted** `ROUND_DOWN_TO_PAGE`/`ROUND_UP_TO_PAGE` in `codeman.h` to widen the page size to `size_t` before the bit-NOT mask, avoiding MSVC C4319 (zero-extending `uint32_t` to `size_t`)