### PR TITLE
JIT: Fix untracked uses of `lvLiveInOutOfHndlr`

### DIFF
--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -633,7 +633,12 @@ bool Compiler::optCanMoveNullCheckPastTree(GenTree* tree, bool isInsideTry, bool
             else if (isInsideTry)
             {
                 // Inside try we allow only stores to locals not live in handlers.
-                result = tree->OperIs(GT_STORE_LCL_VAR) && !lvaTable[tree->AsLclVar()->GetLclNum()].lvLiveInOutOfHndlr;
+                result = false;
+                if (tree->OperIs(GT_STORE_LCL_VAR))
+                {
+                    LclVarDsc* varDsc = lvaGetDesc(tree->AsLclVar());
+                    result            = varDsc->lvTracked && !varDsc->lvLiveInOutOfHndlr;
+                }
             }
             else
             {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -5000,7 +5000,7 @@ bool Compiler::gtIsLikelyRegVar(GenTree* tree)
 
     // If this is an EH-live var, return false if it is a def,
     // as it will have to go to memory.
-    if (varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0))
+    if (varDsc->lvTracked && varDsc->lvLiveInOutOfHndlr && ((tree->gtFlags & GTF_VAR_DEF) != 0))
     {
         return false;
     }

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -3632,7 +3632,7 @@ void Compiler::lvaComputePreciseRefCounts(bool isRecompute, bool setSlotNumbers)
                     // count those in our heuristic for register allocation, since they always
                     // must be stored, so there's no value in enregistering them at defs; only
                     // if there are enough uses to justify it.
-                    if (varDsc->lvLiveInOutOfHndlr && !varDsc->lvDoNotEnregister &&
+                    if (varDsc->lvTracked && varDsc->lvLiveInOutOfHndlr && !varDsc->lvDoNotEnregister &&
                         ((node->gtFlags & GTF_VAR_DEF) != 0))
                     {
                         varDsc->incRefCnts(0, this);

--- a/src/coreclr/jit/sideeffects.h
+++ b/src/coreclr/jit/sideeffects.h
@@ -129,12 +129,17 @@ public:
 
             if ((m_flags & ALIAS_WRITES_LCL_VAR) != 0)
             {
-                // Stores to 'lvLiveInOutOfHndlr' locals cannot be reordered with
+                // Stores to that may have uses in handlers cannot be reordered with
                 // exception-throwing nodes so we conservatively consider them
                 // globally visible.
 
                 LclVarDsc* const varDsc = m_compiler->lvaGetDesc(LclNum());
-                return varDsc->lvLiveInOutOfHndlr != 0;
+                if (varDsc->lvTracked)
+                {
+                    return varDsc->lvLiveInOutOfHndlr != 0;
+                }
+
+                return m_compiler->compHndBBtabCount > 0;
             }
 
             return false;

--- a/src/coreclr/jit/sideeffects.h
+++ b/src/coreclr/jit/sideeffects.h
@@ -129,7 +129,7 @@ public:
 
             if ((m_flags & ALIAS_WRITES_LCL_VAR) != 0)
             {
-                // Stores to that may have uses in handlers cannot be reordered with
+                // Stores to locals live into handlers cannot be reordered with
                 // exception-throwing nodes so we conservatively consider them
                 // globally visible.
 


### PR DESCRIPTION
Things that depend on this property for correctness reasons need to check `lvTracked` and properly handle untracked cases conservatively.

Some small number of regressions expected.

I am working on a change that among other things will encapsulate this property so that it can only be checked for `lvTracked` cases, but wanted to extract these regressions to their own PR.