### PR TITLE
Apply fixes for coreclr-interp on linux-riscv64

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -870,6 +870,11 @@ if(CLR_CMAKE_HOST_UNIX_ARMV6)
    add_compile_options(-mfloat-abi=hard)
 endif(CLR_CMAKE_HOST_UNIX_ARMV6)
 
+if(CLR_CMAKE_HOST_UNIX_RISCV64)
+  add_compile_options(-march=rv64gc)
+  add_compile_options(-mabi=lp64d)
+endif(CLR_CMAKE_HOST_UNIX_RISCV64)
+
 if(CLR_CMAKE_HOST_UNIX_X86)
   add_compile_options(-msse2)
 endif()

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -2888,7 +2888,6 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *
                     else
                     {
                         _ASSERTE(info.flags == FpStruct::UseIntCallConv);
-                        _ASSERTE(thReturnValueType.AsMethodTable()->IsRegPassedStruct());
                         unsigned size = thReturnValueType.GetSize();
                         if (size <= 8)
                         {

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -1081,7 +1081,7 @@ Load_Ref A7, a7
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetVoid, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a4, 16(fp)
     sub sp, sp, a3
     mv t2, a0
@@ -1102,7 +1102,7 @@ NESTED_END CallJittedMethodRetVoid, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetBuff, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a4, 16(fp)
     sub sp, sp, a3
     mv t2, a0
@@ -1124,7 +1124,7 @@ NESTED_END CallJittedMethodRetBuff, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI1, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1150,7 +1150,7 @@ NESTED_END CallJittedMethodRetI1, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI2, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1176,7 +1176,7 @@ NESTED_END CallJittedMethodRetI2, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1202,7 +1202,7 @@ NESTED_END CallJittedMethodRetU1, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1228,7 +1228,7 @@ NESTED_END CallJittedMethodRetU2, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1252,7 +1252,7 @@ NESTED_END CallJittedMethodRetI8, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetDouble, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1276,7 +1276,7 @@ NESTED_END CallJittedMethodRetDouble, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetFloat, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1300,7 +1300,7 @@ NESTED_END CallJittedMethodRetFloat, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRet2I8, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1325,7 +1325,7 @@ NESTED_END CallJittedMethodRet2I8, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRet2Double, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1350,7 +1350,7 @@ NESTED_END CallJittedMethodRet2Double, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRet2Float, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1375,7 +1375,7 @@ NESTED_END CallJittedMethodRet2Float, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetFloatInt, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1400,7 +1400,7 @@ NESTED_END CallJittedMethodRetFloatInt, _TEXT
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetIntFloat, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, 32
     sd a2, 16(fp)
     sd a4, 24(fp)
     sub sp, sp, a3
@@ -1424,7 +1424,7 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
     PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // IR bytecode address
-    mv t6, METHODDESC_REGISTER
+    mv s1, METHODDESC_REGISTER
 
     INLINE_GETTHREAD t5 // thrashes a0
     beqz t5, LOCAL_LABEL(NoManagedThreadOrCallStub)
@@ -1436,7 +1436,7 @@ NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
 
 LOCAL_LABEL(NoManagedThreadOrCallStub):
     addi a0, sp, __PWTB_TransitionBlock
-    mv a1, t6
+    mv a1, s1
     call C_FUNC(GetInterpThreadContextWithPossiblyMissingThreadOrCallStub)
     mv t4, a0
 
@@ -1445,12 +1445,12 @@ LOCAL_LABEL(HaveInterpThreadContext):
     RESTORE_ARGUMENT_REGISTERS sp, __PWTB_ArgumentRegisters
     RESTORE_FLOAT_ARGUMENT_REGISTERS sp, __PWTB_FloatArgumentRegisters
 
-    ld t3, 0(t6) // InterpMethod*
+    ld t3, 0(s1) // InterpMethod*
     ld t3, OFFSETOF__InterpMethod__pCallStub(t3)
     beqz t3, LOCAL_LABEL(NoManagedThreadOrCallStub)
     addi t2, t3, OFFSETOF__CallStubHeader__Routines
     ld t3, OFFSETOF__InterpThreadContext__pStackPointer(t4)
-    // t6 contains IR bytecode address
+    // s1 contains IR bytecode address
     // Copy the arguments to the interpreter stack, invoke the InterpExecMethod and load the return value
     ld t4, 0(t2)
     addi t2, t2, 8
@@ -1463,10 +1463,10 @@ LOCAL_LABEL(HaveInterpThreadContext):
 NESTED_END InterpreterStub, _TEXT
 
 NESTED_ENTRY InterpreterStubRetVoid, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, ra,   16
@@ -1474,10 +1474,10 @@ NESTED_ENTRY InterpreterStubRetVoid, _TEXT, NoHandler
 NESTED_END InterpreterStubRetVoid, _TEXT
 
 NESTED_ENTRY InterpreterStubRetI8, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     ld a0, 0(a0)
@@ -1486,10 +1486,10 @@ NESTED_ENTRY InterpreterStubRetI8, _TEXT, NoHandler
 NESTED_END InterpreterStubRetI8, _TEXT
 
 NESTED_ENTRY InterpreterStubRetDouble, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     fld fa0, 0(a0)
@@ -1498,21 +1498,21 @@ NESTED_ENTRY InterpreterStubRetDouble, _TEXT, NoHandler
 NESTED_END InterpreterStubRetDouble, _TEXT
 
 NESTED_ENTRY InterpreterStubRetBuff, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     mv   a2, a0        // save caller's return buffer in a2
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv   a1, t6        // the IR bytecode pointer (x19)
+    mv   a1, s1        // the IR bytecode pointer
     call C_FUNC(ExecuteInterpretedMethod)
     EPILOG_RESTORE_REG_PAIR_INDEXED   fp, ra, 16
     EPILOG_RETURN
 NESTED_END InterpreterStubRetBuff, _TEXT
 
 NESTED_ENTRY InterpreterStubRet2I8, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     ld a1, 8(a0)
@@ -1522,10 +1522,10 @@ NESTED_ENTRY InterpreterStubRet2I8, _TEXT, NoHandler
 NESTED_END InterpreterStubRet2I8, _TEXT
 
 NESTED_ENTRY InterpreterStubRet2Double, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     fld fa0, 0(a0)
@@ -1535,10 +1535,10 @@ NESTED_ENTRY InterpreterStubRet2Double, _TEXT, NoHandler
 NESTED_END InterpreterStubRet2Double, _TEXT
 
 NESTED_ENTRY InterpreterStubRetFloat, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     flw fa0, 0(a0)
@@ -1547,10 +1547,10 @@ NESTED_ENTRY InterpreterStubRetFloat, _TEXT, NoHandler
 NESTED_END InterpreterStubRetFloat, _TEXT
 
 NESTED_ENTRY InterpreterStubRet2Float, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     flw fa0, 0(a0)
@@ -1560,10 +1560,10 @@ NESTED_ENTRY InterpreterStubRet2Float, _TEXT, NoHandler
 NESTED_END InterpreterStubRet2Float, _TEXT
 
 NESTED_ENTRY InterpreterStubRetFloatInt, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     fld fa0, 0(a0)
@@ -1573,10 +1573,10 @@ NESTED_ENTRY InterpreterStubRetFloatInt, _TEXT, NoHandler
 NESTED_END InterpreterStubRetFloatInt, _TEXT
 
 NESTED_ENTRY InterpreterStubRetIntFloat, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, -16
+    PROLOG_SAVE_REG_PAIR_INDEXED   fp, ra, 16
     // The +16 is for the fp, ra above
     addi a0, sp, __PWTB_TransitionBlock + 16
-    mv a1, t6 // the IR bytecode pointer
+    mv a1, s1 // the IR bytecode pointer
     mv a2, zero
     call C_FUNC(ExecuteInterpretedMethod)
     ld a1, 0(a0)


### PR DESCRIPTION
First time we ran the tests (with https://github.com/dotnet/runtime/pull/127909) and found issues with interpreter tests.

1. clang-21 defaults to rvv baseline, previously clang-18 was defaulting to rv64gc; so we need to pin to our baseline for runtime binaries. This program helped figuring out SIGILL:
```sh
$ cat riscv_default_probe.c 
#if defined(__riscv_v)
#error At RVV (__riscv_v)
#elif defined(__riscv_b)
#error At Bitmanip (__riscv_b)
#elif defined(__riscv_zfa)
#error At Zfa
#elif defined(__riscv_zfh)
#error At Zfh
#elif defined(__riscv_d)
#error At D
#elif defined(__riscv_f)
#error At F
#elif defined(__riscv_c)
#error At C
#elif defined(__riscv_m)
#error At M
#elif defined(__riscv_a)
#error At A
#elif defined(__riscv_i)
#error At I
#else
#error At unknown baseline
#endif

$ clang-21 --target=riscv64-unknown-linux-gnu -c riscv_default_probe.c
riscv_default_probe.c:2:2: error: At RVV (__riscv_v)
    2 | #error At RVV (__riscv_v)
      |  ^

# vs.

$ clang-18 --target=riscv64-unknown-linux-gnu -c riscv_default_probe.c
riscv_default_probe.c:10:2: error: At D
   10 | #error At D
      |  ^
```

2. Remove negative sign from prolog offset; it was growing in opposite direction.
3. Remove an invalid assert in the RISC-V/LoongArch return classification path. After fixing offset issue, tests progressed to `TestCallingConvention2Rev` and then tripped a debug-only check that is AMD64-specific and not applicable on these targets. Return classification here is already handled by FP-struct info plus size-based integer mapping, so removing the assert preserves intended behavior and unblocks the interpreter calling-convention tests.

Fixes https://github.com/dotnet/runtime/issues/127860