### PR TITLE
Fix DispatchProxy TypeLoadException for generic type arguments

### DIFF
--- a/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
+++ b/src/libraries/System.Reflection.DispatchProxy/src/System/Reflection/DispatchProxyGenerator.cs
@@ -246,6 +246,17 @@ namespace System.Reflection
                         GenerateInstanceOfIgnoresAccessChecksToAttribute(assemblyName);
                     }
                 }
+
+                if (type.IsGenericType)
+                {
+                    foreach (Type genericArg in type.GetGenericArguments())
+                    {
+                        if (!genericArg.IsGenericParameter)
+                        {
+                            EnsureTypeIsVisible(genericArg);
+                        }
+                    }
+                }
             }
         }
 

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -188,7 +188,6 @@
     <!-- test failures -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Formats.Nrbf\tests\System.Formats.Nrbf.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq.Expressions\tests\System.Linq.Expressions.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Reflection.DispatchProxy\tests\System.Reflection.DispatchProxy.Tests.csproj" />
     <!-- long running suites -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Linq\tests\System.Linq.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Memory\tests\System.Memory.Tests.csproj" />


### PR DESCRIPTION
EnsureTypeIsVisible did not recursively check generic type arguments, so when proxying an interface like IFoo<TInternal> where TInternal is internal to another assembly, the dynamic proxy assembly lacked the required IgnoresAccessChecksToAttribute for that assembly.

This caused TypeLoadException (attempting to implement an inaccessible interface) when the proxy was the first to reference that type. The bug was masked on desktop by test execution order: other tests happened to add the attribute as a side effect first.

The fix recursively calls EnsureTypeIsVisible on all generic type arguments, matching the VM own recursive accessibility check in ClassLoader::CanAccessClass.

Also enables System.Reflection.DispatchProxy.Tests on browser/CoreCLR since all 89 tests now pass.