### PR TITLE
Enable Android arm32 queue validation

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-android.yml
@@ -63,8 +63,8 @@ jobs:
     buildConfig: Release
     runtimeFlavor: mono
     platforms:
-    # Disabled until https://github.com/dotnet/runtime/issues/125440 is resolved.
-    # - android_arm
+    # Validate the dedicated Android Arm32 queue with the Mono libraries leg.
+    - android_arm
     - android_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -94,7 +94,9 @@ jobs:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
-    - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
+    - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.platform, 'android_arm')) }}:
+      - Windows.11.Amd64.Android.Arm32.Open
+    - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Windows.11.Amd64.Android.Open
 
     # iOS Simulator/Mac Catalyst arm64

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -95,7 +95,7 @@ jobs:
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(parameters.platform, 'android_arm')) }}:
-      - Windows.11.Amd64.Android.Arm32.Open
+      - windows.11.amd64.android-armel.open
     - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Windows.11.Amd64.Android.Open
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI-generated with Copilot.

## Summary
- enable the Android arm32 Mono libraries leg in the dedicated `runtime-android` pipeline
- route public `android_arm` library jobs to `windows.11.amd64.android-armel.open`
- keep existing Android arm64 queue selection unchanged

## Validation goal
This PR is intended to validate that the new Android arm32 Helix queue runs successfully for at least one Android arm32 test leg.

## How to trigger
Queue the dedicated Android pipeline for this PR with:

```
/azp run runtime-android
```

That should exercise the enabled `android_arm` Mono libraries leg on `windows.11.amd64.android-armel.open`.
