### PR TITLE
Add AggressiveInlining to hex conversion methods

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/AltSvcHeaderParser.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System.Net.Http.Headers
@@ -285,6 +286,7 @@ namespace System.Net.Http.Headers
         /// <summary>
         /// Reads a hex nibble. Specialized for ALPN protocol names as they explicitly can not contain lower-case hex.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool TryReadAlpnHexDigit(char ch, out int nibble)
         {
             int result = HexConverter.FromUpperChar(ch);

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace System.Net.NetworkInformation
 {
@@ -385,6 +386,7 @@ namespace System.Net.NetworkInformation
             return ipAddress;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static byte HexToByte(char val)
         {
             int result = HexConverter.FromChar(val);

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -1515,6 +1515,7 @@ namespace System
         // Throws:
         //  ArgumentException
         //
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int FromHex(char digit)
         {
             int result = HexConverter.FromChar(digit);

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -5,6 +5,7 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace System
@@ -505,6 +506,7 @@ namespace System
         /// Converts 2 hex chars to a byte (returned in a char), e.g, "0a" becomes (char)0x0A.
         /// <para>If either char is not hex, returns <see cref="Uri.c_DummyChar"/>.</para>
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static char DecodeHexChars(int first, int second)
         {
             int a = HexConverter.FromChar(first);


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/pull/124702#issuecomment-3938980794

cc: @EgorBo