### PR TITLE
JIT: Fix SELECT to relop changing type and check cond evaluates to 0 or 1

### DIFF
--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -814,6 +814,11 @@ GenTree* OptIfConversionDsc::TrySelectToCnsOpCond(GenTreeConditional* select)
     GenTree* trueInput  = select->gtOp1;
     GenTree* falseInput = select->gtOp2;
 
+    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
+    {
+        return nullptr;
+    }
+
     if (!trueInput->IsIntegralConst() || !falseInput->IsIntegralConst())
     {
         return nullptr;
@@ -876,7 +881,7 @@ GenTree* OptIfConversionDsc::TrySelectToLclOpCond(GenTreeConditional* select)
     GenTree* oper = select->gtOp1;
     GenTree* lcl  = select->gtOp2;
 
-    if (!cond->OperIsCompare())
+    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
     {
         return nullptr;
     }
@@ -929,6 +934,11 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
     GenTree* cond = select->gtCond;
     GenTree* oper = select->gtOp1;
     GenTree* zero = select->gtOp2;
+
+    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
+    {
+        return nullptr;
+    }
 
     bool isCondReversed = !zero->IsIntegralConst();
     if (isCondReversed)

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -814,12 +814,7 @@ GenTree* OptIfConversionDsc::TrySelectToCnsOpCond(GenTreeConditional* select)
     GenTree* trueInput  = select->gtOp1;
     GenTree* falseInput = select->gtOp2;
 
-    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
-    {
-        return nullptr;
-    }
-
-    if (!trueInput->IsIntegralConst() || !falseInput->IsIntegralConst())
+    if (!cond->OperIsCompare() || !trueInput->IsIntegralConst() || !falseInput->IsIntegralConst())
     {
         return nullptr;
     }
@@ -827,13 +822,14 @@ GenTree* OptIfConversionDsc::TrySelectToCnsOpCond(GenTreeConditional* select)
     int64_t trueVal  = trueInput->AsIntConCommon()->IntegralValue();
     int64_t falseVal = falseInput->AsIntConCommon()->IntegralValue();
 
-    if (trueVal == 1 && falseVal == 0)
+    if ((trueVal == 1 && falseVal == 0) || (trueVal == 0 && falseVal == 1))
     {
-        return cond;
-    }
-    else if (trueVal == 0 && falseVal == 1)
-    {
-        return m_compiler->gtReverseCond(cond);
+        GenTree* retCond = (trueVal == 1) ? cond : m_compiler->gtReverseCond(cond);
+        if (retCond->TypeGet() != select->TypeGet())
+        {
+            retCond = m_compiler->gtNewCastNode(select->TypeGet(), retCond, true, select->TypeGet());
+        }
+        return retCond;
     }
 
 #ifdef TARGET_RISCV64
@@ -881,7 +877,7 @@ GenTree* OptIfConversionDsc::TrySelectToLclOpCond(GenTreeConditional* select)
     GenTree* oper = select->gtOp1;
     GenTree* lcl  = select->gtOp2;
 
-    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
+    if (!cond->OperIsCompare())
     {
         return nullptr;
     }
@@ -935,7 +931,7 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
     GenTree* oper = select->gtOp1;
     GenTree* zero = select->gtOp2;
 
-    if (!cond->OperIsCompare() || cond->TypeGet() != select->TypeGet())
+    if (!cond->OperIsCompare())
     {
         return nullptr;
     }


### PR DESCRIPTION
```cs
static long Fail(bool cond)
{
    if (cond) // cond is TYP_INT
    {
        return 1L;
    }
    return 0L;
}
```
This get's transformed to `return cond;` However we need to insert a CAST from int to long to presever the type, which I am doing here.

Also add `cond->OperIsCompare()` checks for the opts that rely on `cond` being either 0 or 1, since it could be "anything":
<img width="351" height="114" alt="image" src="https://github.com/user-attachments/assets/f064986e-704a-4a8e-b9da-7d1f4e653250" />
