### PR TITLE
crossgen2: Add Length Prefix to Crossgen-Generated Wasm

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
@@ -25,9 +25,14 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         public ObjectNode.ObjectData Encode(ISymbolDefinitionNode symbolDefinitionNode)
         {
 #if READYTORUN
-            byte[] encodedThunk = new byte[FunctionBody.EncodeSize()];
+            int bodySize = FunctionBody.EncodeSize();
+            int sizePrefixLength = (int)DwarfHelper.SizeOfULEB128((ulong)bodySize);
+            byte[] encodedThunk = new byte[bodySize + sizePrefixLength];
+
+            DwarfHelper.WriteULEB128(encodedThunk, (ulong)bodySize);
+            FunctionBody.Encode(encodedThunk.AsSpan(sizePrefixLength));
+
             Relocation[] relocs = new Relocation[FunctionBody.EncodeRelocationCount()];
-            FunctionBody.Encode(encodedThunk.AsSpan());
             FunctionBody.EncodeRelocations(relocs.AsSpan());
     
             return new ObjectNode.ObjectData(encodedThunk, relocs, 1, new ISymbolDefinitionNode[] { symbolDefinitionNode });

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_Wasm/WasmEmitter.cs
@@ -25,12 +25,8 @@ namespace ILCompiler.DependencyAnalysis.Wasm
         public ObjectNode.ObjectData Encode(ISymbolDefinitionNode symbolDefinitionNode)
         {
 #if READYTORUN
-            int bodySize = FunctionBody.EncodeSize();
-            int sizePrefixLength = (int)DwarfHelper.SizeOfULEB128((ulong)bodySize);
-            byte[] encodedThunk = new byte[bodySize + sizePrefixLength];
-
-            DwarfHelper.WriteULEB128(encodedThunk, (ulong)bodySize);
-            FunctionBody.Encode(encodedThunk.AsSpan(sizePrefixLength));
+            byte[] encodedThunk = new byte[FunctionBody.EncodeSize()];
+            FunctionBody.Encode(encodedThunk);
 
             Relocation[] relocs = new Relocation[FunctionBody.EncodeRelocationCount()];
             FunctionBody.EncodeRelocations(relocs.AsSpan());

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
@@ -84,20 +84,6 @@ namespace ILCompiler.ObjectWriter
         private protected SectionWriter GetOrCreateSection(ObjectNodeSection section)
             => GetOrCreateSection(section, default, default);
 
-        private readonly SectionWriter.Params _defaultParams = new SectionWriter.Params
-        {
-            LengthEncodeFormat = LengthEncodeFormat.None
-        };
-
-        /// <summary>
-        /// Some architectures may require section-specific params for the writer. For example, on Wasm,
-        /// certain sections require length prefixes before each object entry which the section writer does support,
-        /// but this has to be indicated by a particular implementation.
-        /// </summary>
-        /// <param name="section"></param>
-        /// <returns></returns>
-        private protected virtual SectionWriter.Params WriterParams(ObjectNodeSection section) => _defaultParams;
-
         /// <summary>
         /// Get or creates an object file section.
         /// </summary>
@@ -139,8 +125,7 @@ namespace ILCompiler.ObjectWriter
             return new SectionWriter(
                 this,
                 sectionIndex,
-                sectionData,
-                WriterParams(section));
+                sectionData);
         }
 
         private protected bool ShouldShareSymbol(ObjectNode node)
@@ -482,13 +467,9 @@ namespace ILCompiler.ObjectWriter
 
                 if (nodeContents.Relocs is not null)
                 {
-                    // For platforms such as Wasm where we must prepend the length before writing blocks,
-                    // we need to adjust the offset of the relocation by the length prefix
-                    uint additionalOffset = sectionWriter.HasLengthPrefix ? sectionWriter.LengthPrefixSize(nodeContents.Data.Length) : 0;
-
                     blocksToRelocate.Add(new BlockToRelocate(
                         sectionWriter.SectionIndex,
-                        sectionWriter.Position + additionalOffset,
+                        sectionWriter.Position,
                         nodeContents.Data,
                         nodeContents.Relocs));
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionWriter.cs
@@ -11,69 +11,26 @@ using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {
-    internal enum LengthEncodeFormat
-    {
-        ULEB128,
-        None,
-    }
-
     internal struct SectionWriter
     {
         private readonly ObjectWriter _objectWriter;
         private readonly SectionData _sectionData;
 
-        private readonly Params _params;
-
         public int SectionIndex { get; init; }
         public readonly IBufferWriter<byte> Buffer => _sectionData.BufferWriter;
-
-        public struct Params
-        {
-            public LengthEncodeFormat LengthEncodeFormat;
-        }
-
-        public bool HasLengthPrefix => _params.LengthEncodeFormat != LengthEncodeFormat.None;
 
         internal SectionWriter(
             ObjectWriter objectWriter,
             int sectionIndex,
-            SectionData sectionData,
-            Params ps)
+            SectionData sectionData)
         {
             _objectWriter = objectWriter;
             SectionIndex = sectionIndex;
             _sectionData = sectionData;
-            _params = ps;
-        }
-
-        public readonly void EmitLengthPrefix(ulong length)
-        {
-            switch (_params.LengthEncodeFormat)
-            {
-                case LengthEncodeFormat.ULEB128:
-                    WriteULEB128(length);
-                    break;
-                case LengthEncodeFormat.None:
-                    break;
-                default:
-                    throw new InvalidOperationException("Length prefix encoding not specified");
-            }
-        }
-
-        public readonly uint LengthPrefixSize(int length)
-        {
-            switch (_params.LengthEncodeFormat)
-            {
-                case LengthEncodeFormat.ULEB128:
-                    return DwarfHelper.SizeOfULEB128((ulong)length);
-                default:
-                    return 0;
-            }
         }
 
         public readonly void EmitData(ReadOnlyMemory<byte> data)
         {
-            EmitLengthPrefix((ulong)data.Length);
             _sectionData.AppendData(data);
         }
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -104,8 +104,10 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
         public int EncodeRelocations(Span<Relocation> buffer)
         {
+            uint bodySize = (uint)BodyContentSize();
+            int bodySizePrefixLength = (int)DwarfHelper.SizeOfULEB128(bodySize);
             int relocsEncoded = _body.EncodeRelocations(buffer);
-            WasmExpr.OffsetRelocationsByOffset(buffer.Slice(0, relocsEncoded), _locals.Length);
+            WasmExpr.OffsetRelocationsByOffset(buffer.Slice(0, relocsEncoded), bodySizePrefixLength + _locals.Length);
             return relocsEncoded;
         }
     }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmInstructions.cs
@@ -85,13 +85,17 @@ namespace ILCompiler.ObjectWriter.WasmInstructions
 
         public int EncodeSize()
         {
-            return BodyContentSize();
+            int bodySize = BodyContentSize();
+            int sizePrefixLength = (int)DwarfHelper.SizeOfULEB128((ulong)bodySize);
+            return sizePrefixLength + bodySize;
         }
 
         public int Encode(Span<byte> buffer)
         {
-            _locals.CopyTo(buffer);
-            int pos = _locals.Length;
+            int contentSize = BodyContentSize();
+            int pos = DwarfHelper.WriteULEB128(buffer, (ulong)contentSize);
+            _locals.CopyTo(buffer.Slice(pos));
+            pos += _locals.Length;
             pos += _body.Encode(buffer.Slice(pos));
 
             return pos;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -360,7 +360,6 @@ namespace ILCompiler.ObjectWriter
             body.Encode(data);
 
             // We must emit the length prefix explicitly
-            Debug.Assert(!codeWriter.HasLengthPrefix);
             codeWriter.WriteULEB128((ulong)codeSize);
             codeWriter.EmitData(data);
             _uniqueSymbols.Add(name.ToString(), _methodCount);
@@ -478,14 +477,6 @@ namespace ILCompiler.ObjectWriter
             }
 
             return section;
-        }
-
-        private protected override SectionWriter.Params WriterParams(ObjectNodeSection section)
-        {
-            return new SectionWriter.Params
-            {
-                LengthEncodeFormat = LengthEncodeFormat.None
-            };
         }
 
         private protected override void CreateSection(ObjectNodeSection section, Utf8String comdatName, Utf8String symbolName, int sectionIndex, Stream sectionStream)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -359,8 +359,6 @@ namespace ILCompiler.ObjectWriter
             byte[] data = new byte[codeSize];
             body.Encode(data);
 
-            // We must emit the length prefix explicitly
-            codeWriter.WriteULEB128((ulong)codeSize);
             codeWriter.EmitData(data);
             _uniqueSymbols.Add(name.ToString(), _methodCount);
             _methodCount++;


### PR DESCRIPTION
#127773 adds length prefixes directly to emitted Wasm code in the JIT. This change is a follow up which adds length prefixes directly to generated wasm import thunks and stubs in crossgen. It also removes the logic in the Object Writer around handling length prefixes, since these will now be encoded in the `ObjectData` itself. 