### PR TITLE
Improve some string Rune helpers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -523,7 +523,14 @@ namespace System
         /// <returns><see langword="true"/> if <paramref name="value"/> matches the end of this instance; otherwise, <see langword="false"/>.</returns>
         public bool EndsWith(Rune value)
         {
-            return EndsWith(value, StringComparison.Ordinal);
+            if (value.IsBmp)
+            {
+                return EndsWith((char)value.Value);
+            }
+
+            UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar((uint)value.Value, out char highSurrogate, out char lowSurrogate);
+
+            return Length > 1 && this[^2] == highSurrogate && this[^1] == lowSurrogate;
         }
 
         /// <summary>
@@ -1134,7 +1141,14 @@ namespace System
         /// <returns><see langword="true"/> if value matches the beginning of this string; otherwise, <see langword="false"/>.</returns>
         public bool StartsWith(Rune value)
         {
-            return StartsWith(value, StringComparison.Ordinal);
+            if (value.IsBmp)
+            {
+                return StartsWith((char)value.Value);
+            }
+
+            UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar((uint)value.Value, out char highSurrogate, out char lowSurrogate);
+
+            return Length > 1 && _firstChar == highSurrogate && this[1] == lowSurrogate;
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1454,9 +1454,9 @@ namespace System
         /// </returns>
         public string Replace(Rune oldRune, Rune newRune)
         {
-            if (Length == 0)
+            if (oldRune.IsBmp && newRune.IsBmp)
             {
-                return this;
+                return Replace((char)oldRune.Value, (char)newRune.Value);
             }
 
             ReadOnlySpan<char> oldChars = oldRune.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
@@ -1682,16 +1682,16 @@ namespace System
         /// <returns>An array whose elements contain the substrings from this instance that are delimited by <paramref name="separator"/>.</returns>
         public string[] Split(Rune separator, int count, StringSplitOptions options = StringSplitOptions.None)
         {
-            ReadOnlySpan<char> separatorSpan = separator.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
-
-            if (separatorSpan.Length == 1)
+            if (separator.IsBmp)
             {
-                return Split(separatorSpan[0], count, options);
+                return Split((char)separator.Value, count, options);
             }
 
             ArgumentOutOfRangeException.ThrowIfNegative(count);
 
             CheckStringSplitOptions(options);
+
+            ReadOnlySpan<char> separatorSpan = separator.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
 
             // Ensure matching the string separator overload.
             return (count <= 1 || Length == 0) ? CreateSplitArrayOfThisAsSoleValue(options, count) : Split(separatorSpan, count, options);
@@ -2411,39 +2411,28 @@ namespace System
         /// </returns>
         public string Trim(Rune trimRune)
         {
-            if (Length == 0)
+            if (trimRune.IsBmp)
             {
-                return this;
+                return Trim((char)trimRune.Value);
             }
 
-            // Convert trimRune to span
-            ReadOnlySpan<char> trimChars = trimRune.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
+            UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar((uint)trimRune.Value, out char highSurrogate, out char lowSurrogate);
 
             // Trim start
             int index = 0;
-            while (index < Length && this.AsSpan(index).StartsWith(trimChars))
+            while ((uint)(index + 1) < (uint)Length && this[index] == highSurrogate && this[index + 1] == lowSurrogate)
             {
-                index += trimChars.Length;
-            }
-
-            if (index >= Length)
-            {
-                return Empty;
+                index += 2;
             }
 
             // Trim end
-            int endIndex = Length - 1;
-            while (endIndex >= index && this.AsSpan(index..(endIndex + 1)).EndsWith(trimChars))
+            int endIndex = Length - 2;
+            while (endIndex > index && this[endIndex] == highSurrogate && this[endIndex + 1] == lowSurrogate)
             {
-                endIndex -= trimChars.Length;
+                endIndex -= 2;
             }
 
-            if (endIndex < index)
-            {
-                return Empty;
-            }
-
-            return this[index..(endIndex + 1)];
+            return this[index..(endIndex + 2)];
         }
 
         // Removes a set of characters from the beginning and end of this string.
@@ -2497,24 +2486,17 @@ namespace System
         /// </returns>
         public string TrimStart(Rune trimRune)
         {
-            if (Length == 0)
+            if (trimRune.IsBmp)
             {
-                return this;
+                return TrimStart((char)trimRune.Value);
             }
 
-            // Convert trimRune to span
-            ReadOnlySpan<char> trimChars = trimRune.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
+            UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar((uint)trimRune.Value, out char highSurrogate, out char lowSurrogate);
 
-            // Trim start
             int index = 0;
-            while (index < Length && this.AsSpan(index).StartsWith(trimChars))
+            while ((uint)(index + 1) < (uint)Length && this[index] == highSurrogate && this[index + 1] == lowSurrogate)
             {
-                index += trimChars.Length;
-            }
-
-            if (index >= Length)
-            {
-                return Empty;
+                index += 2;
             }
 
             return this[index..];
@@ -2571,27 +2553,20 @@ namespace System
         /// </returns>
         public string TrimEnd(Rune trimRune)
         {
-            if (Length == 0)
+            if (trimRune.IsBmp)
             {
-                return this;
+                return TrimEnd((char)trimRune.Value);
             }
 
-            // Convert trimRune to span
-            ReadOnlySpan<char> trimChars = trimRune.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
+            UnicodeUtility.GetUtf16SurrogatesFromSupplementaryPlaneScalar((uint)trimRune.Value, out char highSurrogate, out char lowSurrogate);
 
-            // Trim end
-            int endIndex = Length - 1;
-            while (endIndex >= 0 && this.AsSpan(..(endIndex + 1)).EndsWith(trimChars))
+            int endIndex = Length - 2;
+            while ((uint)endIndex < (uint)Length && this[endIndex] == highSurrogate && this[endIndex + 1] == lowSurrogate)
             {
-                endIndex -= trimChars.Length;
+                endIndex -= 2;
             }
 
-            if (endIndex < 0)
-            {
-                return Empty;
-            }
-
-            return this[..(endIndex + 1)];
+            return this[..(endIndex + 2)];
         }
 
         // Removes a set of characters from the end of this string.

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -1691,10 +1691,14 @@ namespace System
 
             CheckStringSplitOptions(options);
 
-            ReadOnlySpan<char> separatorSpan = separator.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
-
             // Ensure matching the string separator overload.
-            return (count <= 1 || Length == 0) ? CreateSplitArrayOfThisAsSoleValue(options, count) : Split(separatorSpan, count, options);
+            if (count <= 1 || Length == 0)
+            {
+                return CreateSplitArrayOfThisAsSoleValue(options, count);
+            }
+
+            ReadOnlySpan<char> separatorSpan = separator.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);
+            return Split(separatorSpan, count, options);
         }
 
         // Creates an array of strings by splitting this string at each

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -52,6 +52,11 @@ namespace System
         /// <returns><see langword="true"/> if <paramref name="value"/> occurs within this string; otherwise, <see langword="false"/>.</returns>
         public bool Contains(Rune value)
         {
+            if (value.IsBmp)
+            {
+                return Contains((char)value.Value);
+            }
+
             return Contains(value, StringComparison.Ordinal);
         }
 


### PR DESCRIPTION
| Method                  | Toolchain         | Mean      | Error     | Ratio |
|------------------------ |------------------ |----------:|----------:|------:|
| ContainsBmp             | \main\corerun.exe | 11.018 ns | 0.0416 ns |  1.00 |
| ContainsBmp             | \pr\corerun.exe   |  5.335 ns | 0.0090 ns |  0.48 |
|                         |                   |           |           |       |
| ContainsSupplementary   | \main\corerun.exe | 14.186 ns | 0.0586 ns |  1.00 |
| ContainsSupplementary   | \pr\corerun.exe   | 15.075 ns | 0.0278 ns |  1.06 |
|                         |                   |           |           |       |
| StartsWithBmp           | \main\corerun.exe |  5.637 ns | 0.0063 ns |  1.00 |
| StartsWithBmp           | \pr\corerun.exe   |  2.193 ns | 0.0021 ns |  0.39 |
|                         |                   |           |           |       |
| StartsWithSupplementary | \main\corerun.exe |  9.371 ns | 0.0070 ns |  1.00 |
| StartsWithSupplementary | \pr\corerun.exe   |  2.822 ns | 0.0041 ns |  0.30 |
|                         |                   |           |           |       |
| EndsWithBmp             | \main\corerun.exe |  5.641 ns | 0.0076 ns |  1.00 |
| EndsWithBmp             | \pr\corerun.exe   |  2.505 ns | 0.0022 ns |  0.44 |
|                         |                   |           |           |       |
| EndsWithSupplementary   | \main\corerun.exe |  9.400 ns | 0.0273 ns |  1.00 |
| EndsWithSupplementary   | \pr\corerun.exe   |  3.135 ns | 0.0031 ns |  0.33 |
|                         |                   |           |           |       |
| ReplaceBothBmp          | \main\corerun.exe | 59.146 ns | 0.6353 ns |  1.00 |
| ReplaceBothBmp          | \pr\corerun.exe   | 29.462 ns | 0.3781 ns |  0.50 |
|                         |                   |           |           |       |
| ReplaceSupplementary    | \main\corerun.exe | 62.393 ns | 0.5636 ns |  1.00 |
| ReplaceSupplementary    | \pr\corerun.exe   | 61.546 ns | 0.5907 ns |  0.99 |
|                         |                   |           |           |       |
| SplitBmp                | \main\corerun.exe | 51.507 ns | 0.8753 ns |  1.00 |
| SplitBmp                | \pr\corerun.exe   | 51.466 ns | 1.0191 ns |  1.00 |
|                         |                   |           |           |       |
| SplitSupplementary      | \main\corerun.exe | 49.510 ns | 0.9627 ns |  1.00 |
| SplitSupplementary      | \pr\corerun.exe   | 48.681 ns | 0.4651 ns |  0.98 |
|                         |                   |           |           |       |
| TrimBmp                 | \main\corerun.exe | 35.152 ns | 0.1661 ns |  1.00 |
| TrimBmp                 | \pr\corerun.exe   | 14.858 ns | 0.1258 ns |  0.42 |
|                         |                   |           |           |       |
| TrimSupplementary       | \main\corerun.exe | 23.888 ns | 0.1723 ns |  1.00 |
| TrimSupplementary       | \pr\corerun.exe   | 13.587 ns | 0.1036 ns |  0.57 |
|                         |                   |           |           |       |
| TrimStartBmp            | \main\corerun.exe | 17.435 ns | 0.1468 ns |  1.00 |
| TrimStartBmp            | \pr\corerun.exe   | 12.658 ns | 0.0918 ns |  0.73 |
|                         |                   |           |           |       |
| TrimStartSupplementary  | \main\corerun.exe | 17.189 ns | 0.1117 ns |  1.00 |
| TrimStartSupplementary  | \pr\corerun.exe   | 12.552 ns | 0.0952 ns |  0.73 |
|                         |                   |           |           |       |
| TrimEndBmp              | \main\corerun.exe | 24.816 ns | 0.1445 ns |  1.00 |
| TrimEndBmp              | \pr\corerun.exe   | 11.842 ns | 0.0948 ns |  0.48 |
|                         |                   |           |           |       |
| TrimEndSupplementary    | \main\corerun.exe | 19.257 ns | 0.1592 ns |  1.00 |
| TrimEndSupplementary    | \pr\corerun.exe   | 11.465 ns | 0.1043 ns |  0.60 |