### PR TITLE
Fold more branches via O1K_VN <relop> O2K_VN comparisons

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -904,6 +904,10 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                    curAssertion.GetOp2().GetCheckedBoundConstant());
             break;
 
+        case O2K_VN:
+            printf("VN " FMT_VN "", curAssertion.GetOp2().GetVN());
+            break;
+
         default:
             unreached();
             break;
@@ -1421,6 +1425,13 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
                 mayHaveDuplicates |= optAssertionHasAssertionsForVN(addOpVN, /* addIfNotFound */ canAddNewAssertions);
             }
         }
+        else if (newAssertion.GetOp2().KindIs(O2K_VN))
+        {
+            // For VN <relop> VN assertions, register op2's VN too so consumers can find
+            // the assertion when iterating from the op2 side.
+            mayHaveDuplicates |= optAssertionHasAssertionsForVN(newAssertion.GetOp2().GetVN(),
+                                                                /* addIfNotFound */ canAddNewAssertions);
+        }
 
         if (mayHaveDuplicates)
         {
@@ -1548,6 +1559,12 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
         case O2K_SUBRANGE:
         case O2K_LCLVAR_COPY:
             assert(optLocalAssertionProp);
+            break;
+
+        case O2K_VN:
+            assert(!optLocalAssertionProp);
+            assert(assertion.GetOp1().KindIs(O1K_VN));
+            assert(assertion.IsRelop());
             break;
 
         case O2K_ZEROOBJ:
@@ -1802,6 +1819,24 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     if (vnStore->IsVNIntegralConstant(op2VN, &cns) && (!isUnsignedRelop || (cns > 0)))
     {
         AssertionDsc   dsc = AssertionDsc::CreateConstantBound(this, relopFunc, op1VN, op2VN);
+        AssertionIndex idx = optAddAssertion(dsc);
+        optCreateComplementaryAssertion(idx);
+        return idx;
+    }
+
+    // "X relop Y" where neither side is a constant nor a checked bound.
+    // For now, we only create such assertions for signed comparisons of int32 (and smaller, after promotion).
+    // This widens what global assertion prop can reason about: e.g. "b > a" combined with "a > 10"
+    // can be used to deduce "b > 10".
+    //
+    // To keep table pressure under control, we only create the assertion if at least one of the
+    // operands already has assertions registered. Otherwise the new assertion has no other facts
+    // it can chain with and is unlikely to enable any deduction, while still consuming a slot
+    // (and potentially crowding out useful ones).
+    if (!isUnsignedRelop && (op1VN != op2VN) && !vnStore->IsVNConstant(op1VN) && !vnStore->IsVNConstant(op2VN) &&
+        (optAssertionHasAssertionsForVN(op1VN) || optAssertionHasAssertionsForVN(op2VN)))
+    {
+        AssertionDsc   dsc = AssertionDsc::CreateRelopVN(this, relopFunc, op1VN, op2VN);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7984,7 +7984,8 @@ public:
                                    // nor it implies that it's never negative.
         O2K_ZEROOBJ,
         O2K_SUBRANGE,
-        O2K_CONST_VEC
+        O2K_CONST_VEC,
+        O2K_VN, // op2 is an arbitrary value number (used for VN <relop> VN assertions in global prop).
     };
 
     struct AssertionDsc
@@ -8130,7 +8131,7 @@ public:
             ValueNum GetVN() const
             {
                 assert(!m_compiler->optLocalAssertionProp);
-                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CONST_VEC));
+                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CONST_VEC, O2K_VN));
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -8481,6 +8482,9 @@ public:
                 case O2K_SUBRANGE:
                     return GetOp2().GetIntegralRange().Equals(that.GetOp2().GetIntegralRange());
 
+                case O2K_VN:
+                    return GetOp2().GetVN() == that.GetOp2().GetVN();
+
                 default:
                     assert(!"Unexpected value for GetOp2().m_kind in AssertionDsc.");
                     break;
@@ -8738,6 +8742,24 @@ public:
             dsc.m_op2.m_kind           = O2K_CONST_INT;
             dsc.m_op2.m_vn             = cnsVN;
             dsc.m_op2.m_icon.m_iconVal = cns;
+            return dsc;
+        }
+
+        // Create "op1VN <relop> op2VN" assertion where both operands are arbitrary value numbers
+        // (used by global assertion prop for VN-to-VN signed comparisons of int32 and smaller).
+        static AssertionDsc CreateRelopVN(const Compiler* comp, VNFunc relop, ValueNum op1VN, ValueNum op2VN)
+        {
+            assert(!comp->optLocalAssertionProp);
+            assert(op1VN != ValueNumStore::NoVN);
+            assert(op2VN != ValueNumStore::NoVN);
+            assert(op1VN != op2VN);
+
+            AssertionDsc dsc    = CreateEmptyAssertion(comp);
+            dsc.m_assertionKind = FromVNFunc(relop);
+            dsc.m_op1.m_kind    = O1K_VN;
+            dsc.m_op1.m_vn      = op1VN;
+            dsc.m_op2.m_kind    = O2K_VN;
+            dsc.m_op2.m_vn      = op2VN;
             return dsc;
         }
     };

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1416,7 +1416,13 @@ void RangeCheck::MergeEdgeAssertionsWorker(Compiler*                        comp
                 cmpOper = GenTree::SwapRelop(cmpOper);
             }
 
-            Range otherRange = GetRangeFromAssertionsWorker(comp, otherVN, assertions, budget - 1, visited);
+            if (budget <= 0)
+            {
+                continue;
+            }
+
+            budget--;
+            Range otherRange = GetRangeFromAssertionsWorker(comp, otherVN, assertions, budget, visited);
             if (!otherRange.IsConstantRange())
             {
                 continue;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -940,7 +940,7 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
 
     // MergeEdgeAssertionsWorker may recursively call back to GetRangeFromAssertionsWorker for other VN-to-VN assertion
     // lookups.
-    int edgeAssertionsBudget = min(4, budget);
+    int edgeAssertionsBudget = min(3, budget);
     MergeEdgeAssertionsWorker(comp, num, ValueNumStore::NoVN, assertions, &result, /* canUseCheckedBounds */ false,
                               edgeAssertionsBudget, visited);
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1404,13 +1404,16 @@ void RangeCheck::MergeEdgeAssertionsWorker(Compiler*                        comp
             ValueNum otherVN;
             if (op1VN == normalLclVN)
             {
+                // Assertion is "normalLclVN <cmpOper> otherVN" - keep cmpOper as-is.
                 otherVN = op2VN;
-                cmpOper = GenTree::SwapRelop(cmpOper);
             }
             else
             {
+                // Assertion is "otherVN <cmpOper> normalLclVN" - swap to get
+                // "normalLclVN <swappedCmpOper> otherVN".
                 assert(op2VN == normalLclVN);
                 otherVN = op1VN;
+                cmpOper = GenTree::SwapRelop(cmpOper);
             }
 
             Range otherRange = GetRangeFromAssertionsWorker(comp, otherVN, assertions, budget - 1, visited);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1054,7 +1054,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
     // budget for VN-to-VN assertion lookups.
     ValueNumStore::SmallValueNumSet visited;
     MergeEdgeAssertionsWorker(comp, normalLclVN, preferredBoundVN, assertions, pRange, canUseCheckedBounds,
-                              /* budget */ 4, &visited);
+                              /* budget */ 3, &visited);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -938,7 +938,12 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
         result = phiRange;
     }
 
-    MergeEdgeAssertions(comp, num, ValueNumStore::NoVN, assertions, &result, false);
+    // MergeEdgeAssertionsWorker may recursively call back to GetRangeFromAssertionsWorker for other VN-to-VN assertion
+    // lookups.
+    int edgeAssertionsBudget = min(2, budget);
+    MergeEdgeAssertionsWorker(comp, num, ValueNumStore::NoVN, assertions, &result, /* canUseCheckedBounds */ false,
+                              edgeAssertionsBudget, visited);
+
     assert(result.IsConstantRange());
     return result;
 }
@@ -1044,6 +1049,37 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                                      ASSERT_VALARG_TP assertions,
                                      Range*           pRange,
                                      bool             canUseCheckedBounds)
+{
+    // Public entry point: no shared visited set; create a fresh one and use a small recursion
+    // budget for VN-to-VN assertion lookups.
+    ValueNumStore::SmallValueNumSet visited;
+    MergeEdgeAssertionsWorker(comp, normalLclVN, preferredBoundVN, assertions, pRange, canUseCheckedBounds,
+                              /* budget */ 2, &visited);
+}
+
+//------------------------------------------------------------------------
+// MergeEdgeAssertionsWorker: Worker for MergeEdgeAssertions that takes a visited set and recursion
+//    budget for VN-to-VN assertion lookups.
+//
+// Arguments:
+//    comp                - the compiler instance
+//    normalLclVN         - the value number to look for assertions for
+//    preferredBoundVN    - when this VN is set, it will be given preference over constant limits
+//    assertions          - the assertions to use
+//    pRange              - the range to tighten with assertions
+//    canUseCheckedBounds - true if we can use checked bounds assertions (cache)
+//    budget               - the remaining budget for recursive VN-to-VN assertion lookups
+//    visited              - the set of value numbers already visited in the current search path to prevent infinite
+//    recursion
+//
+void RangeCheck::MergeEdgeAssertionsWorker(Compiler*                        comp,
+                                           ValueNum                         normalLclVN,
+                                           ValueNum                         preferredBoundVN,
+                                           ASSERT_VALARG_TP                 assertions,
+                                           Range*                           pRange,
+                                           bool                             canUseCheckedBounds,
+                                           int                              budget,
+                                           ValueNumStore::SmallValueNumSet* visited)
 {
     Range assertedRange = Range(Limit(Limit::keUnknown));
     if (BitVecOps::IsEmpty(comp->apTraits, assertions))
@@ -1342,6 +1378,67 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             {
                 continue;
             }
+        }
+        // Current assertion is of the form "X <relop> Y" where both X and Y are arbitrary VNs
+        // We try to derive a bound on normalLclVN by recursively computing the range of the other operand.
+        //
+        // Example:
+        //
+        // if (a > 10 && a < 100)
+        // {
+        //    if (normalLclVN > a) // a is an unknown VN with [11..99] range derived from assertions.
+        //    {
+        //
+        else if (curAssertion.IsRelop() && curAssertion.GetOp2().KindIs(Compiler::O2K_VN) &&
+                 (curAssertion.GetOp1().GetVN() == normalLclVN || curAssertion.GetOp2().GetVN() == normalLclVN))
+        {
+            ValueNum op1VN = curAssertion.GetOp1().GetVN();
+            ValueNum op2VN = curAssertion.GetOp2().GetVN();
+
+            cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
+            if (isUnsigned)
+            {
+                continue;
+            }
+
+            ValueNum otherVN;
+            if (op1VN == normalLclVN)
+            {
+                otherVN = op2VN;
+                cmpOper = GenTree::SwapRelop(cmpOper);
+            }
+            else
+            {
+                assert(op2VN == normalLclVN);
+                otherVN = op1VN;
+            }
+
+            Range otherRange = GetRangeFromAssertionsWorker(comp, otherVN, assertions, budget - 1, visited);
+            if (!otherRange.IsConstantRange())
+            {
+                continue;
+            }
+
+            // Derive a constant limit for normalLclVN from the constant range of otherVN.
+            // We use the most useful bound for each direction of the comparison.
+            int derivedLimit;
+            switch (cmpOper)
+            {
+                case GT_LT:
+                case GT_LE:
+                    // normalLclVN < otherVN (or <=)  =>  normalLclVN <(=) otherVN.UpperLimit
+                    derivedLimit = otherRange.UpperLimit().GetConstant();
+                    break;
+                case GT_GT:
+                case GT_GE:
+                    // normalLclVN > otherVN (or >=)  =>  normalLclVN >(=) otherVN.LowerLimit
+                    derivedLimit = otherRange.LowerLimit().GetConstant();
+                    break;
+
+                default:
+                    continue;
+            }
+            limit = Limit(Limit::keConstant, derivedLimit);
         }
         // Current assertion is not supported, ignore it
         else

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -940,7 +940,7 @@ Range RangeCheck::GetRangeFromAssertionsWorker(
 
     // MergeEdgeAssertionsWorker may recursively call back to GetRangeFromAssertionsWorker for other VN-to-VN assertion
     // lookups.
-    int edgeAssertionsBudget = min(2, budget);
+    int edgeAssertionsBudget = min(4, budget);
     MergeEdgeAssertionsWorker(comp, num, ValueNumStore::NoVN, assertions, &result, /* canUseCheckedBounds */ false,
                               edgeAssertionsBudget, visited);
 
@@ -1054,7 +1054,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
     // budget for VN-to-VN assertion lookups.
     ValueNumStore::SmallValueNumSet visited;
     MergeEdgeAssertionsWorker(comp, normalLclVN, preferredBoundVN, assertions, pRange, canUseCheckedBounds,
-                              /* budget */ 2, &visited);
+                              /* budget */ 4, &visited);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -827,6 +827,18 @@ private:
                                     Range*           pRange,
                                     bool             canUseCheckedBounds = true);
 
+    // Internal worker used by GetRangeFromAssertionsWorker: same as the public overload
+    // but threads a recursion budget and visited set so that VN-to-VN assertions can be
+    // resolved by recursing into GetRangeFromAssertionsWorker without unbounded work.
+    static void MergeEdgeAssertionsWorker(Compiler*                        comp,
+                                          ValueNum                         num,
+                                          ValueNum                         preferredBoundVN,
+                                          ASSERT_VALARG_TP                 assertions,
+                                          Range*                           pRange,
+                                          bool                             canUseCheckedBounds,
+                                          int                              budget,
+                                          ValueNumStore::SmallValueNumSet* visited);
+
     // The maximum possible value of the given "limit". If such a value could not be determined
     // return "false". For example: CORINFO_Array_MaxLength for array length.
     bool GetLimitMax(Limit& limit, int* pMax);


### PR DESCRIPTION
Minimal example:
```cs
if (x > 10 && x < 100)
{
    if (y > x) // means y > 11
    {
        return y > 0; // always true 
```