### PR TITLE
JIT: Fold redundant CHKCAST through VN-to-handle assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1946,6 +1946,20 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
         }
     }
 
+    // Handle "VN ==/!= class handle" pattern. T
+    if (!optLocalAssertionProp && relop->OperIs(GT_EQ, GT_NE) && op2->TypeIs(TYP_I_IMPL))
+    {
+        ValueNum op1VN = optConservativeNormalVN(op1);
+        ValueNum hndVN = optConservativeNormalVN(op2);
+        if ((op1VN != ValueNumStore::NoVN) && vnStore->IsVNTypeHandle(hndVN))
+        {
+            AssertionDsc   dsc = AssertionDsc::CreateConstVNAssertion(this, op1VN, hndVN, relop->OperIs(GT_EQ), GTF_ICON_CLASS_HDL);
+            AssertionIndex idx = optAddAssertion(dsc);
+            optCreateComplementaryAssertion(idx);
+            return idx;
+        }
+    }
+
     // Check for op1 or op2 to be lcl var and if so, keep it in op1.
     if (!op1->OperIs(GT_LCL_VAR) && op2->OperIs(GT_LCL_VAR))
     {
@@ -2413,6 +2427,49 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
         }
     }
     return NO_ASSERTION_INDEX;
+}
+
+//------------------------------------------------------------------------------
+// optAssertionGetVNHandleClass:
+//    Look for an assertion of the form "VN(tree) == handle_const_class" among
+//    the live assertions and, if found, return the recorded class handle.
+//
+// Arguments:
+//    tree       - tree whose VN we look up
+//    assertions - the live assertion set
+//
+// Return Value:
+//    The asserted class handle, or NO_CLASS_HANDLE if no such assertion exists.
+//
+CORINFO_CLASS_HANDLE Compiler::optAssertionGetVNHandleClass(GenTree* tree, ASSERT_VALARG_TP assertions)
+{
+    assert(!optLocalAssertionProp);
+
+    const ValueNum treeVN = vnStore->VNConservativeNormalValue(tree->gtVNPair);
+    if ((treeVN == ValueNumStore::NoVN) || !optAssertionHasAssertionsForVN(treeVN))
+    {
+        return NO_CLASS_HANDLE;
+    }
+
+    if (IsAot())
+    {
+        // todo: fix
+        return NO_CLASS_HANDLE;
+    }
+
+    BitVecOps::Iter iter(apTraits, assertions);
+    unsigned        bvIndex = 0;
+    while (iter.NextElem(&bvIndex))
+    {
+        const AssertionDsc& curAssertion = optGetAssertion(GetAssertionIndex(bvIndex));
+        if (curAssertion.KindIs(OAK_EQUAL) && curAssertion.GetOp1().KindIs(O1K_VN) &&
+            (curAssertion.GetOp1().GetVN() == treeVN) && curAssertion.GetOp2().KindIs(O2K_CONST_INT) &&
+            (curAssertion.GetOp2().GetIconFlag() == GTF_ICON_CLASS_HDL))
+        {
+            return reinterpret_cast<CORINFO_CLASS_HANDLE>(curAssertion.GetOp2().GetIntConstant());
+        }
+    }
+    return NO_CLASS_HANDLE;
 }
 
 //------------------------------------------------------------------------------
@@ -5286,6 +5343,30 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
                 objArg = fgMakeMultiUse(&objCallArg->NodeRef());
                 objArg = gtWrapWithSideEffects(objArg, call, GTF_SIDE_EFFECT, true);
                 return optAssertionProp_Update(objArg, call, stmt);
+            }
+
+            // If castToArg is not a constant class handle (e.g., it's a shared-generic runtime lookup),
+            // see if we have an assertion of the form "castToArg.VN == handle_const" that lets us treat
+            // it as a constant for cast-folding purposes.
+            if (!castToArg->IsIconHandle(GTF_ICON_CLASS_HDL))
+            {
+                CORINFO_CLASS_HANDLE assertedClass = optAssertionGetVNHandleClass(castToArg, assertions);
+                if (assertedClass != NO_CLASS_HANDLE)
+                {
+                    bool                 isExact;
+                    bool                 isNonNull;
+                    CORINFO_CLASS_HANDLE objClass = gtGetClassHandle(objArg, &isExact, &isNonNull);
+                    if ((objClass != NO_CLASS_HANDLE) &&
+                        (info.compCompHnd->compareTypesForCast(objClass, assertedClass) == TypeCompareState::Must))
+                    {
+                        JITDUMP("\nDid VN based runtime-lookup cast prop in " FMT_BB ":\n", compCurBB->bbNum);
+                        DISPTREE(call);
+
+                        objArg = fgMakeMultiUse(&objCallArg->NodeRef());
+                        objArg = gtWrapWithSideEffects(objArg, call, GTF_SIDE_EFFECT, true);
+                        return optAssertionProp_Update(objArg, call, stmt);
+                    }
+                }
             }
 
             // Leave a hint for fgLateCastExpansion that obj is never null.

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8740,6 +8740,29 @@ public:
             dsc.m_op2.m_icon.m_iconVal = cns;
             return dsc;
         }
+
+        // Create "O1K_VN(op1VN) ==/!= constant" assertion where the constant is identified by its VN.
+        static AssertionDsc CreateConstVNAssertion(const Compiler* comp,
+                                                   ValueNum        op1VN,
+                                                   ValueNum        cnsVN,
+                                                   bool            equals,
+                                                   GenTreeFlags    iconFlags = GTF_EMPTY,
+                                                   FieldSeq*       fieldSeq  = nullptr)
+        {
+            assert(!comp->optLocalAssertionProp);
+            assert(op1VN != ValueNumStore::NoVN);
+            assert(cnsVN != ValueNumStore::NoVN);
+
+            AssertionDsc dsc           = CreateEmptyAssertion(comp);
+            dsc.m_assertionKind        = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
+            dsc.m_op1.m_kind           = O1K_VN;
+            dsc.m_op1.m_vn             = op1VN;
+            dsc.m_op2.m_kind           = O2K_CONST_INT;
+            dsc.m_op2.m_vn             = cnsVN;
+            dsc.m_op2.m_icon.m_iconVal = comp->vnStore->CoercedConstantValue<ssize_t>(cnsVN);
+            dsc.m_op2.SetIconFlag(iconFlags, fieldSeq);
+            return dsc;
+        }
     };
 
 protected:
@@ -8823,10 +8846,11 @@ public:
     AssertionIndex optAddAssertion(const AssertionDsc& assertion);
 
     // Used for respective assertion propagations.
-    AssertionIndex optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
-    AssertionIndex optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
-    bool           optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
-    bool           optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
+    AssertionIndex       optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
+    AssertionIndex       optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
+    CORINFO_CLASS_HANDLE optAssertionGetVNHandleClass(GenTree* tree, ASSERT_VALARG_TP assertions);
+    bool                 optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
+    bool                 optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
 
     AssertionIndex optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP assertions, GenTree* op1, GenTree* op2);
     AssertionIndex optLocalAssertionIsEqualOrNotEqual(


### PR DESCRIPTION
```cs
public static T Test<T>(T generic, string concrete)
    => typeof(T) == typeof(string) ? (T)(object)concrete : generic;
```
before:
```asm
G_M63165_IG01:  ;; offset=0x0000
       sub      rsp, 40
       mov      qword ptr [rsp+0x20], rcx
       mov      rax, rdx
G_M63165_IG02:  ;; offset=0x000C
       mov      rcx, qword ptr [rcx+0x18]
       mov      rcx, qword ptr [rcx]
       mov      rdx, 0x7FFB701AE8B8      ; System.String
       cmp      rcx, rdx
       jne      SHORT G_M63165_IG08
G_M63165_IG03:  ;; offset=0x0022
       mov      rax, r8
       test     rax, rax
       je       SHORT G_M63165_IG06
G_M63165_IG04:  ;; offset=0x002A
       cmp      qword ptr [rax], rcx
       je       SHORT G_M63165_IG06
G_M63165_IG05:  ;; offset=0x002F
       mov      rdx, r8
       call     CORINFO_HELP_CHKCASTANY
G_M63165_IG06:  ;; offset=0x0037
       nop      
G_M63165_IG07:  ;; offset=0x0038
       add      rsp, 40
       ret      
G_M63165_IG08:  ;; offset=0x003D
       add      rsp, 40
       ret      
; Total bytes of code 66,
```
now:
```asm
G_M63165_IG01:
       push     rax
       mov      qword ptr [rsp], rcx
G_M63165_IG02:
       mov      rax, qword ptr [rcx+0x18]
       mov      rax, qword ptr [rax]
       mov      rcx, 0x7FFBBF01E8B8      ; System.String
       cmp      rax, rcx
       mov      rax, rdx
       cmove    rax, r8
G_M63165_IG03:
       add      rsp, 8
       ret      
; Total bytes of code 37
```