### PR TITLE
JIT: fix value-probing schema index collision with handle histogram

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -1436,9 +1436,13 @@ public:
 
     union
     {
-        unsigned bbStkTempsOut;          // base# for output stack temps
-        int      bbHistogramSchemaIndex; // schema index for histogram instrumentation
+        unsigned bbStkTempsOut;                // base# for output stack temps
+        int      bbHandleHistogramSchemaIndex; // schema index for handle (class/method) histogram instrumentation
     };
+
+    int bbValueHistogramSchemaIndex; // schema index for value histogram instrumentation
+                                     // Placed here so it consumes the existing tail padding before
+                                     // bbTryIndex/bbHndIndex without growing BasicBlock.
 
 #define MAX_XCPTN_INDEX (USHRT_MAX - 1)
 

--- a/src/coreclr/jit/fgprofile.cpp
+++ b/src/coreclr/jit/fgprofile.cpp
@@ -2361,7 +2361,7 @@ void HandleHistogramProbeInstrumentor::Prepare(bool isPreImport)
     //
     for (BasicBlock* const block : m_compiler->Blocks())
     {
-        block->bbHistogramSchemaIndex = -1;
+        block->bbHandleHistogramSchemaIndex = -1;
     }
 #endif
 }
@@ -2382,7 +2382,7 @@ void HandleHistogramProbeInstrumentor::BuildSchemaElements(BasicBlock* block, Sc
 
     // Remember the schema index for this block.
     //
-    block->bbHistogramSchemaIndex = (int)schema.size();
+    block->bbHandleHistogramSchemaIndex = (int)schema.size();
 
     // Scan the statements and identify the class probes
     //
@@ -2416,7 +2416,7 @@ void HandleHistogramProbeInstrumentor::Instrument(BasicBlock* block, Schema& sch
 
     // Scan the statements and add class probes
     //
-    int histogramSchemaIndex = block->bbHistogramSchemaIndex;
+    int histogramSchemaIndex = block->bbHandleHistogramSchemaIndex;
     assert((histogramSchemaIndex >= 0) && (histogramSchemaIndex < (int)schema.size()));
 
     HandleHistogramProbeInserter insertProbes(schema, profileMemory, &histogramSchemaIndex, m_instrCount);
@@ -2445,7 +2445,7 @@ void ValueInstrumentor::Prepare(bool isPreImport)
     //
     for (BasicBlock* const block : m_compiler->Blocks())
     {
-        block->bbCountSchemaIndex = -1;
+        block->bbValueHistogramSchemaIndex = -1;
     }
 #endif
 }
@@ -2465,7 +2465,7 @@ void ValueInstrumentor::BuildSchemaElements(BasicBlock* block, Schema& schema)
         return;
     }
 
-    block->bbHistogramSchemaIndex = (int)schema.size();
+    block->bbValueHistogramSchemaIndex = (int)schema.size();
 
     BuildValueHistogramProbeSchemaGen                             schemaGen(schema, m_schemaCount);
     ValueHistogramProbeVisitor<BuildValueHistogramProbeSchemaGen> visitor(m_compiler, schemaGen);
@@ -2491,7 +2491,7 @@ void ValueInstrumentor::Instrument(BasicBlock* block, Schema& schema, uint8_t* p
         return;
     }
 
-    int histogramSchemaIndex = block->bbHistogramSchemaIndex;
+    int histogramSchemaIndex = block->bbValueHistogramSchemaIndex;
     assert((histogramSchemaIndex >= 0) && (histogramSchemaIndex < (int)schema.size()));
 
     ValueHistogramProbeInserter insertProbes(schema, profileMemory, &histogramSchemaIndex, m_instrCount);


### PR DESCRIPTION
Both `HandleHistogramProbeInstrumentor` and `ValueInstrumentor` were writing to the same `BasicBlock::bbHistogramSchemaIndex` field. The value instrumentor was essentially copy-pasted from the type histogram one and inherited the same field without adjusting for the fact that a block can be processed by both.

## The bug

When a single basic block has both `BBF_HAS_HISTOGRAM_PROFILE` (e.g. a virtual call) and `BBF_HAS_VALUE_PROFILE` (a `SpanHelpers.Memmove` / `SpanHelpers.SequenceEqual` special intrinsic), schema build runs in this order:

1. `HandleHistogramProbeInstrumentor::BuildSchemaElements` writes `bbHistogramSchemaIndex = N` and appends `H` handle-histogram entries.
2. `ValueInstrumentor::BuildSchemaElements` **overwrites** with `bbHistogramSchemaIndex = N + H` and appends value entries.

Then `HandleHistogramProbeInstrumentor::Instrument` runs first for the block, reads `N + H`, and `ReadHistogramAndAdvance` lands on a `ValueHistogramIntCount`/`ValueHistogramLongCount` kind. It returns early without setting `typeHistogram`/`methodHistogram`:

* In **DEBUG**, the assert at https://github.com/dotnet/runtime/blob/main/src/coreclr/jit/fgprofile.cpp#L2077 (`"Expected at least one handle histogram when inserting probes"`) fires, and so does `InstrCount() == compHandleHistogramProbeCount` later.
* In **retail**, `helperCallNode` stays `nullptr` and `gtNewOperNode(GT_COMMA, TYP_REF, helperCallNode, tmpNode2)` is built with a `nullptr` child -- malformed IR, not just a missed probe.

The pattern is common: any method that has a virtual call followed by `Span<T>.CopyTo` / `MemoryExtensions.SequenceEqual` / `Buffer.Memmove` in the same block can hit it once those calls inline down to the recognized `SpanHelpers` intrinsics.

While at it I also noticed a copy-paste typo in `ValueInstrumentor::Prepare` that cleared `bbCountSchemaIndex` instead of its own field. Benign today (count instrumentor's `Prepare` cleared it earlier), but indicative of the shaky copy-paste.

## The fix

Split the per-block schema index into two dedicated fields:

* `bbHistogramSchemaIndex` -> `bbHandleHistogramSchemaIndex` (used by `HandleHistogramProbeInstrumentor`)
* new `bbValueHistogramSchemaIndex` (used by `ValueInstrumentor`)

The new field is placed right after the existing union so it consumes the pre-existing 4-byte tail padding before `bbTryIndex`/`bbHndIndex`. **`sizeof(BasicBlock)` is unchanged on x64 (280 bytes before and after**, verified with a temporary `PrintSize<sizeof(BasicBlock)>` probe).

