### PR TITLE
Add `Bundler.ComputeBundleContents` to `Microsoft.NET.HostModel`

### DIFF
--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/BundleContents.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/BundleContents.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+namespace Microsoft.NET.HostModel.Bundle
+{
+    /// <summary>
+    /// Describes the contents of a bundle.
+    /// </summary>
+    public sealed class BundleContents
+    {
+        /// <summary>
+        /// The host binary that serves as the bundle container.
+        /// </summary>
+        public FileSpec Host { get; }
+
+        /// <summary>
+        /// Files that will be embedded in the bundle.
+        /// </summary>
+        public IReadOnlyList<FileSpec> IncludedFiles { get; }
+
+        /// <summary>
+        /// Files that are excluded from the bundle and should be published alongside the host.
+        /// </summary>
+        public IReadOnlyList<FileSpec> ExcludedFiles { get; }
+
+        internal (FileSpec Spec, FileType Type)[] TypedIncludedFiles { get; }
+
+        internal BundleContents(FileSpec host, (FileSpec Spec, FileType Type)[] includedFiles, IReadOnlyList<FileSpec> excludedFiles)
+        {
+            Host = host;
+            TypedIncludedFiles = includedFiles;
+            IncludedFiles = System.Array.ConvertAll(includedFiles, x => x.Spec);
+            ExcludedFiles = excludedFiles;
+        }
+    }
+}

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/BundleContents.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/BundleContents.cs
@@ -27,7 +27,7 @@ namespace Microsoft.NET.HostModel.Bundle
 
         internal (FileSpec Spec, FileType Type)[] TypedIncludedFiles { get; }
 
-        internal BundleContents(FileSpec host, (FileSpec Spec, FileType Type)[] includedFiles, IReadOnlyList<FileSpec> excludedFiles)
+        internal BundleContents(FileSpec host, (FileSpec Spec, FileType Type)[] includedFiles, FileSpec[] excludedFiles)
         {
             Host = host;
             TypedIncludedFiles = includedFiles;

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -248,43 +248,43 @@ namespace Microsoft.NET.HostModel.Bundle
         internal static ReadOnlySpan<byte> BundleHeaderSignature => BundleHeaderPlaceholder.Slice(8);
 
         /// <summary>
-        /// Generate a bundle, given the specification of embedded files
+        /// Generate a bundle, given the specification of embedded files.
         /// </summary>
         /// <param name="fileSpecs">
-        /// An enumeration FileSpecs for the files to be embedded.
-        ///
-        /// Files in fileSpecs that are not bundled within the single file bundle,
-        /// and should be published as separate files are marked as "IsExcluded" by this method.
-        /// This doesn't include unbundled files that should be dropped, and not published as output.
+        /// An enumeration of FileSpecs for the files to be embedded.
+        /// Files that are excluded from the bundle have their <see cref="FileSpec.Excluded"/> flag set by this method.
         /// </param>
         /// <returns>
-        /// The full path the generated bundle file
+        /// The full path of the generated bundle file.
         /// </returns>
         /// <exceptions>
-        /// ArgumentException if input is invalid
+        /// ArgumentException if input is invalid.
         /// IOExceptions and ArgumentExceptions from callees flow to the caller.
         /// </exceptions>
         public string GenerateBundle(IReadOnlyList<FileSpec> fileSpecs)
+        {
+            return GenerateBundle(ComputeBundleContents(fileSpecs));
+        }
+
+        /// <summary>
+        /// Generate a bundle from the given <see cref="BundleContents"/>,
+        /// as computed by <see cref="ComputeBundleContents"/>.
+        /// </summary>
+        /// <param name="bundleContents">
+        /// The bundle contents from <see cref="ComputeBundleContents"/>.
+        /// </param>
+        /// <returns>
+        /// The full path of the generated bundle file.
+        /// </returns>
+        public string GenerateBundle(BundleContents bundleContents)
         {
             _tracer.Log($"Bundler Version: {BundlerMajorVersion}.{BundlerMinorVersion}");
             _tracer.Log($"Bundle  Version: {BundleManifest.BundleVersion}");
             _tracer.Log($"Target Runtime: {_target}");
             _tracer.Log($"Bundler Options: {_options}");
-            if (fileSpecs.Any(x => !x.IsValid()))
-            {
-                throw new ArgumentException("Invalid input specification: Found entry with empty source-path or bundle-relative-path.");
-            }
-            string hostSource;
-            try
-            {
-                hostSource = fileSpecs.Where(x => x.BundleRelativePath.Equals(_hostName)).Single().SourcePath;
-            }
-            catch (InvalidOperationException)
-            {
-                throw new ArgumentException("Invalid input specification: Must specify the host binary");
-            }
 
-            (FileSpec Spec, FileType Type)[] relativePathToSpec = GetFilteredFileSpecs(fileSpecs);
+            string hostSource = bundleContents.Host.SourcePath;
+            (FileSpec Spec, FileType Type)[] relativePathToSpec = bundleContents.TypedIncludedFiles;
             long bundledFilesSize = 0;
             // Conservatively estimate the size of bundled files.
             // Assume no compression and worst case alignment for assemblies.
@@ -445,6 +445,38 @@ namespace Microsoft.NET.HostModel.Bundle
             return headerOffset != 0;
         }
 
+        /// <summary>
+        /// Compute which files would be included in or excluded from the bundle
+        /// for the given set of input file specs and the bundler's current options.
+        /// </summary>
+        /// <param name="fileSpecs">
+        /// An enumeration of FileSpecs for the files to potentially be embedded.
+        /// Files that are excluded from the bundle have their <see cref="FileSpec.Excluded"/> flag set by this method.
+        /// </param>
+        /// <returns>
+        /// A <see cref="BundleContents"/> describing which files would be included in
+        /// and excluded from the bundle.
+        /// </returns>
+        public BundleContents ComputeBundleContents(IReadOnlyList<FileSpec> fileSpecs)
+        {
+            if (fileSpecs.Any(x => !x.IsValid()))
+            {
+                throw new ArgumentException("Invalid input specification: Found entry with empty source-path or bundle-relative-path.");
+            }
+
+            FileSpec? hostSpec = fileSpecs.FirstOrDefault(x => IsHost(x.BundleRelativePath));
+            if (hostSpec is null)
+            {
+                throw new ArgumentException("Invalid input specification: Must specify the host binary");
+            }
+
+            var included = GetFilteredFileSpecs(fileSpecs.Where(x => !IsHost(x.BundleRelativePath)));
+            return new BundleContents(
+                hostSpec,
+                included,
+                fileSpecs.Where(x => x.Excluded).ToArray());
+        }
+
         private (FileSpec Spec, FileType Type)[] GetFilteredFileSpecs(IEnumerable<FileSpec> fileSpecs)
         {
             // Note: We're comparing file paths both on the OS we're running on as well as on the target OS for the app
@@ -454,11 +486,6 @@ namespace Microsoft.NET.HostModel.Bundle
             foreach (var fileSpec in fileSpecs)
             {
                 string relativePath = fileSpec.BundleRelativePath;
-
-                if (IsHost(relativePath))
-                {
-                    continue;
-                }
 
                 if (ShouldIgnore(relativePath))
                 {

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -278,6 +278,15 @@ namespace Microsoft.NET.HostModel.Bundle
         /// </returns>
         public string GenerateBundle(BundleContents bundleContents)
         {
+#if NET
+            ArgumentNullException.ThrowIfNull(bundleContents);
+#else
+            if (bundleContents is null)
+            {
+                throw new ArgumentNullException(nameof(bundleContents));
+            }
+#endif
+
             _tracer.Log($"Bundler Version: {BundlerMajorVersion}.{BundlerMinorVersion}");
             _tracer.Log($"Bundle  Version: {BundleManifest.BundleVersion}");
             _tracer.Log($"Target Runtime: {_target}");
@@ -464,25 +473,27 @@ namespace Microsoft.NET.HostModel.Bundle
                 throw new ArgumentException("Invalid input specification: Found entry with empty source-path or bundle-relative-path.");
             }
 
-            FileSpec? hostSpec = fileSpecs.FirstOrDefault(x => IsHost(x.BundleRelativePath));
-            if (hostSpec is null)
+            FileSpec[] hostSpecs = fileSpecs.Where(x => IsHost(x.BundleRelativePath)).ToArray();
+            if (hostSpecs.Length != 1)
             {
-                throw new ArgumentException("Invalid input specification: Must specify the host binary");
+                throw new ArgumentException($"Invalid input specification: Must specify exactly one entry for the host binary '{_hostName}'");
             }
 
-            var included = GetFilteredFileSpecs(fileSpecs.Where(x => !IsHost(x.BundleRelativePath)));
+            FileSpec hostSpec = hostSpecs[0];
+            var (included, excluded) = GetFilteredFileSpecs(fileSpecs.Where(x => x != hostSpec));
             return new BundleContents(
                 hostSpec,
                 included,
-                fileSpecs.Where(x => x.Excluded).ToArray());
+                excluded);
         }
 
-        private (FileSpec Spec, FileType Type)[] GetFilteredFileSpecs(IEnumerable<FileSpec> fileSpecs)
+        private ((FileSpec Spec, FileType Type)[] Included, FileSpec[] Excluded) GetFilteredFileSpecs(IEnumerable<FileSpec> fileSpecs)
         {
             // Note: We're comparing file paths both on the OS we're running on as well as on the target OS for the app
             // We can't really make assumptions about the file systems (even on Linux there can be case insensitive file systems
             // and vice versa for Windows). So it's safer to do case sensitive comparison everywhere.
             var relativePathToSpec = new Dictionary<string, (FileSpec Spec, FileType Type)>(StringComparer.Ordinal);
+            var excluded = new List<FileSpec>();
             foreach (var fileSpec in fileSpecs)
             {
                 string relativePath = fileSpec.BundleRelativePath;
@@ -499,6 +510,7 @@ namespace Microsoft.NET.HostModel.Bundle
                 {
                     _tracer.Log($"Exclude [{type}]: {relativePath}");
                     fileSpec.Excluded = true;
+                    excluded.Add(fileSpec);
                     continue;
                 }
 
@@ -517,7 +529,8 @@ namespace Microsoft.NET.HostModel.Bundle
                     relativePathToSpec.Add(fileSpec.BundleRelativePath, (fileSpec, type));
                 }
             }
-            return relativePathToSpec.Values.ToArray();
+
+            return (relativePathToSpec.Values.ToArray(), excluded.ToArray());
         }
 
         /// <summary>

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -315,6 +315,113 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
             bundler.BundleManifest.Contains(otherContentName).Should().Be(options.HasFlag(BundleOptions.BundleOtherFiles));
         }
 
+        [InlineData(BundleOptions.None)]
+        [InlineData(BundleOptions.BundleNativeBinaries)]
+        [InlineData(BundleOptions.BundleOtherFiles)]
+        [InlineData(BundleOptions.BundleAllContent)]
+        [InlineData(BundleOptions.BundleSymbolFiles)]
+        [Theory]
+        public void ComputeBundleContents(BundleOptions options)
+        {
+            TestApp app = sharedTestState.App;
+            string devJsonName = Path.GetFileName(app.RuntimeDevConfigJson);
+            string appSymbolName = $"{app.Name}.pdb";
+            string otherContentName = "other.txt";
+            FileSpec[] fileSpecs = new FileSpec[]
+            {
+                new FileSpec(Binaries.AppHost.FilePath, BundlerHostName),
+                new FileSpec(app.AppDll, Path.GetRelativePath(app.Location, app.AppDll)),
+                new FileSpec(app.DepsJson, Path.GetRelativePath(app.Location, app.DepsJson)),
+                new FileSpec(app.RuntimeConfigJson, Path.GetRelativePath(app.Location, app.RuntimeConfigJson)),
+                new FileSpec(app.RuntimeConfigJson, devJsonName),
+                new FileSpec(Path.Combine(app.Location, appSymbolName), appSymbolName),
+                new FileSpec(Binaries.CoreClr.FilePath, Binaries.CoreClr.FileName),
+                new FileSpec(app.RuntimeConfigJson, otherContentName),
+            };
+
+            Bundler bundler = CreateBundlerInstance(options);
+            BundleContents contents = bundler.ComputeBundleContents(fileSpecs);
+
+            // App's dll, .deps.json, and .runtimeconfig.json should always be included
+            Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == Path.GetFileName(app.AppDll));
+            Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == Path.GetFileName(app.DepsJson));
+            Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == Path.GetFileName(app.RuntimeConfigJson));
+
+            // Host should be identified separately
+            Assert.Equal(BundlerHostName, contents.Host.BundleRelativePath);
+            Assert.DoesNotContain(contents.IncludedFiles, f => f.BundleRelativePath == BundlerHostName);
+            Assert.DoesNotContain(contents.ExcludedFiles, f => f.BundleRelativePath == BundlerHostName);
+
+            // App's .runtimeconfig.dev.json is ignored (not in either list)
+            Assert.DoesNotContain(contents.IncludedFiles, f => f.BundleRelativePath == devJsonName);
+            Assert.DoesNotContain(contents.ExcludedFiles, f => f.BundleRelativePath == devJsonName);
+
+            // Symbols
+            if (options.HasFlag(BundleOptions.BundleSymbolFiles))
+            {
+                Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == appSymbolName);
+                Assert.DoesNotContain(contents.ExcludedFiles, f => f.BundleRelativePath == appSymbolName);
+            }
+            else
+            {
+                Assert.Contains(contents.ExcludedFiles, f => f.BundleRelativePath == appSymbolName);
+                Assert.DoesNotContain(contents.IncludedFiles, f => f.BundleRelativePath == appSymbolName);
+            }
+
+            // Native libraries
+            if (options.HasFlag(BundleOptions.BundleNativeBinaries))
+            {
+                Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == Binaries.CoreClr.FileName);
+                Assert.DoesNotContain(contents.ExcludedFiles, f => f.BundleRelativePath == Binaries.CoreClr.FileName);
+            }
+            else
+            {
+                Assert.Contains(contents.ExcludedFiles, f => f.BundleRelativePath == Binaries.CoreClr.FileName);
+                Assert.DoesNotContain(contents.IncludedFiles, f => f.BundleRelativePath == Binaries.CoreClr.FileName);
+            }
+
+            // Other files
+            if (options.HasFlag(BundleOptions.BundleOtherFiles))
+            {
+                Assert.Contains(contents.IncludedFiles, f => f.BundleRelativePath == otherContentName);
+                Assert.DoesNotContain(contents.ExcludedFiles, f => f.BundleRelativePath == otherContentName);
+            }
+            else
+            {
+                Assert.Contains(contents.ExcludedFiles, f => f.BundleRelativePath == otherContentName);
+                Assert.DoesNotContain(contents.IncludedFiles, f => f.BundleRelativePath == otherContentName);
+            }
+
+        }
+
+        [Fact]
+        public void ComputeBundleContents_GenerateBundle()
+        {
+            TestApp app = sharedTestState.App;
+            FileSpec[] fileSpecs = new FileSpec[]
+            {
+                new FileSpec(Binaries.AppHost.FilePath, BundlerHostName),
+                new FileSpec(app.AppDll, Path.GetRelativePath(app.Location, app.AppDll)),
+                new FileSpec(app.DepsJson, Path.GetRelativePath(app.Location, app.DepsJson)),
+                new FileSpec(app.RuntimeConfigJson, Path.GetRelativePath(app.Location, app.RuntimeConfigJson)),
+                new FileSpec(Binaries.CoreClr.FilePath, Binaries.CoreClr.FileName),
+            };
+
+            // Generate bundle directly from file specs
+            Bundler directBundler = CreateBundlerInstance();
+            string directBundlePath = directBundler.GenerateBundle(fileSpecs);
+
+            // Generate bundle via ComputeBundleContents + GenerateBundle(BundleContents)
+            Bundler computedBundler = CreateBundlerInstance();
+            BundleContents contents = computedBundler.ComputeBundleContents(fileSpecs);
+            string computedBundlePath = computedBundler.GenerateBundle(contents);
+
+            // Both paths should produce bundles with the same manifest entries
+            var directEntries = directBundler.BundleManifest.Files.Select(f => (f.RelativePath, f.Size, f.CompressedSize, f.Type)).OrderBy(e => e.RelativePath);
+            var computedEntries = computedBundler.BundleManifest.Files.Select(f => (f.RelativePath, f.Size, f.CompressedSize, f.Type)).OrderBy(e => e.RelativePath);
+            Assert.Equal(directEntries, computedEntries);
+        }
+
         [Fact]
         public void FileSizes()
         {

--- a/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
+++ b/src/installer/tests/Microsoft.NET.HostModel.Tests/Bundle/BundlerConsistencyTests.cs
@@ -409,12 +409,12 @@ namespace Microsoft.NET.HostModel.Bundle.Tests
 
             // Generate bundle directly from file specs
             Bundler directBundler = CreateBundlerInstance();
-            string directBundlePath = directBundler.GenerateBundle(fileSpecs);
+            directBundler.GenerateBundle(fileSpecs);
 
             // Generate bundle via ComputeBundleContents + GenerateBundle(BundleContents)
             Bundler computedBundler = CreateBundlerInstance();
             BundleContents contents = computedBundler.ComputeBundleContents(fileSpecs);
-            string computedBundlePath = computedBundler.GenerateBundle(contents);
+            computedBundler.GenerateBundle(contents);
 
             // Both paths should produce bundles with the same manifest entries
             var directEntries = directBundler.BundleManifest.Files.Select(f => (f.RelativePath, f.Size, f.CompressedSize, f.Type)).OrderBy(e => e.RelativePath);


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with assistance from GitHub Copilot.

Resolves https://github.com/dotnet/runtime/issues/124051

Adds an API to compute which files would be included in or excluded from a single-file bundle without actually generating the bundle. This enables the SDK to properly support build incrementality by determining bundle membership ahead of time.

cc @dotnet/appmodel @AaronRobinsonMSFT @baronfel 

## New API

```csharp
namespace Microsoft.NET.HostModel.Bundle;

public sealed class BundleContents
{
    public FileSpec Host { get; }
    public IReadOnlyList<FileSpec> IncludedFiles { get; }
    public IReadOnlyList<FileSpec> ExcludedFiles { get; }
}

public class Bundler
{
    public BundleContents ComputeBundleContents(IReadOnlyList<FileSpec> fileSpecs);
    public string GenerateBundle(BundleContents bundleContents);
}
```

## Changes

- Added `BundleContents` class with `Host`, `IncludedFiles`, and `ExcludedFiles` properties
- Added `Bundler.ComputeBundleContents()` to determine bundle membership without generating the bundle
- Added `Bundler.GenerateBundle(BundleContents)` overload to generate a bundle from pre-computed contents (skipping re-filtering and type inference)
- Refactored existing `GenerateBundle(IReadOnlyList<FileSpec>)` to delegate through `ComputeBundleContents`
- Moved host pre-filtering out of `GetFilteredFileSpecs` into both callers for clarity
- Added tests for `ComputeBundleContents` covering all `BundleOptions` variants and round-trip equivalence with `GenerateBundle`