### PR TITLE
Cleanup VisitOperandUses and GenTreeVisitor to check common kinds rather than be a big switch

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -12691,306 +12691,245 @@ public:
             }
         }
 
-        switch (node->OperGet())
+        if (node->OperIsLeaf())
         {
-            // Leaf lclVars
-            case GT_LCL_VAR:
-            case GT_LCL_FLD:
-            case GT_LCL_ADDR:
-                if (TVisitor::DoLclVarsOnly)
-                {
-                    result = reinterpret_cast<TVisitor*>(this)->PreOrderVisit(use, user);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                FALLTHROUGH;
-
-            // Leaf nodes
-            case GT_CATCH_ARG:
-            case GT_ASYNC_CONTINUATION:
-            case GT_ASYNC_RESUME_INFO:
-            case GT_LABEL:
-            case GT_FTN_ADDR:
-            case GT_FTN_ENTRY:
-            case GT_RET_EXPR:
-            case GT_CNS_INT:
-            case GT_CNS_LNG:
-            case GT_CNS_DBL:
-            case GT_CNS_STR:
-#if defined(FEATURE_SIMD)
-            case GT_CNS_VEC:
-#endif // FEATURE_SIMD
-#if defined(FEATURE_MASKED_HW_INTRINSICS)
-            case GT_CNS_MSK:
-#endif // FEATURE_MASKED_HW_INTRINSICS
-            case GT_MEMORYBARRIER:
-            case GT_JMP:
-            case GT_JCC:
-            case GT_SETCC:
-            case GT_NO_OP:
-            case GT_START_NONGC:
-            case GT_START_PREEMPTGC:
-            case GT_PROF_HOOK:
-            case GT_PHI_ARG:
-            case GT_JMPTABLE:
-            case GT_PHYSREG:
-            case GT_IL_OFFSET:
-            case GT_RECORD_ASYNC_RESUME:
-            case GT_NOP:
-            case GT_SWIFT_ERROR:
-            case GT_GCPOLL:
-            case GT_WASM_THROW_REF:
-            case GT_WASM_JEXCEPT:
-                break;
-
-            // Lclvar unary operators
-            case GT_STORE_LCL_VAR:
-            case GT_STORE_LCL_FLD:
-                if (TVisitor::DoLclVarsOnly)
-                {
-                    result = reinterpret_cast<TVisitor*>(this)->PreOrderVisit(use, user);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                FALLTHROUGH;
-
-            // Standard unary operators
-            case GT_NOT:
-            case GT_NEG:
-            case GT_BSWAP:
-            case GT_BSWAP16:
-            case GT_COPY:
-            case GT_RELOAD:
-            case GT_ARR_LENGTH:
-            case GT_MDARR_LENGTH:
-            case GT_MDARR_LOWER_BOUND:
-            case GT_CAST:
-            case GT_BITCAST:
-            case GT_CKFINITE:
-            case GT_LCLHEAP:
-            case GT_IND:
-            case GT_BLK:
-            case GT_BOX:
-            case GT_ALLOCOBJ:
-            case GT_INIT_VAL:
-            case GT_JTRUE:
-            case GT_SWITCH:
-            case GT_NULLCHECK:
-            case GT_PUTARG_REG:
-            case GT_PUTARG_STK:
-            case GT_RETURNTRAP:
-            case GT_FIELD_ADDR:
-            case GT_RETURN:
-            case GT_RETURN_SUSPEND:
-            case GT_PATCHPOINT_FORCED:
-            case GT_NONLOCAL_JMP:
-            case GT_RETFILT:
-            case GT_RUNTIMELOOKUP:
-            case GT_ARR_ADDR:
-            case GT_KEEPALIVE:
-            case GT_INC_SATURATE:
+            if (TVisitor::DoLclVarsOnly && node->OperIs(GT_LCL_VAR, GT_LCL_FLD, GT_LCL_ADDR))
             {
-                GenTreeUnOp* const unOp = node->AsUnOp();
-                if (unOp->gtOp1 != nullptr)
-                {
-                    result = WalkTree(&unOp->gtOp1, unOp);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                break;
-            }
-
-            // Special nodes
-            case GT_PHI:
-                for (GenTreePhi::Use& use : node->AsPhi()->Uses())
-                {
-                    result = WalkTree(&use.NodeRef(), node);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                break;
-
-            case GT_FIELD_LIST:
-                for (GenTreeFieldList::Use& use : node->AsFieldList()->Uses())
-                {
-                    result = WalkTree(&use.NodeRef(), node);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                break;
-
-            case GT_CMPXCHG:
-            {
-                GenTreeCmpXchg* const cmpXchg = node->AsCmpXchg();
-
-                result = WalkTree(&cmpXchg->Addr(), cmpXchg);
+                result = reinterpret_cast<TVisitor*>(this)->PreOrderVisit(use, user);
                 if (result == fgWalkResult::WALK_ABORT)
                 {
                     return result;
                 }
-                result = WalkTree(&cmpXchg->Data(), cmpXchg);
-                if (result == fgWalkResult::WALK_ABORT)
-                {
-                    return result;
-                }
-                result = WalkTree(&cmpXchg->Comparand(), cmpXchg);
-                if (result == fgWalkResult::WALK_ABORT)
-                {
-                    return result;
-                }
-                break;
             }
+        }
+        else if (node->OperIsBinary())
+        {
+            GenTreeOp* const op = node->AsOp();
 
-            case GT_ARR_ELEM:
+            GenTree** op1Use = &op->gtOp1;
+            GenTree** op2Use = &op->gtOp2;
+
+            if (TVisitor::UseExecutionOrder && node->IsReverseOp())
             {
-                GenTreeArrElem* const arrElem = node->AsArrElem();
+                std::swap(op1Use, op2Use);
+            }
 
-                result = WalkTree(&arrElem->gtArrObj, arrElem);
+            if (*op1Use != nullptr)
+            {
+                result = WalkTree(op1Use, op);
                 if (result == fgWalkResult::WALK_ABORT)
                 {
                     return result;
                 }
-
-                const unsigned rank = arrElem->gtArrRank;
-                for (unsigned dim = 0; dim < rank; dim++)
-                {
-                    result = WalkTree(&arrElem->gtArrInds[dim], arrElem);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                break;
             }
-
-            case GT_CALL:
+            else
             {
-                GenTreeCall* const call = node->AsCall();
-
-                for (CallArg& arg : call->gtArgs.EarlyArgs())
-                {
-                    result = WalkTree(&arg.EarlyNodeRef(), call);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-
-                for (CallArg& arg : call->gtArgs.LateArgs())
-                {
-                    result = WalkTree(&arg.LateNodeRef(), call);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-
-                if (call->gtControlExpr != nullptr)
-                {
-                    result = WalkTree(&call->gtControlExpr, call);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                }
-                break;
+                assert(node->NullOp1Legal());
             }
 
-#if defined(FEATURE_HW_INTRINSICS)
-            case GT_HWINTRINSIC:
-                if (TVisitor::UseExecutionOrder && node->IsReverseOp())
+            // We can have null op1 and non-null op2 for some nodes, such as GT_LEA
+
+            if (*op2Use != nullptr)
+            {
+                result = WalkTree(op2Use, op);
+                if (result == fgWalkResult::WALK_ABORT)
                 {
-                    assert(node->AsMultiOp()->GetOperandCount() == 2);
-                    result = WalkTree(&node->AsMultiOp()->Op(2), node);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
-                    result = WalkTree(&node->AsMultiOp()->Op(1), node);
-                    if (result == fgWalkResult::WALK_ABORT)
-                    {
-                        return result;
-                    }
+                    return result;
                 }
-                else
+            }
+            else
+            {
+                assert(node->NullOp2Legal());
+            }
+        }
+        else if (node->OperIsUnary())
+        {
+            if (TVisitor::DoLclVarsOnly && node->OperIsLocalStore())
+            {
+                result = reinterpret_cast<TVisitor*>(this)->PreOrderVisit(use, user);
+                if (result == fgWalkResult::WALK_ABORT)
                 {
-                    for (GenTree** use : node->AsMultiOp()->UseEdges())
+                    return result;
+                }
+            }
+
+            GenTreeUnOp* const unOp = node->AsUnOp();
+
+            if (unOp->gtOp1 != nullptr)
+            {
+                result = WalkTree(&unOp->gtOp1, unOp);
+                if (result == fgWalkResult::WALK_ABORT)
+                {
+                    return result;
+                }
+            }
+            else
+            {
+                assert(node->NullOp1Legal());
+            }
+        }
+        else
+        {
+            assert(node->OperIsSpecial());
+
+            switch (node->OperGet())
+            {
+                case GT_PHI:
+                    for (GenTreePhi::Use& use : node->AsPhi()->Uses())
                     {
-                        result = WalkTree(use, node);
+                        result = WalkTree(&use.NodeRef(), node);
                         if (result == fgWalkResult::WALK_ABORT)
                         {
                             return result;
                         }
                     }
+                    break;
+
+                case GT_FIELD_LIST:
+                    for (GenTreeFieldList::Use& use : node->AsFieldList()->Uses())
+                    {
+                        result = WalkTree(&use.NodeRef(), node);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+                    break;
+
+                case GT_CMPXCHG:
+                {
+                    GenTreeCmpXchg* const cmpXchg = node->AsCmpXchg();
+
+                    result = WalkTree(&cmpXchg->Addr(), cmpXchg);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+                    result = WalkTree(&cmpXchg->Data(), cmpXchg);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+                    result = WalkTree(&cmpXchg->Comparand(), cmpXchg);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+                    break;
                 }
-                break;
+
+                case GT_ARR_ELEM:
+                {
+                    GenTreeArrElem* const arrElem = node->AsArrElem();
+
+                    result = WalkTree(&arrElem->gtArrObj, arrElem);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+
+                    const unsigned rank = arrElem->gtArrRank;
+                    for (unsigned dim = 0; dim < rank; dim++)
+                    {
+                        result = WalkTree(&arrElem->gtArrInds[dim], arrElem);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+                    break;
+                }
+
+                case GT_CALL:
+                {
+                    GenTreeCall* const call = node->AsCall();
+
+                    for (CallArg& arg : call->gtArgs.EarlyArgs())
+                    {
+                        result = WalkTree(&arg.EarlyNodeRef(), call);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+
+                    for (CallArg& arg : call->gtArgs.LateArgs())
+                    {
+                        result = WalkTree(&arg.LateNodeRef(), call);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+
+                    if (call->gtControlExpr != nullptr)
+                    {
+                        result = WalkTree(&call->gtControlExpr, call);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+                    break;
+                }
+
+#if defined(FEATURE_HW_INTRINSICS)
+                case GT_HWINTRINSIC:
+                    if (TVisitor::UseExecutionOrder && node->IsReverseOp())
+                    {
+                        assert(node->AsMultiOp()->GetOperandCount() == 2);
+                        result = WalkTree(&node->AsMultiOp()->Op(2), node);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                        result = WalkTree(&node->AsMultiOp()->Op(1), node);
+                        if (result == fgWalkResult::WALK_ABORT)
+                        {
+                            return result;
+                        }
+                    }
+                    else
+                    {
+                        for (GenTree** use : node->AsMultiOp()->UseEdges())
+                        {
+                            result = WalkTree(use, node);
+                            if (result == fgWalkResult::WALK_ABORT)
+                            {
+                                return result;
+                            }
+                        }
+                    }
+                    break;
 #endif // defined(FEATURE_HW_INTRINSICS)
 
-            case GT_SELECT:
-            {
-                GenTreeConditional* const conditional = node->AsConditional();
-
-                result = WalkTree(&conditional->gtCond, conditional);
-                if (result == fgWalkResult::WALK_ABORT)
+                case GT_SELECT:
                 {
-                    return result;
-                }
-                result = WalkTree(&conditional->gtOp1, conditional);
-                if (result == fgWalkResult::WALK_ABORT)
-                {
-                    return result;
-                }
-                result = WalkTree(&conditional->gtOp2, conditional);
-                if (result == fgWalkResult::WALK_ABORT)
-                {
-                    return result;
-                }
-                break;
-            }
+                    GenTreeConditional* const conditional = node->AsConditional();
 
-            // Binary nodes
-            default:
-            {
-                assert(node->OperIsBinary());
-
-                GenTreeOp* const op = node->AsOp();
-
-                GenTree** op1Use = &op->gtOp1;
-                GenTree** op2Use = &op->gtOp2;
-
-                if (TVisitor::UseExecutionOrder && node->IsReverseOp())
-                {
-                    std::swap(op1Use, op2Use);
-                }
-
-                if (*op1Use != nullptr)
-                {
-                    result = WalkTree(op1Use, op);
+                    result = WalkTree(&conditional->gtCond, conditional);
                     if (result == fgWalkResult::WALK_ABORT)
                     {
                         return result;
                     }
-                }
-
-                if (*op2Use != nullptr)
-                {
-                    result = WalkTree(op2Use, op);
+                    result = WalkTree(&conditional->gtOp1, conditional);
                     if (result == fgWalkResult::WALK_ABORT)
                     {
                         return result;
                     }
+                    result = WalkTree(&conditional->gtOp2, conditional);
+                    if (result == fgWalkResult::WALK_ABORT)
+                    {
+                        return result;
+                    }
+                    break;
                 }
-                break;
+
+                default:
+                {
+                    assert(!"unhandled special node");
+                    break;
+                }
             }
         }
 

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4408,23 +4408,21 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
         if (op->gtOp1 != nullptr)
         {
             RETURN_IF_ABORT(visitor(&op->gtOp1));
-
-            if (op->gtOp2 != nullptr)
-            {
-                return visitor(&op->gtOp2);
-            }
-            else
-            {
-                assert(NullOp2Legal());
-            }
         }
         else
         {
             assert(NullOp1Legal());
-            assert(NullOp2Legal());
+        }
 
-            // we should never have a null op1 and non-null op2
-            assert(op->gtOp2 == nullptr);
+        // We can have null op1 and non-null op2 for some nodes, such as GT_LEA
+
+        if (op->gtOp2 != nullptr)
+        {
+            return visitor(&op->gtOp2);
+        }
+        else
+        {
+            assert(NullOp2Legal());
         }
         return VisitResult::Continue;
     }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4413,6 +4413,18 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
             {
                 return visitor(&op->gtOp2);
             }
+            else
+            {
+                assert(NullOp2Legal());
+            }
+        }
+        else
+        {
+            assert(NullOp1Legal());
+            assert(NullOp2Legal());
+
+            // we should never have a null op1 and non-null op2
+            assert(op->gtOp2 == nullptr);
         }
         return VisitResult::Continue;
     }
@@ -4424,6 +4436,10 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
         if (unOp->gtOp1 != nullptr)
         {
             return visitor(&unOp->gtOp1);
+        }
+        else
+        {
+            assert(NullOp1Legal());
         }
         return VisitResult::Continue;
     }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4396,96 +4396,42 @@ GenTree::VisitResult GenTree::VisitOperands(TVisitor visitor)
 template <typename TVisitor>
 GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
 {
+    if (OperIsLeaf())
+    {
+        return VisitResult::Continue;
+    }
+
+    if (OperIsBinary())
+    {
+        GenTreeOp* op = AsOp();
+
+        if (op->gtOp1 != nullptr)
+        {
+            RETURN_IF_ABORT(visitor(&op->gtOp1));
+
+            if (op->gtOp2 != nullptr)
+            {
+                return visitor(&op->gtOp2);
+            }
+        }
+        return VisitResult::Continue;
+    }
+
+    if (OperIsUnary())
+    {
+        GenTreeUnOp* unOp = AsUnOp();
+
+        if (unOp->gtOp1 != nullptr)
+        {
+            return visitor(&unOp->gtOp1);
+        }
+        return VisitResult::Continue;
+    }
+
+    assert(OperIsSpecial());
+
     switch (OperGet())
     {
-        // Leaf nodes
-        case GT_LCL_VAR:
-        case GT_LCL_FLD:
-        case GT_LCL_ADDR:
-        case GT_CATCH_ARG:
-        case GT_ASYNC_CONTINUATION:
-        case GT_ASYNC_RESUME_INFO:
-        case GT_LABEL:
-        case GT_FTN_ADDR:
-        case GT_FTN_ENTRY:
-        case GT_RET_EXPR:
-        case GT_CNS_INT:
-        case GT_CNS_LNG:
-        case GT_CNS_DBL:
-        case GT_CNS_STR:
-#if defined(FEATURE_SIMD)
-        case GT_CNS_VEC:
-#endif // FEATURE_SIMD
-#if defined(FEATURE_MASKED_HW_INTRINSICS)
-        case GT_CNS_MSK:
-#endif // FEATURE_MASKED_HW_INTRINSICS
-        case GT_MEMORYBARRIER:
-        case GT_JMP:
-        case GT_JCC:
-        case GT_SETCC:
-        case GT_NO_OP:
-        case GT_START_NONGC:
-        case GT_START_PREEMPTGC:
-        case GT_PROF_HOOK:
-        case GT_PHI_ARG:
-        case GT_JMPTABLE:
-        case GT_PHYSREG:
-        case GT_IL_OFFSET:
-        case GT_RECORD_ASYNC_RESUME:
-        case GT_NOP:
-        case GT_SWIFT_ERROR:
-        case GT_GCPOLL:
-        case GT_WASM_THROW_REF:
-        case GT_WASM_JEXCEPT:
-            return VisitResult::Continue;
-
-            // Unary operators with an optional operand
-        case GT_FIELD_ADDR:
-        case GT_RETURN:
-        case GT_RETFILT:
-            if (this->AsUnOp()->gtOp1 == nullptr)
-            {
-                return VisitResult::Continue;
-            }
-            FALLTHROUGH;
-
-            // Standard unary operators
-        case GT_STORE_LCL_VAR:
-        case GT_STORE_LCL_FLD:
-        case GT_NOT:
-        case GT_NEG:
-        case GT_BSWAP:
-        case GT_BSWAP16:
-        case GT_COPY:
-        case GT_RELOAD:
-        case GT_ARR_LENGTH:
-        case GT_MDARR_LENGTH:
-        case GT_MDARR_LOWER_BOUND:
-        case GT_CAST:
-        case GT_BITCAST:
-        case GT_CKFINITE:
-        case GT_LCLHEAP:
-        case GT_IND:
-        case GT_BLK:
-        case GT_BOX:
-        case GT_ALLOCOBJ:
-        case GT_INIT_VAL:
-        case GT_RUNTIMELOOKUP:
-        case GT_ARR_ADDR:
-        case GT_JTRUE:
-        case GT_SWITCH:
-        case GT_NULLCHECK:
-        case GT_PUTARG_REG:
-        case GT_PUTARG_STK:
-        case GT_RETURNTRAP:
-        case GT_KEEPALIVE:
-        case GT_INC_SATURATE:
-        case GT_RETURN_SUSPEND:
-        case GT_PATCHPOINT_FORCED:
-        case GT_NONLOCAL_JMP:
-            return visitor(&this->AsUnOp()->gtOp1);
-
-            // Variadic nodes
 #if defined(FEATURE_HW_INTRINSICS)
         case GT_HWINTRINSIC:
             for (GenTree** use : this->AsMultiOp()->UseEdges())
@@ -4493,9 +4439,8 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
                 RETURN_IF_ABORT(visitor(use));
             }
             return VisitResult::Continue;
-#endif // defined(FEATURE_HW_INTRINSICS)
+#endif
 
-            // Special nodes
         case GT_PHI:
             for (GenTreePhi::Use& use : AsPhi()->Uses())
             {
@@ -4557,19 +4502,11 @@ GenTree::VisitResult GenTree::VisitOperandUses(TVisitor visitor)
             return visitor(&cond->gtOp2);
         }
 
-        // Binary nodes
         default:
-            assert(this->OperIsBinary());
-            if (AsOp()->gtOp1 != nullptr)
-            {
-                RETURN_IF_ABORT(visitor(&AsOp()->gtOp1));
-            }
-
-            if (AsOp()->gtOp2 != nullptr)
-            {
-                return visitor(&AsOp()->gtOp2);
-            }
+        {
+            assert(!"unhandled special node");
             return VisitResult::Continue;
+        }
     }
 }
 


### PR DESCRIPTION
This should notably reduce risk as well. Some handling had been missed before like `GT_LZCNT` not being handled and hitting the default binary path instead.

### TP impact on Linux x64
```
linux x64
* Overall (-0.09% to -0.04%)
* MinOpts (-0.10% to +0.04%)
* FullOpts (-0.11% to -0.04%)
```

### TP impact on Windows x64
```
linux arm64
* Overall (-0.21% to -0.15%)
* MinOpts (-0.14% to -0.04%)
* FullOpts (-0.26% to -0.16%)

linux x64
* Overall (-0.23% to -0.15%)
* MinOpts (-0.16% to -0.02%)
* FullOpts (-0.28% to -0.15%)

osx arm64
* Overall (-0.21% to -0.16%)
* MinOpts (-0.13% to -0.06%)
* FullOpts (-0.22% to -0.16%)

windows arm64
* Overall (-0.21% to -0.15%)
* MinOpts (-0.14% to -0.04%)
* FullOpts (-0.27% to -0.16%)

windows x64
* Overall (-0.23% to -0.15%)
* MinOpts (-0.16% to -0.02%)
* FullOpts (-0.29% to -0.15%)
```

Windows x86 has a TP hit, from `-0.00% to +0.06%` for MinOpts, but that should be fine given the wins we see elsewhere and the improved robustness for the visitors when new node kinds are introduced.