### PR TITLE
Remove buildConfig from sccache cache key to share across PR/rolling builds

### DIFF
--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -19,13 +19,20 @@ steps:
     # Set up the Azure Pipeline Cache for sccache's local cache directory.
     # Use a rolling key so each build can update the cache; restoreKeys
     # falls back to the most recent saved entry.
+    #
+    # buildConfig is intentionally excluded from the key: it reflects
+    # the *managed* Configuration (Debug for PRs, Release for rolling
+    # builds), but sccache only caches native (C/C++) compilations whose
+    # flags are controlled by RuntimeConfiguration (-rc), which is
+    # constant per leg regardless of buildConfig.  Omitting it lets PR
+    # builds warm-start from rolling-build caches saved in the main scope.
     - task: Cache@2
       displayName: Sccache cache
       inputs:
-        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | ${{ parameters.buildConfig }} | "$(Build.BuildId)"
+        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | "$(Build.BuildId)"
         path: $(Pipeline.Workspace)/.sccache
         restoreKeys: |
-          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | ${{ parameters.buildConfig }}
+          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }}
 
     # Configure sccache environment and add binary to PATH.
     # The sccache package is restored by runtime-prereqs.proj during the build.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
@@ -500,7 +500,7 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
         }
 
-        protected override partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        protected override unsafe partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography
             return CngHelpers.Duplicate(_key.HandleNoDuplicate, _key.IsEphemeral);
         }
 
-        protected override partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        protected override unsafe partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
             // We intentionally don't special case otherParty being an instance of X25519DiffieHellmanCng and always
             // export the public key into the current instance's provider.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography
         public partial CngKey GetKey();
 
         /// <inheritdoc/>
-        protected override partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination);
+        protected override unsafe partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination);
 
         /// <inheritdoc/>
         protected override partial void ExportPublicKeyCore(Span<byte> destination);


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with the assistance of GitHub Copilot.

## Summary

Remove `buildConfig` (Debug/Release) from the sccache ADO Pipeline Cache key so that PR builds can warm-start from rolling-build caches.

## Problem

The sccache cache key included `buildConfig`, which is `Debug` for PR builds and `Release` for rolling builds. This created completely separate cache namespaces, meaning:

- Rolling builds saved caches to `sccache|...|Release|...` keys in the `refs/heads/main` scope
- PR builds looked for `sccache|...|Debug|...` keys, never finding rolling build caches
- **Every first build of a new PR started with a cold sccache cache (0% hit rate)**
- Cache hits only occurred on subsequent pushes to the *same* PR

## Why this is safe

The native compiler flags are determined by `-rc` (RuntimeConfiguration), **not** `-c` (Configuration):

| Leg | `-rc` (native) | `-c` (managed) PR | `-c` (managed) Rolling |
|-----|----------------|-------------------|------------------------|
| CoreCLR_Libraries | **Release** | Debug | Release |
| Libraries_CheckedCoreCLR | **Checked** | Debug | Release |

Since `-rc` is hardcoded per leg, the CMake build type and native compiler flags are identical between PR and rolling builds. The `-c` flag only affects managed code, which sccache doesn't cache.

## Expected impact

PR builds will restore sccache caches from rolling builds (saved in the main scope), giving ~99% hit rates on first push — a **33-46% reduction in build time** for the linux-x64 native compilation legs based on [prior analysis](https://gist.github.com/steveisok/15758f11d9c5e8e2e29455cd768da955).
