### PR TITLE
Use 'dotnet package download' for sccache instead of PackageDownload

### DIFF
--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -11,7 +11,7 @@ parameters:
   shouldContinueOnError: false
   osSubgroup: ''
 
-  # sccache NuGet package version — keep in sync with runtime-prereqs.proj
+  # sccache NuGet package version
   sccacheVersion: '0.15.0'
 
 steps:
@@ -34,14 +34,14 @@ steps:
         restoreKeys: |
           sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }}
 
-    # Configure sccache environment and add binary to PATH.
-    # The sccache package is restored by runtime-prereqs.proj during the build.
+    # Download the sccache NuGet package and configure the environment.
     - script: |
         sccacheVersion="${{ parameters.sccacheVersion }}"
         sccacheDir="$(Build.SourcesDirectory)/.packages/sccache/${sccacheVersion}/tools"
-        mkdir -p "$sccacheDir"
+        "$(Build.SourcesDirectory)/eng/common/dotnet.sh" package download "sccache@${sccacheVersion}" -o "$(Build.SourcesDirectory)/.packages" -v quiet
+        chmod +x "$sccacheDir/sccache"
         echo "##vso[task.prependpath]$sccacheDir"
         echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
         echo "##vso[task.setvariable variable=SCCACHE_IDLE_TIMEOUT]0"
         echo "##vso[task.setvariable variable=USE_SCCACHE]true"
-      displayName: Configure sccache
+      displayName: Download and configure sccache

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -174,13 +174,6 @@ if [[ "$__TargetArch" != "$__HostArch" ]]; then
 fi
 
 if [[ "$USE_SCCACHE" == "true" ]]; then
-    # NuGet strips execute permissions; restore them using the known package path.
-    # Try the CI-local packages dir first, then fall back to the global NuGet cache.
-    for sccacheBin in "$__RepoRootDir/.packages/sccache"/*/tools/sccache "$HOME/.nuget/packages/sccache"/*/tools/sccache; do
-        if [[ -f "$sccacheBin" ]]; then
-            chmod +x "$sccacheBin"
-        fi
-    done
     __CMakeArgs="-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache $__CMakeArgs"
 fi
 

--- a/src/coreclr/runtime-prereqs.proj
+++ b/src/coreclr/runtime-prereqs.proj
@@ -10,10 +10,6 @@
     <AssemblyName>.NET Runtime</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup Condition="$([MSBuild]::IsOsPlatform(Linux)) and '$(ContinuousIntegrationBuild)' == 'true'">
-    <PackageDownload Include="sccache" Version="[0.15.0]" />
-  </ItemGroup>
-
   <Import Project="$(RepositoryEngineeringDir)versioning.targets" />
   <Import Project="$(RepositoryEngineeringDir)nativepgo.targets" />
 


### PR DESCRIPTION
Replace the PackageDownload item in runtime-prereqs.proj with an explicit 'dotnet package download' call in the pipeline setup step. This downloads the sccache NuGet package before the build starts, making the setup self-contained and removing the dependency on the MSBuild restore phase.