### PR TITLE
Model typeof(delegate*<...>) as SystemTypeValue in Roslyn analyzer

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/SingleValueExtensions.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/TrimAnalysis/SingleValueExtensions.cs
@@ -34,6 +34,7 @@ namespace ILLink.RoslynAnalyzer.TrimAnalysis
                 SymbolKind.NamedType => new SystemTypeValue(new TypeProxy(type)),
                 // If the symbol is an Array type, the BaseType is System.Array
                 SymbolKind.ArrayType => new SystemTypeValue(new TypeProxy(type.BaseType!)),
+                SymbolKind.FunctionPointerType => new SystemTypeValue(new TypeProxy(type)),
                 SymbolKind.ErrorType => UnknownValue.Instance,
                 _ => null
             };

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyGetTypeDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/AssemblyGetTypeDataFlow.cs
@@ -129,9 +129,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             typeof(InnerType[]).Assembly.GetType("Mono.Linker.Tests.Cases.DataFlow.AssemblyGetTypeDataFlow+InnerType");
         }
 
-        // The Roslyn analyzer models typeof(delegate*<...>) as Top (no SystemTypeValue), so
-        // the Type.Assembly intrinsic short-circuits and no warning is emitted.
-        [ExpectedWarning("IL2026", Tool.Trimmer | Tool.NativeAot, "Roslyn analyzer doesn't model typeof for function pointers")]
+        [ExpectedWarning("IL2026")]
         static unsafe void TestFunctionPointerReceiver()
         {
             typeof(delegate*<InnerType, void>).Assembly.GetType("Mono.Linker.Tests.Cases.DataFlow.AssemblyGetTypeDataFlow+InnerType");


### PR DESCRIPTION
The Roslyn analyzer previously returned null (Top) from FromTypeSymbol for SymbolKind.FunctionPointerType, causing Type.get_Assembly to short-circuit and silently widen to Top. NativeAOT models function pointer ldtoken as SystemTypeValue(funcPtr).

Update AssemblyGetTypeDataFlow.TestFunctionPointerReceiver to expect the warning in all tools.