### PR TITLE
[Android] Bridge SocketsHttpHandler to java.net.ProxySelector

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
@@ -10,8 +10,9 @@ internal static partial class Interop
     {
         internal enum AndroidProxyType
         {
-            Http = 0,
-            Socks = 1,
+            Direct = 0,
+            Http = 1,
+            Socks = 2,
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         internal struct AndroidProxyInfo
         {
             public int Type;     // AndroidProxyType
-            public IntPtr Host;  // NUL-terminated UTF-8, malloc'd in native
+            public IntPtr Host;  // NUL-terminated UTF-16; read via Marshal.PtrToStringUni; freed by FreeProxyResult
             public int Port;
         }
 

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Proxy.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class AndroidCrypto
+    {
+        internal enum AndroidProxyType
+        {
+            Http = 0,
+            Socks = 1,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct AndroidProxyInfo
+        {
+            public int Type;     // AndroidProxyType
+            public IntPtr Host;  // NUL-terminated UTF-8, malloc'd in native
+            public int Port;
+        }
+
+        [LibraryImport(Libraries.AndroidCryptoNative,
+            EntryPoint = "AndroidCryptoNative_GetProxyForUrl",
+            StringMarshalling = StringMarshalling.Utf8)]
+        internal static unsafe partial int GetProxyForUrl(
+            string url,
+            out int count,
+            out AndroidProxyInfo* proxies);
+
+        [LibraryImport(Libraries.AndroidCryptoNative,
+            EntryPoint = "AndroidCryptoNative_FreeProxyResult")]
+        internal static unsafe partial void FreeProxyResult(
+            AndroidProxyInfo* proxies, int count);
+    }
+}

--- a/src/libraries/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/libraries/System.Net.Http/src/System.Net.Http.csproj
@@ -329,9 +329,19 @@
     <Compile Include="System\Net\Http\SocketsHttpHandler\CurrentUserIdentityProvider.Unix.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'browser' and '$(TargetPlatformIdentifier)' != 'wasi' and '$(TargetPlatformIdentifier)' != 'osx' and '$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'tvos' and '$(TargetPlatformIdentifier)' != 'maccatalyst'">
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != '' and '$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'browser' and '$(TargetPlatformIdentifier)' != 'wasi' and '$(TargetPlatformIdentifier)' != 'osx' and '$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'tvos' and '$(TargetPlatformIdentifier)' != 'maccatalyst' and '$(TargetPlatformIdentifier)' != 'android'">
     <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
     <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">
+    <Compile Include="System\Net\Http\SocketsHttpHandler\HttpNoProxy.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Android.cs" />
+    <Compile Include="System\Net\Http\SocketsHttpHandler\AndroidPlatformProxy.Android.cs" />
+    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs"
+             Link="Common\Interop\Android\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.Proxy.cs"
+             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.Proxy.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos' or '$(TargetPlatformIdentifier)' == 'maccatalyst'">

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -122,9 +122,15 @@ namespace System.Net.Http
                 return false;
             }
 
-            proxyUri = new UriBuilder(scheme, host, entry.Port).Uri;
-
-            return true;
+            try
+            {
+                proxyUri = new UriBuilder(scheme, host, entry.Port).Uri;
+                return true;
+            }
+            catch (UriFormatException)
+            {
+                return false;
+            }
         }
 
         // SocketsHttpHandler's pattern is: call IsBypassed first; if it returns false,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -53,15 +53,32 @@ namespace System.Net.Http
                 for (int i = 0; i < count; i++)
                 {
                     Interop.AndroidCrypto.AndroidProxyInfo entry = proxies[i];
+                    Interop.AndroidCrypto.AndroidProxyType type = (Interop.AndroidCrypto.AndroidProxyType)entry.Type;
+
+                    if (type == Interop.AndroidCrypto.AndroidProxyType.Direct)
+                    {
+                        // Java's Proxy.NO_PROXY is represented as Proxy.Type.DIRECT.
+                        // Preserve ProxySelector ordering by treating DIRECT as the
+                        // selected result rather than skipping to a later fallback proxy.
+                        return null;
+                    }
 
                     // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5).
                     // Unlike HTTP CONNECT, SOCKS tunnels arbitrary TCP at the socket
                     // layer. SocketsHttpHandler accepts "socks5://" via
                     // HttpUtilities.IsSupportedProxyScheme. Android's
                     // java.net.Proxy.Type.SOCKS maps to SOCKS5 on modern Android.
-                    string scheme = entry.Type == (int)Interop.AndroidCrypto.AndroidProxyType.Socks
-                        ? "socks5"
-                        : "http";
+                    string? scheme = type switch
+                    {
+                        Interop.AndroidCrypto.AndroidProxyType.Http => "http",
+                        Interop.AndroidCrypto.AndroidProxyType.Socks => "socks5",
+                        _ => null,
+                    };
+
+                    if (scheme is null)
+                    {
+                        continue;
+                    }
 
                     // The native PAL allocates the host as NUL-terminated UTF-16
                     // (Marshal.PtrToStringUni is a zero-conversion copy).

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -52,43 +52,10 @@ namespace System.Net.Http
                 // connect error rather than an automatic retry.
                 for (int i = 0; i < count; i++)
                 {
-                    Interop.AndroidCrypto.AndroidProxyInfo entry = proxies[i];
-                    Interop.AndroidCrypto.AndroidProxyType type = (Interop.AndroidCrypto.AndroidProxyType)entry.Type;
-
-                    if (type == Interop.AndroidCrypto.AndroidProxyType.Direct)
+                    if (TryCreateProxyUri(proxies[i], out Uri? proxyUri))
                     {
-                        // Java's Proxy.NO_PROXY is represented as Proxy.Type.DIRECT.
-                        // Preserve ProxySelector ordering by treating DIRECT as the
-                        // selected result rather than skipping to a later fallback proxy.
-                        return null;
+                        return proxyUri;
                     }
-
-                    // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5).
-                    // Unlike HTTP CONNECT, SOCKS tunnels arbitrary TCP at the socket
-                    // layer. SocketsHttpHandler accepts "socks5://" via
-                    // HttpUtilities.IsSupportedProxyScheme. Android's
-                    // java.net.Proxy.Type.SOCKS maps to SOCKS5 on modern Android.
-                    string? scheme = type switch
-                    {
-                        Interop.AndroidCrypto.AndroidProxyType.Http => "http",
-                        Interop.AndroidCrypto.AndroidProxyType.Socks => "socks5",
-                        _ => null,
-                    };
-
-                    if (scheme is null)
-                    {
-                        continue;
-                    }
-
-                    // The native PAL allocates the host as NUL-terminated UTF-16
-                    // (Marshal.PtrToStringUni is a zero-conversion copy).
-                    string? host = Marshal.PtrToStringUni(entry.Host);
-                    if (string.IsNullOrEmpty(host))
-                    {
-                        continue;
-                    }
-
-                    return new UriBuilder(scheme, host, entry.Port).Uri;
                 }
 
                 return null;
@@ -97,6 +64,50 @@ namespace System.Net.Http
             {
                 Interop.AndroidCrypto.FreeProxyResult(proxies, count);
             }
+        }
+
+        internal static bool TryCreateProxyUri(Interop.AndroidCrypto.AndroidProxyInfo entry, out Uri? proxyUri)
+        {
+            proxyUri = null;
+
+            Interop.AndroidCrypto.AndroidProxyType type = (Interop.AndroidCrypto.AndroidProxyType)entry.Type;
+
+            if (type == Interop.AndroidCrypto.AndroidProxyType.Direct)
+            {
+                // Java's Proxy.NO_PROXY is represented as Proxy.Type.DIRECT.
+                // Preserve ProxySelector ordering by treating DIRECT as the
+                // selected result rather than skipping to a later fallback proxy.
+                return true;
+            }
+
+            // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5).
+            // Unlike HTTP CONNECT, SOCKS tunnels arbitrary TCP at the socket
+            // layer. SocketsHttpHandler accepts "socks5://" via
+            // HttpUtilities.IsSupportedProxyScheme. Android's
+            // java.net.Proxy.Type.SOCKS maps to SOCKS5 on modern Android.
+            string? scheme = type switch
+            {
+                Interop.AndroidCrypto.AndroidProxyType.Http => "http",
+                Interop.AndroidCrypto.AndroidProxyType.Socks => "socks5",
+                _ => null,
+            };
+
+            if (scheme is null)
+            {
+                return false;
+            }
+
+            // The native PAL allocates the host as NUL-terminated UTF-16
+            // (Marshal.PtrToStringUni is a zero-conversion copy).
+            string? host = Marshal.PtrToStringUni(entry.Host);
+            if (string.IsNullOrEmpty(host))
+            {
+                return false;
+            }
+
+            proxyUri = new UriBuilder(scheme, host, entry.Port).Uri;
+
+            return true;
         }
 
         // SocketsHttpHandler's pattern is: call IsBypassed first; if it returns false,

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -46,18 +46,26 @@ namespace System.Net.Http
 
             try
             {
-                // ProxySelector returns entries in preference order. We take the first one.
+                // ProxySelector returns entries in preference order. We take the first.
                 // SocketsHttpHandler does not currently have an opt-in fallback API for
                 // multiple proxies; if the chosen proxy is unreachable the user sees the
                 // connect error rather than an automatic retry.
                 for (int i = 0; i < count; i++)
                 {
                     Interop.AndroidCrypto.AndroidProxyInfo entry = proxies[i];
+
+                    // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5).
+                    // Unlike HTTP CONNECT, SOCKS tunnels arbitrary TCP at the socket
+                    // layer. SocketsHttpHandler accepts "socks5://" via
+                    // HttpUtilities.IsSupportedProxyScheme. Android's
+                    // java.net.Proxy.Type.SOCKS maps to SOCKS5 on modern Android.
                     string scheme = entry.Type == (int)Interop.AndroidCrypto.AndroidProxyType.Socks
                         ? "socks5"
                         : "http";
 
-                    string? host = Marshal.PtrToStringUTF8(entry.Host);
+                    // The native PAL allocates the host as NUL-terminated UTF-16
+                    // (Marshal.PtrToStringUni is a zero-conversion copy).
+                    string? host = Marshal.PtrToStringUni(entry.Host);
                     if (string.IsNullOrEmpty(host))
                     {
                         continue;
@@ -74,12 +82,12 @@ namespace System.Net.Http
             }
         }
 
-        public bool IsBypassed(Uri host)
-        {
-            ArgumentNullException.ThrowIfNull(host);
-            // Computing the real answer is as expensive as GetProxy; mirror MacProxy.
-            Uri? proxyUri = GetProxy(host);
-            return proxyUri is null || Equals(proxyUri, host);
-        }
+        // SocketsHttpHandler's pattern is: call IsBypassed first; if it returns false,
+        // call GetProxy. For us, computing IsBypassed *correctly* would require calling
+        // GetProxy first, which would mean two JNI round-trips per request.
+        // Instead, we always return false (same approach as HttpWindowsProxy:349–360) so
+        // that SHH always calls GetProxy exactly once and discovers "no proxy" via a
+        // null return.
+        public bool IsBypassed(Uri host) => false;
     }
 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -46,10 +46,13 @@ namespace System.Net.Http
 
             try
             {
-                // ProxySelector returns entries in preference order. We take the first.
-                // SocketsHttpHandler does not currently have an opt-in fallback API for
-                // multiple proxies; if the chosen proxy is unreachable the user sees the
-                // connect error rather than an automatic retry.
+                // ProxySelector returns entries in preference order. We surface only the
+                // first usable one as a single Uri. SocketsHttpHandler can fail over across
+                // multiple proxies when the IWebProxy also implements IMultiWebProxy (see
+                // HttpConnectionPoolManager / HttpWindowsProxy), but AndroidPlatformProxy does
+                // not implement that interface, so the remaining ProxySelector entries are not
+                // used for automatic fallback: if the chosen proxy is unreachable the caller
+                // sees the connect error rather than an automatic retry.
                 for (int i = 0; i < count; i++)
                 {
                     if (TryCreateProxyUri(proxies[i], out Uri? proxyUri))

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -108,6 +108,15 @@ namespace System.Net.Http
                 return false;
             }
 
+            // entry.Port originates from java.net.InetSocketAddress.getPort() and crosses the
+            // JNI boundary, so treat it as untrusted. A usable proxy needs a real port; anything
+            // outside the valid TCP range would make UriBuilder throw, which the caller would see
+            // as a failed entry. Skip it instead so a later ProxySelector entry can be tried.
+            if (entry.Port is < 1 or > 65535)
+            {
+                return false;
+            }
+
             proxyUri = new UriBuilder(scheme, host, entry.Port).Uri;
 
             return true;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -39,7 +39,7 @@ namespace System.Net.Http
             int count = 0;
             int rc = Interop.AndroidCrypto.GetProxyForUrl(url, out count, out proxies);
 
-            if (rc != 0 || count == 0 || proxies == null)
+            if (rc != 0 || proxies == null)
             {
                 return null;
             }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -53,15 +53,7 @@ namespace System.Net.Http
                 // not implement that interface, so the remaining ProxySelector entries are not
                 // used for automatic fallback: if the chosen proxy is unreachable the caller
                 // sees the connect error rather than an automatic retry.
-                for (int i = 0; i < count; i++)
-                {
-                    if (TryCreateProxyUri(proxies[i], out Uri? proxyUri))
-                    {
-                        return proxyUri;
-                    }
-                }
-
-                return null;
+                return SelectProxyUri(new ReadOnlySpan<Interop.AndroidCrypto.AndroidProxyInfo>(proxies, count));
             }
             finally
             {
@@ -69,26 +61,39 @@ namespace System.Net.Http
             }
         }
 
-        internal static bool TryCreateProxyUri(Interop.AndroidCrypto.AndroidProxyInfo entry, out Uri? proxyUri)
+        internal static Uri? SelectProxyUri(ReadOnlySpan<Interop.AndroidCrypto.AndroidProxyInfo> entries)
+        {
+            foreach (Interop.AndroidCrypto.AndroidProxyInfo entry in entries)
+            {
+                // Java's Proxy.NO_PROXY is represented as Proxy.Type.DIRECT. Preserve
+                // ProxySelector ordering by treating the first DIRECT entry as the selected
+                // result (no proxy) rather than skipping ahead to a later fallback proxy.
+                if ((Interop.AndroidCrypto.AndroidProxyType)entry.Type == Interop.AndroidCrypto.AndroidProxyType.Direct)
+                {
+                    return null;
+                }
+
+                if (TryCreateProxyUri(entry, out Uri? proxyUri))
+                {
+                    return proxyUri;
+                }
+            }
+
+            return null;
+        }
+
+        private static bool TryCreateProxyUri(Interop.AndroidCrypto.AndroidProxyInfo entry, out Uri? proxyUri)
         {
             proxyUri = null;
-
-            Interop.AndroidCrypto.AndroidProxyType type = (Interop.AndroidCrypto.AndroidProxyType)entry.Type;
-
-            if (type == Interop.AndroidCrypto.AndroidProxyType.Direct)
-            {
-                // Java's Proxy.NO_PROXY is represented as Proxy.Type.DIRECT.
-                // Preserve ProxySelector ordering by treating DIRECT as the
-                // selected result rather than skipping to a later fallback proxy.
-                return true;
-            }
 
             // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5).
             // Unlike HTTP CONNECT, SOCKS tunnels arbitrary TCP at the socket
             // layer. SocketsHttpHandler accepts "socks5://" via
             // HttpUtilities.IsSupportedProxyScheme. Android's
             // java.net.Proxy.Type.SOCKS maps to SOCKS5 on modern Android.
-            string? scheme = type switch
+            // DIRECT (java.net.Proxy.NO_PROXY) yields no scheme and is handled by
+            // SelectProxyUri before reaching this helper.
+            string? scheme = (Interop.AndroidCrypto.AndroidProxyType)entry.Type switch
             {
                 Interop.AndroidCrypto.AndroidProxyType.Http => "http",
                 Interop.AndroidCrypto.AndroidProxyType.Socks => "socks5",

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AndroidPlatformProxy.Android.cs
@@ -1,0 +1,85 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// An <see cref="IWebProxy"/> that defers proxy resolution to the
+    /// Android platform via <c>java.net.ProxySelector</c>. Honors Wi-Fi
+    /// proxy, MDM-deployed system proxy, PAC scripts, and per-network
+    /// or VPN proxies — the same source <c>java.net.HttpURLConnection</c>
+    /// consults.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The Android proxy APIs (<c>ProxySelector</c>, <c>ProxyInfo</c>,
+    /// <c>ConnectivityManager</c>) do not surface credentials. The
+    /// <see cref="Credentials"/> property is required by
+    /// <see cref="IWebProxy"/> but is never populated by this class.
+    /// Apps that need to authenticate to a system-detected proxy should
+    /// set <c>HttpClientHandler.DefaultProxyCredentials</c> (or
+    /// <c>SocketsHttpHandler.DefaultProxyCredentials</c>) — the same
+    /// behavior as on macOS and Windows.
+    /// </para>
+    /// </remarks>
+    internal sealed class AndroidPlatformProxy : IWebProxy
+    {
+        public ICredentials? Credentials { get; set; }
+
+        public unsafe Uri? GetProxy(Uri destination)
+        {
+            ArgumentNullException.ThrowIfNull(destination);
+
+            string url = destination.AbsoluteUri;
+
+            Interop.AndroidCrypto.AndroidProxyInfo* proxies = null;
+            int count = 0;
+            int rc = Interop.AndroidCrypto.GetProxyForUrl(url, out count, out proxies);
+
+            if (rc != 0 || count == 0 || proxies == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                // ProxySelector returns entries in preference order. We take the first one.
+                // SocketsHttpHandler does not currently have an opt-in fallback API for
+                // multiple proxies; if the chosen proxy is unreachable the user sees the
+                // connect error rather than an automatic retry.
+                for (int i = 0; i < count; i++)
+                {
+                    Interop.AndroidCrypto.AndroidProxyInfo entry = proxies[i];
+                    string scheme = entry.Type == (int)Interop.AndroidCrypto.AndroidProxyType.Socks
+                        ? "socks5"
+                        : "http";
+
+                    string? host = Marshal.PtrToStringUTF8(entry.Host);
+                    if (string.IsNullOrEmpty(host))
+                    {
+                        continue;
+                    }
+
+                    return new UriBuilder(scheme, host, entry.Port).Uri;
+                }
+
+                return null;
+            }
+            finally
+            {
+                Interop.AndroidCrypto.FreeProxyResult(proxies, count);
+            }
+        }
+
+        public bool IsBypassed(Uri host)
+        {
+            ArgumentNullException.ThrowIfNull(host);
+            // Computing the real answer is as expensive as GetProxy; mirror MacProxy.
+            Uri? proxyUri = GetProxy(host);
+            return proxyUri is null || Equals(proxyUri, host);
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
@@ -28,6 +28,21 @@ namespace System.Net.Http
             return new HttpNoProxy();
         }
 
+        // Feature switch: System.Net.Http.UseAndroidSystemProxy
+        //
+        // Defaults to true. Apps may opt out (set to "false" via
+        // <RuntimeHostConfigurationOption>) for the following reasons:
+        //
+        //   * Back-compat with apps that previously ran on SocketsHttpHandler
+        //     (i.e. UseNativeHttpHandler=false) and got env-var-only proxy
+        //     behavior. Suddenly honoring the system proxy could change the
+        //     destination of their HTTP requests; this switch is the escape
+        //     hatch.
+        //   * Trimming: when set to false at publish time, the linker can
+        //     trim the AndroidPlatformProxy class, the Interop P/Invoke
+        //     declarations, and (transitively) leave the native pal_proxy
+        //     code referenced only by other paths.
+        //   * Testing / debugging where pure env-var behavior is required.
         [FeatureSwitchDefinition("System.Net.Http.UseAndroidSystemProxy")]
         private static bool UseAndroidSystemProxy =>
             RuntimeSettingParser.QueryRuntimeSettingSwitch(

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace System.Net.Http
+{
+    internal static partial class SystemProxyInfo
+    {
+        public static IWebProxy ConstructSystemProxy()
+        {
+            // 1. Honor HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars first.
+            //    This matches the Unix convention and lets dev/test flows
+            //    (e.g. Charles/Fiddler) keep working unchanged.
+            if (HttpEnvironmentProxy.TryCreate(out IWebProxy? envProxy))
+            {
+                return envProxy;
+            }
+
+            // 2. Defer to the Android platform proxy via java.net.ProxySelector.
+            //    Wi-Fi proxy, MDM-deployed proxy, PAC scripts, and per-network
+            //    or VPN-attached ProxyInfo are all surfaced through this path.
+            if (UseAndroidSystemProxy)
+            {
+                return new AndroidPlatformProxy();
+            }
+
+            return new HttpNoProxy();
+        }
+
+        [FeatureSwitchDefinition("System.Net.Http.UseAndroidSystemProxy")]
+        private static bool UseAndroidSystemProxy =>
+            RuntimeSettingParser.QueryRuntimeSettingSwitch(
+                "System.Net.Http.UseAndroidSystemProxy",
+                defaultValue: true);
+    }
+}

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Android.cs
@@ -44,7 +44,7 @@ namespace System.Net.Http
         //     code referenced only by other paths.
         //   * Testing / debugging where pure env-var behavior is required.
         [FeatureSwitchDefinition("System.Net.Http.UseAndroidSystemProxy")]
-        private static bool UseAndroidSystemProxy =>
+        private static bool UseAndroidSystemProxy { get; } =
             RuntimeSettingParser.QueryRuntimeSettingSwitch(
                 "System.Net.Http.UseAndroidSystemProxy",
                 defaultValue: true);

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -938,6 +938,27 @@ namespace System.Net.Http.Functional.Tests
             }).DisposeAsync();
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsAndroid))]
+        [InlineData("http://example.com/")]
+        [InlineData("https://example.com/")]
+        [InlineData("http://example.com:8080/some/path?query=1")]
+        public void DefaultProxy_Android_GetProxy_NoConfiguredProxy_DoesNotThrow(string destination)
+        {
+            // On Android, DefaultProxy resolves through AndroidPlatformProxy, which crosses into
+            // native code and java.net.ProxySelector via JNI. We cannot mutate the emulator/device
+            // system proxy settings from a test without risking leaking that state into other
+            // workloads, so the only behavior we can safely assert is that the resolution path is
+            // robust when no proxy is configured: GetProxy must not throw and must return either a
+            // proxy URI or null (meaning "connect directly").
+            IWebProxy proxy = HttpClient.DefaultProxy;
+            var uri = new Uri(destination);
+
+            Uri? result = proxy.GetProxy(uri);
+            proxy.IsBypassed(uri);
+
+            Assert.True(result is null || result.IsAbsoluteUri);
+        }
+
         [Fact]
         public async Task PatchAsync_Canceled_Throws()
         {

--- a/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/libraries/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -5,6 +5,9 @@
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent)-unix;$(NetCoreAppCurrent)-browser;$(NetCoreAppCurrent)-osx;$(NetCoreAppCurrent)-maccatalyst;$(NetCoreAppCurrent)-ios;$(NetCoreAppCurrent)-tvos;$(NetCoreAppCurrent)-android</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' != 'android'">
+    <Compile Remove="SystemProxyInfoTest.Android.cs" />
+  </ItemGroup>
   <!-- Do not reference these assemblies from the TargetingPack since we are building part of the source code for tests. -->
   <ItemGroup>
     <DefaultReferenceExclusion Include="System.Net.Http" />
@@ -249,8 +252,16 @@
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" Condition=" '$(TargetPlatformIdentifier)' == 'osx' or '$(TargetPlatformIdentifier)' == 'ios' or '$(TargetPlatformIdentifier)' == 'tvos'"
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.OSX.cs" />
-    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" Condition="'$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'osx' and '$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'tvos'"
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" Condition="'$(TargetPlatformIdentifier)' != 'windows' and '$(TargetPlatformIdentifier)' != 'osx' and '$(TargetPlatformIdentifier)' != 'ios' and '$(TargetPlatformIdentifier)' != 'tvos' and '$(TargetPlatformIdentifier)' != 'android'"
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Unix.cs" />
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Android.cs" Condition="'$(TargetPlatformIdentifier)' == 'android'"
+             Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Android.cs" />
+    <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\AndroidPlatformProxy.Android.cs" Condition="'$(TargetPlatformIdentifier)' == 'android'"
+             Link="ProductionCode\System\Net\Http\SocketsHttpHandler\AndroidPlatformProxy.Android.cs" />
+    <Compile Include="$(CommonPath)Interop\Android\Interop.Libraries.cs" Condition="'$(TargetPlatformIdentifier)' == 'android'"
+             Link="Common\Interop\Android\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Android\System.Security.Cryptography.Native.Android\Interop.Proxy.cs" Condition="'$(TargetPlatformIdentifier)' == 'android'"
+             Link="Common\Interop\Android\System.Security.Cryptography.Native.Android\Interop.Proxy.cs" />
     <Compile Include="..\..\src\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" Condition="'$(TargetPlatformIdentifier)' == 'windows'"
              Link="ProductionCode\System\Net\Http\SocketsHttpHandler\SystemProxyInfo.Windows.cs" />
     <Compile Include="$(CommonPath)System\Net\Http\HttpHandlerDefaults.cs"

--- a/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
+using Xunit;
+
+namespace System.Net.Http.Tests
+{
+    public partial class SystemProxyInfoTest
+    {
+        [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
+        [InlineData(false, typeof(HttpNoProxy))]
+        [InlineData(true, typeof(AndroidPlatformProxy))]
+        public async Task Ctor_AndroidSystemProxySwitch_SelectsExpectedProxy(bool useAndroidSystemProxy, Type expectedType)
+        {
+            await RemoteExecutor.Invoke((switchValue, expectedTypeName) =>
+            {
+                AppContext.SetSwitch("System.Net.Http.UseAndroidSystemProxy", bool.Parse(switchValue));
+
+                IWebProxy proxy = SystemProxyInfo.ConstructSystemProxy();
+
+                Assert.Equal(expectedTypeName, proxy.GetType().Name);
+            }, useAndroidSystemProxy.ToString(), expectedType.Name).DisposeAsync();
+        }
+
+        [Theory]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Direct, null, 0, true, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 8080, true, "http://proxy.example:8080/")]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 1080, true, "socks5://proxy.example:1080/")]
+        [InlineData((Interop.AndroidCrypto.AndroidProxyType)42, "proxy.example", 8080, false, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "", 8080, false, null)]
+        public void AndroidPlatformProxy_TryCreateProxyUri_PreservesProxySelectorEntrySemantics(
+            Interop.AndroidCrypto.AndroidProxyType proxyType,
+            string? host,
+            int port,
+            bool expectedResult,
+            string? expectedUri)
+        {
+            IntPtr hostPtr = host is null ? IntPtr.Zero : Marshal.StringToCoTaskMemUni(host);
+            try
+            {
+                bool result = AndroidPlatformProxy.TryCreateProxyUri(CreateProxyEntry(proxyType, hostPtr, port), out Uri? proxyUri);
+
+                Assert.Equal(expectedResult, result);
+                Assert.Equal(expectedUri, proxyUri?.AbsoluteUri);
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(hostPtr);
+            }
+        }
+
+        private static Interop.AndroidCrypto.AndroidProxyInfo CreateProxyEntry(
+            Interop.AndroidCrypto.AndroidProxyType proxyType,
+            IntPtr host,
+            int port)
+        {
+            return new Interop.AndroidCrypto.AndroidProxyInfo
+            {
+                Type = (int)proxyType,
+                Host = host,
+                Port = port
+            };
+        }
+    }
+}

--- a/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
@@ -18,6 +18,15 @@ namespace System.Net.Http.Tests
         {
             await RemoteExecutor.Invoke((switchValue, expectedTypeName) =>
             {
+                // The child process may inherit HTTP(S)_PROXY / NO_PROXY (etc.) from the CI
+                // environment. ConstructSystemProxy checks those first, so clear them to make
+                // sure we actually exercise the AndroidPlatformProxy / HttpNoProxy selection.
+                foreach (string envVar in new[] { "http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY",
+                                                  "all_proxy", "ALL_PROXY", "no_proxy", "NO_PROXY", "GATEWAY_INTERFACE" })
+                {
+                    Environment.SetEnvironmentVariable(envVar, null);
+                }
+
                 AppContext.SetSwitch("System.Net.Http.UseAndroidSystemProxy", bool.Parse(switchValue));
 
                 IWebProxy proxy = SystemProxyInfo.ConstructSystemProxy();
@@ -32,6 +41,9 @@ namespace System.Net.Http.Tests
         [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 1080, true, "socks5://proxy.example:1080/")]
         [InlineData((Interop.AndroidCrypto.AndroidProxyType)42, "proxy.example", 8080, false, null)]
         [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "", 8080, false, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 0, false, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", -1, false, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 70000, false, null)]
         public void AndroidPlatformProxy_TryCreateProxyUri_PreservesProxySelectorEntrySemantics(
             Interop.AndroidCrypto.AndroidProxyType proxyType,
             string? host,

--- a/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.Android.cs
@@ -36,33 +36,82 @@ namespace System.Net.Http.Tests
         }
 
         [Theory]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Direct, null, 0, true, null)]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 8080, true, "http://proxy.example:8080/")]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 1080, true, "socks5://proxy.example:1080/")]
-        [InlineData((Interop.AndroidCrypto.AndroidProxyType)42, "proxy.example", 8080, false, null)]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "", 8080, false, null)]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 0, false, null)]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", -1, false, null)]
-        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 70000, false, null)]
-        public void AndroidPlatformProxy_TryCreateProxyUri_PreservesProxySelectorEntrySemantics(
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Direct, null, 0, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 8080, "http://proxy.example:8080/")]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 1080, "socks5://proxy.example:1080/")]
+        [InlineData((Interop.AndroidCrypto.AndroidProxyType)42, "proxy.example", 8080, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "", 8080, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", 0, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Http, "proxy.example", -1, null)]
+        [InlineData(Interop.AndroidCrypto.AndroidProxyType.Socks, "proxy.example", 70000, null)]
+        public void AndroidPlatformProxy_SelectProxyUri_MapsSingleEntry(
             Interop.AndroidCrypto.AndroidProxyType proxyType,
             string? host,
             int port,
-            bool expectedResult,
             string? expectedUri)
         {
             IntPtr hostPtr = host is null ? IntPtr.Zero : Marshal.StringToCoTaskMemUni(host);
             try
             {
-                bool result = AndroidPlatformProxy.TryCreateProxyUri(CreateProxyEntry(proxyType, hostPtr, port), out Uri? proxyUri);
+                Interop.AndroidCrypto.AndroidProxyInfo[] entries = [CreateProxyEntry(proxyType, hostPtr, port)];
 
-                Assert.Equal(expectedResult, result);
+                Uri? proxyUri = AndroidPlatformProxy.SelectProxyUri(entries);
+
                 Assert.Equal(expectedUri, proxyUri?.AbsoluteUri);
             }
             finally
             {
                 Marshal.FreeCoTaskMem(hostPtr);
             }
+        }
+
+        [Fact]
+        public void AndroidPlatformProxy_SelectProxyUri_DirectEntryStopsFallback()
+        {
+            IntPtr hostPtr = Marshal.StringToCoTaskMemUni("proxy.example");
+            try
+            {
+                // DIRECT precedes a usable HTTP entry: ProxySelector ordering means the
+                // selected result is "no proxy", so the later entry must not be used.
+                Interop.AndroidCrypto.AndroidProxyInfo[] entries =
+                [
+                    CreateProxyEntry(Interop.AndroidCrypto.AndroidProxyType.Direct, IntPtr.Zero, 0),
+                    CreateProxyEntry(Interop.AndroidCrypto.AndroidProxyType.Http, hostPtr, 8080),
+                ];
+
+                Assert.Null(AndroidPlatformProxy.SelectProxyUri(entries));
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(hostPtr);
+            }
+        }
+
+        [Fact]
+        public void AndroidPlatformProxy_SelectProxyUri_SkipsUnusableEntries()
+        {
+            IntPtr hostPtr = Marshal.StringToCoTaskMemUni("proxy.example");
+            try
+            {
+                // An unknown proxy type is skipped in favor of the next usable entry.
+                Interop.AndroidCrypto.AndroidProxyInfo[] entries =
+                [
+                    CreateProxyEntry((Interop.AndroidCrypto.AndroidProxyType)42, IntPtr.Zero, 0),
+                    CreateProxyEntry(Interop.AndroidCrypto.AndroidProxyType.Http, hostPtr, 8080),
+                ];
+
+                Assert.Equal("http://proxy.example:8080/", AndroidPlatformProxy.SelectProxyUri(entries)?.AbsoluteUri);
+            }
+            finally
+            {
+                Marshal.FreeCoTaskMem(hostPtr);
+            }
+        }
+
+        [Fact]
+        public void AndroidPlatformProxy_SelectProxyUri_NoEntriesReturnsNull()
+        {
+            Assert.Null(AndroidPlatformProxy.SelectProxyUri(ReadOnlySpan<Interop.AndroidCrypto.AndroidProxyInfo>.Empty));
         }
 
         private static Interop.AndroidCrypto.AndroidProxyInfo CreateProxyEntry(

--- a/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/SystemProxyInfoTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace System.Net.Http.Tests
 {
-    public class SystemProxyInfoTest
+    public partial class SystemProxyInfoTest
     {
         // This will clean specific environmental variables
         // to be sure they do not interfere with the test.

--- a/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/CMakeLists.txt
@@ -22,6 +22,7 @@ set(NATIVECRYPTO_SOURCES
     pal_memory.c
     pal_misc.c
     pal_pbkdf2.c
+    pal_proxy.c
     pal_rsa.c
     pal_signature.c
     pal_ssl.c

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -504,6 +504,35 @@ jmethodID g_DotnetX509KeyManagerCtor;
 jclass    g_PalPbkdf2;
 jmethodID g_PalPbkdf2Pbkdf2OneShot;
 
+// java/net/ProxySelector
+jclass    g_ProxySelector;
+jmethodID g_ProxySelector_getDefault;
+jmethodID g_ProxySelector_select;
+
+// java/net/Proxy
+jclass    g_Proxy;
+jmethodID g_ProxyType_method;
+jmethodID g_Proxy_address;
+
+// java/net/Proxy$Type
+jclass    g_ProxyType;
+jfieldID  g_ProxyType_HTTP;
+jfieldID  g_ProxyType_SOCKS;
+
+// java/net/InetSocketAddress
+jclass    g_InetSocketAddress;
+jmethodID g_InetSocketAddress_getHostString;
+jmethodID g_InetSocketAddress_getPort;
+
+// java/net/URI
+jclass    g_URI;
+jmethodID g_URI_create;
+
+// java/util/List
+jclass    g_List;
+jmethodID g_ListSize;
+jmethodID g_ListGet;
+
 jobject ToGRef(JNIEnv *env, jobject lref)
 {
     if (lref)
@@ -1110,6 +1139,29 @@ jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 
     g_PalPbkdf2              = GetClassGRef(env, "net/dot/android/crypto/PalPbkdf2");
     g_PalPbkdf2Pbkdf2OneShot = GetMethod(env, true, g_PalPbkdf2, "pbkdf2OneShot", "(Ljava/lang/String;[BLjava/nio/ByteBuffer;ILjava/nio/ByteBuffer;)I");
+
+    g_ProxySelector            = GetClassGRef(env, "java/net/ProxySelector");
+    g_ProxySelector_getDefault = GetMethod(env, true,  g_ProxySelector, "getDefault", "()Ljava/net/ProxySelector;");
+    g_ProxySelector_select     = GetMethod(env, false, g_ProxySelector, "select",     "(Ljava/net/URI;)Ljava/util/List;");
+
+    g_Proxy             = GetClassGRef(env, "java/net/Proxy");
+    g_ProxyType_method  = GetMethod(env, false, g_Proxy, "type",    "()Ljava/net/Proxy$Type;");
+    g_Proxy_address     = GetMethod(env, false, g_Proxy, "address", "()Ljava/net/SocketAddress;");
+
+    g_ProxyType       = GetClassGRef(env, "java/net/Proxy$Type");
+    g_ProxyType_HTTP  = GetField(env, true, g_ProxyType, "HTTP",  "Ljava/net/Proxy$Type;");
+    g_ProxyType_SOCKS = GetField(env, true, g_ProxyType, "SOCKS", "Ljava/net/Proxy$Type;");
+
+    g_InetSocketAddress               = GetClassGRef(env, "java/net/InetSocketAddress");
+    g_InetSocketAddress_getHostString = GetMethod(env, false, g_InetSocketAddress, "getHostString", "()Ljava/lang/String;");
+    g_InetSocketAddress_getPort       = GetMethod(env, false, g_InetSocketAddress, "getPort",       "()I");
+
+    g_URI        = GetClassGRef(env, "java/net/URI");
+    g_URI_create = GetMethod(env, true, g_URI, "create", "(Ljava/lang/String;)Ljava/net/URI;");
+
+    g_List      = GetClassGRef(env, "java/util/List");
+    g_ListSize  = GetMethod(env, false, g_List, "size", "()I");
+    g_ListGet   = GetMethod(env, false, g_List, "get",  "(I)Ljava/lang/Object;");
 
     return JNI_VERSION_1_6;
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -715,6 +715,21 @@ JNIEnv* GetJNIEnv(void)
     return env;
 }
 
+uint16_t* AllocateString(JNIEnv* env, jstring source)
+{
+    if (source == NULL)
+        return NULL;
+
+    // GetStringLength is in 16-bit Java code-units, which is exactly the format we copy
+    // out via GetStringRegion. The buffer holds (len + 1) uint16_t for the NUL terminator.
+    jsize len = (*env)->GetStringLength(env, source);
+    uint16_t* buffer = xmalloc(sizeof(uint16_t) * (size_t)(len + 1));
+    buffer[len] = '\0';
+
+    (*env)->GetStringRegion(env, source, 0, len, (jchar*)buffer);
+    return buffer;
+}
+
 jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 {
     (void)reserved;

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -528,11 +528,6 @@ jmethodID g_InetSocketAddress_getPort;
 jclass    g_URI;
 jmethodID g_URI_create;
 
-// java/util/List
-jclass    g_List;
-jmethodID g_ListSize;
-jmethodID g_ListGet;
-
 jobject ToGRef(JNIEnv *env, jobject lref)
 {
     if (lref)
@@ -1173,10 +1168,6 @@ jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
 
     g_URI        = GetClassGRef(env, "java/net/URI");
     g_URI_create = GetMethod(env, true, g_URI, "create", "(Ljava/lang/String;)Ljava/net/URI;");
-
-    g_List      = GetClassGRef(env, "java/util/List");
-    g_ListSize  = GetMethod(env, false, g_List, "size", "()I");
-    g_ListGet   = GetMethod(env, false, g_List, "get",  "(I)Ljava/lang/Object;");
 
     return JNI_VERSION_1_6;
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.c
@@ -516,6 +516,7 @@ jmethodID g_Proxy_address;
 
 // java/net/Proxy$Type
 jclass    g_ProxyType;
+jfieldID  g_ProxyType_DIRECT;
 jfieldID  g_ProxyType_HTTP;
 jfieldID  g_ProxyType_SOCKS;
 
@@ -1158,9 +1159,10 @@ jint AndroidCryptoNative_InitLibraryOnLoad (JavaVM *vm, void *reserved)
     g_ProxyType_method  = GetMethod(env, false, g_Proxy, "type",    "()Ljava/net/Proxy$Type;");
     g_Proxy_address     = GetMethod(env, false, g_Proxy, "address", "()Ljava/net/SocketAddress;");
 
-    g_ProxyType       = GetClassGRef(env, "java/net/Proxy$Type");
-    g_ProxyType_HTTP  = GetField(env, true, g_ProxyType, "HTTP",  "Ljava/net/Proxy$Type;");
-    g_ProxyType_SOCKS = GetField(env, true, g_ProxyType, "SOCKS", "Ljava/net/Proxy$Type;");
+    g_ProxyType        = GetClassGRef(env, "java/net/Proxy$Type");
+    g_ProxyType_DIRECT = GetField(env, true, g_ProxyType, "DIRECT", "Ljava/net/Proxy$Type;");
+    g_ProxyType_HTTP   = GetField(env, true, g_ProxyType, "HTTP",   "Ljava/net/Proxy$Type;");
+    g_ProxyType_SOCKS  = GetField(env, true, g_ProxyType, "SOCKS",  "Ljava/net/Proxy$Type;");
 
     g_InetSocketAddress               = GetClassGRef(env, "java/net/InetSocketAddress");
     g_InetSocketAddress_getHostString = GetMethod(env, false, g_InetSocketAddress, "getHostString", "()Ljava/lang/String;");

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -540,11 +540,6 @@ extern jmethodID g_InetSocketAddress_getPort;
 extern jclass    g_URI;
 extern jmethodID g_URI_create;
 
-// java/util/List
-extern jclass    g_List;
-extern jmethodID g_ListSize;
-extern jmethodID g_ListGet;
-
 // Compatibility macros
 #if !defined (__mallocfunc)
 #if defined (__clang__) || defined (__GNUC__)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -624,6 +624,16 @@ jclass GetClassGRef(JNIEnv *env, const char* name) ARGS_NON_NULL(1);
 // Print and clear any JNI exceptions. Returns true if there was an exception, false otherwise.
 bool CheckJNIExceptions(JNIEnv* env) ARGS_NON_NULL_ALL;
 
+// Allocates a NUL-terminated UTF-16 buffer (via xmalloc) and copies the contents of the
+// supplied Java String into it. Returns NULL when source is NULL. Aborts on allocation
+// failure (matches xmalloc semantics). Caller frees with free().
+//
+// This is the standard PAL helper for returning a String to managed code as UTF-16 —
+// System.String is internally UTF-16, so Marshal.PtrToStringUni on the managed side is
+// a zero-conversion memcpy. Using GetStringUTFRegion would produce *modified* UTF-8
+// (which is not standard UTF-8) and force an extra Encoding.UTF8.GetString allocation.
+uint16_t* AllocateString(JNIEnv* env, jstring source) ARGS_NON_NULL(1);
+
 // Clear any JNI exceptions without printing them. Returns true if there was an exception, false otherwise.
 bool TryClearJNIExceptions(JNIEnv* env) ARGS_NON_NULL_ALL;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -516,6 +516,35 @@ extern jmethodID g_DotnetX509KeyManagerCtor;
 extern jclass    g_PalPbkdf2;
 extern jmethodID g_PalPbkdf2Pbkdf2OneShot;
 
+// java/net/ProxySelector
+extern jclass    g_ProxySelector;
+extern jmethodID g_ProxySelector_getDefault;
+extern jmethodID g_ProxySelector_select;
+
+// java/net/Proxy
+extern jclass    g_Proxy;
+extern jmethodID g_ProxyType_method;  // Proxy.type() -> Proxy$Type
+extern jmethodID g_Proxy_address;     // Proxy.address() -> SocketAddress
+
+// java/net/Proxy$Type
+extern jclass    g_ProxyType;
+extern jfieldID  g_ProxyType_HTTP;
+extern jfieldID  g_ProxyType_SOCKS;
+
+// java/net/InetSocketAddress
+extern jclass    g_InetSocketAddress;
+extern jmethodID g_InetSocketAddress_getHostString;
+extern jmethodID g_InetSocketAddress_getPort;
+
+// java/net/URI
+extern jclass    g_URI;
+extern jmethodID g_URI_create;
+
+// java/util/List
+extern jclass    g_List;
+extern jmethodID g_ListSize;
+extern jmethodID g_ListGet;
+
 // Compatibility macros
 #if !defined (__mallocfunc)
 #if defined (__clang__) || defined (__GNUC__)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_jni.h
@@ -528,6 +528,7 @@ extern jmethodID g_Proxy_address;     // Proxy.address() -> SocketAddress
 
 // java/net/Proxy$Type
 extern jclass    g_ProxyType;
+extern jfieldID  g_ProxyType_DIRECT;
 extern jfieldID  g_ProxyType_HTTP;
 extern jfieldID  g_ProxyType_SOCKS;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -148,7 +148,9 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         uint16_t* host = AllocateString(env, (jstring)iter[jhost]);
 
         result[written].type = type;
-        result[written].host = host; // ownership transferred to the result; lifetime ≥ jhost
+        // host is an independent heap copy (see AllocateString), not an alias of the jhost
+        // local ref. Its lifetime is owned by the result array and released by FreeProxyResult.
+        result[written].host = host;
         result[written].port = (int32_t)port;
         written++;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -1,0 +1,195 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "pal_proxy.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+// Copy a Java String into a NUL-terminated UTF-8 heap buffer.
+// Returns NULL on allocation failure or on JNI exception / empty input.
+static char* CopyJStringToUtf8(JNIEnv* env, jstring s)
+{
+    if (s == NULL)
+        return NULL;
+
+    jsize charLen = (*env)->GetStringLength(env, s);
+    jsize byteLen = (*env)->GetStringUTFLength(env, s);
+    if (byteLen <= 0)
+        return NULL;
+
+    char* buf = (char*)malloc((size_t)byteLen + 1);
+    if (buf == NULL)
+        return NULL;
+
+    (*env)->GetStringUTFRegion(env, s, 0, charLen, buf);
+    if (TryClearJNIExceptions(env))
+    {
+        free(buf);
+        return NULL;
+    }
+
+    buf[byteLen] = '\0';
+    return buf;
+}
+
+PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
+                                                     int32_t*    outCount,
+                                                     AndroidProxyInfo** outProxies)
+{
+    abort_if_invalid_pointer_argument(outCount);
+    abort_if_invalid_pointer_argument(outProxies);
+
+    *outCount = 0;
+    *outProxies = NULL;
+
+    if (urlUtf8 == NULL)
+        return 0; // treat as "no proxy"
+
+    JNIEnv* env = GetJNIEnv();
+    int32_t ret = 0;
+    AndroidProxyInfo* result = NULL;
+    int32_t written = 0;
+
+    // All transient outer-scope local refs go here. RELEASE_LOCALS(loc, env)
+    // at the cleanup label releases them exactly once on every path.
+    INIT_LOCALS(loc, jurl, juri, jselector, jlist,
+                     jproxyTypeHttp, jproxyTypeSocks);
+
+    loc[jurl] = make_java_string(env, urlUtf8); // aborts on OOM
+
+    // URI.create(url) — IllegalArgumentException for malformed input.
+    loc[juri] = (*env)->CallStaticObjectMethod(env, g_URI, g_URI_create, loc[jurl]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    // ProxySelector.getDefault() — VM-wide singleton; may throw SecurityException.
+    loc[jselector] = (*env)->CallStaticObjectMethod(env, g_ProxySelector, g_ProxySelector_getDefault);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (loc[jselector] == NULL)
+        goto cleanup;
+
+    // ProxySelector.select(uri)
+    loc[jlist] = (*env)->CallObjectMethod(env, loc[jselector], g_ProxySelector_select, loc[juri]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (loc[jlist] == NULL)
+        goto cleanup;
+
+    // Resolve the Proxy.Type enum constants for IsSameObject comparisons.
+    loc[jproxyTypeHttp]  = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_HTTP);
+    loc[jproxyTypeSocks] = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_SOCKS);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    jint n = (*env)->CallIntMethod(env, loc[jlist], g_ListSize);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (n <= 0)
+        goto cleanup;
+
+    result = (AndroidProxyInfo*)calloc((size_t)n, sizeof(AndroidProxyInfo));
+    if (result == NULL)
+    {
+        ret = -1;
+        goto cleanup;
+    }
+
+    for (jint i = 0; i < n; i++)
+    {
+        // Per-iteration locals — released at the end of each loop body.
+        INIT_LOCALS(iter, jproxy, jtype, jaddr, jhost);
+
+        iter[jproxy] = (*env)->CallObjectMethod(env, loc[jlist], g_ListGet, i);
+        if (CheckJNIExceptions(env) || iter[jproxy] == NULL)
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        iter[jtype] = (*env)->CallObjectMethod(env, iter[jproxy], g_ProxyType_method);
+        if (CheckJNIExceptions(env) || iter[jtype] == NULL)
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        int32_t type;
+        if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeHttp]))
+        {
+            type = ANDROID_PROXY_TYPE_HTTP;
+        }
+        else if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeSocks]))
+        {
+            type = ANDROID_PROXY_TYPE_SOCKS;
+        }
+        else
+        {
+            // DIRECT or unknown — no result entry.
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        iter[jaddr] = (*env)->CallObjectMethod(env, iter[jproxy], g_Proxy_address);
+        if (CheckJNIExceptions(env)
+            || iter[jaddr] == NULL
+            || !(*env)->IsInstanceOf(env, iter[jaddr], g_InetSocketAddress))
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        iter[jhost] = (*env)->CallObjectMethod(env, iter[jaddr], g_InetSocketAddress_getHostString);
+        if (CheckJNIExceptions(env) || iter[jhost] == NULL)
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        jint port = (*env)->CallIntMethod(env, iter[jaddr], g_InetSocketAddress_getPort);
+        if (CheckJNIExceptions(env))
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        char* host = CopyJStringToUtf8(env, (jstring)iter[jhost]);
+        if (host == NULL)
+        {
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+
+        result[written].type = type;
+        result[written].host = host; // ownership transferred to result; lifetime ≥ jhost
+        result[written].port = (int32_t)port;
+        written++;
+
+        RELEASE_LOCALS(iter, env);
+    }
+
+cleanup:
+    RELEASE_LOCALS(loc, env);
+
+    if (ret == 0)
+    {
+        *outCount = written;
+        *outProxies = result;
+    }
+    else if (result != NULL)
+    {
+        // Error path: free anything we may have partially populated.
+        for (int32_t i = 0; i < written; i++)
+            free(result[i].host);
+        free(result);
+    }
+
+    return ret;
+}
+
+PALEXPORT void AndroidCryptoNative_FreeProxyResult(AndroidProxyInfo* proxies, int32_t count)
+{
+    if (proxies == NULL)
+        return;
+
+    for (int32_t i = 0; i < count; i++)
+        free(proxies[i].host);
+
+    free(proxies);
+}

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -4,34 +4,6 @@
 #include "pal_proxy.h"
 
 #include <stdlib.h>
-#include <string.h>
-
-// Copy a Java String into a NUL-terminated UTF-8 heap buffer.
-// Returns NULL on allocation failure or on JNI exception / empty input.
-static char* CopyJStringToUtf8(JNIEnv* env, jstring s)
-{
-    if (s == NULL)
-        return NULL;
-
-    jsize charLen = (*env)->GetStringLength(env, s);
-    jsize byteLen = (*env)->GetStringUTFLength(env, s);
-    if (byteLen <= 0)
-        return NULL;
-
-    char* buf = (char*)malloc((size_t)byteLen + 1);
-    if (buf == NULL)
-        return NULL;
-
-    (*env)->GetStringUTFRegion(env, s, 0, charLen, buf);
-    if (TryClearJNIExceptions(env))
-    {
-        free(buf);
-        return NULL;
-    }
-
-    buf[byteLen] = '\0';
-    return buf;
-}
 
 PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
                                                      int32_t*    outCount,
@@ -51,8 +23,8 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
     AndroidProxyInfo* result = NULL;
     int32_t written = 0;
 
-    // All transient outer-scope local refs go here. RELEASE_LOCALS(loc, env)
-    // at the cleanup label releases them exactly once on every path.
+    // All transient outer-scope local refs go here. RELEASE_LOCALS(loc, env) at the
+    // cleanup label releases them exactly once on every path.
     INIT_LOCALS(loc, jurl, juri, jselector, jlist,
                      jproxyTypeHttp, jproxyTypeSocks);
 
@@ -117,6 +89,11 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         }
         else if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeSocks]))
         {
+            // SOCKS is a transport-level proxy protocol (RFC 1928 for SOCKS5). Unlike
+            // HTTP CONNECT, it tunnels arbitrary TCP at the socket layer rather than
+            // negotiating at the HTTP layer. Android's java.net.Proxy.Type.SOCKS maps
+            // to SOCKS5 in modern Java; SocketsHttpHandler accepts the "socks5://"
+            // scheme via HttpUtilities.IsSupportedProxyScheme.
             type = ANDROID_PROXY_TYPE_SOCKS;
         }
         else
@@ -149,15 +126,13 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
             continue;
         }
 
-        char* host = CopyJStringToUtf8(env, (jstring)iter[jhost]);
-        if (host == NULL)
-        {
-            RELEASE_LOCALS(iter, env);
-            continue;
-        }
+        // Copy the host as NUL-terminated UTF-16. Marshal.PtrToStringUni on the managed
+        // side is a zero-conversion copy because System.String is internally UTF-16.
+        // AllocateString aborts on allocation failure; we never see a NULL return here.
+        uint16_t* host = AllocateString(env, (jstring)iter[jhost]);
 
         result[written].type = type;
-        result[written].host = host; // ownership transferred to result; lifetime ≥ jhost
+        result[written].host = host; // ownership transferred to the result; lifetime ≥ jhost
         result[written].port = (int32_t)port;
         written++;
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -26,7 +26,7 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
     // All transient outer-scope local refs go here. RELEASE_LOCALS(loc, env) at the
     // cleanup label releases them exactly once on every path.
     INIT_LOCALS(loc, jurl, juri, jselector, jlist,
-                     jproxyTypeHttp, jproxyTypeSocks);
+                     jproxyTypeDirect, jproxyTypeHttp, jproxyTypeSocks);
 
     loc[jurl] = make_java_string(env, urlUtf8); // aborts on OOM
 
@@ -47,8 +47,9 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         goto cleanup;
 
     // Resolve the Proxy.Type enum constants for IsSameObject comparisons.
-    loc[jproxyTypeHttp]  = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_HTTP);
-    loc[jproxyTypeSocks] = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_SOCKS);
+    loc[jproxyTypeDirect] = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_DIRECT);
+    loc[jproxyTypeHttp]   = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_HTTP);
+    loc[jproxyTypeSocks]  = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_SOCKS);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     jint n = (*env)->CallIntMethod(env, loc[jlist], g_CollectionSize);
@@ -83,7 +84,17 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         }
 
         int32_t type;
-        if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeHttp]))
+        if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeDirect]))
+        {
+            result[written].type = ANDROID_PROXY_TYPE_DIRECT;
+            result[written].host = NULL;
+            result[written].port = 0;
+            written++;
+
+            RELEASE_LOCALS(iter, env);
+            continue;
+        }
+        else if ((*env)->IsSameObject(env, iter[jtype], loc[jproxyTypeHttp]))
         {
             type = ANDROID_PROXY_TYPE_HTTP;
         }
@@ -98,7 +109,7 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         }
         else
         {
-            // DIRECT or unknown — no result entry.
+            // Unknown proxy type: no result entry.
             RELEASE_LOCALS(iter, env);
             continue;
         }
@@ -149,8 +160,8 @@ cleanup:
     }
     else if (result != NULL)
     {
-        // Either an error path or no proxy entries survived filtering (DIRECT-only,
-        // unknown types, etc). Free anything we may have partially populated so that
+        // Either an error path or no proxy entries survived filtering (unknown types,
+        // invalid addresses, etc). Free anything we may have partially populated so that
         // callers can rely on outProxies == NULL whenever outCount == 0.
         for (int32_t i = 0; i < written; i++)
             free(result[i].host);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -51,7 +51,7 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
     loc[jproxyTypeSocks] = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_SOCKS);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
-    jint n = (*env)->CallIntMethod(env, loc[jlist], g_ListSize);
+    jint n = (*env)->CallIntMethod(env, loc[jlist], g_CollectionSize);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     if (n <= 0)
         goto cleanup;
@@ -142,14 +142,16 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
 cleanup:
     RELEASE_LOCALS(loc, env);
 
-    if (ret == 0)
+    if (ret == 0 && written > 0)
     {
         *outCount = written;
         *outProxies = result;
     }
     else if (result != NULL)
     {
-        // Error path: free anything we may have partially populated.
+        // Either an error path or no proxy entries survived filtering (DIRECT-only,
+        // unknown types, etc). Free anything we may have partially populated so that
+        // callers can rely on outProxies == NULL whenever outCount == 0.
         for (int32_t i = 0; i < written; i++)
             free(result[i].host);
         free(result);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.c
@@ -32,17 +32,20 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
 
     // URI.create(url) — IllegalArgumentException for malformed input.
     loc[juri] = (*env)->CallStaticObjectMethod(env, g_URI, g_URI_create, loc[jurl]);
-    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (TryClearJNIExceptions(env))
+        goto cleanup;
 
     // ProxySelector.getDefault() — VM-wide singleton; may throw SecurityException.
     loc[jselector] = (*env)->CallStaticObjectMethod(env, g_ProxySelector, g_ProxySelector_getDefault);
-    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (TryClearJNIExceptions(env))
+        goto cleanup;
     if (loc[jselector] == NULL)
         goto cleanup;
 
     // ProxySelector.select(uri)
     loc[jlist] = (*env)->CallObjectMethod(env, loc[jselector], g_ProxySelector_select, loc[juri]);
-    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (TryClearJNIExceptions(env))
+        goto cleanup;
     if (loc[jlist] == NULL)
         goto cleanup;
 
@@ -50,10 +53,12 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
     loc[jproxyTypeDirect] = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_DIRECT);
     loc[jproxyTypeHttp]   = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_HTTP);
     loc[jproxyTypeSocks]  = (*env)->GetStaticObjectField(env, g_ProxyType, g_ProxyType_SOCKS);
-    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (TryClearJNIExceptions(env))
+        goto cleanup;
 
     jint n = (*env)->CallIntMethod(env, loc[jlist], g_CollectionSize);
-    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+    if (TryClearJNIExceptions(env))
+        goto cleanup;
     if (n <= 0)
         goto cleanup;
 
@@ -70,14 +75,14 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         INIT_LOCALS(iter, jproxy, jtype, jaddr, jhost);
 
         iter[jproxy] = (*env)->CallObjectMethod(env, loc[jlist], g_ListGet, i);
-        if (CheckJNIExceptions(env) || iter[jproxy] == NULL)
+        if (TryClearJNIExceptions(env) || iter[jproxy] == NULL)
         {
             RELEASE_LOCALS(iter, env);
             continue;
         }
 
         iter[jtype] = (*env)->CallObjectMethod(env, iter[jproxy], g_ProxyType_method);
-        if (CheckJNIExceptions(env) || iter[jtype] == NULL)
+        if (TryClearJNIExceptions(env) || iter[jtype] == NULL)
         {
             RELEASE_LOCALS(iter, env);
             continue;
@@ -115,7 +120,7 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         }
 
         iter[jaddr] = (*env)->CallObjectMethod(env, iter[jproxy], g_Proxy_address);
-        if (CheckJNIExceptions(env)
+        if (TryClearJNIExceptions(env)
             || iter[jaddr] == NULL
             || !(*env)->IsInstanceOf(env, iter[jaddr], g_InetSocketAddress))
         {
@@ -124,14 +129,14 @@ PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
         }
 
         iter[jhost] = (*env)->CallObjectMethod(env, iter[jaddr], g_InetSocketAddress_getHostString);
-        if (CheckJNIExceptions(env) || iter[jhost] == NULL)
+        if (TryClearJNIExceptions(env) || iter[jhost] == NULL)
         {
             RELEASE_LOCALS(iter, env);
             continue;
         }
 
         jint port = (*env)->CallIntMethod(env, iter[jaddr], g_InetSocketAddress_getPort);
-        if (CheckJNIExceptions(env))
+        if (TryClearJNIExceptions(env))
         {
             RELEASE_LOCALS(iter, env);
             continue;

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "pal_compiler.h"
+#include "pal_jni.h"
+#include "pal_types.h"
+
+typedef enum
+{
+    ANDROID_PROXY_TYPE_HTTP  = 0,
+    ANDROID_PROXY_TYPE_SOCKS = 1,
+} AndroidProxyType;
+
+typedef struct
+{
+    int32_t type;  // AndroidProxyType
+    char*   host;  // NUL-terminated UTF-8, malloc'd; freed via AndroidCryptoNative_FreeProxyResult
+    int32_t port;
+} AndroidProxyInfo;
+
+// Resolves the system proxy chain for the destination URL by querying
+// java.net.ProxySelector.getDefault().select(URI.create(url)).
+//
+// On success returns 0. *outCount is the number of HTTP/SOCKS entries
+// (DIRECT entries are skipped). *outProxies is an array of
+// AndroidProxyInfo allocated via malloc; the caller must release it
+// via AndroidCryptoNative_FreeProxyResult.
+//
+// Any JNI exception (malformed URI, SecurityException, ...) is treated
+// as "no proxy" and the function returns success with outCount == 0.
+//
+// On allocation failure returns -1.
+PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
+                                                     int32_t*    outCount,
+                                                     AndroidProxyInfo** outProxies);
+
+PALEXPORT void AndroidCryptoNative_FreeProxyResult(AndroidProxyInfo* proxies, int32_t count);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
@@ -32,10 +32,13 @@ typedef struct
 // DIRECT entries represent Java's Proxy.NO_PROXY / Proxy.Type.DIRECT and have
 // NULL host and port 0.
 //
-// Any JNI exception (malformed URI, SecurityException, ...) is treated
-// as "no proxy" and the function returns success with outCount == 0.
+// JNI exceptions while constructing the URI or resolving the proxy list are
+// treated as "no proxy" and the function returns success with outCount == 0.
+// JNI exceptions while reading an individual proxy entry are cleared and that
+// entry is skipped; previously read entries may still be returned.
 //
-// On allocation failure returns -1.
+// On result-array allocation failure returns -1. Host-string allocation uses
+// xmalloc via AllocateString and aborts on allocation failure.
 PALEXPORT int32_t AndroidCryptoNative_GetProxyForUrl(const char* urlUtf8,
                                                      int32_t*    outCount,
                                                      AndroidProxyInfo** outProxies);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
@@ -15,9 +15,11 @@ typedef enum
 
 typedef struct
 {
-    int32_t type;  // AndroidProxyType
-    char*   host;  // NUL-terminated UTF-8, malloc'd; freed via AndroidCryptoNative_FreeProxyResult
-    int32_t port;
+    int32_t   type;  // AndroidProxyType
+    uint16_t* host;  // NUL-terminated UTF-16, allocated via xmalloc (so .NET internals
+                     // can read it directly with Marshal.PtrToStringUni / new string(char*));
+                     // freed via AndroidCryptoNative_FreeProxyResult.
+    int32_t   port;
 } AndroidProxyInfo;
 
 // Resolves the system proxy chain for the destination URL by querying

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_proxy.h
@@ -9,8 +9,9 @@
 
 typedef enum
 {
-    ANDROID_PROXY_TYPE_HTTP  = 0,
-    ANDROID_PROXY_TYPE_SOCKS = 1,
+    ANDROID_PROXY_TYPE_DIRECT = 0,
+    ANDROID_PROXY_TYPE_HTTP   = 1,
+    ANDROID_PROXY_TYPE_SOCKS  = 2,
 } AndroidProxyType;
 
 typedef struct
@@ -25,10 +26,11 @@ typedef struct
 // Resolves the system proxy chain for the destination URL by querying
 // java.net.ProxySelector.getDefault().select(URI.create(url)).
 //
-// On success returns 0. *outCount is the number of HTTP/SOCKS entries
-// (DIRECT entries are skipped). *outProxies is an array of
-// AndroidProxyInfo allocated via malloc; the caller must release it
-// via AndroidCryptoNative_FreeProxyResult.
+// On success returns 0. *outCount is the number of DIRECT/HTTP/SOCKS
+// entries. *outProxies is an array of AndroidProxyInfo allocated via
+// malloc; the caller must release it via AndroidCryptoNative_FreeProxyResult.
+// DIRECT entries represent Java's Proxy.NO_PROXY / Proxy.Type.DIRECT and have
+// NULL host and port 0.
 //
 // Any JNI exception (malformed URI, SecurityException, ...) is treated
 // as "no proxy" and the function returns success with outCount == 0.

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_sslstream.c
@@ -30,8 +30,6 @@ struct ApplicationProtocolData_t
     int32_t length;
 };
 
-ARGS_NON_NULL(1) static uint16_t* AllocateString(JNIEnv* env, jstring source);
-
 ARGS_NON_NULL_ALL static PAL_SSLStreamStatus DoHandshake(JNIEnv* env, SSLStream* sslStream);
 ARGS_NON_NULL_ALL static PAL_SSLStreamStatus DoWrap(JNIEnv* env, SSLStream* sslStream, int* handshakeStatus, int* bytesConsumed);
 ARGS_NON_NULL_ALL static PAL_SSLStreamStatus DoUnwrap(JNIEnv* env, SSLStream* sslStream, int* handshakeStatus);
@@ -1276,20 +1274,4 @@ bool AndroidCryptoNative_SSLStreamShutdown(SSLStream* sslStream)
 
     PAL_SSLStreamStatus status = Close(env, sslStream);
     return status == SSLStreamStatus_Closed;
-}
-
-static uint16_t* AllocateString(JNIEnv* env, jstring source)
-{
-    if (source == NULL)
-        return NULL;
-
-    // Length with null terminator
-    jsize len = (*env)->GetStringLength(env, source);
-
-    // +1 for null terminator.
-    uint16_t* buffer = xmalloc(sizeof(uint16_t) * (size_t)(len + 1));
-    buffer[len] = '\0';
-
-    (*env)->GetStringRegion(env, source, 0, len, (jchar*)buffer);
-    return buffer;
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request (description and code) was drafted with the assistance of GitHub Copilot CLI.

## Summary

Adds an `AndroidPlatformProxy : IWebProxy` that resolves the system proxy chain for `SocketsHttpHandler` on Android by JNI-calling `java.net.ProxySelector.getDefault().select(URI.create(url))`.

This brings the Android system proxy — Wi-Fi proxy, MDM-deployed proxy, PAC scripts, per-network and VPN-attached `ProxyInfo` — to the managed HTTP stack, matching the behavior `HttpURLConnection` / `AndroidMessageHandler` exhibit today. Closes the largest behavioral regression apps would face when flipping the default `HttpClientHandler` backend from `AndroidMessageHandler` to `SocketsHttpHandler` on `net*-android*` (`SystemProxyInfo.Unix.cs` currently honors only env vars on Android).

Implementation lives entirely in `dotnet/runtime` — no dependency on `dotnet/android`, no `[UnsafeAccessor]` into `Mono.Android`.

## Background

`HttpClient.DefaultProxy` on Android currently resolves to `HttpEnvironmentProxy` (env-var only) via the shared Unix path:

```
runtime/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/SystemProxyInfo.Unix.cs
```

In contrast, `java.net.HttpURLConnection` (and therefore `AndroidMessageHandler`) defers to `java.net.ProxySelector.getDefault()`, which on Android consults system properties, `ConnectivityManager.getDefaultProxy()`, per-network `LinkProperties.getHttpProxy()`, and PAC scripts (via the privileged `PacProxyService`). All of that is silently lost when an app switches to `SocketsHttpHandler` today.

## What this PR changes

### Native PAL (`System.Security.Cryptography.Native.Android`)

- `pal_proxy.{h,c}` — `AndroidCryptoNative_GetProxyForUrl` / `AndroidCryptoNative_FreeProxyResult`.
  - Pure C/JNI; no `.java` helper (we're just calling APIs, not implementing a Java interface).
  - Uses the existing `pal_jni.h` macros (`INIT_LOCALS`, `RELEASE_LOCALS`, `ON_EXCEPTION_PRINT_AND_GOTO`) for leak-safe local-ref handling on every exception path.
  - Per-iteration `INIT_LOCALS(iter, …)` + `RELEASE_LOCALS` on every `continue` to prevent local-ref-table overflow on large proxy lists.
- `pal_jni.{h,c}` — global refs added for `java.net.ProxySelector`, `Proxy`, `Proxy$Type` (`HTTP`/`SOCKS` jfieldIDs), `InetSocketAddress`, `URI`, `java.util.List`. All populated once in `InitializeJObjectsForPal`.
- `pal_jni.{h,c}` — promotes `AllocateString` (previously private to `pal_sslstream.c`) into a shared PAL helper. It returns a NUL-terminated UTF-16 buffer that managed code reads via `Marshal.PtrToStringUni` (zero-conversion memcpy: both Java and .NET strings are internally UTF-16). `pal_sslstream.c` is updated to use the shared helper.
- `CMakeLists.txt` — `pal_proxy.c` added to `NATIVECRYPTO_SOURCES`.

### Managed (`System.Net.Http`)

- `AndroidPlatformProxy.Android.cs` — `IWebProxy` implementation (same shape as `MacProxy`).
  - `GetProxy(uri)` P/Invokes the PAL, takes the first non-`DIRECT` entry, falls back to direct on any failure.
  - `IsBypassed(_) => false` (matches `HttpWindowsProxy.cs:349–360` rationale: computing the real answer costs the same as `GetProxy`, so we let SHH call `GetProxy` exactly once per pool key).
  - `Credentials` exists (required by `IWebProxy`) but is never populated by us — Android's proxy APIs do not surface credentials. Users authenticate via `HttpClientHandler.DefaultProxyCredentials`, the same as on macOS (`MacProxy` has the same limitation tracked as #24799).
- `SystemProxyInfo.Android.cs` — env vars first (`HttpEnvironmentProxy`), then `AndroidPlatformProxy`, then `HttpNoProxy`. Gated by a new `FeatureSwitchDefinition("System.Net.Http.UseAndroidSystemProxy")` with default `true`.
- `Interop.Proxy.cs` — `[LibraryImport]` declarations.
- `System.Net.Http.csproj` — new `<ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'android'">` adds the three managed files and the Android `Interop.Libraries.cs`. The existing fall-through ItemGroup is updated to exclude Android.

## Feature switch: `System.Net.Http.UseAndroidSystemProxy`

Defaults to `true`. Apps can opt out via `<RuntimeHostConfigurationOption>` (or by setting the property name in `runtimeconfig.json`):

```xml
<RuntimeHostConfigurationOption
    Include="System.Net.Http.UseAndroidSystemProxy"
    Value="false" Trim="true" />
```

Three legitimate reasons to disable:
1. **Back-compat** with apps that previously ran on `SocketsHttpHandler` and got env-var-only behavior — honoring the system proxy could change which server their HTTP requests reach.
2. **Trimming** — the linker can trim `AndroidPlatformProxy` and the P/Invokes when set to `false` at publish time.
3. **Test/debug** isolation where pure env-var behavior is required.

## SOCKS support

`ProxySelector` may return `Proxy.Type.SOCKS` (transport-level proxy protocol per RFC 1928; tunnels arbitrary TCP at the socket layer). On modern Android `Proxy.Type.SOCKS` maps to SOCKS5. We translate to a `socks5://host:port` URI; `SocketsHttpHandler` accepts that scheme via `HttpUtilities.IsSupportedProxyScheme`.

## Verification

- ✅ `./build.sh libs.native -os android -arch arm64` — 0 warnings, 0 errors.
- ✅ `dotnet build src/libraries/System.Net.Http/src/System.Net.Http.csproj /p:TargetOS=android /p:TargetArchitecture=arm64` — 0 warnings, 0 errors across all RIDs (also confirmed `pal_sslstream.c` still links cleanly after moving `AllocateString` out).
- ✅ `nm -D libSystem.Security.Cryptography.Native.Android.so` confirms both `AndroidCryptoNative_GetProxyForUrl` and `AndroidCryptoNative_FreeProxyResult` are exported.

## What this PR does NOT do (follow-ups)

- **No tests yet.** A device-test APK modeled on the `AndroidPlatformTrustTests` from #124173 is the right follow-up. The test matrix should cover: Wi-Fi system proxy honored, `Settings.Global.HTTP_PROXY` honored, PAC script evaluated, no-proxy fall-through, bypass list, `UseProxy=false` skips, explicit handler `Proxy` overrides, `DefaultProxyCredentials` flows to `Proxy-Authorization`, feature switch off.
- **No lib rename.** The new code lives in `System.Security.Cryptography.Native.Android` even though the lib's scope is now broader than crypto. Renaming it (e.g. `System.Net.Native.Android`) is a separate, mechanical refactor.
- **`pal_eckey.c` and `pal_x509chain.c` still have inline duplicates** of the `AllocateString` pattern. Hoisting them to use the shared helper is a separate cleanup.
- **No MAUI/Android SDK MSBuild wiring** for a per-app `$(UseAndroidSystemProxy)` property. The runtime config switch can be set explicitly today via `<RuntimeHostConfigurationOption>`; SDK-level wiring can come in `dotnet/android`.

## Microsoft Reviewers: Open in [CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/dotnet/runtime/pull/$PR)
