### PR TITLE
Clear entire range on decommit

### DIFF
--- a/src/coreclr/gc/memory.cpp
+++ b/src/coreclr/gc/memory.cpp
@@ -368,7 +368,7 @@ size_t gc_heap::decommit_region (heap_segment* region, int bucket, int h_number)
         decommit_succeeded_p));
     if (require_clearing_memory_p)
     {
-        uint8_t* clear_end = never_decommit_p ? heap_segment_used (region) : heap_segment_committed (region);
+        uint8_t* clear_end = heap_segment_committed (region);
         size_t clear_size = clear_end - page_start;
         memclr (page_start, clear_size);
         heap_segment_used (region) = heap_segment_mem (region);


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/127892 ([comment](https://github.com/dotnet/runtime/issues/127892#issuecomment-4416649761))

Detailed analysis from @cshung here: https://cshung.github.io/posts/memory-corruption-5/

This logic was also very recently touched by https://github.com/dotnet/runtime/pull/127328 so we may want @pavelsavara to look as well, but I suspect we would see the same heap corruption that was happening with large pages in WASM builds as well. 

I didn't add a comment for the change because it felt a bit odd to reference `never_decommit_p` or huge pages when the code was being removed, but I could add something to try and prevent this optimization from being re-introduced if you all feel appropriate (or feel free to just edit an appropriate comment in)

Thanks again for taking this seriously and helping us track this down! 

CC: @mangod9 