### PR TITLE
[wasm] Allow empty string module names for JS imports in WASM runtime

### DIFF
--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JSImportTest.cs
@@ -58,6 +58,12 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
             Assert.Contains("intentionallyMissingImportAsync must be a Function but was undefined", ex.Message);
         }
 
+        [Fact]
+        public void EmptyModuleNameImport()
+        {
+            Assert.Equal("empty module", JavaScriptTestHelper.EmptyModuleNameEcho("empty module"));
+        }
+
 #if !FEATURE_WASM_MANAGED_THREADS // because in MT JSHost.ImportAsync is really async, it will finish before the caller could cancel it
         [Fact]
         public async Task CancelableImportAsync()

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.cs
@@ -46,6 +46,9 @@ namespace System.Runtime.InteropServices.JavaScript.Tests
         [JSImport("intentionallyMissingImportAsync", "JavaScriptTestHelper")]
         public static partial Task IntentionallyMissingImportAsync();
 
+        [JSImport("emptyModuleNameEcho", "")]
+        public static partial string EmptyModuleNameEcho(string message);
+
         [JSImport("catch1toString", "JavaScriptTestHelper")]
         public static partial string catch1toString(string message, string functionName);
 

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/tests/System.Runtime.InteropServices.JavaScript.UnitTests/System/Runtime/InteropServices/JavaScript/JavaScriptTestHelper.mjs
@@ -495,6 +495,11 @@ globalThis.rebound = {
 
 export async function setup() {
     dllExports = await App.runtime.getAssemblyExports("System.Runtime.InteropServices.JavaScript.Tests.dll");
+    App.runtime.setModuleImports("", { emptyModuleNameEcho });
+}
+
+function emptyModuleNameEcho(message) {
+    return message;
 }
 
 // console.log('JavaScriptTestHelper:' Object.keys(globalThis.JavaScriptTestHelper));

--- a/src/mono/browser/runtime/invoke-js.ts
+++ b/src/mono/browser/runtime/invoke-js.ts
@@ -382,7 +382,7 @@ function mono_wasm_lookup_js_import (function_name: string, js_module_name: stri
 
     let scope: any = {};
     const parts = function_name.split(".");
-    if (js_module_name) {
+    if (js_module_name != null) {
         scope = importedModules.get(js_module_name);
         if (WasmEnableThreads) {
             mono_assert(scope, () => `ES6 module ${js_module_name} was not imported yet, please call JSHost.ImportAsync() on the UI or JSWebWorker thread first in order to invoke ${function_name}.`);


### PR DESCRIPTION
## Description

Allow `""` to be used as a valid JS module name for `[JSImport]` in the Mono WASM runtime.

Previously, `mono_wasm_lookup_js_import` used a truthy check for `js_module_name`, so `[JSImport(..., "")]` skipped the module import registry and fell back to global/internal lookup behavior. This meant imports registered with `setModuleImports("", imports)` could not be resolved.

The runtime now checks `js_module_name != null`, preserving existing behavior for omitted module names while allowing the empty string as a real module key.

## Testing

Added a regression test that registers imports with `setModuleImports("", ...)`, calls a managed `[JSImport(..., "")]`, and verifies it resolves through the empty-string module entry.
