### PR TITLE
Limit sccache cache size to 3.5 GB to reduce transfer overhead

### DIFF
--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -42,7 +42,7 @@ steps:
         mkdir -p "$sccacheDir"
         echo "##vso[task.prependpath]$sccacheDir"
         echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
-        echo "##vso[task.setvariable variable=SCCACHE_CACHE_SIZE]3.5G"
+        echo "##vso[task.setvariable variable=SCCACHE_CACHE_SIZE]3584M"
         echo "##vso[task.setvariable variable=SCCACHE_IDLE_TIMEOUT]0"
         echo "##vso[task.setvariable variable=USE_SCCACHE]true"
       displayName: Configure sccache

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -42,6 +42,7 @@ steps:
         mkdir -p "$sccacheDir"
         echo "##vso[task.prependpath]$sccacheDir"
         echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
+        echo "##vso[task.setvariable variable=SCCACHE_CACHE_SIZE]3.5G"
         echo "##vso[task.setvariable variable=SCCACHE_IDLE_TIMEOUT]0"
         echo "##vso[task.setvariable variable=USE_SCCACHE]true"
       displayName: Configure sccache


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

The sccache local cache grows unboundedly (default 10 GB max) as stale entries accumulate across rolling builds. It's currently at ~6-7 GB and growing ~0.5 GB per rolling build cycle. The cache restore/save overhead is ~3 minutes per leg, eating into the ~9 minute build time savings sccache provides.

## Change

Sets `SCCACHE_CACHE_SIZE=3.5G` to force LRU eviction of stale entries, keeping the cache close to its working set size (~3 GB for ~3,482 compiled objects).

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Cache size | ~6-7 GB (growing) | ~3.5 GB (stable) |
| Restore time | ~1 min | ~30s |
| Save time | ~1:45 | ~50s |
| Total overhead/leg | ~3 min | ~1.5 min |
| Net savings/leg | ~6 min | ~7.5 min |

If hit rates drop due to premature eviction, the limit can be raised.