### PR TITLE
Enable sccache for linux-musl-x64 coreclr builds

### DIFF
--- a/eng/pipelines/coreclr/templates/sccache-stats.yml
+++ b/eng/pipelines/coreclr/templates/sccache-stats.yml
@@ -12,7 +12,7 @@ parameters:
   osSubgroup: ''
 
 steps:
-  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, ''), eq(parameters.archType, 'x64')) }}:
+  - ${{ if and(eq(parameters.osGroup, 'linux'), or(eq(parameters.osSubgroup, ''), eq(parameters.osSubgroup, '_musl')), eq(parameters.archType, 'x64')) }}:
     - script: sccache --show-stats || true
       displayName: Sccache stats
       condition: always()

--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -15,7 +15,7 @@ parameters:
   sccacheVersion: '0.15.0'
 
 steps:
-  - ${{ if and(eq(parameters.osGroup, 'linux'), eq(parameters.osSubgroup, ''), eq(parameters.archType, 'x64')) }}:
+  - ${{ if and(eq(parameters.osGroup, 'linux'), or(eq(parameters.osSubgroup, ''), eq(parameters.osSubgroup, '_musl')), eq(parameters.archType, 'x64')) }}:
     # Set up the Azure Pipeline Cache for sccache's local cache directory.
     # Use a rolling key so each build can update the cache; restoreKeys
     # falls back to the most recent saved entry.
@@ -29,10 +29,10 @@ steps:
     - task: Cache@2
       displayName: Sccache cache
       inputs:
-        key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | "$(Build.BuildId)"
+        key: sccache | ${{ parameters.osGroup }}${{ parameters.osSubgroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | "$(Build.BuildId)"
         path: $(Pipeline.Workspace)/.sccache
         restoreKeys: |
-          sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }}
+          sccache | ${{ parameters.osGroup }}${{ parameters.osSubgroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }}
 
     # Configure sccache environment and add binary to PATH.
     # The sccache package is restored by runtime-prereqs.proj during the build.


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Extends sccache caching from linux-x64 to also cover linux-musl-x64 coreclr build legs. Based on the linux-x64 results (~9 min/leg gross savings, 97.59% hit rate at steady state), this should provide similar speedups for the musl legs.

## Changes

- **setup-sccache.yml**: Widen condition to include `osSubgroup == '_musl'`; add `osSubgroup` to cache key to keep musl/glibc caches separate
- **sccache-stats.yml**: Widen condition to match

## Why this works

- The sccache NuGet package (v0.15.0) is a **statically-linked** binary — verified with `file` showing `static-pie linked`. Works on both glibc and musl.
- The sccache package is already downloaded by `runtime-prereqs.proj` on all Linux CI builds (line 13-14, condition: `IsOsPlatform(Linux)`).
- Cache keys include `osSubgroup` so musl builds get `sccache|linux_musl|x64|...` vs `sccache|linux|x64|...` for glibc — no cross-contamination.
- For non-musl builds, `osSubgroup` is empty, so the key is **unchanged** — existing caches remain valid.

## Also included

`SCCACHE_CACHE_SIZE=3.5G` limit (from #128048) to prevent unbounded cache growth.