### PR TITLE
Make sccache cache task non-fatal

### DIFF
--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -28,6 +28,7 @@ steps:
     # builds warm-start from rolling-build caches saved in the main scope.
     - task: Cache@2
       displayName: Sccache cache
+      continueOnError: true
       inputs:
         key: sccache | ${{ parameters.osGroup }} | ${{ parameters.archType }} | ${{ parameters.nameSuffix }} | "$(Build.BuildId)"
         path: $(Pipeline.Workspace)/.sccache


### PR DESCRIPTION
> [!NOTE]
> This PR was created with Copilot assistance.

The `Cache@2` task for sccache can fail when the disk runs out of space during the post-job cache upload (see [build log](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1416149&view=logs&jobId=826908f3-d824-5a25-6bc6-d6f6821a85ed&j=826908f3-d824-5a25-6bc6-d6f6821a85ed&t=8d9c03b3-2d45-45ba-b13a-b97de665fc76)). Since this is purely a performance optimization, a failure should not fail the entire build.

This adds `continueOnError: true` so the task reports a warning instead of an error on failure.

Fixes #128051