### PR TITLE
Use only 10 bytes of RNG in Guid.CreateVersion7 on Unix

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
@@ -37,11 +37,6 @@ namespace System
         // Returns a Guid whose bytes 6..15 contain cryptographically-secure random data, as
         // required by CreateVersion7. Bytes 0..5 are intentionally left uninitialized; the
         // caller overwrites them with the unix_ts_ms timestamp.
-        //
-        // Asking for only 10 bytes (instead of all 16) hits the Apple CoreCrypto fast path
-        // for <=12 byte requests and reduces the amount of entropy pulled from the kernel
-        // on other Unix platforms. The version and variant fields are applied by the caller,
-        // so this helper does not set them (unlike NewGuid which produces a v4 Guid).
         private static unsafe Guid CreateVersion7Random()
         {
             Unsafe.SkipInit(out Guid g);

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.Unix.cs
@@ -33,5 +33,25 @@ namespace System
 
             return g;
         }
+
+        // Returns a Guid whose bytes 6..15 contain cryptographically-secure random data, as
+        // required by CreateVersion7. Bytes 0..5 are intentionally left uninitialized; the
+        // caller overwrites them with the unix_ts_ms timestamp.
+        //
+        // Asking for only 10 bytes (instead of all 16) hits the Apple CoreCrypto fast path
+        // for <=12 byte requests and reduces the amount of entropy pulled from the kernel
+        // on other Unix platforms. The version and variant fields are applied by the caller,
+        // so this helper does not set them (unlike NewGuid which produces a v4 Guid).
+        private static unsafe Guid CreateVersion7Random()
+        {
+            Unsafe.SkipInit(out Guid g);
+#if !TARGET_WASI
+            Interop.GetCryptographicallySecureRandomBytes((byte*)&g + 6, 10);
+#else
+            // TODOWASI: crypto secure random bytes
+            Interop.GetRandomBytes((byte*)&g + 6, 10);
+#endif
+            return g;
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.Windows.cs
@@ -19,6 +19,15 @@ namespace System
             return g;
         }
 
+        // Returns a Guid whose bytes 6..15 contain cryptographically-secure random data, as
+        // required by CreateVersion7. Bytes 0..5 are unspecified; the caller overwrites them
+        // with the unix_ts_ms timestamp.
+        //
+        // On Windows we keep using CoCreateGuid via NewGuid: it has been measured to be
+        // faster than BCryptGenRandom for this size class, and the 6 bytes that get
+        // overwritten by the timestamp don't make BCryptGenRandom competitive.
+        private static Guid CreateVersion7Random() => NewGuid();
+
         private static void ThrowForHr(int hr)
         {
             // We don't expect that this will ever throw an error, none are even documented, and so we don't want to pull

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -305,13 +305,6 @@ namespace System
         /// </remarks>
         public static Guid CreateVersion7(DateTimeOffset timestamp)
         {
-            // NewGuid uses CoCreateGuid on Windows and Interop.GetCryptographicallySecureRandomBytes on Unix to get
-            // cryptographically-secure random bytes. We could use Interop.BCrypt.BCryptGenRandom to generate the random
-            // bytes on Windows, as is done in RandomNumberGenerator, but that's measurably slower than using CoCreateGuid.
-            // And while CoCreateGuid only generates 122 bits of randomness, the other 6 bits being for the version / variant
-            // fields, this method also needs those bits to be non-random, so we can just use NewGuid for efficiency.
-            Guid result = NewGuid();
-
             // 2^48 is roughly 8925.5 years, which from the Unix Epoch means we won't
             // overflow until around July of 10,895. So there isn't any need to handle
             // it given that DateTimeOffset.MaxValue is December 31, 9999. However, we
@@ -320,6 +313,13 @@ namespace System
 
             long unix_ts_ms = timestamp.ToUnixTimeMilliseconds();
             ArgumentOutOfRangeException.ThrowIfNegative(unix_ts_ms, nameof(timestamp));
+
+            // UUIDv7 only consumes 74 bits of randomness, which fit in the trailing 10 bytes
+            // of the GUID (12 bits of rand_a in bytes 6..7 next to the 4-bit version field,
+            // and 62 bits of rand_b in bytes 8..15 next to the 2-bit variant field). Bytes 0..5
+            // are overwritten with unix_ts_ms below, so the platform-specific helper only needs
+            // to ensure bytes 6..15 of the returned Guid contain crypto-secure random data.
+            Guid result = CreateVersion7Random();
 
             Unsafe.AsRef(in result._a) = (int)(unix_ts_ms >> 16);
             Unsafe.AsRef(in result._b) = (short)(unix_ts_ms);


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with help from GitHub Copilot (AI-generated content).

`Guid.CreateVersion7` only needs **74 bits of randomness** (12 bits of `rand_a` + 62 bits of `rand_b`), all of which live in the trailing 10 bytes of the GUID. The first 6 bytes are immediately overwritten with the `unix_ts_ms` timestamp, so any random bytes generated for them are wasted work.

This PR introduces a small `CreateVersion7Random` helper:
- **Apple / Linux / Browser / WASI**: requests just 10 bytes from `GetCryptographicallySecureRandomBytes` (or `GetRandomBytes` on WASI), filling only bytes 6..15 of the result.
- **Windows**: unchanged — keeps using `CoCreateGuid` via `NewGuid()` (the existing comment notes this is faster than `BCryptGenRandom` for this size class).

Motivation: on Apple platforms `CCRandomGenerateBytes` has a fast path for requests `<= 12` bytes, so cutting the request from 16 to 10 bytes hits that path. Other Unix platforms benefit slightly from pulling less entropy from the kernel.

Also moves the `ArgumentOutOfRangeException.ThrowIfNegative(unix_ts_ms, ...)` check ahead of the RNG call so an invalid timestamp short-circuits without paying for entropy.

No behavioral change: the randomness fed into `rand_a`/`rand_b` is still cryptographically secure, the version/variant fields are still applied, and existing tests should continue to pass.

I'll trigger @EgorBot on this PR for `-osx_arm64 -osx_x64 -linux_x64 -linux_arm64` to confirm the speedup in a follow-up comment.

## Benchmark

```cs
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Running;

BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);

public class Bench
{
    [Benchmark]
    public Guid CreateVersion7() => Guid.CreateVersion7();
}
```

## Results

**Apple M4 macos26:**

| Method         | Toolchain          | Mean      | Error    | Ratio | 
|--------------- |------------------- |----------:|---------:|------:|
| CreateVersion7 | PR #128055 |  79.63 ns | 0.516 ns |  1.00 | 
| CreateVersion7 | main      | 193.90 ns | 0.896 ns |  2.44 |

**Intel Core i5-8500B macos15:**

| Method         | Toolchain          | Mean     | Error    | Ratio | 
|--------------- |------------------- |---------:|---------:|------:|
| CreateVersion7 | PR #128055 | 177.5 ns |  3.45 ns |  1.00 | 
| CreateVersion7 | main      | 416.2 ns | 32.15 ns |  2.35 |

