### PR TITLE
Change VMPTR IPC events to ensure endianness consistency

### DIFF
--- a/src/coreclr/debug/di/breakpoint.cpp
+++ b/src/coreclr/debug/di/breakpoint.cpp
@@ -522,11 +522,11 @@ HRESULT CordbStepper::StepRange(BOOL fStepIn,
 
     if (m_frame == NULL)
     {
-        pEvent->StepData.frameToken = LEAF_MOST_FRAME;
+        pEvent->StepData.frameToken = (CORDB_ADDRESS)0;
     }
     else
     {
-        pEvent->StepData.frameToken = m_frame->GetFramePointer();
+        pEvent->StepData.frameToken = PTR_TO_CORDB_ADDRESS(m_frame->GetFramePointer().GetSPValue());
     }
 
     pEvent->StepData.stepIn = (fStepIn != 0);
@@ -688,11 +688,11 @@ HRESULT CordbStepper::StepOut()
 
     if (m_frame == NULL)
     {
-        pEvent->StepData.frameToken = LEAF_MOST_FRAME;
+        pEvent->StepData.frameToken = (CORDB_ADDRESS)0;
     }
     else
     {
-        pEvent->StepData.frameToken = m_frame->GetFramePointer();
+        pEvent->StepData.frameToken = PTR_TO_CORDB_ADDRESS(m_frame->GetFramePointer().GetSPValue());
     }
 
     pEvent->StepData.totalRangeCount = 0;

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -5580,7 +5580,7 @@ void CordbProcess::RawDispatchEvent(
         {
             STRESS_LOG4(LF_CORDB, LL_INFO100,
                 "RCET::DRCE: Exception2 0x%p 0x%X 0x%X 0x%X\n",
-                 pEvent->ExceptionCallback2.framePointer.GetSPValue(),
+                 CORDB_ADDRESS_TO_PTR(pEvent->ExceptionCallback2.framePointer),
                  pEvent->ExceptionCallback2.nOffset,
                  pEvent->ExceptionCallback2.eventType,
                  pEvent->ExceptionCallback2.dwFlags
@@ -5602,7 +5602,7 @@ void CordbProcess::RawDispatchEvent(
             //
             RSSmartPtr<CordbFrame> pFrame;
 
-            FramePointer fp = pEvent->ExceptionCallback2.framePointer;
+            FramePointer fp = FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(pEvent->ExceptionCallback2.framePointer));
             if (fp != LEAF_MOST_FRAME)
             {
                 // The interface forces us to pass a FramePointer via an ICorDebugFrame.

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -2184,7 +2184,7 @@ HRESULT CordbThread::InterceptCurrentException(ICorDebugFrame * pFrame)
             GetProcess()->InitIPCEvent(&event, DB_IPCE_INTERCEPT_EXCEPTION, true, VMPTR_AppDomain::NullPtr());
 
             event.InterceptException.vmThreadToken = m_vmThreadToken;
-            event.InterceptException.frameToken  = pRealFrame->GetFramePointer();
+            event.InterceptException.frameToken  = PTR_TO_CORDB_ADDRESS(pRealFrame->GetFramePointer().GetSPValue());
 
             hr = GetProcess()->m_cordb->SendIPCEvent(GetProcess(), &event, sizeof(DebuggerIPCEvent));
 

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -11437,7 +11437,7 @@ void Debugger::TypeHandleToBasicTypeInfo(AppDomain *pAppDomain, TypeHandle th, D
     case ELEMENT_TYPE_BYREF:
         res->vmTypeHandle = WrapTypeHandle(th);
         res->metadataToken = mdTokenNil;
-        res->vmAssembly.SetRawPtr(NULL);
+        res->vmAssembly = VMPTR_Assembly::NullPtr();
                 break;
 
     case ELEMENT_TYPE_CLASS:
@@ -11455,7 +11455,7 @@ void Debugger::TypeHandleToBasicTypeInfo(AppDomain *pAppDomain, TypeHandle th, D
     default:
         res->vmTypeHandle = VMPTR_TypeHandle::NullPtr();
         res->metadataToken = mdTokenNil;
-        res->vmAssembly.SetRawPtr(NULL);
+        res->vmAssembly = VMPTR_Assembly::NullPtr();
                 break;
     }
     return;

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -7158,7 +7158,7 @@ HRESULT Debugger::SendExceptionHelperAndBlock(
     //
     InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
-    ipce->ExceptionCallback2.framePointer = framePointer;
+    ipce->ExceptionCallback2.framePointer = PTR_TO_CORDB_ADDRESS(framePointer.GetSPValue());
     ipce->ExceptionCallback2.eventType = eventType;
     ipce->ExceptionCallback2.nOffset = (UINT)nOffset;
     ipce->ExceptionCallback2.dwFlags = dwFlags;
@@ -7311,7 +7311,7 @@ void Debugger::SendExceptionEventsWorker(
 
             InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
-            ipce->ExceptionCallback2.framePointer = framePointer;
+            ipce->ExceptionCallback2.framePointer = PTR_TO_CORDB_ADDRESS(framePointer.GetSPValue());
             ipce->ExceptionCallback2.eventType = DEBUG_EXCEPTION_USER_FIRST_CHANCE;
             ipce->ExceptionCallback2.nOffset = (UINT)nOffset;
             ipce->ExceptionCallback2.dwFlags = fIsInterceptable ? DEBUG_EXCEPTION_CAN_BE_INTERCEPTED : 0;
@@ -7970,7 +7970,7 @@ void Debugger::SendCatchHandlerFound(
                 //
                 InitIPCEvent(ipce, DB_IPCE_EXCEPTION_CALLBACK2, pThread);
 
-                ipce->ExceptionCallback2.framePointer = fp;
+                ipce->ExceptionCallback2.framePointer = PTR_TO_CORDB_ADDRESS(fp.GetSPValue());
                 ipce->ExceptionCallback2.eventType = DEBUG_EXCEPTION_CATCH_HANDLER_FOUND;
                 ipce->ExceptionCallback2.nOffset = (UINT)nOffset;
                 ipce->ExceptionCallback2.dwFlags = dwFlags;
@@ -10292,7 +10292,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
             LOG((LF_CORDB,LL_INFO10000, "D::HIPCE: frame SP:%p "
                 "StepIn:%s RangeIL:%s RangeCount:%u MapStop:0x%x "
                 "InterceptStop:0x%x AppD:%p\n",
-                pEvent->StepData.frameToken.GetSPValue(),
+                CORDB_ADDRESS_TO_PTR(pEvent->StepData.frameToken),
                 (pEvent->StepData.stepIn ? "true" : "false"),
                 (pEvent->StepData.rangeIL ? "true" : "false"),
                 pEvent->StepData.rangeCount,
@@ -10348,7 +10348,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
 
                 _ASSERTE(cRanges == 0 || ((cRanges > 0) && (cRanges == pEvent->StepData.rangeCount)));
 
-                if (!pStepper->Step(pEvent->StepData.frameToken,
+                if (!pStepper->Step(FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(pEvent->StepData.frameToken)),
                                     pEvent->StepData.stepIn,
                                     &(pEvent->StepData.range),
                                     cRanges,
@@ -10422,7 +10422,7 @@ bool Debugger::HandleIPCEvent(DebuggerIPCEvent * pEvent)
                 // Safe to stack trace b/c we're stopped.
                 StackTraceTicket ticket(pThread);
 
-                pStepper->StepOut(pEvent->StepData.frameToken, ticket);
+                pStepper->StepOut(FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(pEvent->StepData.frameToken)), ticket);
 
                 pIPCResult->StepData.stepperToken.Set(pStepper);
             }
@@ -11107,7 +11107,7 @@ HRESULT Debugger::GetAndSendInterceptCommand(DebuggerIPCEvent *event)
             //
             // Now start processing the parameters from the event.
             //
-            FramePointer targetFramePointer = event->InterceptException.frameToken;
+            FramePointer targetFramePointer = FramePointer::MakeFramePointer(CORDB_ADDRESS_TO_PTR(event->InterceptException.frameToken));
 
             ControllerStackInfo csi;
 

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1187,7 +1187,7 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
         FramePointer fp;
-        fp.m_sp = PTR_TO_CORDB_ADDRESS(sp);
+        fp.m_sp = sp;
         return fp;
     }
 
@@ -1222,13 +1222,16 @@ private:
     FramePointer &operator=(BYTE* sp);
     FramePointer &operator=(const BYTE* sp);
 
-    Portable<CORDB_ADDRESS> m_sp;
+    LPVOID m_sp;
 };
 
 // For non-IA64 platforms, we use stack pointers as frame pointers.
 // (Stack grows towards smaller address.)
 #define LEAF_MOST_FRAME FramePointer::MakeFramePointer((LPVOID)NULL)
 #define ROOT_MOST_FRAME FramePointer::MakeFramePointer((LPVOID)-1)
+
+static_assert(sizeof(FramePointer) == sizeof(void*));
+
 
 inline bool IsCloserToLeaf(FramePointer fp1, FramePointer fp2)
 {
@@ -1963,7 +1966,7 @@ struct MSLAYOUT DebuggerIPCEvent
         {
             LSPTR_STEPPER stepperToken;
             Portable<VMPTR_Thread> vmThreadToken;
-            FramePointer frameToken;
+            Portable<CORDB_ADDRESS> frameToken;
             Portable<bool> stepIn;
             Portable<bool> rangeIL;
             Portable<bool> IsJMCStop;
@@ -2221,7 +2224,7 @@ struct MSLAYOUT DebuggerIPCEvent
 
         struct MSLAYOUT
         {
-            FramePointer framePointer;
+            Portable<CORDB_ADDRESS> framePointer;
             Portable<UINT> nOffset;
             Portable<CorDebugExceptionCallbackType> eventType;
             Portable<DWORD> dwFlags;
@@ -2237,7 +2240,7 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             Portable<VMPTR_Thread> vmThreadToken;
-            FramePointer frameToken;
+            Portable<CORDB_ADDRESS> frameToken;
         } InterceptException;
 
         struct MSLAYOUT

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1932,18 +1932,18 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             Portable<mdMethodDef> funcMetadataToken;
-            VMPTR_Module pModule;
+            Portable<VMPTR_Module> pModule;
         } DisableOptData;
 
         struct MSLAYOUT
         {
             Portable<bool> enableEvents;
-            VMPTR_Object vmObj;
+            Portable<VMPTR_Object> vmObj;
         } ForceCatchHandlerFoundData;
 
         struct MSLAYOUT
         {
-            VMPTR_Module vmModule;
+            Portable<VMPTR_Module> vmModule;
             Portable<mdTypeDef> classMetadataToken;
             Portable<bool> Enabled;
         } CustomNotificationData;
@@ -1962,7 +1962,7 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             LSPTR_STEPPER stepperToken;
-            VMPTR_Thread vmThreadToken;
+            Portable<VMPTR_Thread> vmThreadToken;
             FramePointer frameToken;
             Portable<bool> stepIn;
             Portable<bool> rangeIL;
@@ -2002,7 +2002,7 @@ struct MSLAYOUT DebuggerIPCEvent
         // Apply an EnC edit
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;                    // Module to edit
+            Portable<VMPTR_Assembly> vmAssembly;          // Module to edit
             Portable<DWORD> cbDeltaMetadata;              // size of blob pointed to by pDeltaMetadata
             Portable<CORDB_ADDRESS> pDeltaMetadata;       // pointer to delta metadata in debuggee
                                                           // it's the RS's responsibility to allocate and free

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -396,7 +396,10 @@ public:
 inline ULONG_PTR LsPtrToCookie(GeneralLsPointer p) {
     return (ULONG_PTR)(CORDB_ADDRESS)p.m_ptr;
 }
-#define VmPtrToCookie(vm) LsPtrToCookie((vm).ToLsPtr())
+template <typename T>
+inline ULONG_PTR VmPtrToCookie(T vm) { return LsPtrToCookie(vm.ToLsPtr()); }
+template <typename T>
+inline ULONG_PTR VmPtrToCookie(Portable<T> vm) { return LsPtrToCookie(static_cast<T>(vm).ToLsPtr()); }
 
 
 #ifdef RIGHT_SIDE_COMPILE
@@ -643,7 +646,7 @@ class MSLAYOUT VMPTR_Base
     // - In DAC: must be marshalled to a host-pointer and then they can be used via DAC
     // - In RS: opaque handles.
 private:
-    Portable<CORDB_ADDRESS> m_addr;
+    CORDB_ADDRESS m_addr;
 
 public:
     typedef VMPTR_Base<TTargetPtr,TDacPtr> VMPTR_This;
@@ -687,9 +690,11 @@ public:
     // This will set initialize from a Target pointer. Since this is happening in the
     // Left-side (Target), the pointer is local.
     // This is commonly used by the Left-side to create a VMPTR_ for a notification event.
-    void SetRawPtr(TTargetPtr * ptr)
+    static VMPTR_This MakePtr(TTargetPtr * ptr)
     {
-        m_addr = PTR_TO_CORDB_ADDRESS(ptr);
+        VMPTR_This t;
+        t.m_addr = PTR_TO_CORDB_ADDRESS(ptr);
+        return t;
     }
 
     // This will get the raw underlying target pointer.
@@ -699,15 +704,6 @@ public:
     {
         return reinterpret_cast<TTargetPtr*>((TADDR)m_addr);
     }
-
-    // Convenience for converting TTargetPtr --> VMPTR
-    static VMPTR_This MakePtr(TTargetPtr * ptr)
-    {
-        VMPTR_This t;
-        t.SetRawPtr(ptr);
-        return t;
-    }
-
 
 #else
     //
@@ -1191,7 +1187,7 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
         FramePointer fp;
-        fp.m_sp = sp;
+        fp.m_sp = PTR_TO_CORDB_ADDRESS(sp);
         return fp;
     }
 
@@ -1215,7 +1211,7 @@ public:
     // CordbChain are really FramePointers.
     LPVOID GetSPValue() const
     {
-        return m_sp;
+        return CORDB_ADDRESS_TO_PTR(m_sp);
     }
 
 
@@ -1226,7 +1222,7 @@ private:
     FramePointer &operator=(BYTE* sp);
     FramePointer &operator=(const BYTE* sp);
 
-    LPVOID m_sp;
+    Portable<CORDB_ADDRESS> m_sp;
 };
 
 // For non-IA64 platforms, we use stack pointers as frame pointers.
@@ -1457,8 +1453,8 @@ struct MSLAYOUT DebuggerIPCE_BasicTypeData
 {
     Portable<CorElementType> elementType;
     Portable<mdTypeDef> metadataToken;
-    VMPTR_Assembly  vmAssembly;
-    VMPTR_TypeHandle vmTypeHandle;
+    Portable<VMPTR_Assembly> vmAssembly;
+    Portable<VMPTR_TypeHandle> vmTypeHandle;
 };
 
 // DebuggerIPCE_ExpandedTypeData contains more information showing further
@@ -1492,8 +1488,8 @@ struct MSLAYOUT DebuggerIPCE_ExpandedTypeData
         struct MSLAYOUT
         {
             Portable<mdTypeDef> metadataToken;
-            VMPTR_Assembly vmAssembly;
-            VMPTR_TypeHandle typeHandle; // if non-null then further fetches will be needed to get type arguments
+            Portable<VMPTR_Assembly> vmAssembly;
+            Portable<VMPTR_TypeHandle> typeHandle; // if non-null then further fetches will be needed to get type arguments
         } ClassTypeData;
 
         // used for E_T_PTR, E_T_BYREF etc.
@@ -1874,8 +1870,8 @@ struct MSLAYOUT DebuggerIPCEvent
     Portable<DebuggerIPCEventType> type;
     Portable<DWORD> processId;
     Portable<DWORD> threadId;
-    VMPTR_AppDomain vmAppDomain;
-    VMPTR_Thread vmThread;
+    Portable<VMPTR_AppDomain> vmAppDomain;
+    Portable<VMPTR_Thread> vmThread;
 
     Portable<HRESULT> hr;
     Portable<bool> replyRequired;
@@ -1887,32 +1883,32 @@ struct MSLAYOUT DebuggerIPCEvent
         {
             // Module whose metadata is being updated
             // This tells the RS that the metadata for that module has become invalid.
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
 
         } MetadataUpdateData;
 
         struct MSLAYOUT
         {
             // Handle to CLR's internal appdomain object.
-            VMPTR_AppDomain vmAppDomain;
+            Portable<VMPTR_AppDomain> vmAppDomain;
         } AppDomainData;
 
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
         } AssemblyData;
 
         // Debug event that a module has been loaded
         struct MSLAYOUT
         {
             // Module that was just loaded.
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
         }LoadModuleData;
 
 
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             LSPTR_ASSEMBLY debuggerAssemblyToken;
         } UnloadModuleData;
 
@@ -1921,14 +1917,14 @@ struct MSLAYOUT DebuggerIPCEvent
         // Queury PDB from OOP
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
         } UpdateModuleSymsData;
 
         struct MSLAYOUT
         {
             LSPTR_BREAKPOINT breakpointToken;
             Portable<mdMethodDef> funcMetadataToken;
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<bool> isIL;
             Portable<UINT> offset;
             Portable<UINT> encVersion;
@@ -2026,33 +2022,33 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             Portable<mdTypeDef> classMetadataToken;
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             LSPTR_ASSEMBLY classDebuggerAssemblyToken;
         } LoadClass;
 
         struct MSLAYOUT
         {
             Portable<mdTypeDef> classMetadataToken;
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             LSPTR_ASSEMBLY classDebuggerAssemblyToken;
         } UnloadClass;
 
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<bool> flag;
         } SetClassLoad;
 
         struct MSLAYOUT
         {
-            VMPTR_OBJECTHANDLE vmExceptionHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmExceptionHandle;
             Portable<bool> firstChance;
             Portable<bool> continuable;
         } Exception;
 
         struct MSLAYOUT
         {
-            VMPTR_Thread vmThreadToken;
+            Portable<VMPTR_Thread> vmThreadToken;
         } ClearException;
 
         struct MSLAYOUT
@@ -2069,10 +2065,10 @@ struct MSLAYOUT DebuggerIPCEvent
         {
             Portable<CORDB_ADDRESS> startAddress;
             Portable<bool> fCanSetIPOnly;
-            VMPTR_Thread vmThreadToken;
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Thread> vmThreadToken;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<mdMethodDef> mdMethod;
-            VMPTR_MethodDesc vmMethodDesc;
+            Portable<VMPTR_MethodDesc> vmMethodDesc;
             Portable<ULONG64> offset;
             Portable<bool> fIsIL;
         } SetIP; // this is also used for CanSetIP
@@ -2096,7 +2092,7 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             // assembly for the domain in which the notification occurred
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
 
             // metadata token for the type of the CustomNotification object's type
             Portable<mdTypeDef> classToken;
@@ -2104,7 +2100,7 @@ struct MSLAYOUT DebuggerIPCEvent
 
         struct MSLAYOUT
         {
-            VMPTR_Thread vmThreadToken;
+            Portable<VMPTR_Thread> vmThreadToken;
             Portable<CorDebugThreadState> debugState;
         } SetAllDebugState;
 
@@ -2124,9 +2120,9 @@ struct MSLAYOUT DebuggerIPCEvent
             Portable<CORDB_ADDRESS> resultAddr;
 
             // AppDomain that the result is in.
-            VMPTR_AppDomain vmAppDomain;
+            Portable<VMPTR_AppDomain> vmAppDomain;
 
-            VMPTR_OBJECTHANDLE vmObjectHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmObjectHandle;
             DebuggerIPCE_ExpandedTypeData resultType;
         } FuncEvalComplete;
 
@@ -2148,21 +2144,21 @@ struct MSLAYOUT DebuggerIPCEvent
         struct MSLAYOUT
         {
             Portable<CORDB_ADDRESS> objectRefAddress;
-            VMPTR_OBJECTHANDLE vmObjectHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmObjectHandle;
             Portable<CORDB_ADDRESS> newReference;
         } SetReference;
 
         struct MSLAYOUT
         {
             Portable<NameChangeType> eventType;
-            VMPTR_AppDomain vmAppDomain;
-            VMPTR_Thread vmThread;
+            Portable<VMPTR_AppDomain> vmAppDomain;
+            Portable<VMPTR_Thread> vmThread;
         } NameChange;
 
         // EnC Remap opportunity
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<mdMethodDef> funcMetadataToken;      // methodDef of function with remap opportunity
             Portable<ULONG64> currentVersionNumber;         // version currently executing
             Portable<ULONG64> resumeVersionNumber;          // latest version
@@ -2174,7 +2170,7 @@ struct MSLAYOUT DebuggerIPCEvent
         // EnC Remap has taken place
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<mdMethodDef> funcMetadataToken;         // methodDef of function that was remapped
         } EnCRemapComplete;
 
@@ -2182,7 +2178,7 @@ struct MSLAYOUT DebuggerIPCEvent
         // specific edit made by EnC (function add/update or field add).
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<mdToken> memberMetadataToken;   // Either a methodDef token indicating the function that
                                                      // was updated/added, or a fieldDef token indicating the
                                                      // field which was added.
@@ -2203,7 +2199,7 @@ struct MSLAYOUT DebuggerIPCEvent
         // @todo - Perhaps we can bundle these up so we can set multiple funcs w/ 1 event?
         struct MSLAYOUT
         {
-            VMPTR_Assembly vmAssembly;
+            Portable<VMPTR_Assembly> vmAssembly;
             Portable<mdMethodDef> funcMetadataToken;
             Portable<DWORD> dwStatus;
         } SetJMCFunctionStatus;
@@ -2216,13 +2212,13 @@ struct MSLAYOUT DebuggerIPCEvent
 
         struct MSLAYOUT
         {
-            VMPTR_OBJECTHANDLE vmObjectHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmObjectHandle;
         } CreateHandleResult;
 
         // used in DB_IPCE_DISPOSE_HANDLE event
         struct MSLAYOUT
         {
-            VMPTR_OBJECTHANDLE vmObjectHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmObjectHandle;
             Portable<CorDebugHandleType> handleType;
         } DisposeHandle;
 
@@ -2232,7 +2228,7 @@ struct MSLAYOUT DebuggerIPCEvent
             Portable<UINT> nOffset;
             Portable<CorDebugExceptionCallbackType> eventType;
             Portable<DWORD> dwFlags;
-            VMPTR_OBJECTHANDLE vmExceptionHandle;
+            Portable<VMPTR_OBJECTHANDLE> vmExceptionHandle;
         } ExceptionCallback2;
 
         struct MSLAYOUT
@@ -2243,13 +2239,13 @@ struct MSLAYOUT DebuggerIPCEvent
 
         struct MSLAYOUT
         {
-            VMPTR_Thread vmThreadToken;
+            Portable<VMPTR_Thread> vmThreadToken;
             FramePointer frameToken;
         } InterceptException;
 
         struct MSLAYOUT
         {
-            VMPTR_Module vmModule;
+            Portable<VMPTR_Module> vmModule;
             Portable<CORDB_ADDRESS> pMetadataStart;
             Portable<ULONG> nMetadataSize;
         } MetadataUpdateRequest;

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1211,7 +1211,7 @@ public:
     // CordbChain are really FramePointers.
     LPVOID GetSPValue() const
     {
-        return CORDB_ADDRESS_TO_PTR(m_sp);
+        return m_sp;
     }
 
 
@@ -1656,11 +1656,11 @@ struct MSLAYOUT DebuggerIPCE_FuncEvalArgData
 //
 struct MSLAYOUT DebuggerIPCE_FuncEvalInfo
 {
-    VMPTR_Thread vmThreadToken;
+    Portable<VMPTR_Thread> vmThreadToken;
     Portable<DebuggerIPCE_FuncEvalType> funcEvalType;
     Portable<mdMethodDef> funcMetadataToken;
     Portable<mdTypeDef> funcClassMetadataToken;
-    VMPTR_Assembly vmAssembly;
+    Portable<VMPTR_Assembly> vmAssembly;
     RSPTR_CORDBEVAL funcEvalKey;
     Portable<bool> evalDuringException;
 

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1506,7 +1506,7 @@ struct MSLAYOUT DebuggerIPCE_ExpandedTypeData
         // used for E_T_FNPTR
         struct MSLAYOUT
         {
-            VMPTR_TypeHandle typeHandle; // if non-null then further fetches needed to get type arguments
+            Portable<VMPTR_TypeHandle> typeHandle; // if non-null then further fetches needed to get type arguments
         } NaryTypeData;
 
     };

--- a/src/coreclr/debug/inc/dbgipcevents.h
+++ b/src/coreclr/debug/inc/dbgipcevents.h
@@ -1230,9 +1230,6 @@ private:
 #define LEAF_MOST_FRAME FramePointer::MakeFramePointer((LPVOID)NULL)
 #define ROOT_MOST_FRAME FramePointer::MakeFramePointer((LPVOID)-1)
 
-static_assert(sizeof(FramePointer) == sizeof(void*));
-
-
 inline bool IsCloserToLeaf(FramePointer fp1, FramePointer fp2)
 {
     return (fp1.m_sp < fp2.m_sp);

--- a/src/coreclr/inc/dbgportable.h
+++ b/src/coreclr/inc/dbgportable.h
@@ -139,14 +139,14 @@ public:
     }
 
     template <typename Dummy = T>
-    auto GetRawPtr() -> decltype(Dummy().GetRawPtr())
+    auto GetRawPtr() const -> decltype(Dummy().GetRawPtr())
     {
         Dummy tmp = *this;
         return tmp.GetRawPtr();
     }
 
     template <typename Dummy = T>
-    auto GetDacPtr() -> decltype(Dummy().GetDacPtr())
+    auto GetDacPtr() const -> decltype(Dummy().GetDacPtr())
     {
         Dummy tmp = *this;
         return tmp.GetDacPtr();
@@ -160,9 +160,10 @@ public:
         *this = tmp;
     }
 
-    bool IsNull()
+    template <typename Dummy = T>
+    auto IsNull() const -> decltype(Dummy().IsNull())
     {
-        T tmp = *this;
+        Dummy tmp = *this;
         return tmp.IsNull();
     }
 

--- a/src/coreclr/inc/dbgportable.h
+++ b/src/coreclr/inc/dbgportable.h
@@ -129,6 +129,43 @@ public:
 #endif // DBG_BYTE_SWAP_REQUIRED
     }
 
+    // Forwarders to T's methods. Each one goes through operator=/operator T().
+    // Each is templated (or has a Dummy default) so it isn't instantiated for T's that don't define
+    // the underlying method (e.g. Portable<CORDB_ADDRESS>). Intended to be used for Portable<VMPTR>.
+    template <typename TPtr>
+    void SetRawPtr(TPtr * ptr)
+    {
+        *this = T::MakePtr(ptr);
+    }
+
+    template <typename Dummy = T>
+    auto GetRawPtr() -> decltype(Dummy().GetRawPtr())
+    {
+        Dummy tmp = *this;
+        return tmp.GetRawPtr();
+    }
+
+    template <typename Dummy = T>
+    auto GetDacPtr() -> decltype(Dummy().GetDacPtr())
+    {
+        Dummy tmp = *this;
+        return tmp.GetDacPtr();
+    }
+
+    template <typename TAddr>
+    void SetDacTargetPtr(TAddr addr)
+    {
+        T tmp;
+        tmp.SetDacTargetPtr(addr);
+        *this = tmp;
+    }
+
+    bool IsNull()
+    {
+        T tmp = *this;
+        return tmp.IsNull();
+    }
+
 private:
 #ifdef DBG_BYTE_SWAP_REQUIRED
     // Big endian helper routine to swap the order of bytes of an arbitrary sized type

--- a/src/coreclr/inc/dbgportable.h
+++ b/src/coreclr/inc/dbgportable.h
@@ -132,8 +132,8 @@ public:
     // Forwarders to T's methods. Each one goes through operator=/operator T().
     // Each is templated (or has a Dummy default) so it isn't instantiated for T's that don't define
     // the underlying method (e.g. Portable<CORDB_ADDRESS>). Intended to be used for Portable<VMPTR>.
-    template <typename TPtr>
-    void SetRawPtr(TPtr * ptr)
+    template <typename TPtr, typename Dummy = T>
+    auto SetRawPtr(TPtr * ptr) -> decltype(Dummy::MakePtr(ptr), void())
     {
         *this = T::MakePtr(ptr);
     }
@@ -152,10 +152,10 @@ public:
         return tmp.GetDacPtr();
     }
 
-    template <typename TAddr>
-    void SetDacTargetPtr(TAddr addr)
+    template <typename TAddr, typename Dummy = T>
+    auto SetDacTargetPtr(TAddr addr) -> decltype(Dummy().SetDacTargetPtr(addr))
     {
-        T tmp;
+        Dummy tmp;
         tmp.SetDacTargetPtr(addr);
         *this = tmp;
     }


### PR DESCRIPTION
The inadvertent consequence of https://github.com/dotnet/runtime/pull/127943 is that since VMPTR now wraps a `Portable<CORDB_ADDRESS>`, VMPTR is propagated as a little-endian value across DBI, DAC, and EE, as opposed to solely in the IPC layer. Changing this such that VMPTR wraps CORDB_ADDRESS and we have `Portable<VMPTR>` in the IPC layer - remains little-endian in IPC, but the conversion operator to a VMPTR converts it to the machine endianness.