### PR TITLE
Fix ConstructorInfo.GetGenericArguments to return empty array

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Reflection/RuntimeConstructorInfo.CoreCLR.cs
@@ -159,7 +159,6 @@ namespace System.Reflection
 
         #region MemberInfo Overrides
         public override string Name => RuntimeMethodHandle.GetName(this);
-        public override MemberTypes MemberType => MemberTypes.Constructor;
 
         public override Type? DeclaringType => m_reflectedTypeCache.IsGlobal ? null : m_declaringType;
 

--- a/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
+++ b/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeConstructorInfo.cs
@@ -32,12 +32,6 @@ namespace System.Reflection.Runtime.MethodInfos
 
         public abstract override Type DeclaringType { get; }
 
-        public sealed override Type[] GetGenericArguments()
-        {
-            // Constructors cannot be generic. Desktop compat dictates that We throw NotSupported rather than returning a 0-length array.
-            throw new NotSupportedException();
-        }
-
         [RequiresUnreferencedCode("Trimming may change method bodies. For example it can change some instructions, remove branches or local variables.")]
         public sealed override MethodBody GetMethodBody()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ConstructorInfo.cs
@@ -13,6 +13,9 @@ namespace System.Reflection
 
         public override MemberTypes MemberType => MemberTypes.Constructor;
 
+        // Constructors are never generic methods, so the generic method arguments are always empty.
+        public override Type[] GetGenericArguments() => [];
+
         [DebuggerHidden]
         [DebuggerStepThrough]
         public object Invoke(object?[]? parameters) => Invoke(BindingFlags.Default, binder: null, parameters: parameters, culture: null);

--- a/src/libraries/System.Reflection.Context/tests/CustomConstructorInfoTests.cs
+++ b/src/libraries/System.Reflection.Context/tests/CustomConstructorInfoTests.cs
@@ -142,10 +142,10 @@ namespace System.Reflection.Context.Tests
         }
 
         [Fact]
-        public void GetGenericArguments_ThrowsNotSupported()
+        public void GetGenericArguments_ReturnsEmpty()
         {
-            // Constructors don't support GetGenericArguments
-            Assert.Throws<NotSupportedException>(() => _customConstructor.GetGenericArguments());
+            // Constructors are never generic methods, so GetGenericArguments returns an empty array.
+            Assert.Empty(_customConstructor.GetGenericArguments());
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMethodBodySupported))]

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Method/MethodInvariants.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Method/MethodInvariants.cs
@@ -106,7 +106,12 @@ namespace System.Reflection.Tests
             Assert.False(c.IsConstructedGenericMethod());
             Assert.False(c.IsGenericMethod);
 
+#if NET
             Assert.Empty(c.GetGenericArguments());
+#else
+            // On .NET Framework, ConstructorInfo.GetGenericArguments() throws NotSupportedException.
+            Assert.Throws<NotSupportedException>(() => c.GetGenericArguments());
+#endif
         }
 
         private static void TestMethodInfoCommonInvariants(this MethodInfo m)

--- a/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Method/MethodInvariants.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/tests/src/Tests/Method/MethodInvariants.cs
@@ -106,7 +106,7 @@ namespace System.Reflection.Tests
             Assert.False(c.IsConstructedGenericMethod());
             Assert.False(c.IsGenericMethod);
 
-            Assert.Throws<NotSupportedException>(() => c.GetGenericArguments());
+            Assert.Empty(c.GetGenericArguments());
         }
 
         private static void TestMethodInfoCommonInvariants(this MethodInfo m)

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -12309,6 +12309,7 @@ namespace System.Reflection
         protected ConstructorInfo() { }
         public override System.Reflection.MemberTypes MemberType { get { throw null; } }
         public override bool Equals(object? obj) { throw null; }
+        public override System.Type[] GetGenericArguments() { throw null; }
         public override int GetHashCode() { throw null; }
         public object Invoke(object?[]? parameters) { throw null; }
         public abstract object Invoke(System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder? binder, object?[]? parameters, System.Globalization.CultureInfo? culture);

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
@@ -141,6 +141,9 @@ namespace System.Reflection.Tests
 
             ConstructorInfo[] genericTypeConstructors = GetConstructors(typeof(GenericClassWithConstructor<int>));
             Assert.All(genericTypeConstructors, constructorInfo => Assert.Empty(constructorInfo.GetGenericArguments()));
+
+            ConstructorInfo[] openGenericTypeConstructors = GetConstructors(typeof(GenericClassWithConstructor<>));
+            Assert.All(openGenericTypeConstructors, constructorInfo => Assert.Empty(constructorInfo.GetGenericArguments()));
         }
 
         // Use this class only from the Invoke_StaticConstructorMultipleTimes method

--- a/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Reflection.Tests/ConstructorInfoTests.cs
@@ -133,6 +133,16 @@ namespace System.Reflection.Tests
             Assert.True(constructors[0].IsPublic);
         }
 
+        [Fact]
+        public void GetGenericArguments_ReturnsEmptyArray()
+        {
+            ConstructorInfo[] constructors = GetConstructors(typeof(ClassWith3Constructors));
+            Assert.All(constructors, constructorInfo => Assert.Empty(constructorInfo.GetGenericArguments()));
+
+            ConstructorInfo[] genericTypeConstructors = GetConstructors(typeof(GenericClassWithConstructor<int>));
+            Assert.All(genericTypeConstructors, constructorInfo => Assert.Empty(constructorInfo.GetGenericArguments()));
+        }
+
         // Use this class only from the Invoke_StaticConstructorMultipleTimes method
         public static class ClassWithStaticConstructorThatIsCalledMultipleTimesViaReflection
         {
@@ -157,6 +167,12 @@ namespace System.Reflection.Tests
     public class ConstructorInfoDerived : ConstructorInfoAbstractBase
     {
         public ConstructorInfoDerived() { }
+    }
+
+    public class GenericClassWithConstructor<T>
+    {
+        public GenericClassWithConstructor() { }
+        public GenericClassWithConstructor(T value) { }
     }
 
     public class ClassWith3Constructors


### PR DESCRIPTION
Constructors are never generic methods in the CLR (there is no IL or language support for generic constructors). Previously, calling GetGenericArguments() on a ConstructorInfo threw NotSupportedException because the call fell through to the base MethodBase implementation, which throws by design when not overridden.

RuntimeMethodInfo returns an empty array for non-generic methods, but RuntimeConstructorInfo did not override the method and so threw. Add a single override on the abstract ConstructorInfo base so the fix applies uniformly to all subclasses (CoreCLR, Mono, NativeAOT, MetadataLoadContext, custom ConstructorInfo subclasses, etc.).

Fixes #128041