### PR TITLE
Add Copilot CLI settings.local.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -380,3 +380,6 @@ test:.cs
 *.tempLog.xml
 *.testResults.xml
 *.testStats.csv
+
+# Copilot CLI local configuration
+.github/copilot/settings.local.json


### PR DESCRIPTION
Copilot CLI has an additional configuration file called "local repository" that allows configuration to override a repository's configuration, but should not be checked in.

From [the docs](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference#local-settings-githubcopilotsettingslocaljson):

> Create .github/copilot/settings.local.json in the repository for personal overrides that should not be committed. Add this file to .gitignore.

> The local configuration file uses the same schema as the repository configuration file (.github/copilot/settings.json) and takes precedence over it.
