### PR TITLE
Make LimitArrayPoolWriteStream.ReturnAllPooledBuffers idempotent

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -1077,10 +1077,12 @@ namespace System.Net.Http
 
             private void ReturnAllPooledBuffers()
             {
-                if (_pooledBuffers is byte[]?[] buffers)
+                // Use Interlocked exchanges so that concurrent Dispose() calls cannot
+                // double-return the same buffer to the pool. Stream.Dispose isn't required
+                // to be thread-safe, but a buffer returned twice corrupts the shared pool
+                // process-wide, so we make this method idempotent under racing callers.
+                if (Interlocked.Exchange(ref _pooledBuffers, null) is byte[]?[] buffers)
                 {
-                    _pooledBuffers = null;
-
                     foreach (byte[]? buffer in buffers)
                     {
                         if (buffer is null)
@@ -1092,15 +1094,15 @@ namespace System.Net.Http
                     }
                 }
 
-                Debug.Assert(_lastBuffer is not null);
+                // Capture the last buffer reference before claiming the pooled flag.
+                // Whichever caller wins the bool exchange owns the captured reference;
+                // losers skip the Return and just clear the field.
                 byte[] lastBuffer = _lastBuffer;
-                _lastBuffer = null!;
-
-                if (_lastBufferIsPooled)
+                if (Interlocked.Exchange(ref _lastBufferIsPooled, false))
                 {
-                    _lastBufferIsPooled = false;
                     ArrayPool<byte>.Shared.Return(lastBuffer);
                 }
+                _lastBuffer = null!;
             }
 
             public override void Write(byte[] buffer, int offset, int count)


### PR DESCRIPTION
Makes `LimitArrayPoolWriteStream.ReturnAllPooledBuffers` idempotent under concurrent `Dispose()` so that user code cannot accidentally double-return the same buffer to `ArrayPool<byte>.Shared`. Two `Interlocked.Exchange` calls on the existing fields are enough — no new allocations or fast-path overhead in the single-threaded case.

It's not a security issue, just makes code more robust to buggy implementations 

```cs
using var content = new RacingContent();
await content.LoadIntoBufferAsync(int.MaxValue);

internal sealed class RacingContent : HttpContent
{
    private static readonly byte[] s_payload = new byte[16 * 1024];

    protected override bool TryComputeLength(out long length) { length = 0; return false; }

    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
    {
        await stream.WriteAsync(s_payload);   // populates _pooledBuffers[0]
        await stream.WriteAsync(s_payload);   // _lastBuffer is now pooled

        // if stream.Dispose is called in parallel here before we exit - it will lead to double-free in ArrayPool
    }
}
```

> [!NOTE]
> This PR was authored with the assistance of GitHub Copilot.
