### PR TITLE
X25519DiffieHellman agreement with byte-based public keys

### DIFF
--- a/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X25519.cs
+++ b/src/libraries/Common/src/Interop/OSX/System.Security.Cryptography.Native.Apple/Interop.X25519.cs
@@ -23,6 +23,15 @@ internal static partial class Interop
             Span<byte> destination,
             int destinationLength);
 
+        [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes")]
+        [UnmanagedCallConv(CallConvs = [ typeof(CallConvSwift) ])]
+        private static partial int AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes(
+            SafeX25519KeyHandle key,
+            ReadOnlySpan<byte> peerKey,
+            int peerKeyLength,
+            Span<byte> destination,
+            int destinationLength);
+
         [LibraryImport(Libraries.AppleCryptoNative, EntryPoint = "AppleCryptoNative_X25519ExportPrivateKey")]
         [UnmanagedCallConv(CallConvs = [ typeof(CallConvSwift) ])]
         private static partial int AppleCryptoNative_X25519ExportPrivateKey(
@@ -67,6 +76,32 @@ internal static partial class Interop
                     throw new CryptographicException();
                 default:
                     Debug.Fail($"Unexpected result from {nameof(AppleCryptoNative_X25519DeriveRawSecretAgreement)}: {ret}.");
+                    throw new CryptographicException();
+            }
+        }
+
+        internal static void X25519DeriveRawSecretAgreementWithBytes(
+            SafeX25519KeyHandle key,
+            ReadOnlySpan<byte> peerKey,
+            Span<byte> destination)
+        {
+            const int Success = 1;
+            const int KeyDerivationFailed = 0;
+            int ret = AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes(
+                key,
+                peerKey,
+                peerKey.Length,
+                destination,
+                destination.Length);
+
+            switch (ret)
+            {
+                case Success:
+                    return;
+                case KeyDerivationFailed:
+                    throw new CryptographicException();
+                default:
+                    Debug.Fail($"Unexpected result from {nameof(AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes)}: {ret}.");
                     throw new CryptographicException();
             }
         }

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
@@ -30,6 +30,15 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519GenerateKey")]
         private static partial SafeEvpPKeyHandle CryptoNative_X25519GenerateKey();
 
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519DeriveSecretAgreementWithPublicKey")]
+        private static partial int CryptoNative_X25519DeriveSecretAgreementWithPublicKey(
+            SafeEvpPKeyHandle key,
+            IntPtr extraHandle,
+            ReadOnlySpan<byte> peerKey,
+            int peerKeyLength,
+            Span<byte> secret,
+            uint secretLength);
+
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519IsValidHandle")]
         private static partial int CryptoNative_X25519IsValidHandle(
             SafeEvpPKeyHandle key,
@@ -125,6 +134,32 @@ internal static partial class Interop
             }
 
             return key;
+        }
+
+        internal static int X25519DeriveSecretAgreementWithPublicKey(
+            SafeEvpPKeyHandle key,
+            ReadOnlySpan<byte> peerKey,
+            Span<byte> destination)
+        {
+            Debug.Assert(key != null);
+            Debug.Assert(peerKey.Length == X25519DiffieHellman.PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == X25519DiffieHellman.SecretAgreementSizeInBytes);
+
+            int written = CryptoNative_X25519DeriveSecretAgreementWithPublicKey(
+                key,
+                key.ExtraHandle,
+                peerKey,
+                peerKey.Length,
+                destination,
+                (uint)destination.Length);
+
+            if (written <= 0)
+            {
+                Debug.Assert(written == 0);
+                throw CreateOpenSslCryptographicException();
+            }
+
+            return written;
         }
 
         internal static SafeEvpPKeyHandle X25519ImportPublicKey(ReadOnlySpan<byte> source)

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
@@ -147,7 +147,7 @@ internal static partial class Interop
 
             int written = CryptoNative_X25519DeriveSecretAgreementWithPublicKey(
                 key,
-                key.ExtraHandle,
+                GetExtraHandle(key),
                 peerKey,
                 peerKey.Length,
                 destination,

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.X25519.cs
@@ -30,8 +30,8 @@ internal static partial class Interop
         [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519GenerateKey")]
         private static partial SafeEvpPKeyHandle CryptoNative_X25519GenerateKey();
 
-        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519DeriveSecretAgreementWithPublicKey")]
-        private static partial int CryptoNative_X25519DeriveSecretAgreementWithPublicKey(
+        [LibraryImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X25519DeriveSecretAgreementWithBytes")]
+        private static partial int CryptoNative_X25519DeriveSecretAgreementWithBytes(
             SafeEvpPKeyHandle key,
             IntPtr extraHandle,
             ReadOnlySpan<byte> peerKey,
@@ -136,7 +136,7 @@ internal static partial class Interop
             return key;
         }
 
-        internal static int X25519DeriveSecretAgreementWithPublicKey(
+        internal static int X25519DeriveSecretAgreementWithBytes(
             SafeEvpPKeyHandle key,
             ReadOnlySpan<byte> peerKey,
             Span<byte> destination)
@@ -145,7 +145,7 @@ internal static partial class Interop
             Debug.Assert(peerKey.Length == X25519DiffieHellman.PublicKeySizeInBytes);
             Debug.Assert(destination.Length == X25519DiffieHellman.SecretAgreementSizeInBytes);
 
-            int written = CryptoNative_X25519DeriveSecretAgreementWithPublicKey(
+            int written = CryptoNative_X25519DeriveSecretAgreementWithBytes(
                 key,
                 GetExtraHandle(key),
                 peerKey,

--- a/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
+++ b/src/libraries/System.Security.Cryptography/ref/System.Security.Cryptography.cs
@@ -3449,8 +3449,11 @@ namespace System.Security.Cryptography
         protected X25519DiffieHellman() { }
         public static bool IsSupported { get { throw null; } }
         public byte[] DeriveRawSecretAgreement(System.Security.Cryptography.X25519DiffieHellman otherParty) { throw null; }
+        public byte[] DeriveRawSecretAgreement(byte[] otherPartyPublicKey) { throw null; }
         public void DeriveRawSecretAgreement(System.Security.Cryptography.X25519DiffieHellman otherParty, System.Span<byte> destination) { }
+        public void DeriveRawSecretAgreement(System.ReadOnlySpan<byte> otherPartyPublicKey, System.Span<byte> destination) { }
         protected abstract void DeriveRawSecretAgreementCore(System.Security.Cryptography.X25519DiffieHellman otherParty, System.Span<byte> destination);
+        protected abstract void DeriveRawSecretAgreementCore(System.ReadOnlySpan<byte> otherPartyPublicKey, System.Span<byte> destination);
         public void Dispose() { }
         protected virtual void Dispose(bool disposing) { }
         public byte[] ExportPrivateKey() { throw null; }
@@ -3499,6 +3502,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.SupportedOSPlatformAttribute("windows")]
         public X25519DiffieHellmanCng(System.Security.Cryptography.CngKey key) { }
         protected override void DeriveRawSecretAgreementCore(System.Security.Cryptography.X25519DiffieHellman otherParty, System.Span<byte> destination) { }
+        protected override void DeriveRawSecretAgreementCore(System.ReadOnlySpan<byte> otherPartyPublicKey, System.Span<byte> destination) { }
         protected override void Dispose(bool disposing) { }
         protected override void ExportPrivateKeyCore(System.Span<byte> destination) { }
         protected override void ExportPublicKeyCore(System.Span<byte> destination) { }
@@ -3515,6 +3519,7 @@ namespace System.Security.Cryptography
         [System.Runtime.Versioning.UnsupportedOSPlatformAttribute("windows")]
         public X25519DiffieHellmanOpenSsl(System.Security.Cryptography.SafeEvpPKeyHandle pkeyHandle) { }
         protected override void DeriveRawSecretAgreementCore(System.Security.Cryptography.X25519DiffieHellman otherParty, System.Span<byte> destination) { }
+        protected override void DeriveRawSecretAgreementCore(System.ReadOnlySpan<byte> otherPartyPublicKey, System.Span<byte> destination) { }
         protected override void Dispose(bool disposing) { }
         public System.Security.Cryptography.SafeEvpPKeyHandle DuplicateKeyHandle() { throw null; }
         protected override void ExportPrivateKeyCore(System.Span<byte> destination) { }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Cng.NotSupported.cs
@@ -505,6 +505,11 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
         }
 
+        protected override partial void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);
+        }
+
         protected override partial void ExportPrivateKeyCore(Span<byte> destination)
         {
             throw new PlatformNotSupportedException(SR.PlatformNotSupported_CryptographyCng);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellman.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellman.cs
@@ -83,6 +83,40 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
+        ///   Derives a raw secret agreement with the other party's public key.
+        /// </summary>
+        /// <param name="otherPartyPublicKey">
+        ///   The other party's public key.
+        /// </param>
+        /// <returns>
+        ///   The secret agreement.
+        /// </returns>
+        /// <remarks>
+        ///   The raw secret agreement value is expected to be used as input into a Key Derivation Function,
+        ///   and not used directly as key material.
+        /// </remarks>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="otherPartyPublicKey" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="otherPartyPublicKey" /> has a length that is not <see cref="PublicKeySizeInBytes" />.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during the secret agreement derivation.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public byte[] DeriveRawSecretAgreement(byte[] otherPartyPublicKey)
+        {
+            ArgumentNullException.ThrowIfNull(otherPartyPublicKey);
+            ThrowIfPublicKeyWrongSize(otherPartyPublicKey, nameof(otherPartyPublicKey));
+            ThrowIfDisposed();
+
+            byte[] buffer = new byte[SecretAgreementSizeInBytes];
+            DeriveRawSecretAgreementCore(otherPartyPublicKey, buffer);
+            return buffer;
+        }
+
+        /// <summary>
         ///   Derives a raw secret agreement with the other party's key, writing it into the provided buffer.
         /// </summary>
         /// <param name="otherParty">
@@ -118,6 +152,43 @@ namespace System.Security.Cryptography
 
             ThrowIfDisposed();
             DeriveRawSecretAgreementCore(otherParty, destination);
+        }
+
+        /// <summary>
+        ///   Derives a raw secret agreement with the other party's public key, writing it into the provided buffer.
+        /// </summary>
+        /// <param name="otherPartyPublicKey">
+        ///   The other party's public key.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the secret agreement.
+        /// </param>
+        /// <remarks>
+        ///   The raw secret agreement value is expected to be used as input into a Key Derivation Function,
+        ///   and not used directly as key material.
+        /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///   <para><paramref name="otherPartyPublicKey" /> has a length that is not <see cref="PublicKeySizeInBytes" />.</para>
+        ///   <para>-or-</para>
+        ///   <para><paramref name="destination" /> is the incorrect length to receive the secret agreement.</para>
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during the secret agreement derivation.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">The object has already been disposed.</exception>
+        public void DeriveRawSecretAgreement(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            ThrowIfPublicKeyWrongSize(otherPartyPublicKey, nameof(otherPartyPublicKey));
+
+            if (destination.Length != SecretAgreementSizeInBytes)
+            {
+                throw new ArgumentException(
+                    SR.Format(SR.Argument_DestinationImprecise, SecretAgreementSizeInBytes),
+                    nameof(destination));
+            }
+
+            ThrowIfDisposed();
+            DeriveRawSecretAgreementCore(otherPartyPublicKey, destination);
         }
 
         /// <summary>
@@ -735,6 +806,21 @@ namespace System.Security.Cryptography
         ///   An error occurred during the secret agreement derivation.
         /// </exception>
         protected abstract void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination);
+
+        /// <summary>
+        ///   When overridden in a derived class, derives a raw secret agreement with the other party's public key,
+        ///   writing it into the provided buffer.
+        /// </summary>
+        /// <param name="otherPartyPublicKey">
+        ///   The other party's public key.
+        /// </param>
+        /// <param name="destination">
+        ///   The buffer to receive the secret agreement.
+        /// </param>
+        /// <exception cref="CryptographicException">
+        ///   An error occurred during the secret agreement derivation.
+        /// </exception>
+        protected abstract void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination);
 
         /// <summary>
         ///   When overridden in a derived class, exports the private key into the provided buffer.
@@ -1483,6 +1569,12 @@ namespace System.Security.Cryptography
         private protected void ThrowIfDisposed()
         {
             ObjectDisposedException.ThrowIf(_disposed, typeof(X25519DiffieHellman));
+        }
+
+        private static void ThrowIfPublicKeyWrongSize(ReadOnlySpan<byte> publicKey, string paramName)
+        {
+            if (publicKey.Length != PublicKeySizeInBytes)
+                throw new ArgumentException(SR.Argument_PublicKeyWrongSizeForAlgorithm, paramName);
         }
 
         private protected static void ThrowIfNotSupported()

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
@@ -41,17 +41,28 @@ namespace System.Security.Cryptography
         {
             // We intentionally don't special case otherParty being an instance of X25519DiffieHellmanCng and always
             // export the public key into the current instance's provider.
-            scoped Span<byte> publicKeyBuffer;
+            Span<byte> publicKeyBytes = stackalloc byte[PublicKeySizeInBytes];
+            otherParty.ExportPublicKey(publicKeyBytes);
+            DeriveRawSecretAgreementWithPublicKey(publicKeyBytes, destination);
+        }
+
+        protected override partial void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            DeriveRawSecretAgreementWithPublicKey(otherPartyPublicKey, destination);
+        }
+
+        private void DeriveRawSecretAgreementWithPublicKey(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            scoped Span<byte> reducedPublicKey;
 
             unsafe
             {
-                publicKeyBuffer = stackalloc byte[PublicKeySizeInBytes * 2];
+                reducedPublicKey = stackalloc byte[PublicKeySizeInBytes];
             }
 
-            Span<byte> publicKeyBytes = publicKeyBuffer.Slice(0, PublicKeySizeInBytes);
-            Span<byte> reducedPublicKey = publicKeyBuffer.Slice(PublicKeySizeInBytes, PublicKeySizeInBytes);
-            otherParty.ExportPublicKey(publicKeyBytes);
-            X25519WindowsHelpers.ReducePublicKey(publicKeyBytes, reducedPublicKey);
+            X25519WindowsHelpers.ReducePublicKey(otherPartyPublicKey, reducedPublicKey);
 
             // CNG does not permit cross-provider key agreements. Import the public key in to the same provider
             // as the current key.
@@ -103,11 +114,6 @@ namespace System.Security.Cryptography
                     }
                 }
             }
-        }
-
-        protected override partial void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
-        {
-            throw new NotImplementedException();
         }
 
         protected override partial void ExportPublicKeyCore(Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.Windows.cs
@@ -105,6 +105,11 @@ namespace System.Security.Cryptography
             }
         }
 
+        protected override partial void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override partial void ExportPublicKeyCore(Span<byte> destination)
         {
             Debug.Assert(destination.Length == PublicKeySizeInBytes);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanCng.cs
@@ -56,6 +56,9 @@ namespace System.Security.Cryptography
         protected override unsafe partial void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination);
 
         /// <inheritdoc/>
+        protected override partial void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination);
+
+        /// <inheritdoc/>
         protected override partial void ExportPublicKeyCore(Span<byte> destination);
 
         /// <inheritdoc/>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
@@ -19,8 +19,9 @@ namespace System.Security.Cryptography
             _hasPrivate = hasPrivate;
         }
 
-        protected override unsafe void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
 
             if (otherParty is X25519DiffieHellmanImplementation x25519impl)
@@ -29,14 +30,21 @@ namespace System.Security.Cryptography
             }
             else
             {
-                Span<byte> publicKeyBuffer = stackalloc byte[PublicKeySizeInBytes];
-                otherParty.ExportPublicKey(publicKeyBuffer);
-
-                using (SafeX25519KeyHandle publicKey = Interop.AppleCrypto.X25519ImportPublicKey(publicKeyBuffer))
+                unsafe
                 {
-                    Interop.AppleCrypto.X25519DeriveRawSecretAgreement(_key, publicKey, destination);
+                    Span<byte> publicKeyBuffer = stackalloc byte[PublicKeySizeInBytes];
+                    otherParty.ExportPublicKey(publicKeyBuffer);
+                    DeriveRawSecretAgreementWithPublicKey(publicKeyBuffer, destination);
                 }
             }
+        }
+
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            ThrowIfPrivateNeeded();
+            DeriveRawSecretAgreementWithPublicKey(otherPartyPublicKey, destination);
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)
@@ -91,6 +99,11 @@ namespace System.Security.Cryptography
         {
             if (!_hasPrivate)
                 throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
+        }
+
+        private void DeriveRawSecretAgreementWithPublicKey(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            Interop.AppleCrypto.X25519DeriveRawSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography
                 {
                     Span<byte> publicKeyBuffer = stackalloc byte[PublicKeySizeInBytes];
                     otherParty.ExportPublicKey(publicKeyBuffer);
-                    DeriveRawSecretAgreementWithPublicKey(publicKeyBuffer, destination);
+                    Interop.AppleCrypto.X25519DeriveRawSecretAgreementWithBytes(_key, publicKeyBuffer, destination);
                 }
             }
         }
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
             Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
-            DeriveRawSecretAgreementWithPublicKey(otherPartyPublicKey, destination);
+            Interop.AppleCrypto.X25519DeriveRawSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)
@@ -101,9 +101,5 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
         }
 
-        private void DeriveRawSecretAgreementWithPublicKey(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
-        {
-            Interop.AppleCrypto.X25519DeriveRawSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
-        }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Apple.cs
@@ -100,6 +100,5 @@ namespace System.Security.Cryptography
             if (!_hasPrivate)
                 throw new CryptographicException(SR.Cryptography_CSP_NoPrivateKey);
         }
-
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.NotSupported.cs
@@ -15,6 +15,12 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
         }
 
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
+        }
+
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             Debug.Fail("Caller should have checked platform availability.");

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography
             _hasPrivate = hasPrivate;
         }
 
-        protected override unsafe void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
@@ -32,12 +32,11 @@ namespace System.Security.Cryptography
             }
             else
             {
-                Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
-                otherParty.ExportPublicKey(publicKey);
-
-                using (SafeEvpPKeyHandle peerKeyHandle = Interop.Crypto.X25519ImportPublicKey(publicKey))
+                unsafe
                 {
-                    written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, peerKeyHandle, destination);
+                    Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
+                    otherParty.ExportPublicKey(publicKey);
+                    written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, publicKey, destination);
                 }
             }
 
@@ -50,7 +49,17 @@ namespace System.Security.Cryptography
 
         protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
         {
-            throw new NotImplementedException();
+            Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            ThrowIfPrivateNeeded();
+
+            int written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, otherPartyPublicKey, destination);
+
+            if (written != SecretAgreementSizeInBytes)
+            {
+                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey)} wrote an unexpected number of bytes: {written}.");
+                throw new CryptographicException();
+            }
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
@@ -48,6 +48,11 @@ namespace System.Security.Cryptography
             }
         }
 
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             Debug.Assert(destination.Length == PrivateKeySizeInBytes);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.OpenSsl.cs
@@ -36,7 +36,7 @@ namespace System.Security.Cryptography
                 {
                     Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
                     otherParty.ExportPublicKey(publicKey);
-                    written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, publicKey, destination);
+                    written = Interop.Crypto.X25519DeriveSecretAgreementWithBytes(_key, publicKey, destination);
                 }
             }
 
@@ -53,11 +53,11 @@ namespace System.Security.Cryptography
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
 
-            int written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, otherPartyPublicKey, destination);
+            int written = Interop.Crypto.X25519DeriveSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
 
             if (written != SecretAgreementSizeInBytes)
             {
-                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey)} wrote an unexpected number of bytes: {written}.");
+                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithBytes)} wrote an unexpected number of bytes: {written}.");
                 throw new CryptographicException();
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
@@ -33,67 +33,76 @@ namespace System.Security.Cryptography
         [MemberNotNullWhen(true, nameof(s_algHandle))]
         internal static new bool IsSupported => s_algHandle is not null;
 
-        protected override unsafe void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
+        protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
         {
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
-            int written;
 
             if (otherParty is X25519DiffieHellmanImplementation x25519impl)
             {
-                using (SafeBCryptSecretHandle secret = Interop.BCrypt.BCryptSecretAgreement(_key, x25519impl._key))
-                {
-                    Interop.BCrypt.BCryptDeriveKey(
-                        secret,
-                        BCryptNative.KeyDerivationFunction.Raw,
-                        in Unsafe.NullRef<Interop.BCrypt.BCryptBufferDesc>(),
-                        destination,
-                        out written);
-                }
+                DeriveRawSecretAgreementWithKey(x25519impl._key, destination);
             }
             else
             {
-                Span<byte> publicKeyBytes = stackalloc byte[PublicKeySizeInBytes];
-                otherParty.ExportPublicKey(publicKeyBytes);
-
-                using (X25519DiffieHellmanImplementation otherPartyImplementation = ImportPublicKeyImpl(publicKeyBytes))
-                using (SafeBCryptSecretHandle secret = Interop.BCrypt.BCryptSecretAgreement(_key, otherPartyImplementation._key))
+                unsafe
                 {
-                    Interop.BCrypt.BCryptDeriveKey(
-                        secret,
-                        BCryptNative.KeyDerivationFunction.Raw,
-                        in Unsafe.NullRef<Interop.BCrypt.BCryptBufferDesc>(),
-                        destination,
-                        out written);
+                    Span<byte> publicKeyBytes = stackalloc byte[PublicKeySizeInBytes];
+
+                    otherParty.ExportPublicKey(publicKeyBytes);
+
+                    using (SafeBCryptKeyHandle otherPartyKey = ImportPublicKey(publicKeyBytes, out _))
+                    {
+                        DeriveRawSecretAgreementWithKey(otherPartyKey, destination);
+                    }
                 }
-            }
-
-            if (written != SecretAgreementSizeInBytes)
-            {
-                destination.Clear();
-                Debug.Fail($"Unexpected number of bytes written: {written}.");
-                throw new CryptographicException();
-            }
-
-            // CNG with BCRYPT_NO_KEY_VALIDATION permits low-order public keys, which produce
-            // an all-zero shared secret. Other platforms reject these at
-            // derive time per RFC 7748 6.1.
-            // We still need BCRYPT_NO_KEY_VALIDATION though because there are small subgroup keys that work, which do
-            // not produce all zero shared secrets.
-            if (CryptographicOperations.FixedTimeEquals(destination, 0))
-            {
-                throw new CryptographicException();
-            }
-            else
-            {
-                // BCryptDeriveKey exports with the wrong endianness.
-                destination.Reverse();
             }
         }
 
         protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
         {
-            throw new NotImplementedException();
+            Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            ThrowIfPrivateNeeded();
+
+            using (SafeBCryptKeyHandle otherPartyKey = ImportPublicKey(otherPartyPublicKey, out _))
+            {
+                DeriveRawSecretAgreementWithKey(otherPartyKey, destination);
+            }
+        }
+
+        private void DeriveRawSecretAgreementWithKey(SafeBCryptKeyHandle otherPartyKey, Span<byte> destination)
+        {
+            using (SafeBCryptSecretHandle secret = Interop.BCrypt.BCryptSecretAgreement(_key, otherPartyKey))
+            {
+                Interop.BCrypt.BCryptDeriveKey(
+                    secret,
+                    BCryptNative.KeyDerivationFunction.Raw,
+                    in Unsafe.NullRef<Interop.BCrypt.BCryptBufferDesc>(),
+                    destination,
+                    out int written);
+
+                if (written != SecretAgreementSizeInBytes)
+                {
+                    destination.Clear();
+                    Debug.Fail($"Unexpected number of bytes written: {written}.");
+                    throw new CryptographicException();
+                }
+
+                // CNG with BCRYPT_NO_KEY_VALIDATION permits low-order public keys, which produce
+                // an all-zero shared secret. Other platforms reject these at
+                // derive time per RFC 7748 6.1.
+                // We still need BCRYPT_NO_KEY_VALIDATION though because there are small subgroup keys that work, which do
+                // not produce all zero shared secrets.
+                if (CryptographicOperations.FixedTimeEquals(destination, 0))
+                {
+                    throw new CryptographicException();
+                }
+                else
+                {
+                    // BCryptDeriveKey exports with the wrong endianness.
+                    destination.Reverse();
+                }
+            }
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)
@@ -155,12 +164,9 @@ namespace System.Security.Cryptography
             return new X25519DiffieHellmanImplementation(key, hasPrivate: true, privatePreservation: preservation);
         }
 
-        internal static unsafe X25519DiffieHellmanImplementation ImportPublicKeyImpl(ReadOnlySpan<byte> source)
+        internal static X25519DiffieHellmanImplementation ImportPublicKeyImpl(ReadOnlySpan<byte> source)
         {
-            Span<byte> reducedPublicKey = stackalloc byte[PublicKeySizeInBytes];
-            bool requiredReduction = X25519WindowsHelpers.ReducePublicKey(source, reducedPublicKey);
-
-            SafeBCryptKeyHandle key = ImportKey(false, reducedPublicKey, out _);
+            SafeBCryptKeyHandle key = ImportPublicKey(source, out bool requiredReduction);
 
             Debug.Assert(!key.IsInvalid);
             return new X25519DiffieHellmanImplementation(
@@ -168,6 +174,20 @@ namespace System.Security.Cryptography
                 hasPrivate: false,
                 privatePreservation: 0,
                 requiredReduction ? source.ToArray() : null);
+        }
+
+        private static SafeBCryptKeyHandle ImportPublicKey(ReadOnlySpan<byte> source, out bool requiredReduction)
+        {
+            scoped Span<byte> reducedPublicKey;
+
+            unsafe
+            {
+                reducedPublicKey = stackalloc byte[PublicKeySizeInBytes];
+            }
+
+            requiredReduction = X25519WindowsHelpers.ReducePublicKey(source, reducedPublicKey);
+
+            return ImportKey(false, reducedPublicKey, out _);
         }
 
         private void ExportKey(bool privateKey, Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
@@ -91,6 +91,11 @@ namespace System.Security.Cryptography
             }
         }
 
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             ExportKey(true, destination);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanImplementation.Windows.cs
@@ -47,13 +47,8 @@ namespace System.Security.Cryptography
                 unsafe
                 {
                     Span<byte> publicKeyBytes = stackalloc byte[PublicKeySizeInBytes];
-
                     otherParty.ExportPublicKey(publicKeyBytes);
-
-                    using (SafeBCryptKeyHandle otherPartyKey = ImportPublicKey(publicKeyBytes, out _))
-                    {
-                        DeriveRawSecretAgreementWithKey(otherPartyKey, destination);
-                    }
+                    DeriveRawSecretAgreementWithKey(publicKeyBytes, destination);
                 }
             }
         }
@@ -63,7 +58,11 @@ namespace System.Security.Cryptography
             Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
+            DeriveRawSecretAgreementWithKey(otherPartyPublicKey, destination);
+        }
 
+        private void DeriveRawSecretAgreementWithKey(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
             using (SafeBCryptKeyHandle otherPartyKey = ImportPublicKey(otherPartyPublicKey, out _))
             {
                 DeriveRawSecretAgreementWithKey(otherPartyKey, destination);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
@@ -27,7 +27,8 @@ namespace System.Security.Cryptography
 
         protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
         {
-            throw new NotImplementedException();
+            Debug.Fail("Caller should have checked platform availability.");
+            throw new PlatformNotSupportedException();
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.NotSupported.cs
@@ -25,6 +25,11 @@ namespace System.Security.Cryptography
             throw new PlatformNotSupportedException();
         }
 
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             Debug.Fail("Caller should have checked platform availability.");

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography
             {
                 Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
                 otherParty.ExportPublicKey(publicKey);
-                written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, publicKey, destination);
+                written = Interop.Crypto.X25519DeriveSecretAgreementWithBytes(_key, publicKey, destination);
             }
 
             if (written != SecretAgreementSizeInBytes)
@@ -70,11 +70,11 @@ namespace System.Security.Cryptography
             Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
             ThrowIfPrivateNeeded();
 
-            int written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, otherPartyPublicKey, destination);
+            int written = Interop.Crypto.X25519DeriveSecretAgreementWithBytes(_key, otherPartyPublicKey, destination);
 
             if (written != SecretAgreementSizeInBytes)
             {
-                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey)} wrote an unexpected number of bytes: {written}.");
+                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithBytes)} wrote an unexpected number of bytes: {written}.");
                 throw new CryptographicException();
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -68,6 +68,11 @@ namespace System.Security.Cryptography
             }
         }
 
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            throw new NotImplementedException();
+        }
+
         protected override void ExportPrivateKeyCore(Span<byte> destination)
         {
             Debug.Assert(destination.Length == PrivateKeySizeInBytes);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellmanOpenSsl.OpenSsl.cs
@@ -54,11 +54,7 @@ namespace System.Security.Cryptography
             {
                 Span<byte> publicKey = stackalloc byte[PublicKeySizeInBytes];
                 otherParty.ExportPublicKey(publicKey);
-
-                using (SafeEvpPKeyHandle peerKeyHandle = Interop.Crypto.X25519ImportPublicKey(publicKey))
-                {
-                    written = Interop.Crypto.EvpPKeyDeriveSecretAgreement(_key, peerKeyHandle, destination);
-                }
+                written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, publicKey, destination);
             }
 
             if (written != SecretAgreementSizeInBytes)
@@ -70,7 +66,17 @@ namespace System.Security.Cryptography
 
         protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
         {
-            throw new NotImplementedException();
+            Debug.Assert(otherPartyPublicKey.Length == PublicKeySizeInBytes);
+            Debug.Assert(destination.Length == SecretAgreementSizeInBytes);
+            ThrowIfPrivateNeeded();
+
+            int written = Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey(_key, otherPartyPublicKey, destination);
+
+            if (written != SecretAgreementSizeInBytes)
+            {
+                Debug.Fail($"{nameof(Interop.Crypto.X25519DeriveSecretAgreementWithPublicKey)} wrote an unexpected number of bytes: {written}.");
+                throw new CryptographicException();
+            }
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
@@ -113,6 +113,22 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void DeriveRawSecretAgreement_BytesWithInstance_Symmetric()
+        {
+            using X25519DiffieHellman key1 = GenerateKey();
+            using X25519DiffieHellman key2 = GenerateKey();
+
+            byte[] secret1 = key1.DeriveRawSecretAgreement(key2.ExportPublicKey());
+            byte[] secret2 = key1.DeriveRawSecretAgreement(key2);
+            byte[] secret3 = key2.DeriveRawSecretAgreement(key1.ExportPublicKey());
+            byte[] secret4 = key2.DeriveRawSecretAgreement(key1);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+            AssertExtensions.SequenceEqual(secret2, secret3);
+            AssertExtensions.SequenceEqual(secret3, secret4);
+        }
+
+        [Fact]
         public void DeriveRawSecretAgreement_ExactBuffers()
         {
             using X25519DiffieHellman key1 = GenerateKey();
@@ -283,6 +299,9 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman key = ImportPrivateKey(privateKey);
 
             Assert.ThrowsAny<CryptographicException>(() => key.DeriveRawSecretAgreement(peerPublicKey));
+
+            // Show that the object is still functional after derive throws.
+            AssertExtensions.SequenceEqual(privateKey, key.ExportPrivateKey());
         }
 
         [ConditionalFact(nameof(IsNotStrictKeyValidatingPlatform))]
@@ -297,6 +316,9 @@ namespace System.Security.Cryptography.Tests
 
             Assert.ThrowsAny<CryptographicException>(
                 () => key.DeriveRawSecretAgreement(peerPublicKey, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+
+            // Show that the object is still functional after derive throws.
+            AssertExtensions.SequenceEqual(privateKey, key.ExportPrivateKey());
         }
 
         [Theory]

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanBaseTests.cs
@@ -101,6 +101,18 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void DeriveRawSecretAgreement_Bytes_Symmetric()
+        {
+            using X25519DiffieHellman key1 = GenerateKey();
+            using X25519DiffieHellman key2 = GenerateKey();
+
+            byte[] secret1 = key1.DeriveRawSecretAgreement(key2.ExportPublicKey());
+            byte[] secret2 = key2.DeriveRawSecretAgreement(key1.ExportPublicKey());
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
         public void DeriveRawSecretAgreement_ExactBuffers()
         {
             using X25519DiffieHellman key1 = GenerateKey();
@@ -115,6 +127,20 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public void DeriveRawSecretAgreement_Bytes_ExactBuffers()
+        {
+            using X25519DiffieHellman key1 = GenerateKey();
+            using X25519DiffieHellman key2 = GenerateKey();
+
+            byte[] secret1 = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            byte[] secret2 = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            key1.DeriveRawSecretAgreement(key2.ExportPublicKey(), secret1);
+            key2.DeriveRawSecretAgreement(key1.ExportPublicKey(), secret2);
+
+            AssertExtensions.SequenceEqual(secret1, secret2);
+        }
+
+        [Fact]
         public void DeriveRawSecretAgreement_PublicKeyOnly_Throws()
         {
             using X25519DiffieHellman xdh = GenerateKey();
@@ -122,7 +148,40 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman other = GenerateKey();
 
             Assert.Throws<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other));
-            Assert.Throws<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_ExactBuffers_PublicKeyOnly_Throws()
+        {
+            using X25519DiffieHellman xdh = GenerateKey();
+            using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
+            using X25519DiffieHellman other = GenerateKey();
+
+            Assert.Throws<CryptographicException>(() =>
+                publicOnly.DeriveRawSecretAgreement(other, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_Bytes_PublicKeyOnly_Throws()
+        {
+            using X25519DiffieHellman xdh = GenerateKey();
+            using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
+            using X25519DiffieHellman other = GenerateKey();
+
+            Assert.Throws<CryptographicException>(() => publicOnly.DeriveRawSecretAgreement(other.ExportPublicKey()));
+        }
+
+        [Fact]
+        public void DeriveRawSecretAgreement_Bytes_ExactBuffers_PublicKeyOnly_Throws()
+        {
+            using X25519DiffieHellman xdh = GenerateKey();
+            using X25519DiffieHellman publicOnly = ImportPublicKey(xdh.ExportPublicKey());
+            using X25519DiffieHellman other = GenerateKey();
+
+            Assert.Throws<CryptographicException>(() =>
+                publicOnly.DeriveRawSecretAgreement(
+                    other.ExportPublicKey(),
+                    new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
         }
 
         [Theory]
@@ -134,10 +193,39 @@ namespace System.Security.Cryptography.Tests
 
             byte[] secret = key.DeriveRawSecretAgreement(peer);
             AssertExtensions.SequenceEqual(vector.SharedSecret, secret);
+        }
+
+        [Theory]
+        [MemberData(nameof(DeriveSecretAgreementVectorsForCurrentPlatform))]
+        public void DeriveRawSecretAgreement_ExactBuffers_Vectors(DeriveSecretAgreementVector vector)
+        {
+            using X25519DiffieHellman key = ImportPrivateKey(vector.PrivateKey);
+            using X25519DiffieHellman peer = ImportPublicKey(vector.PeerPublicKey);
 
             byte[] secretBuffer = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
             key.DeriveRawSecretAgreement(peer, secretBuffer);
             AssertExtensions.SequenceEqual(vector.SharedSecret, secretBuffer);
+        }
+
+        [Theory]
+        [MemberData(nameof(DeriveSecretAgreementVectorsForCurrentPlatform))]
+        public void DeriveRawSecretAgreement_Bytes_Vectors(DeriveSecretAgreementVector vector)
+        {
+            using X25519DiffieHellman key = ImportPrivateKey(vector.PrivateKey);
+
+            byte[] secretWithBytes = key.DeriveRawSecretAgreement(vector.PeerPublicKey);
+            AssertExtensions.SequenceEqual(vector.SharedSecret, secretWithBytes);
+        }
+
+        [Theory]
+        [MemberData(nameof(DeriveSecretAgreementVectorsForCurrentPlatform))]
+        public void DeriveRawSecretAgreement_Bytes_ExactBuffers_Vectors(DeriveSecretAgreementVector vector)
+        {
+            using X25519DiffieHellman key = ImportPrivateKey(vector.PrivateKey);
+
+            byte[] secretWithBytesBuffer = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            key.DeriveRawSecretAgreement(vector.PeerPublicKey, secretWithBytesBuffer);
+            AssertExtensions.SequenceEqual(vector.SharedSecret, secretWithBytesBuffer);
         }
 
         [Theory]
@@ -167,8 +255,48 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellman peer = ImportPublicKey(peerPublicKey);
 
             Assert.ThrowsAny<CryptographicException>(() => key.DeriveRawSecretAgreement(peer));
+        }
+
+        [ConditionalFact(nameof(IsNotStrictKeyValidatingPlatform))]
+        public void DeriveRawSecretAgreement_ExactBuffers_ZeroSharedSecret_Throws()
+        {
+            // Wycheproof tcId 64: peer public key is a low-order point on Curve25519.
+            // This low-order point produces a shared secret that is all zeros.
+            byte[] privateKey = Convert.FromHexString("387355d995616090503aafad49da01fb3dc3eda962704eaee6b86f9e20c92579");
+            byte[] peerPublicKey = Convert.FromHexString("5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157");
+
+            using X25519DiffieHellman key = ImportPrivateKey(privateKey);
+            using X25519DiffieHellman peer = ImportPublicKey(peerPublicKey);
+
             Assert.ThrowsAny<CryptographicException>(
                 () => key.DeriveRawSecretAgreement(peer, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [ConditionalFact(nameof(IsNotStrictKeyValidatingPlatform))]
+        public void DeriveRawSecretAgreement_Bytes_ZeroSharedSecret_Throws()
+        {
+            // Wycheproof tcId 64: peer public key is a low-order point on Curve25519.
+            // This low-order point produces a shared secret that is all zeros.
+            byte[] privateKey = Convert.FromHexString("387355d995616090503aafad49da01fb3dc3eda962704eaee6b86f9e20c92579");
+            byte[] peerPublicKey = Convert.FromHexString("5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157");
+
+            using X25519DiffieHellman key = ImportPrivateKey(privateKey);
+
+            Assert.ThrowsAny<CryptographicException>(() => key.DeriveRawSecretAgreement(peerPublicKey));
+        }
+
+        [ConditionalFact(nameof(IsNotStrictKeyValidatingPlatform))]
+        public void DeriveRawSecretAgreement_Bytes_ExactBuffers_ZeroSharedSecret_Throws()
+        {
+            // Wycheproof tcId 64: peer public key is a low-order point on Curve25519.
+            // This low-order point produces a shared secret that is all zeros.
+            byte[] privateKey = Convert.FromHexString("387355d995616090503aafad49da01fb3dc3eda962704eaee6b86f9e20c92579");
+            byte[] peerPublicKey = Convert.FromHexString("5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157");
+
+            using X25519DiffieHellman key = ImportPrivateKey(privateKey);
+
+            Assert.ThrowsAny<CryptographicException>(
+                () => key.DeriveRawSecretAgreement(peerPublicKey, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
         }
 
         [Theory]
@@ -524,6 +652,11 @@ namespace System.Security.Cryptography.Tests
             protected override void DeriveRawSecretAgreementCore(X25519DiffieHellman otherParty, Span<byte> destination)
             {
                 _inner.DeriveRawSecretAgreement(otherParty, destination);
+            }
+
+            protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+            {
+                _inner.DeriveRawSecretAgreement(otherPartyPublicKey, destination);
             }
 
             protected override void ExportPrivateKeyCore(Span<byte> destination)

--- a/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanContractTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X25519DiffieHellmanContractTests.cs
@@ -59,11 +59,31 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public static void DeriveRawSecretAgreement_Allocated_NullOtherPartyPublicKey()
+        {
+            using X25519DiffieHellmanContract xdh = new();
+            AssertExtensions.Throws<ArgumentNullException>("otherPartyPublicKey", () =>
+                xdh.DeriveRawSecretAgreement((byte[])null));
+        }
+
+        [Fact]
         public static void DeriveRawSecretAgreement_Exact_NullOtherParty()
         {
             using X25519DiffieHellmanContract xdh = new();
             AssertExtensions.Throws<ArgumentNullException>("otherParty", () =>
-                xdh.DeriveRawSecretAgreement(null, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+                xdh.DeriveRawSecretAgreement(
+                    (X25519DiffieHellman)null,
+                    new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [Theory]
+        [InlineData(X25519DiffieHellman.PublicKeySizeInBytes - 1)]
+        [InlineData(X25519DiffieHellman.PublicKeySizeInBytes + 1)]
+        public static void DeriveRawSecretAgreement_Allocated_WrongOtherPartyPublicKeyLength(int publicKeyLength)
+        {
+            using X25519DiffieHellmanContract xdh = new();
+            AssertExtensions.Throws<ArgumentException>("otherPartyPublicKey", () =>
+                xdh.DeriveRawSecretAgreement(new byte[publicKeyLength]));
         }
 
         [Fact]
@@ -79,6 +99,31 @@ namespace System.Security.Cryptography.Tests
                 xdh.DeriveRawSecretAgreement(other, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes + 1]));
         }
 
+        [Theory]
+        [InlineData(X25519DiffieHellman.PublicKeySizeInBytes - 1)]
+        [InlineData(X25519DiffieHellman.PublicKeySizeInBytes + 1)]
+        public static void DeriveRawSecretAgreement_Exact_WrongOtherPartyPublicKeyLength(int publicKeyLength)
+        {
+            using X25519DiffieHellmanContract xdh = new();
+            AssertExtensions.Throws<ArgumentException>("otherPartyPublicKey", () =>
+                xdh.DeriveRawSecretAgreement(
+                    new byte[publicKeyLength],
+                    new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [Fact]
+        public static void DeriveRawSecretAgreement_Exact_WrongDestinationLength_WithOtherPartyPublicKey()
+        {
+            using X25519DiffieHellmanContract xdh = new();
+            byte[] publicKey = new byte[X25519DiffieHellman.PublicKeySizeInBytes];
+
+            AssertExtensions.Throws<ArgumentException>("destination", () =>
+                xdh.DeriveRawSecretAgreement(publicKey, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes - 1]));
+
+            AssertExtensions.Throws<ArgumentException>("destination", () =>
+                xdh.DeriveRawSecretAgreement(publicKey, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes + 1]));
+        }
+
         [Fact]
         public static void DeriveRawSecretAgreement_Allocated_Disposed()
         {
@@ -89,6 +134,15 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public static void DeriveRawSecretAgreement_Allocated_Disposed_WithOtherPartyPublicKey()
+        {
+            X25519DiffieHellmanContract xdh = new();
+            xdh.Dispose();
+            Assert.Throws<ObjectDisposedException>(() =>
+                xdh.DeriveRawSecretAgreement(new byte[X25519DiffieHellman.PublicKeySizeInBytes]));
+        }
+
+        [Fact]
         public static void DeriveRawSecretAgreement_Exact_Disposed()
         {
             X25519DiffieHellmanContract xdh = new();
@@ -96,6 +150,17 @@ namespace System.Security.Cryptography.Tests
             using X25519DiffieHellmanContract other = new();
             Assert.Throws<ObjectDisposedException>(() =>
                 xdh.DeriveRawSecretAgreement(other, new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
+        }
+
+        [Fact]
+        public static void DeriveRawSecretAgreement_Exact_Disposed_WithOtherPartyPublicKey()
+        {
+            X25519DiffieHellmanContract xdh = new();
+            xdh.Dispose();
+            Assert.Throws<ObjectDisposedException>(() =>
+                xdh.DeriveRawSecretAgreement(
+                    new byte[X25519DiffieHellman.PublicKeySizeInBytes],
+                    new byte[X25519DiffieHellman.SecretAgreementSizeInBytes]));
         }
 
         [Fact]
@@ -117,6 +182,25 @@ namespace System.Security.Cryptography.Tests
         }
 
         [Fact]
+        public static void DeriveRawSecretAgreement_Allocated_Works_WithOtherPartyPublicKey()
+        {
+            byte[] publicKey = new byte[X25519DiffieHellman.PublicKeySizeInBytes];
+            publicKey.AsSpan().Fill(0x42);
+            using X25519DiffieHellmanContract xdh = new()
+            {
+                OnDeriveRawSecretAgreementCoreWithBytes = (ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination) =>
+                {
+                    AssertExtensions.SequenceEqual(publicKey, otherPartyPublicKey);
+                    destination.Fill(0xAA);
+                }
+            };
+
+            byte[] agreement = xdh.DeriveRawSecretAgreement(publicKey);
+            Assert.Equal(X25519DiffieHellman.SecretAgreementSizeInBytes, agreement.Length);
+            AssertExtensions.FilledWith<byte>(0xAA, agreement);
+        }
+
+        [Fact]
         public static void DeriveRawSecretAgreement_Exact_Works()
         {
             byte[] buffer = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
@@ -131,6 +215,24 @@ namespace System.Security.Cryptography.Tests
             };
 
             xdh.DeriveRawSecretAgreement(other, buffer);
+        }
+
+        [Fact]
+        public static void DeriveRawSecretAgreement_Exact_Works_WithOtherPartyPublicKey()
+        {
+            byte[] publicKey = new byte[X25519DiffieHellman.PublicKeySizeInBytes];
+            publicKey.AsSpan().Fill(0x42);
+            byte[] buffer = new byte[X25519DiffieHellman.SecretAgreementSizeInBytes];
+            using X25519DiffieHellmanContract xdh = new()
+            {
+                OnDeriveRawSecretAgreementCoreWithBytes = (ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination) =>
+                {
+                    AssertExtensions.SequenceEqual(publicKey, otherPartyPublicKey);
+                    AssertExtensions.Same(buffer, destination);
+                }
+            };
+
+            xdh.DeriveRawSecretAgreement(publicKey, buffer);
         }
 
         [Fact]
@@ -822,12 +924,14 @@ namespace System.Security.Cryptography.Tests
     internal sealed class X25519DiffieHellmanContract : X25519DiffieHellman
     {
         internal DeriveRawSecretAgreementCoreCallback OnDeriveRawSecretAgreementCore { get; set; }
+        internal DeriveRawSecretAgreementCoreWithBytesCallback OnDeriveRawSecretAgreementCoreWithBytes { get; set; }
         internal ExportKeyCoreCallback OnExportPrivateKeyCore { get; set; }
         internal ExportKeyCoreCallback OnExportPublicKeyCore { get; set; }
         internal TryExportPkcs8PrivateKeyCoreCallback OnTryExportPkcs8PrivateKeyCore { get; set; }
         internal Action<bool> OnDispose { get; set; } = (bool disposing) => { };
 
         internal int DeriveRawSecretAgreementCoreCount { get; set; }
+        internal int DeriveRawSecretAgreementCoreWithBytesCount { get; set; }
         internal int ExportPrivateKeyCoreCount { get; set; }
         internal int ExportPublicKeyCoreCount { get; set; }
         internal int TryExportPkcs8PrivateKeyCoreCount { get; set; }
@@ -838,6 +942,12 @@ namespace System.Security.Cryptography.Tests
         {
             DeriveRawSecretAgreementCoreCount++;
             GetCallback(OnDeriveRawSecretAgreementCore)(otherParty, destination);
+        }
+
+        protected override void DeriveRawSecretAgreementCore(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination)
+        {
+            DeriveRawSecretAgreementCoreWithBytesCount++;
+            GetCallback(OnDeriveRawSecretAgreementCoreWithBytes)(otherPartyPublicKey, destination);
         }
 
         protected override void ExportPrivateKeyCore(Span<byte> destination)
@@ -871,6 +981,10 @@ namespace System.Security.Cryptography.Tests
             {
                 Assert.Fail($"Expected call to {nameof(DeriveRawSecretAgreementCore)}.");
             }
+            if (OnDeriveRawSecretAgreementCoreWithBytes is not null && DeriveRawSecretAgreementCoreWithBytesCount == 0)
+            {
+                Assert.Fail($"Expected call to {nameof(DeriveRawSecretAgreementCore)}.");
+            }
             if (OnExportPrivateKeyCore is not null && ExportPrivateKeyCoreCount == 0)
             {
                 Assert.Fail($"Expected call to {nameof(ExportPrivateKeyCore)}.");
@@ -886,6 +1000,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         internal delegate void DeriveRawSecretAgreementCoreCallback(X25519DiffieHellman otherParty, Span<byte> destination);
+        internal delegate void DeriveRawSecretAgreementCoreWithBytesCallback(ReadOnlySpan<byte> otherPartyPublicKey, Span<byte> destination);
         internal delegate void ExportKeyCoreCallback(Span<byte> destination);
         internal delegate bool TryExportPkcs8PrivateKeyCoreCallback(Span<byte> destination, out int bytesWritten);
 

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/entrypoints.c
@@ -116,6 +116,7 @@ static const Entry s_cryptoAppleNative[] =
     DllImportEntry(AppleCryptoNative_StoreEnumerateUserDisallowed)
     DllImportEntry(AppleCryptoNative_StoreEnumerateMachineDisallowed)
     DllImportEntry(AppleCryptoNative_X25519DeriveRawSecretAgreement)
+    DllImportEntry(AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes)
     DllImportEntry(AppleCryptoNative_X25519ExportPrivateKey)
     DllImportEntry(AppleCryptoNative_X25519ExportPublicKey)
     DllImportEntry(AppleCryptoNative_X25519ImportPrivateKey)

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.h
@@ -26,6 +26,7 @@ EXTERN_C void* AppleCryptoNative_DigestReset;
 EXTERN_C void* AppleCryptoNative_DigestClone;
 
 EXTERN_C void* AppleCryptoNative_X25519DeriveRawSecretAgreement;
+EXTERN_C void* AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes;
 EXTERN_C void* AppleCryptoNative_X25519ExportPrivateKey;
 EXTERN_C void* AppleCryptoNative_X25519ExportPublicKey;
 EXTERN_C void* AppleCryptoNative_X25519FreeKey;

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.swift
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_swiftbindings.swift
@@ -561,6 +561,28 @@ public func AppleCryptoNative_DigestCurrent(ctx: UnsafeMutableRawPointer?, pOutp
 //   0: key agreement failed (e.g. peer is a low-order point and the shared
 //      secret would be all-zero; CryptoKit raises an error)
 //  -1: invalid arguments or unexpected error
+private func deriveRawSecretAgreement(
+    key: Curve25519.KeyAgreement.PrivateKey,
+    peerKey: Curve25519.KeyAgreement.PublicKey,
+    pOutput: UnsafeMutablePointer<UInt8>,
+    cbOutput: Int32) -> Int32 {
+    let destination = UnsafeMutableRawBufferPointer(start: pOutput, count: Int(cbOutput))
+
+    guard let sharedSecret = try? key.sharedSecretFromKeyAgreement(with: peerKey) else {
+        return 0
+    }
+
+    let copied = sharedSecret.withUnsafeBytes { rawSecret in
+        return rawSecret.copyBytes(to: destination) == rawSecret.count
+    }
+
+    if (!copied) {
+        return -1
+    }
+
+    return 1
+}
+
 @_silgen_name("AppleCryptoNative_X25519DeriveRawSecretAgreement")
 public func AppleCryptoNative_X25519DeriveRawSecretAgreement(
     keyPtr: UnsafeMutableRawPointer?,
@@ -579,21 +601,33 @@ public func AppleCryptoNative_X25519DeriveRawSecretAgreement(
     }
 
     let peerKey = peerBox.value.getPublic()
-    let destination = UnsafeMutableRawBufferPointer(start: pOutput, count: Int(cbOutput))
+    return deriveRawSecretAgreement(key: key, peerKey: peerKey, pOutput: pOutput, cbOutput: cbOutput)
+}
 
-    guard let sharedSecret = try? key.sharedSecretFromKeyAgreement(with: peerKey) else {
-        return 0
-    }
-
-    let copied = sharedSecret.withUnsafeBytes { rawSecret in
-        return rawSecret.copyBytes(to: destination) == rawSecret.count
-    }
-
-    if (!copied) {
+@_silgen_name("AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes")
+public func AppleCryptoNative_X25519DeriveRawSecretAgreementWithBytes(
+    keyPtr: UnsafeMutableRawPointer?,
+    peerKeyPtr: UnsafeMutableRawPointer?,
+    cbPeerKey: Int32,
+    pOutput: UnsafeMutablePointer<UInt8>?,
+    cbOutput: Int32) -> Int32 {
+    guard let keyPtr, let peerKeyPtr, let pOutput else {
         return -1
     }
 
-    return 1
+    let keyBox = Unmanaged<X25519KeyBox>.fromOpaque(keyPtr).takeUnretainedValue()
+
+    guard case .privateKey(let key) = keyBox.value else {
+        return -1
+    }
+
+    let source = Data(bytesNoCopy: peerKeyPtr, count: Int(cbPeerKey), deallocator: Data.Deallocator.none)
+
+    guard let peerKey = try? Curve25519.KeyAgreement.PublicKey.init(rawRepresentation: source) else {
+        return -1
+    }
+
+    return deriveRawSecretAgreement(key: key, peerKey: peerKey, pOutput: pOutput, cbOutput: cbOutput)
 }
 
 @_silgen_name("AppleCryptoNative_X25519FreeKey")

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -422,6 +422,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslWrite)
     DllImportEntry(CryptoNative_Tls13Supported)
     DllImportEntry(CryptoNative_X25519Available)
+    DllImportEntry(CryptoNative_X25519DeriveSecretAgreementWithPublicKey)
     DllImportEntry(CryptoNative_X25519ExportPrivateKey)
     DllImportEntry(CryptoNative_X25519ExportPublicKey)
     DllImportEntry(CryptoNative_X25519GenerateKey)

--- a/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
+++ b/src/native/libs/System.Security.Cryptography.Native/entrypoints.c
@@ -422,7 +422,7 @@ static const Entry s_cryptoNative[] =
     DllImportEntry(CryptoNative_SslWrite)
     DllImportEntry(CryptoNative_Tls13Supported)
     DllImportEntry(CryptoNative_X25519Available)
-    DllImportEntry(CryptoNative_X25519DeriveSecretAgreementWithPublicKey)
+    DllImportEntry(CryptoNative_X25519DeriveSecretAgreementWithBytes)
     DllImportEntry(CryptoNative_X25519ExportPrivateKey)
     DllImportEntry(CryptoNative_X25519ExportPublicKey)
     DllImportEntry(CryptoNative_X25519GenerateKey)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #include "pal_evp_pkey.h"
+#include "pal_evp_pkey_ecdh.h"
 #include "pal_evp_pkey_x25519.h"
 #include "pal_utilities.h"
 #include "openssl.h"
@@ -118,6 +119,30 @@ EVP_PKEY* CryptoNative_X25519ImportPublicKey(const uint8_t* source, int32_t sour
         NULL,
         source,
         Int32ToSizeT(sourceLength));
+}
+
+int32_t CryptoNative_X25519DeriveSecretAgreementWithPublicKey(EVP_PKEY* pkey,
+                                                              void* extraHandle,
+                                                              const uint8_t* peerKey,
+                                                              int32_t peerKeyLength,
+                                                              uint8_t* secret,
+                                                              uint32_t secretLength)
+{
+    if (pkey == NULL || peerKey == NULL || peerKeyLength <= 0 || secret == NULL || secretLength == 0)
+    {
+        return 0;
+    }
+
+    EVP_PKEY* peerPKey = CryptoNative_X25519ImportPublicKey(peerKey, peerKeyLength);
+
+    if (peerPKey == NULL)
+    {
+        return 0;
+    }
+
+    int32_t ret = CryptoNative_EvpPKeyDeriveSecretAgreement(pkey, extraHandle, peerPKey, secret, secretLength);
+    EVP_PKEY_free(peerPKey);
+    return ret;
 }
 
 int32_t CryptoNative_X25519IsValidHandle(const EVP_PKEY* key, int32_t* hasPrivateKey)

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.c
@@ -121,12 +121,12 @@ EVP_PKEY* CryptoNative_X25519ImportPublicKey(const uint8_t* source, int32_t sour
         Int32ToSizeT(sourceLength));
 }
 
-int32_t CryptoNative_X25519DeriveSecretAgreementWithPublicKey(EVP_PKEY* pkey,
-                                                              void* extraHandle,
-                                                              const uint8_t* peerKey,
-                                                              int32_t peerKeyLength,
-                                                              uint8_t* secret,
-                                                              uint32_t secretLength)
+int32_t CryptoNative_X25519DeriveSecretAgreementWithBytes(EVP_PKEY* pkey,
+                                                          void* extraHandle,
+                                                          const uint8_t* peerKey,
+                                                          int32_t peerKeyLength,
+                                                          uint8_t* secret,
+                                                          uint32_t secretLength)
 {
     if (pkey == NULL || peerKey == NULL || peerKeyLength <= 0 || secret == NULL || secretLength == 0)
     {

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
@@ -41,6 +41,18 @@ Returns the new EVP_PKEY on success, NULL on failure.
 PALEXPORT EVP_PKEY* CryptoNative_X25519ImportPublicKey(const uint8_t* source, int32_t sourceLength);
 
 /*
+Derives an X25519 secret agreement with a raw peer public key.
+
+Returns the number of bytes written on success, 0 on failure.
+*/
+PALEXPORT int32_t CryptoNative_X25519DeriveSecretAgreementWithPublicKey(EVP_PKEY* pkey,
+                                                                        void* extraHandle,
+                                                                        const uint8_t* peerKey,
+                                                                        int32_t peerKeyLength,
+                                                                        uint8_t* secret,
+                                                                        uint32_t secretLength);
+
+/*
 Generates a new X25519 key pair and returns it as an EVP_PKEY.
 
 Returns the new EVP_PKEY on success, NULL on failure.

--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_pkey_x25519.h
@@ -45,12 +45,12 @@ Derives an X25519 secret agreement with a raw peer public key.
 
 Returns the number of bytes written on success, 0 on failure.
 */
-PALEXPORT int32_t CryptoNative_X25519DeriveSecretAgreementWithPublicKey(EVP_PKEY* pkey,
-                                                                        void* extraHandle,
-                                                                        const uint8_t* peerKey,
-                                                                        int32_t peerKeyLength,
-                                                                        uint8_t* secret,
-                                                                        uint32_t secretLength);
+PALEXPORT int32_t CryptoNative_X25519DeriveSecretAgreementWithBytes(EVP_PKEY* pkey,
+                                                                    void* extraHandle,
+                                                                    const uint8_t* peerKey,
+                                                                    int32_t peerKeyLength,
+                                                                    uint8_t* secret,
+                                                                    uint32_t secretLength);
 
 /*
 Generates a new X25519 key pair and returns it as an EVP_PKEY.


### PR DESCRIPTION
Contributes to #128040.

This introduces a `DeriveRawSecretAgreement` that does key agreement with the other party's key as a sequence of bytes instead of forcing creating the instance of `X25519DiffieHellman`. This reduces allocations in the typical use case of X25519.