### PR TITLE
Increase sccache cache size to 5 GiB

### DIFF
--- a/eng/pipelines/coreclr/templates/setup-sccache.yml
+++ b/eng/pipelines/coreclr/templates/setup-sccache.yml
@@ -43,7 +43,7 @@ steps:
         chmod +x "$sccacheDir/sccache"
         echo "##vso[task.prependpath]$sccacheDir"
         echo "##vso[task.setvariable variable=SCCACHE_DIR]$(Pipeline.Workspace)/.sccache"
-        echo "##vso[task.setvariable variable=SCCACHE_CACHE_SIZE]3584M"
+        echo "##vso[task.setvariable variable=SCCACHE_CACHE_SIZE]5120M"
         echo "##vso[task.setvariable variable=SCCACHE_IDLE_TIMEOUT]0"
         echo "##vso[task.setvariable variable=USE_SCCACHE]true"
       displayName: Download and configure sccache


### PR DESCRIPTION
> [!NOTE]
> This PR was created with Copilot assistance.

The 3.5 GiB limit (3584M) was causing sccache to evict useful entries, dropping the hit rate from ~97% to ~89%. The full working set for a native build is around 7-8 GiB. Bumping to 5 GiB (5120M) should recover most of the hit rate.

With `continueOnError` on the Cache task (#128052), any disk space issues during upload will no longer fail the build, so the risk of a larger cache is mitigated.