### PR TITLE
Port more coreclr holders to the LifetimeHolder<Traits> pattern

### DIFF
--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -1071,20 +1071,16 @@ void CordbModule::CopyRemoteMetaData(
 
     // Allocate space for the local copy of the metadata
     // No need to zero out the memory since we'll fill it all here.
-    LPVOID pRawBuffer = CoTaskMemAlloc(buffer.cbSize);
-    if (pRawBuffer == NULL)
+    CoTaskMemHolder<BYTE> pBuffer{ (BYTE*)CoTaskMemAlloc(buffer.cbSize) };
+    if (pBuffer == NULL)
     {
         ThrowOutOfMemory();
     }
 
-    *pLocalBuffer = pRawBuffer;
-
-
-
     // Copy the metadata from the left side
-    GetProcess()->SafeReadBuffer(buffer, (BYTE *)pRawBuffer);
+    GetProcess()->SafeReadBuffer(buffer, pBuffer);
 
-    return;
+    *pLocalBuffer = pBuffer.Detach();
 }
 
 HRESULT CordbModule::QueryInterface(REFIID id, void **pInterface)

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -928,7 +928,7 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
     // copy it over from the remote process
 
     CoTaskMemHolder<VOID> pMetaDataCopy;
-    CopyRemoteMetaData(buffer, pMetaDataCopy.GetAddr());
+    CopyRemoteMetaData(buffer, &pMetaDataCopy);
 
 
     //
@@ -955,7 +955,7 @@ void CordbModule::InitPublicMetaData(TargetBuffer buffer)
                                   reinterpret_cast<IUnknown**>( &m_pIMImport ));
 
     // MetaData has taken ownership -don't free the memory
-    pMetaDataCopy.SuppressRelease();
+    pMetaDataCopy.Detach();
 
     // Immediately restore the old setting.
     HRESULT hrRestore = pDisp->SetOption(MetaDataSetUpdate, &valueOld);
@@ -1009,7 +1009,7 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
 
     // First copy it from the remote process
     CoTaskMemHolder<VOID> pLocalMetaDataPtr;
-    CopyRemoteMetaData(bufferRemoteMetaData, pLocalMetaDataPtr.GetAddr());
+    CopyRemoteMetaData(bufferRemoteMetaData, &pLocalMetaDataPtr);
 
     IMetaDataDispenserEx *  pDisp = GetProcess()->GetDispenser();
     _ASSERTE(pDisp != NULL); // throws on error.
@@ -1037,7 +1037,7 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
     IfFailThrow(hr);
 
     // Success.  MetaData now owns the metadata memory
-    pLocalMetaDataPtr.SuppressRelease();
+    pLocalMetaDataPtr.Detach();
 }
 
 //---------------------------------------------------------------------------------------
@@ -1058,7 +1058,7 @@ void CordbModule::UpdatePublicMetaDataFromRemote(TargetBuffer bufferRemoteMetaDa
 //    Uses an allocator (CoTaskMemHolder) that lets us hand off the memory to the metadata.
 void CordbModule::CopyRemoteMetaData(
     TargetBuffer buffer,
-    CoTaskMemHolder<VOID> * pLocalBuffer)
+    VOID** pLocalBuffer)
 {
     CONTRACTL
     {
@@ -1077,7 +1077,7 @@ void CordbModule::CopyRemoteMetaData(
         ThrowOutOfMemory();
     }
 
-    pLocalBuffer->Assign(pRawBuffer);
+    *pLocalBuffer = pRawBuffer;
 
 
 

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -665,7 +665,7 @@ CordbProcess::CreateDacDbiInterface()
     // same directory as DBI
     if (m_hDacModule == NULL)
     {
-        m_hDacModule.Assign(ShimProcess::GetDacModule(m_cordb->GetDacModulePath()));
+        m_hDacModule = ShimProcess::GetDacModule(m_cordb->GetDacModulePath());
     }
 
     //
@@ -1541,7 +1541,7 @@ void CordbProcess::FreeDac()
     if (m_hDacModule != NULL)
     {
         LOG((LF_CORDB, LL_INFO1000, "Unloading DAC\n"));
-        m_hDacModule.Clear();
+        m_hDacModule.Free();
     }
 }
 

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -4298,7 +4298,7 @@ private:
     BOOL IsFileMetaDataValid();
 
     // Helper to copy metadata buffer from the Target to the host.
-    void CopyRemoteMetaData(TargetBuffer buffer, CoTaskMemHolder<VOID> * pLocalBuffer);
+    void CopyRemoteMetaData(TargetBuffer buffer, VOID** pLocalBuffer);
 
 
     CordbAssembly * ResolveAssemblyInternal(mdToken tkAssemblyRef);
@@ -6752,11 +6752,11 @@ typedef std::function<HRESULT(DWORD index, ICorDebugValue** ppValue)> ValueGette
 class CordbValueEnum : public CordbBase, public ICorDebugValueEnum
 {
 public:
-    CordbValueEnum(CordbProcess* pProcess, 
-                   UINT maxCount, 
+    CordbValueEnum(CordbProcess* pProcess,
+                   UINT maxCount,
                    ValueGetter valueGetter,
                    NeuterList* pNeuterList);
-    
+
     virtual ~CordbValueEnum();
     virtual void Neuter();
 

--- a/src/coreclr/inc/ex.h
+++ b/src/coreclr/inc/ex.h
@@ -281,85 +281,18 @@ protected:
     virtual Exception *DomainBoundCloneHelper() { return CloneHelper(); }
 };
 
-#if 1
-
-inline void Exception__Delete(Exception* pvMemory)
+struct ExceptionTraits final
 {
-  Exception::Delete(pvMemory);
-}
-
-using ExceptionHolder = SpecializedWrapper<Exception, Exception__Delete>;
-#else
-
-//------------------------------------------------------------------------------
-// class ExceptionHolder
-//
-// This is a very lightweight holder class for use inside the EX_TRY family
-//  of macros.  It is based on the standard Holder classes, but has been
-//  highly specialized for this one function, so that extra code can be
-//  removed, and the resulting code can be simple enough for all of the
-//  non-exceptional-case code to be inlined.
-class ExceptionHolder
-{
-private:
-    Exception *m_value;
-    BOOL      m_acquired;
-
-public:
-    FORCEINLINE ExceptionHolder(Exception *pException = NULL, BOOL take = TRUE)
-      : m_value(pException)
+    using Type = Exception*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type value)
     {
-        m_acquired = pException && take;
+        STATIC_CONTRACT_WRAPPER;
+        Exception::Delete(value);
     }
-
-    FORCEINLINE ~ExceptionHolder()
-    {
-        if (m_acquired)
-        {
-            Exception::Delete(m_value);
-        }
-    }
-
-    Exception* operator->() { return m_value; }
-
-    void operator=(Exception *p)
-    {
-        Release();
-        m_value = p;
-        Acquire();
-    }
-
-    BOOL IsNull() { return m_value == NULL; }
-
-    operator Exception*() { return m_value; }
-
-    Exception* GetValue() { return m_value; }
-
-    void SuppressRelease() { m_acquired = FALSE; }
-
-private:
-    void Acquire()
-    {
-        _ASSERTE(!m_acquired);
-
-        if (!IsNull())
-        {
-            m_acquired = TRUE;
-        }
-    }
-    void Release()
-    {
-        if (m_acquired)
-        {
-            _ASSERTE(!IsNull());
-            Exception::Delete(m_value);
-            m_acquired = FALSE;
-        }
-    }
-
 };
 
-#endif
+using ExceptionHolder = LifetimeHolder<ExceptionTraits>;
 
 // ---------------------------------------------------------------------------
 // HRException class.  Implements exception API for exceptions generated from HRESULTs
@@ -934,13 +867,13 @@ Exception *ExThrowWithInnerHelper(Exception *inner);
 
 #define EX_RETHROW                                                                      \
         {                                                                               \
-            __pException.SuppressRelease();                                             \
+            __pException.Detach();                                                      \
             PAL_CPP_RETHROW;                                                            \
         }                                                                               \
 
  // Define a copy of GET_EXCEPTION() that will not be redefined by clrex.h
-#define GET_EXCEPTION() (__pException == NULL ? &__defaultException : __pException.GetValue())
-#define EXTRACT_EXCEPTION() (__pException.Extract())
+#define GET_EXCEPTION() (__pException == NULL ? &__defaultException : static_cast<Exception*>(__pException))
+#define EXTRACT_EXCEPTION() (__pException.Detach())
 
 
 //==============================================================================

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -1054,10 +1054,6 @@ typedef Wrapper<HANDLE, DoNothing<HANDLE>, VoidCloseHandle, (UINT_PTR) -1> Handl
 // Misc holders
 //-----------------------------------------------------------------------------
 
-// A holder for HMODULE.
-FORCEINLINE void HolderFreeLibrary(HMODULE h) { FreeLibrary(h); }
-typedef Wrapper<HMODULE, DoNothing<HMODULE>, HolderFreeLibrary, 0> HModuleHolder;
-
 template<typename T>
 class LifetimeHolder final
 {
@@ -1166,6 +1162,21 @@ struct LocalAllocTraits final
 
 template<typename T>
 using LocalAllocHolder = LifetimeHolder<LocalAllocTraits<T>>;
+
+// A holder for HMODULE.
+struct HModuleTraits final
+{
+    using Type = HMODULE;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type h)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (h != NULL)
+            ::FreeLibrary(h);
+    }
+};
+
+using HModuleHolder = LifetimeHolder<HModuleTraits>;
 
 //
 // We need the following methods to have volatile arguments, so that they can accept

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -1000,46 +1000,6 @@ protected:
 
 
 //-----------------------------------------------------------------------------
-// ResetPointerHolder : pointer which needs to be set to NULL
-//  {
-//      ResetPointerHolder<Foo> holder = &pFoo;
-//  } // "*pFoo=NULL" on out of scope
-//-----------------------------------------------------------------------------
-#ifdef __GNUC__
-// With -fvisibility-inlines-hidden, the Invoke methods below
-// get hidden, which causes warnings when visible classes expose them.
-#define VISIBLE __attribute__ ((visibility("default")))
-#else
-#define VISIBLE
-#endif // __GNUC__
-
-namespace detail
-{
-    template <typename T>
-    struct ZeroMem
-    {
-        static VISIBLE void Invoke(T * pVal)
-        {
-            ZeroMemory(pVal, sizeof(T));
-        }
-    };
-
-    template <typename T>
-    struct ZeroMem<T*>
-    {
-        static VISIBLE void Invoke(T ** pVal)
-        {
-            *pVal = NULL;
-        }
-    };
-
-}
-#undef VISIBLE
-
-template<typename _TYPE>
-using ResetPointerHolder = SpecializedWrapper<_TYPE, detail::ZeroMem<_TYPE>::Invoke>;
-
-//-----------------------------------------------------------------------------
 // Wrap win32 functions using HANDLE
 //-----------------------------------------------------------------------------
 
@@ -1177,6 +1137,37 @@ struct HModuleTraits final
 };
 
 using HModuleHolder = LifetimeHolder<HModuleTraits>;
+
+//-----------------------------------------------------------------------------
+// ResetPointerHolder : pointer which needs to be set to NULL (or zeroed) on
+// scope exit. The holder stores the address of the slot to clear; on Free it
+// nulls the pointer (for pointer T) or zeroes the storage (for non-pointer T).
+//
+//  {
+//      ResetPointerHolder<Foo*> holder{ &pFoo };
+//  } // "pFoo = NULL" on out of scope
+//-----------------------------------------------------------------------------
+template<typename T>
+struct ResetPointerTraits final
+{
+    using Type = T*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type p)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (p == NULL)
+            return;
+
+        // If T is a pointer type, we set the pointer to NULL. If T is a non-pointer type, we zero the memory.
+        if constexpr (std::is_pointer<T>::value)
+            *p = NULL;
+        else
+            ZeroMemory(p, sizeof(T));
+    }
+};
+
+template<typename T>
+using ResetPointerHolder = LifetimeHolder<ResetPointerTraits<T>>;
 
 //
 // We need the following methods to have volatile arguments, so that they can accept

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -883,24 +883,6 @@ template<typename _TYPE>
 using StubHolder = SpecializedWrapper<_TYPE, StubRelease<_TYPE>>;
 
 //-----------------------------------------------------------------------------
-// CoTaskMemHolder : CoTaskMemAlloc allocated memory holder
-//
-//  {
-//      CoTaskMemHolder<Foo> foo = (Foo*) CoTaskMemAlloc(sizeof(Foo));
-//  } // delete foo on out of scope
-//-----------------------------------------------------------------------------
-
-template <typename TYPE>
-FORCEINLINE void DeleteCoTaskMem(TYPE *value)
-{
-    if (value)
-        CoTaskMemFree(value);
-}
-
-template<typename _TYPE>
-using CoTaskMemHolder = SpecializedWrapper<_TYPE, DeleteCoTaskMem<_TYPE>>;
-
-//-----------------------------------------------------------------------------
 // NewHolder : New'ed memory holder
 //
 //  {
@@ -1168,6 +1150,29 @@ struct ResetPointerTraits final
 
 template<typename T>
 using ResetPointerHolder = LifetimeHolder<ResetPointerTraits<T>>;
+
+//-----------------------------------------------------------------------------
+// CoTaskMemHolder : holder for memory allocated by ::CoTaskMemAlloc.
+//
+//  {
+//      CoTaskMemHolder<Foo> foo{ (Foo*)::CoTaskMemAlloc(sizeof(Foo)) };
+//  } // ::CoTaskMemFree(foo) on out of scope
+//-----------------------------------------------------------------------------
+template<typename T>
+struct CoTaskMemTraits final
+{
+    using Type = T*;
+    static constexpr Type Default() { return NULL; }
+    static void Free(Type value)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (value != NULL)
+            ::CoTaskMemFree(value);
+    }
+};
+
+template<typename T>
+using CoTaskMemHolder = LifetimeHolder<CoTaskMemTraits<T>>;
 
 //
 // We need the following methods to have volatile arguments, so that they can accept

--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -844,45 +844,6 @@ template<typename _TYPE>
 using ReleaseHolder = SpecializedWrapper<_TYPE, DoTheRelease<_TYPE>>;
 
 //-----------------------------------------------------------------------------
-// StubHolder : holder for stubs
-//
-// Usage example:
-//
-//  {
-//      StubHolder<Stub> foo;
-//      foo = new Stub();
-//      foo->AddRef();
-//      // Note StubHolder doesn't call AddRef for you.
-//  } // foo->DecRef() on out of scope
-//
-//-----------------------------------------------------------------------------
-
-template<typename _TYPE>
-class ExecutableWriterHolderNoLog;
-
-class ExecutableAllocator;
-
-template <typename TYPE, typename LOGGER=ExecutableAllocator>
-FORCEINLINE void StubRelease(TYPE* value)
-{
-    if (value)
-    {
-#ifdef LOG_EXECUTABLE_ALLOCATOR_STATISTICS
-#ifdef HOST_UNIX
-        LOGGER::LogUsage(__FILE__, __LINE__, __PRETTY_FUNCTION__);
-#else
-        LOGGER::LogUsage(__FILE__, __LINE__, __FUNCTION__);
-#endif
-#endif // LOG_EXECUTABLE_ALLOCATOR_STATISTICS
-        ExecutableWriterHolderNoLog<TYPE> stubWriterHolder(value, sizeof(TYPE));
-        stubWriterHolder.GetRW()->DecRef();
-    }
-}
-
-template<typename _TYPE>
-using StubHolder = SpecializedWrapper<_TYPE, StubRelease<_TYPE>>;
-
-//-----------------------------------------------------------------------------
 // NewHolder : New'ed memory holder
 //
 //  {
@@ -1173,6 +1134,53 @@ struct CoTaskMemTraits final
 
 template<typename T>
 using CoTaskMemHolder = LifetimeHolder<CoTaskMemTraits<T>>;
+
+//-----------------------------------------------------------------------------
+// StubHolder : holder for runtime-emitted Stub-like objects.
+// On scope exit, calls DecRef through the executable-memory
+// writer-holder so the refcount field can be written.
+//
+// Note: StubHolder does NOT call IncRef on assignment - the caller owns
+// matching IncRef/DecRef pairing on the value it hands to the holder.
+//
+// Usage example:
+//
+//  {
+//      StubHolder<Stub> foo;
+//      foo = new Stub();
+//      foo->AddRef();
+//  } // foo->DecRef() on out of scope
+//-----------------------------------------------------------------------------
+template<typename T>
+class ExecutableWriterHolderNoLog;
+
+class ExecutableAllocator;
+
+template<typename T>
+struct StubTraits final
+{
+    using Type = T*;
+    static constexpr Type Default() { return nullptr; }
+    static void Free(Type value)
+    {
+        STATIC_CONTRACT_WRAPPER;
+        if (value != nullptr)
+        {
+#ifdef LOG_EXECUTABLE_ALLOCATOR_STATISTICS
+#ifdef HOST_UNIX
+            ExecutableAllocator::LogUsage(__FILE__, __LINE__, __PRETTY_FUNCTION__);
+#else
+            ExecutableAllocator::LogUsage(__FILE__, __LINE__, __FUNCTION__);
+#endif
+#endif // LOG_EXECUTABLE_ALLOCATOR_STATISTICS
+            ExecutableWriterHolderNoLog<T> stubWriterHolder(value, sizeof(T));
+            stubWriterHolder.GetRW()->DecRef();
+        }
+    }
+};
+
+template<typename T>
+using StubHolder = LifetimeHolder<StubTraits<T>>;
 
 //
 // We need the following methods to have volatile arguments, so that they can accept

--- a/src/coreclr/utilcode/util.cpp
+++ b/src/coreclr/utilcode/util.cpp
@@ -255,7 +255,7 @@ namespace
         _ASSERTE(wszDllPath != nullptr);
 
         // We've got the name of the DLL to load, so load it.
-        HModuleHolder hDll = WszLoadLibrary(wszDllPath, nullptr, GetLoadWithAlteredSearchPathFlag());
+        HModuleHolder hDll{ WszLoadLibrary(wszDllPath, nullptr, GetLoadWithAlteredSearchPathFlag()) };
         if (hDll == nullptr)
             return HRESULT_FROM_GetLastError();
 
@@ -267,10 +267,10 @@ namespace
         // Call the function to get a class object for the rclsid and riid passed in.
         IfFailRet(dllGetClassObject(rclsid, riid, ppv));
 
-        hDll.SuppressRelease();
+        HMODULE hLoadedDll = hDll.Detach();
 
         if (phmodDll != nullptr)
-            *phmodDll = hDll.GetValue();
+            *phmodDll = hLoadedDll;
 
         return hr;
     }
@@ -334,11 +334,11 @@ HRESULT FakeCoCreateInstanceEx(REFCLSID       rclsid,
     // necessary object.
     IfFailRet(classFactory->CreateInstance(NULL, riid, ppv));
 
-    hDll.SuppressRelease();
+    HMODULE hLoadedDll = hDll.Detach();
 
     if (phmodDll != NULL)
     {
-        *phmodDll = hDll.GetValue();
+        *phmodDll = hLoadedDll;
     }
 
     return hr;

--- a/src/coreclr/vm/clrex.h
+++ b/src/coreclr/vm/clrex.h
@@ -754,7 +754,7 @@ class EEFileLoadException : public EEException
 #if defined(_DEBUG)
   // Redefine GET_EXCEPTION to validate CLRLastThrownObjectException as much as possible.
   #undef GET_EXCEPTION
-  #define GET_EXCEPTION() (__pException == NULL ? __defaultException.Validate() : __pException)
+  #define GET_EXCEPTION() (__pException == NULL ? __defaultException.Validate() : static_cast<Exception*>(__pException))
 #endif // _DEBUG
 
 LONG CLRNoCatchHandler(EXCEPTION_POINTERS* pExceptionInfo, PVOID pv);

--- a/src/coreclr/vm/clrex.h
+++ b/src/coreclr/vm/clrex.h
@@ -754,7 +754,7 @@ class EEFileLoadException : public EEException
 #if defined(_DEBUG)
   // Redefine GET_EXCEPTION to validate CLRLastThrownObjectException as much as possible.
   #undef GET_EXCEPTION
-  #define GET_EXCEPTION() (__pException == NULL ? __defaultException.Validate() : __pException.GetValue())
+  #define GET_EXCEPTION() (__pException == NULL ? __defaultException.Validate() : __pException)
 #endif // _DEBUG
 
 LONG CLRNoCatchHandler(EXCEPTION_POINTERS* pExceptionInfo, PVOID pv);
@@ -811,8 +811,8 @@ LONG CLRNoCatchHandler(EXCEPTION_POINTERS* pExceptionInfo, PVOID pv);
             /* a findstr /n will allow you to locate it in a pinch */                   \
             STRESS_LOG1(LF_EH, LL_INFO100,                                              \
                 "EX_RETHROW " INDEBUG(__FILE__) " line %d\n", __LINE__);                \
-            __pException.SuppressRelease();                                             \
-            if ((!__state.DidCatchCxx()) && (GetThreadNULLOk() != NULL))                      \
+            __pException.Detach();                                                      \
+            if ((!__state.DidCatchCxx()) && (GetThreadNULLOk() != NULL))                \
             {                                                                           \
                 if (GetThread()->PreemptiveGCDisabled())                                \
                 {                                                                       \

--- a/src/coreclr/vm/eetoprofinterfaceimpl.cpp
+++ b/src/coreclr/vm/eetoprofinterfaceimpl.cpp
@@ -683,8 +683,7 @@ HRESULT EEToProfInterfaceImpl::CreateProfiler(
     // belongs to this class, so NULL out locals without allowing them to release
     m_pCallback2 = pCallback2.Extract();
     pCallback2 = NULL;
-    m_hmodProfilerDLL = hmodProfilerDLL.Extract();
-    hmodProfilerDLL = NULL;
+    m_hmodProfilerDLL = hmodProfilerDLL.Detach();
 
     // ATTENTION: Please update EEToProfInterfaceImpl::~EEToProfInterfaceImpl() after adding the next ICorProfilerCallback interface here !!!
 

--- a/src/coreclr/vm/stubcache.cpp
+++ b/src/coreclr/vm/stubcache.cpp
@@ -86,6 +86,7 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
 
     STUBHASHENTRY *phe = NULL;
 
+    StubHolder<Stub> pstub;
     {
         CrstHolder ch(&m_crst);
 
@@ -93,15 +94,13 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
         phe = (STUBHASHENTRY*)Find((LPVOID)pRawStub);
         if (phe)
         {
-            StubHolder<Stub> pstub;
             pstub = phe->m_pStub;
 
             ExecutableWriterHolder<Stub> stubWriterHolder(pstub, sizeof(Stub));
             // IncRef as we're returning a reference to our caller.
             stubWriterHolder.GetRW()->IncRef();
 
-            pstub.SuppressRelease();
-            RETURN pstub;
+            RETURN pstub.Detach();
         }
     }
 
@@ -114,7 +113,6 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
     // and link up the stub.
     CodeLabel *plabel = psl->EmitNewCodeLabel();
     psl->EmitBytes(pRawStub, Length(pRawStub));
-    StubHolder<Stub> pstub;
     pstub = psl->Link(m_heap, linkFlags, stubType);
     UINT32 offset = psl->GetLabelOffset(plabel);
 
@@ -162,8 +160,7 @@ Stub *StubCacheBase::Canonicalize(const BYTE * pRawStub, const char *stubType)
         COMPlusThrowOM();
     }
 
-    pstub.SuppressRelease();
-    RETURN pstub;
+    RETURN pstub.Detach();
 }
 
 

--- a/src/coreclr/vm/stublink.cpp
+++ b/src/coreclr/vm/stublink.cpp
@@ -571,10 +571,10 @@ Stub *StubLinker::Link(LoaderHeap *pHeap, DWORD flags, const char *stubType)
 
     _ASSERTE(!pHeap || pHeap->IsExecutable());
 
-    StubHolder<Stub> pStub = Stub::NewStub(
+    StubHolder<Stub> pStub{ Stub::NewStub(
                 pHeap,
                 size,
-                flags);
+                flags) };
     ASSERT(pStub != NULL);
 
     EmitStub(pStub, globalsize, size, pHeap);
@@ -583,7 +583,7 @@ Stub *StubLinker::Link(LoaderHeap *pHeap, DWORD flags, const char *stubType)
     PerfMap::LogStubs(__FUNCTION__, stubType, pStub->GetEntryPoint(), pStub->GetNumCodeBytes(), PerfMapStubType::Individual);
 #endif
 
-    return pStub.Extract();
+    return pStub.Detach();
 }
 
 int StubLinker::CalculateSize(int* pGlobalSize)

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -1620,8 +1620,7 @@ BOOL Thread::HasStarted()
     {
         if (__pException != NULL)
         {
-            __pException.SuppressRelease();
-            m_pExceptionDuringStartup = __pException;
+            m_pExceptionDuringStartup = __pException.Detach();
         }
         res = FALSE;
     }


### PR DESCRIPTION
Continues the migration of legacy `Holder`/`Wrapper`/`SpecializedWrapper`-based resource holders under `src/coreclr/` to the newer `LifetimeHolder<Traits>` pattern (matches the shape already established by `MapViewHolder`, `LocalAllocHolder`, `HKEYHolder`, `BSTRHolder`).

Each commit ports one holder, in isolation, with the call-site updates required for the new API.

## Commits

1. **`HModuleHolder`** — `Wrapper<HMODULE, ...>` → `LifetimeHolder<HModuleTraits>`
   - 3 call sites updated (`vm/eetoprofinterfaceimpl.cpp`, `debug/di/rspriv.h`/`process.cpp`, `utilcode/util.cpp`)

2. **`ResetPointerHolder`** — `SpecializedWrapper<_TYPE, detail::ZeroMem<_TYPE>::Invoke>` → `LifetimeHolder<ResetPointerTraits<T>>`
   - The two `ZeroMem` partial specializations collapse into a single `Free()` using `if constexpr (std::is_pointer<T>::value)`
   - Removes the local `VISIBLE` macro and `detail::ZeroMem` helpers
   - No call-site changes (all 3 call sites use direct-init)

3. **`CoTaskMemHolder`** — `SpecializedWrapper<_TYPE, DeleteCoTaskMem<_TYPE>>` → `LifetimeHolder<CoTaskMemTraits<T>>`
   - `DeleteCoTaskMem` helper removed
   - 5 call-site updates in `debug/di/module.cpp`

4. **`StubHolder`** — `SpecializedWrapper<_TYPE, StubRelease<_TYPE>>` → `LifetimeHolder<StubTraits<T>>`
   - Call-site updates in `vm/stublink.cpp` and `vm/stubcache.cpp`

5. **`ExceptionHolder`** — `SpecializedWrapper<Exception, Exception__Delete>` → `LifetimeHolder<ExceptionTraits>`
   - Removes the dead `#if 1 / #else / #endif` scaffold and the hand-rolled `class ExceptionHolder` in the dead branch
   - Removes the now-unused `Exception__Delete` inline helper
   - Updates `EX_TRY` macro internals in `inc/ex.h` (`EX_RETHROW`, `GET_EXCEPTION()`, `EXTRACT_EXCEPTION()`) and related call sites in `vm/clrex.h` / `vm/threads.cpp`

## Recurring API mapping

For reference, the legacy → `LifetimeHolder` mappings used throughout these commits:

| Legacy | LifetimeHolder |
|---|---|
| `Assign(v)` | `operator=(v)` |
| `Clear()` | `Free()` |
| `Extract()` | `Detach()` |
| `SuppressRelease() + GetValue()` | `Detach()` |
| `HolderType x = expr;` | `HolderType x{ expr };` (value ctor is `explicit`) |

> [!NOTE]
> The contents of this pull request were drafted with the assistance of GitHub Copilot.
