### PR TITLE
[Wasm] Add missing return buffer argument in wasm import thunks

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -196,6 +196,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 wasmLocalIndex++;
             }
 
+            if (hasRetBuffArg)
+            {
+                // FIXME: What do I do here?
+                wasmLocalIndex++;
+            }
+
             for (int i = 0; i < methodSignature.Length; i++)
             {
                 TypeDesc paramType = methodSignature[i];
@@ -306,7 +312,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Pass return buffer argument if needed
             if (hasRetBuffArg)
             {
-                expressions.Add(Local.Get(hasThis ? 1 : 0));
+                expressions.Add(Local.Get(wasmLocalIndex));
                 wasmLocalIndex++;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -306,7 +306,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             // Pass return buffer argument if needed
             if (hasRetBuffArg)
             {
-                expressions.Add(Local.Get(1));
+                expressions.Add(Local.Get(hasThis ? 1 : 0));
                 wasmLocalIndex++;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -198,7 +198,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             if (hasRetBuffArg)
             {
-                // FIXME: What do I do here?
                 wasmLocalIndex++;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/WasmImportThunk.cs
@@ -128,6 +128,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             int[] offsets = new int[methodSignature.Length];
             bool[] isIndirectStructArg = new bool[methodSignature.Length];
+            bool hasRetBuffArg = _wasmSignature.SignatureString[0] == 'S';
 
             int argIndex = 0;
             int argOffset;
@@ -299,6 +300,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 expressions.Add(Local.Get(0));
                 expressions.Add(I32.Load((ulong)transitionBlock.ThisOffset));
+                wasmLocalIndex++;
+            }
+
+            // Pass return buffer argument if needed
+            if (hasRetBuffArg)
+            {
+                expressions.Add(Local.Get(1));
                 wasmLocalIndex++;
             }
 


### PR DESCRIPTION
Fixes errors like
```
Failed to construct WebAssembly module for Webcil image: {
  wasmPath: '/Users/kg/AppData/Local/Temp/wasm-ryujit-runner/sandbox/IL/test-module.wasm',
  errorMessage: 'WebAssembly.Module(): Compiling function #39 failed: not enough arguments on the stack for call_indirect (need 3, got 2) @+8418'
}
Unhandled exception. System.BadImageFormatException: Bad IL format. The format of the file '/Users/kg/AppData/Local/Temp/wasm-ryujit-runner/sandbox/IL/test-module.wasm' is invalid.

#39 WasmDelayLoadHelper->EagerImports->SignaturePointer_ReadyToRunHelper_DelayLoad_MethodCall(ImportSection:MethodImports,Kind:DelayLoadHelper,Sig:S16p) ( i32, i32, i32 ) -> none (75 byte(s))
```

cc @davidwrighton @AndyAyersMS