### PR TITLE
Fix doubling of rental for PKCS#8 exports in PQC and X25519

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -2150,6 +2150,7 @@ namespace System.Security.Cryptography
 
             while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
             {
+                size = buffer.Length;
                 CryptoPool.Return(buffer);
                 size = checked(size * 2);
                 buffer = CryptoPool.Rent(size);

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -1804,6 +1804,7 @@ namespace System.Security.Cryptography
 
             while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
             {
+                size = buffer.Length;
                 CryptoPool.Return(buffer);
                 size = checked(size * 2);
                 buffer = CryptoPool.Rent(size);

--- a/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/SlhDsa.cs
@@ -1959,6 +1959,7 @@ namespace System.Security.Cryptography
 
             while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
             {
+                size = buffer.Length;
                 CryptoPool.Return(buffer);
                 size = checked(size * 2);
                 buffer = CryptoPool.Rent(size);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellman.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X25519DiffieHellman.cs
@@ -1375,6 +1375,7 @@ namespace System.Security.Cryptography
 
             while (!TryExportPkcs8PrivateKeyCore(buffer, out written))
             {
+                size = buffer.Length;
                 CryptoPool.Return(buffer);
                 size = checked(size * 2);
                 buffer = CryptoPool.Rent(size);


### PR DESCRIPTION
The `MLKem`, `MLDsa`, `SlhDsa`, and `X25519DiffieHellman` class had a small quirk with the way their PKCS#8 export work.

It would rent from the CryptoPool to create a buffer to populate, based on `size`. `Rent` is only guaranteed to return a buffer that is _at least_ large enough.

If the `TryExportPkcs8PrivateKeyCore` implementation returned `false`, indicating the buffer was too small, we would double the size and rent again. However, we double based on how much we last asked for, not how much we actually got back.

For example, CryptoPool.Rent would ask for 2592 bytes for ML-DSA-44, and sometimes CryptoPool would give it back an array that is 8192 bytes in size. The Core implementation would return false, indicating that the buffer is too small. The loop would then double it to 5184, and get 8192 back again. So the `TryExportPkcs8PrivateKeyCore` would be called with the same size multiple times in a row.

A unit test `ExportPkcs8PrivateKey_Resizes` exists to ensure that does not happen and that subsequent calls to TryExportPkcs8PrivateKeyCore are always given a larger buffer on the next call - and that test would sometimes fail.
 
Interestingly, `CompositeMLDsa` already has the fix

https://github.com/dotnet/runtime/blob/214a9a47ed90fba82582a43a29d706c2057d894a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLDsa.cs#L1890

So it needed no changes.

Fixes #128110