### PR TITLE
Fix NativeAOT dependent handle secondary access with standalone GC

### DIFF
--- a/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/HandleTableHelpers.cpp
@@ -36,14 +36,14 @@ FCIMPLEND
 FCIMPL2(Object *, RhHandleGetDependent, OBJECTHANDLE handle, Object **ppSecondary)
 {
     Object *pPrimary = ObjectFromHandle(handle);
-    *ppSecondary = (pPrimary != NULL) ? GetDependentHandleSecondary(handle) : NULL;
+    *ppSecondary = (pPrimary != NULL) ? GCHandleUtilities::GetGCHandleManager()->GetDependentHandleSecondary(handle) : NULL;
     return pPrimary;
 }
 FCIMPLEND
 
 FCIMPL2(void, RhHandleSetDependentSecondary, OBJECTHANDLE handle, Object *pSecondary)
 {
-    SetDependentHandleSecondary(handle, pSecondary);
+    GCHandleUtilities::GetGCHandleManager()->SetDependentHandleSecondary(handle, pSecondary);
 }
 FCIMPLEND
 


### PR DESCRIPTION
## Summary
 
 Fix NativeAOT dependent handle secondary get/set helpers to go through `IGCHandleManager` instead of the CoreCLR handle-table helper functions directly.
 
 `RhpHandleAllocDependent` already creates dependent handles through the active `IGCHandleManager`, which is required for standalone GC support. However, `RhHandleGetDependent` and 
`RhHandleSetDependentSecondary` accessed the secondary object through the CoreCLR global helpers:
 
 ```cpp
 GetDependentHandleSecondary(handle)
 SetDependentHandleSecondary(handle, secondary)
```

That assumes the handle is a CoreCLR handle-table handle. With standalone GC enabled, the handle belongs to the standalone GC handle manager, so secondary-object access must use the
same handle-manager abstraction as allocation, free, primary store, and extra-info access.

Details

This changes:

`RhHandleGetDependent`
`RhHandleSetDependentSecondary`

to call:

`GCHandleUtilities::GetGCHandleManager()->GetDependentHandleSecondary(handle)`
`GCHandleUtilities::GetGCHandleManager()->SetDependentHandleSecondary(handle, secondary)`

For the built-in GC handle manager this preserves existing behavior, since the manager implementation forwards to the same CoreCLR helpers internally. For standalone GC
implementations, it lets the active handle manager interpret its own dependent-handle representation.