### PR TITLE
[cdac] Move DataType from Abstractions to Contracts

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -234,9 +234,9 @@ public abstract class Target
     /// <summary>
     /// Returns the information about the given well-known data type in the target process
     /// </summary>
-    /// <param name="type">The name of the well known type</param>
+    /// <param name="typeName">The name of the well known type</param>
     /// <returns>The information about the given type in the target process</returns>
-    public abstract TypeInfo GetTypeInfo(DataType type);
+    public abstract TypeInfo GetTypeInfo(string typeName);
 
     /// <summary>
     /// Get the data cache for the target
@@ -303,10 +303,6 @@ public abstract class Target
         /// The byte offset of the field in an instance of the type in the target process
         /// </summary>
         public int Offset { get; init; }
-        /// <summary>
-        /// The well known data type of the field in the target process
-        /// </summary>
-        public readonly DataType Type { get; init; }
         /// <summary>
         /// The name of the well known data type of the field in the target process, or null
         /// if the target data descriptor did not record a name

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -197,3 +197,9 @@ public enum DataType
     CardTableInfo,
     RegionFreeList,
 }
+
+public static class DataTypeTargetExtensions
+{
+    public static Target.TypeInfo GetTypeInfo(this Target target, DataType type)
+        => target.GetTypeInfo(type.ToString());
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -38,7 +38,6 @@ public sealed unsafe class ContractDescriptorTarget : Target
     private readonly DataTargetDelegates _dataTargetDelegates;
     private readonly Dictionary<string, string> _contracts = [];
     private readonly IReadOnlyDictionary<string, GlobalValue> _globals = new Dictionary<string, GlobalValue>();
-    private readonly Dictionary<DataType, Target.TypeInfo> _knownTypes = [];
     private readonly Dictionary<string, Target.TypeInfo> _types = [];
 
     public override ContractRegistry Contracts { get; }
@@ -133,7 +132,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
         _contracts = [];
 
         // Set pointer type size
-        _knownTypes[DataType.pointer] = new TypeInfo { Size = (uint)_config.PointerSize };
+        _types[DataType.pointer.ToString()] = new TypeInfo { Size = (uint)_config.PointerSize };
 
         HashSet<string> seenTypeNames = new HashSet<string>();
         HashSet<string> seenGlobalNames = new HashSet<string>();
@@ -170,7 +169,6 @@ public sealed unsafe class ContractDescriptorTarget : Target
                             fieldInfos[fieldName] = new Target.FieldInfo()
                             {
                                 Offset = field.Offset,
-                                Type = field.Type is null ? DataType.Unknown : GetDataType(field.Type),
                                 TypeName = field.Type
                             };
                         }
@@ -183,15 +181,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
                     }
                     seenTypeNames.Add(name);
 
-                    DataType dataType = GetDataType(name);
-                    if (dataType is not DataType.Unknown)
-                    {
-                        _knownTypes[dataType] = typeInfo;
-                    }
-                    else
-                    {
-                        _types[name] = typeInfo;
-                    }
+                    _types[name] = typeInfo;
                 }
             }
 
@@ -380,14 +370,6 @@ public sealed unsafe class ContractDescriptorTarget : Target
         };
 
         return true;
-    }
-
-    private static DataType GetDataType(string type)
-    {
-        if (Enum.TryParse(type, false, out DataType dataType) && Enum.IsDefined(dataType))
-            return dataType;
-
-        return DataType.Unknown;
     }
 
     public override int PointerSize => _config.PointerSize;
@@ -583,7 +565,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
 
     public override TargetCodePointer ReadCodePointer(ulong address)
     {
-        TypeInfo codePointerTypeInfo = GetTypeInfo(DataType.CodePointer);
+        TypeInfo codePointerTypeInfo = this.GetTypeInfo(DataType.CodePointer);
         if (codePointerTypeInfo.Size is sizeof(uint))
         {
             return new TargetCodePointer(Read<uint>(address));
@@ -597,7 +579,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
 
     public override bool TryReadCodePointer(ulong address, out TargetCodePointer value)
     {
-        TypeInfo codePointerTypeInfo = GetTypeInfo(DataType.CodePointer);
+        TypeInfo codePointerTypeInfo = this.GetTypeInfo(DataType.CodePointer);
         if (codePointerTypeInfo.Size is sizeof(uint))
         {
             if (TryRead<uint>(address, out uint val))
@@ -821,22 +803,10 @@ public sealed unsafe class ContractDescriptorTarget : Target
 
     #endregion
 
-    public override TypeInfo GetTypeInfo(DataType type)
-    {
-        if (!_knownTypes.TryGetValue(type, out Target.TypeInfo typeInfo))
-            throw new InvalidOperationException($"Failed to get type info for '{type}'");
-
-        return typeInfo;
-    }
-
-    public Target.TypeInfo GetTypeInfo(string type)
+    public override Target.TypeInfo GetTypeInfo(string type)
     {
         if (_types.TryGetValue(type, out Target.TypeInfo typeInfo))
             return typeInfo;
-
-        DataType dataType = GetDataType(type);
-        if (dataType is not DataType.Unknown)
-            return GetTypeInfo(dataType);
 
         throw new InvalidOperationException($"Failed to get type info for '{type}'");
     }

--- a/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.SubDescriptors.cs
+++ b/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.SubDescriptors.cs
@@ -23,8 +23,8 @@ public unsafe partial class TargetTests
         {
             Size = 56,
             Fields = new Dictionary<string, Target.FieldInfo> {
-                { "Field1", new(){ Offset = 8, Type = DataType.uint16, TypeName = DataType.uint16.ToString() }},
-                { "Field2", new(){ Offset = 16, Type = DataType.ObjectHandle, TypeName = DataType.ObjectHandle.ToString() }},
+                { "Field1", new(){ Offset = 8, TypeName = DataType.uint16.ToString() }},
+                { "Field2", new(){ Offset = 16, TypeName = DataType.ObjectHandle.ToString() }},
                 { "Field3", new(){ Offset = 32 }}
             }
         },

--- a/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.cs
+++ b/src/native/managed/cdac/tests/ContractDescriptor/TargetTests.cs
@@ -19,8 +19,8 @@ public unsafe partial class TargetTests
         {
             Size = 56,
             Fields = new Dictionary<string, Target.FieldInfo> {
-                { "Field1", new(){ Offset = 8, Type = DataType.uint16, TypeName = DataType.uint16.ToString() }},
-                { "Field2", new(){ Offset = 16, Type = DataType.ObjectHandle, TypeName = DataType.ObjectHandle.ToString() }},
+                { "Field1", new(){ Offset = 8, TypeName = DataType.uint16.ToString() }},
+                { "Field2", new(){ Offset = 16, TypeName = DataType.ObjectHandle.ToString() }},
                 { "Field3", new(){ Offset = 32 }}
             }
         },

--- a/src/native/managed/cdac/tests/DebuggerTests.cs
+++ b/src/native/managed/cdac/tests/DebuggerTests.cs
@@ -65,7 +65,7 @@ public class DebuggerTests
 
         TargetTestHelpers.LayoutResult debuggerLayout = GetDebuggerLayout(helpers);
         TargetTestHelpers.LayoutResult debuggerRcThreadLayout = GetDebuggerRCThreadLayout(helpers);
-        builder.AddTypes(new()
+        builder.AddTypes(new Dictionary<DataType, Target.TypeInfo>
         {
             [DataType.Debugger] = new Target.TypeInfo() { Fields = debuggerLayout.Fields, Size = debuggerLayout.Stride },
             [DataType.DebuggerRCThread] = new Target.TypeInfo() { Fields = debuggerRcThreadLayout.Fields, Size = debuggerRcThreadLayout.Stride },

--- a/src/native/managed/cdac/tests/ExecutionManager/HashMapTests.cs
+++ b/src/native/managed/cdac/tests/ExecutionManager/HashMapTests.cs
@@ -28,15 +28,14 @@ public class HashMapTests
         MockTarget.Architecture arch,
         Action<MockHashMapBuilder> configure)
     {
-        MockMemorySpace.Builder builder = new(new TargetTestHelpers(arch));
-        MockHashMapBuilder hashMap = new(builder);
+        TestPlaceholderTarget.Builder builder = new(arch);
+        MockHashMapBuilder hashMap = new(builder.MemoryBuilder);
         configure(hashMap);
 
-        return new TestPlaceholderTarget(
-            builder.TargetTestHelpers.Arch,
-            builder.GetMemoryContext().ReadFromTarget,
-            CreateContractTypes(hashMap),
-            CreateContractGlobals(hashMap));
+        return builder
+            .AddTypes(CreateContractTypes(hashMap))
+            .AddGlobals(CreateContractGlobals(hashMap))
+            .Build();
     }
 
     [Theory]

--- a/src/native/managed/cdac/tests/GCMemoryRegionTests.cs
+++ b/src/native/managed/cdac/tests/GCMemoryRegionTests.cs
@@ -61,7 +61,7 @@ public class GCMemoryRegionTests
     {
         var result = new Dictionary<string, Target.FieldInfo>();
         foreach (var (name, offset, type) in fields)
-            result[name] = new Target.FieldInfo { Offset = offset, Type = type };
+            result[name] = new Target.FieldInfo { Offset = offset, TypeName = type.ToString() };
         return result;
     }
 

--- a/src/native/managed/cdac/tests/MethodDescTests.cs
+++ b/src/native/managed/cdac/tests/MethodDescTests.cs
@@ -30,7 +30,7 @@ public class MethodDescTests
                 Size = methodDescBuilder.AsyncMethodDataSize,
                 Fields = new Dictionary<string, Target.FieldInfo>
                 {
-                    [nameof(Data.AsyncMethodData.Flags)] = new Target.FieldInfo { Offset = 0, Type = DataType.Unknown },
+                    [nameof(Data.AsyncMethodData.Flags)] = new Target.FieldInfo { Offset = 0 },
                 },
             },
             [DataType.ArrayMethodDesc] = new Target.TypeInfo { Size = methodDescBuilder.ArrayMethodDescSize },

--- a/src/native/managed/cdac/tests/TargetTestHelpers.cs
+++ b/src/native/managed/cdac/tests/TargetTestHelpers.cs
@@ -147,17 +147,6 @@ internal unsafe class TargetTestHelpers
         };
     }
 
-    internal int SizeOfTypeInfo(Target.TypeInfo info)
-    {
-        int size = 0;
-        foreach (var (_, field) in info.Fields)
-        {
-            size = Math.Max(size, field.Offset + SizeOfPrimitive(field.Type));
-        }
-
-        return size;
-    }
-
     #endregion Mock memory initialization
 
     private static int AlignUp(int offset, int align)
@@ -215,7 +204,7 @@ internal unsafe class TargetTestHelpers
             };
             fieldInfos[name] = new Target.FieldInfo {
                 Offset = offset,
-                Type = type,
+                TypeName = type.ToString(),
             };
             offset += size;
         }
@@ -245,7 +234,6 @@ internal unsafe class TargetTestHelpers
             fields[field.Name] = new Target.FieldInfo
             {
                 Offset = field.Offset,
-                Type = DataType.Unknown,
             };
         }
 

--- a/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
@@ -19,7 +19,7 @@ internal class TestPlaceholderTarget : Target
 {
     private ContractRegistry _contractRegistry;
     private readonly Target.IDataCache _dataCache;
-    private readonly Dictionary<DataType, Target.TypeInfo> _typeInfoCache;
+    private readonly Dictionary<string, Target.TypeInfo> _typeInfoCache;
     private readonly (string Name, ulong Value)[] _globals;
     private readonly (string Name, string Value)[] _globalStrings;
 
@@ -33,7 +33,7 @@ internal class TestPlaceholderTarget : Target
     private static readonly UTF8Encoding strictUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly UTF8Encoding looseUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
-    public TestPlaceholderTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader, Dictionary<DataType, Target.TypeInfo> types = null, (string Name, ulong Value)[] globals = null, (string Name, string Value)[] globalStrings = null, WriteToTargetDelegate? writer = null, AllocateMemoryDelegate? allocateMemory = null)
+    public TestPlaceholderTarget(MockTarget.Architecture arch, ReadFromTargetDelegate reader, Dictionary<string, Target.TypeInfo> types = null, (string Name, ulong Value)[] globals = null, (string Name, string Value)[] globalStrings = null, WriteToTargetDelegate? writer = null, AllocateMemoryDelegate? allocateMemory = null)
     {
         IsLittleEndian = arch.IsLittleEndian;
         PointerSize = arch.Is64Bit ? 8 : 4;
@@ -77,7 +77,7 @@ internal class TestPlaceholderTarget : Target
     {
         private readonly MockTarget.Architecture _arch;
         private readonly MockMemorySpace.Builder _memBuilder;
-        private readonly Dictionary<DataType, Target.TypeInfo> _types = new();
+        private readonly Dictionary<string, Target.TypeInfo> _types = new();
         private readonly List<(string Name, ulong Value)> _globals = new();
         private readonly List<(string Name, string Value)> _globalStrings = new();
         private readonly List<Action<TestContractRegistry>> _contractSetups = new();
@@ -94,6 +94,13 @@ internal class TestPlaceholderTarget : Target
         internal MockMemorySpace.Builder MemoryBuilder => _memBuilder;
 
         public Builder AddTypes(Dictionary<DataType, Target.TypeInfo> types)
+        {
+            foreach (var kvp in types)
+                _types[kvp.Key.ToString()] = kvp.Value;
+            return this;
+        }
+
+        public Builder AddTypes(Dictionary<string, Target.TypeInfo> types)
         {
             foreach (var kvp in types)
                 _types[kvp.Key] = kvp.Value;
@@ -499,9 +506,9 @@ internal class TestPlaceholderTarget : Target
 
     public override TargetPointer ReadPointerFromSpan(ReadOnlySpan<byte> bytes) => throw new NotImplementedException();
 
-    public override Target.TypeInfo GetTypeInfo(DataType dataType)
+    public override Target.TypeInfo GetTypeInfo(string typeName)
     {
-        if (_typeInfoCache.TryGetValue(dataType, out var info))
+        if (_typeInfoCache.TryGetValue(typeName, out var info))
             return info;
 
         throw new NotImplementedException();


### PR DESCRIPTION
Moves the `DataType` enum out of the Abstractions assembly into Contracts, since it represents descriptor schema rather than the abstract Target API. Each user of the DataContractReader.Abstractions can define their own DataType schema.

### Changes
- `DataType.cs` moved from `Microsoft.Diagnostics.DataContractReader.Abstractions` to `Microsoft.Diagnostics.DataContractReader.Contracts`.
- `Target.GetTypeInfo(DataType)` replaced with abstract `Target.GetTypeInfo(string typeName)`.
- Added extension method `DataTypeTargetExtensions.GetTypeInfo(this Target, DataType)` in `DataType.cs` for ergonomics; it forwards to the string overload via `.ToString()`.
- Removed `Target.FieldInfo.Type` (the `DataType` field); `TypeName` (string) is now the sole identifier and is what consumers already used in practice.
- `ContractDescriptorTarget` now stores types in a single `Dictionary<string, Target.TypeInfo>`.
- `TestPlaceholderTarget` storage is string-keyed internally; `Builder.AddTypes(Dictionary<DataType, ...>)` is kept for caller convenience and converts to strings.
- Removed unused `TargetTestHelpers.SizeOfTypeInfo`.

### Verification
- 2041 / 2041 unit tests pass (`Microsoft.Diagnostics.DataContractReader.Tests`).
- Dump tests pending.

> [!NOTE]
> This PR description and the underlying changes were drafted with the assistance of GitHub Copilot.
