### PR TITLE
Fix JsonIgnoreCondition.WhenWritingNull doc

### DIFF
--- a/src/libraries/System.Text.Json/Common/JsonIgnoreCondition.cs
+++ b/src/libraries/System.Text.Json/Common/JsonIgnoreCondition.cs
@@ -27,7 +27,7 @@ namespace System.Text.Json.Serialization
         WhenWritingDefault = 2,
         /// <summary>
         /// If the value is <see langword="null"/>, the property is ignored during serialization.
-        /// This is applied only to reference-type properties and fields.
+        /// This is applied only to reference and nullable value-type properties and fields.
         /// </summary>
         WhenWritingNull = 3,
         /// <summary>


### PR DESCRIPTION
Doc only

It acutally applies to nullable value types too

```
using System;
using System.Text.Json;
using System.Text.Json.Serialization;

Forecast forecast = new()
{
    Date = null,
};
JsonSerializerOptions options = new()
{
    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
};
string forecastJson = JsonSerializer.Serialize<Forecast>(forecast, options);
Console.WriteLine(forecastJson); // Prints "{}"

public class Forecast
{
    public DateTime? Date { get; set; }
};
```

Should I manually make PR to https://github.com/dotnet/docs ?