### PR TITLE
[Stress] Scheduled runs take definition from YML in main

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -8,6 +8,7 @@ schedules:
     include:
     - main
     - release/*.0
+    - release/*.0-staging
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -8,6 +8,7 @@ schedules:
     include:
     - main
     - release/*.0
+    - release/*.0-staging
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
We're not running on staging branches right now. Apparently, the scheduled runs take the definition from main and not their respective branches.