### PR TITLE
Match jit behavior when converting float/double to u1/u2

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1613,11 +1613,11 @@ SWITCH_OPCODE:
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R4:
-                    ConvFpHelper<uint8_t, uint32_t, float>(stack, ip);
+                    ConvFpHelper<uint8_t, int32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U1_R8:
-                    ConvFpHelper<uint8_t, uint32_t, double>(stack, ip);
+                    ConvFpHelper<uint8_t, int32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I2_I4:
@@ -1645,11 +1645,11 @@ SWITCH_OPCODE:
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R4:
-                    ConvFpHelper<uint16_t, uint32_t, float>(stack, ip);
+                    ConvFpHelper<uint16_t, int32_t, float>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_U2_R8:
-                    ConvFpHelper<uint16_t, uint32_t, double>(stack, ip);
+                    ConvFpHelper<uint16_t, int32_t, double>(stack, ip);
                     ip += 3;
                     break;
                 case INTOP_CONV_I4_R4:

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DoubleTests.GenericMath.cs
@@ -346,17 +346,18 @@ namespace System.Tests
 
         [Fact]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/100368")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116823", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
+        // Passes on the interpreter, but interpreter configurations might still use jit fallback
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/116823", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))]
         public static void ConvertToIntegerTest()
         {
             // Signed Values
 
-            Assert.Equal(0, FloatingPointHelper<double>.ConvertToInteger<short>(double.MinValue));
+            Assert.Equal(short.MinValue, FloatingPointHelper<double>.ConvertToInteger<short>(double.MinValue));
             Assert.Equal(int.MinValue, FloatingPointHelper<double>.ConvertToInteger<int>(double.MinValue));
             Assert.Equal(long.MinValue, FloatingPointHelper<double>.ConvertToInteger<long>(double.MinValue));
             Assert.Equal(Int128.MinValue, FloatingPointHelper<double>.ConvertToInteger<Int128>(double.MinValue));
             Assert.Equal(nint.MinValue, FloatingPointHelper<double>.ConvertToInteger<nint>(double.MinValue));
-            Assert.Equal(0, FloatingPointHelper<double>.ConvertToInteger<sbyte>(double.MinValue));
+            Assert.Equal(sbyte.MinValue, FloatingPointHelper<double>.ConvertToInteger<sbyte>(double.MinValue));
 
             Assert.Equal(2, FloatingPointHelper<double>.ConvertToInteger<short>(2.6));
             Assert.Equal(2, FloatingPointHelper<double>.ConvertToInteger<int>(2.6));
@@ -365,12 +366,12 @@ namespace System.Tests
             Assert.Equal(2, FloatingPointHelper<double>.ConvertToInteger<nint>(2.6));
             Assert.Equal(2, FloatingPointHelper<double>.ConvertToInteger<sbyte>(2.6));
 
-            Assert.Equal(-1, FloatingPointHelper<double>.ConvertToInteger<short>(double.MaxValue));
+            Assert.Equal(short.MaxValue, FloatingPointHelper<double>.ConvertToInteger<short>(double.MaxValue));
             Assert.Equal(int.MaxValue, FloatingPointHelper<double>.ConvertToInteger<int>(double.MaxValue));
             Assert.Equal(long.MaxValue, FloatingPointHelper<double>.ConvertToInteger<long>(double.MaxValue));
             Assert.Equal(Int128.MaxValue, FloatingPointHelper<double>.ConvertToInteger<Int128>(double.MaxValue));
             Assert.Equal(nint.MaxValue, FloatingPointHelper<double>.ConvertToInteger<nint>(double.MaxValue));
-            Assert.Equal(-1, FloatingPointHelper<double>.ConvertToInteger<sbyte>(double.MaxValue));
+            Assert.Equal(sbyte.MaxValue, FloatingPointHelper<double>.ConvertToInteger<sbyte>(double.MaxValue));
 
             // Unsigned Values
 

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.GenericMath.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/SingleTests.GenericMath.cs
@@ -346,17 +346,18 @@ namespace System.Tests
 
         [Fact]
         [SkipOnMono("https://github.com/dotnet/runtime/issues/100368")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/116823", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
+        // Passes on the interpreter, but interpreter configurations might still use jit fallback
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/116823", typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime))]
         public static void ConvertToIntegerTest()
         {
             // Signed Values
 
-            Assert.Equal(0, FloatingPointHelper<float>.ConvertToInteger<short>(float.MinValue));
+            Assert.Equal(short.MinValue, FloatingPointHelper<float>.ConvertToInteger<short>(float.MinValue));
             Assert.Equal(int.MinValue, FloatingPointHelper<float>.ConvertToInteger<int>(float.MinValue));
             Assert.Equal(long.MinValue, FloatingPointHelper<float>.ConvertToInteger<long>(float.MinValue));
             Assert.Equal(Int128.MinValue, FloatingPointHelper<float>.ConvertToInteger<Int128>(float.MinValue));
             Assert.Equal(nint.MinValue, FloatingPointHelper<float>.ConvertToInteger<nint>(float.MinValue));
-            Assert.Equal(0, FloatingPointHelper<float>.ConvertToInteger<sbyte>(float.MinValue));
+            Assert.Equal(sbyte.MinValue, FloatingPointHelper<float>.ConvertToInteger<sbyte>(float.MinValue));
 
             Assert.Equal(2, FloatingPointHelper<float>.ConvertToInteger<short>(2.6f));
             Assert.Equal(2, FloatingPointHelper<float>.ConvertToInteger<int>(2.6f));
@@ -365,12 +366,12 @@ namespace System.Tests
             Assert.Equal(2, FloatingPointHelper<float>.ConvertToInteger<nint>(2.6f));
             Assert.Equal(2, FloatingPointHelper<float>.ConvertToInteger<sbyte>(2.6f));
 
-            Assert.Equal(-1, FloatingPointHelper<float>.ConvertToInteger<short>(float.MaxValue));
+            Assert.Equal(short.MaxValue, FloatingPointHelper<float>.ConvertToInteger<short>(float.MaxValue));
             Assert.Equal(int.MaxValue, FloatingPointHelper<float>.ConvertToInteger<int>(float.MaxValue));
             Assert.Equal(long.MaxValue, FloatingPointHelper<float>.ConvertToInteger<long>(float.MaxValue));
             Assert.Equal(Int128.MaxValue, FloatingPointHelper<float>.ConvertToInteger<Int128>(float.MaxValue));
             Assert.Equal(nint.MaxValue, FloatingPointHelper<float>.ConvertToInteger<nint>(float.MaxValue));
-            Assert.Equal(-1, FloatingPointHelper<float>.ConvertToInteger<sbyte>(float.MaxValue));
+            Assert.Equal(sbyte.MaxValue, FloatingPointHelper<float>.ConvertToInteger<sbyte>(float.MaxValue));
 
             // Unsigned Values
 


### PR DESCRIPTION
Previously it converted first to uint32_t, which was doing a saturating conversion. Example:

Before
(ushort)-4567.0f = (ushort)(uint)-4567.0f = (ushort)0 = 0

After
(ushort)-4567.0f = (ushort)(int)-4567.0f = (ushort)-4567 = 60969

Fixes System.Runtime.InteropServices.Tests.NFloatTests.NFloatTo* tests on interpreter