### PR TITLE
[cDAC] Use NativeCodeVersion entry for GetMethodVarInfo offset

### DIFF
--- a/docs/design/datacontracts/DebugInfo.md
+++ b/docs/design/datacontracts/DebugInfo.md
@@ -254,6 +254,7 @@ Contracts used:
 | Contract Name |
 | --- |
 | `ExecutionManager` |
+| `CodeVersions` |
 
 Constants:
 | Constant Name | Meaning | Value |

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IExecutionManager.cs
@@ -97,8 +97,8 @@ public interface IExecutionManager : IContract
     static string IContract.Name { get; } = nameof(ExecutionManager);
     CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => throw new NotImplementedException();
     TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
-    TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
-    TargetCodePointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
+    TargetPointer GetStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
+    TargetPointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();
     void GetMethodRegionInfo(CodeBlockHandle codeInfoHandle, out uint hotSize, out TargetPointer coldStart, out uint coldSize) => throw new NotImplementedException();
     TargetPointer NonVirtualEntry2MethodDesc(TargetCodePointer entrypoint) => throw new NotImplementedException();
     bool IsFunclet(CodeBlockHandle codeInfoHandle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/CodeVersions_1.cs
@@ -138,7 +138,9 @@ internal readonly partial struct CodeVersions_1 : ICodeVersions
         }
         else
         {
-            TargetCodePointer startAddress = executionManager.GetStartAddress(info.Value);
+            TargetCodePointer startAddress = CodePointerUtils.CodePointerFromAddress(
+                executionManager.GetStartAddress(info.Value),
+                _target);
             return GetSpecificNativeCodeVersion(rts, md, startAddress);
         }
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_1.cs
@@ -39,8 +39,8 @@ internal sealed class DebugInfo_1(Target target) : IDebugInfo
             throw new InvalidOperationException($"No CodeBlockHandle found for native code {pCode}.");
         TargetPointer debugInfo = _eman.GetDebugInfo(cbh, out bool hasFlagByte);
 
-        TargetCodePointer nativeCodeStart = _eman.GetStartAddress(cbh);
-        codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - CodePointerUtils.AddressFromCodePointer(nativeCodeStart, _target));
+        TargetPointer nativeCodeStart = _eman.GetStartAddress(cbh);
+        codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - nativeCodeStart);
 
         if (debugInfo == TargetPointer.Null)
             return [];

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
@@ -126,7 +126,7 @@ internal sealed class DebugInfo_2(Target target) : IDebugInfo
         // Compute code offset from the method's native code entry point, not from the code block start.
         // GetStartAddress returns the start of the current code block (which may be a funclet for exception
         // handlers). Variable location offsets are always relative to the method entry point, so we must use
-        // GetNativeCode from the MethodDesc — matching the native DAC's GetMethodVarInfo which uses
+        // GetNativeCode from the NativeCodeVersion, matching the native DAC's GetMethodVarInfo which uses
         // NativeCodeVersion::GetNativeCode() for this purpose
         ICodeVersions cv = _target.Contracts.CodeVersions;
         NativeCodeVersionHandle ncvh = cv.GetNativeCodeVersionForIP(pCode);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
@@ -127,11 +127,12 @@ internal sealed class DebugInfo_2(Target target) : IDebugInfo
         // GetStartAddress returns the start of the current code block (which may be a funclet for exception
         // handlers). Variable location offsets are always relative to the method entry point, so we must use
         // GetNativeCode from the MethodDesc — matching the native DAC's GetMethodVarInfo which uses
-        // NativeCodeVersion::GetNativeCode() for this purpose.
-        IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
-        TargetPointer methodDescAddr = _eman.GetMethodDesc(cbh);
-        MethodDescHandle mdh = rts.GetMethodDescHandle(methodDescAddr);
-        TargetCodePointer nativeCodeStart = rts.GetNativeCode(mdh);
+        // NativeCodeVersion::GetNativeCode() for this purpose
+        ICodeVersions cv = _target.Contracts.CodeVersions;
+        NativeCodeVersionHandle ncvh = cv.GetNativeCodeVersionForIP(pCode);
+        if (!ncvh.Valid)
+            throw new InvalidOperationException($"No NativeCodeVersion found for native code {pCode}.");
+        TargetCodePointer nativeCodeStart = cv.GetNativeCode(ncvh);
         codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - CodePointerUtils.AddressFromCodePointer(nativeCodeStart, _target));
 
         if (debugInfo == TargetPointer.Null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
@@ -46,8 +46,8 @@ internal sealed class DebugInfo_2(Target target) : IDebugInfo
             throw new InvalidOperationException($"No CodeBlockHandle found for native code {pCode}.");
         TargetPointer debugInfo = _eman.GetDebugInfo(cbh, out bool _);
 
-        TargetCodePointer nativeCodeStart = _eman.GetStartAddress(cbh);
-        codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - CodePointerUtils.AddressFromCodePointer(nativeCodeStart, _target));
+        TargetPointer nativeCodeStart = _eman.GetStartAddress(cbh);
+        codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - nativeCodeStart);
 
         if (debugInfo == TargetPointer.Null)
             return [];

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.EEJitManager.cs
@@ -39,7 +39,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
             if (!GetRealCodeHeader(rangeSection, codeStart, out Data.RealCodeHeader? realCodeHeader))
                 return false;
 
-            info = new CodeBlock(codeStart.Value, realCodeHeader.MethodDesc, relativeOffset, rangeSection.Data!.JitManager);
+            info = new CodeBlock(codeStart, realCodeHeader.MethodDesc, relativeOffset, rangeSection.Data!.JitManager);
             return true;
         }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
@@ -44,7 +44,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
             Data.RuntimeFunction function = _runtimeFunctions.GetRuntimeFunction(r2rInfo.RuntimeFunctions, index);
 
             TargetPointer addr = CodePointerUtils.AddressFromCodePointer(jittedCodeAddress, Target);
-            TargetCodePointer startAddress = imageBase + function.BeginAddress;
+            TargetPointer startAddress = imageBase + function.BeginAddress;
             TargetNUInt relativeOffset = new TargetNUInt(addr - startAddress);
 
             // Take hot/cold splitting into account for the relative offset
@@ -62,7 +62,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
                 }
             }
 
-            info = new CodeBlock(startAddress.Value, methodDesc, relativeOffset, rangeSection.Data!.JitManager);
+            info = new CodeBlock(startAddress, methodDesc, relativeOffset, rangeSection.Data!.JitManager);
             return true;
         }
 
@@ -336,7 +336,7 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
         private void GetMethodRVAAndRangeStart(CodeBlockHandle cbh, out TargetPointer methodStart, out TargetPointer rangeStart)
         {
             IExecutionManager executionManager = Target.Contracts.ExecutionManager;
-            methodStart = CodePointerUtils.AddressFromCodePointer(executionManager.GetStartAddress(cbh), Target);
+            methodStart = executionManager.GetStartAddress(cbh);
             rangeStart = executionManager.GetUnwindInfoBaseAddress(cbh);
         }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.ReadyToRunJitManager.cs
@@ -44,7 +44,11 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
             Data.RuntimeFunction function = _runtimeFunctions.GetRuntimeFunction(r2rInfo.RuntimeFunctions, index);
 
             TargetPointer addr = CodePointerUtils.AddressFromCodePointer(jittedCodeAddress, Target);
-            TargetPointer startAddress = imageBase + function.BeginAddress;
+            // The R2R RUNTIME_FUNCTION.BeginAddress encodes thumb code with the thumb bit set on
+            // ARM32. Native RUNTIME_FUNCTION__BeginAddress uses ThumbCodeToDataPointer to strip it
+            // (clrnt.h, ARM32 branch). Mirror that so we store a raw TADDR-style start address.
+            TargetPointer startAddress = CodePointerUtils.AddressFromCodePointer(
+                new TargetCodePointer(imageBase.Value + function.BeginAddress), Target);
             TargetNUInt relativeOffset = new TargetNUInt(addr - startAddress);
 
             // Take hot/cold splitting into account for the relative offset
@@ -52,7 +56,8 @@ internal partial class ExecutionManagerCore<T> : IExecutionManager
             {
                 Debug.Assert(coldFunctionIndex < r2rInfo.NumRuntimeFunctions);
                 Data.RuntimeFunction coldFunction = _runtimeFunctions.GetRuntimeFunction(r2rInfo.RuntimeFunctions, coldFunctionIndex);
-                TargetPointer coldStart = imageBase + coldFunction.BeginAddress;
+                TargetPointer coldStart = CodePointerUtils.AddressFromCodePointer(
+                    new TargetCodePointer(imageBase.Value + coldFunction.BeginAddress), Target);
                 if (addr >= coldStart)
                 {
                     // If the address is in the cold part, the relative offset is the size of the

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
@@ -42,11 +42,11 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
     // Note, because of RelativeOffset, this code info is per code pointer, not per method
     private sealed class CodeBlock
     {
-        public TargetCodePointer StartAddress { get; }
+        public TargetPointer StartAddress { get; }
         public TargetPointer MethodDescAddress { get; }
         public TargetPointer JitManagerAddress { get; }
         public TargetNUInt RelativeOffset { get; }
-        public CodeBlock(TargetCodePointer startAddress, TargetPointer methodDesc, TargetNUInt relativeOffset, TargetPointer jitManagerAddress)
+        public CodeBlock(TargetPointer startAddress, TargetPointer methodDesc, TargetNUInt relativeOffset, TargetPointer jitManagerAddress)
         {
             StartAddress = startAddress;
             MethodDescAddress = methodDesc;
@@ -235,7 +235,7 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
         return info.MethodDescAddress;
     }
 
-    TargetCodePointer IExecutionManager.GetStartAddress(CodeBlockHandle codeInfoHandle)
+    TargetPointer IExecutionManager.GetStartAddress(CodeBlockHandle codeInfoHandle)
     {
         if (!_codeInfos.TryGetValue(codeInfoHandle.Address, out CodeBlock? info))
             throw new InvalidOperationException($"{nameof(CodeBlock)} not found for {codeInfoHandle.Address}");
@@ -243,7 +243,7 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
         return info.StartAddress;
     }
 
-    TargetCodePointer IExecutionManager.GetFuncletStartAddress(CodeBlockHandle codeInfoHandle)
+    TargetPointer IExecutionManager.GetFuncletStartAddress(CodeBlockHandle codeInfoHandle)
     {
         RangeSection range = RangeSectionFromCodeBlockHandle(codeInfoHandle);
         if (range.Data == null)
@@ -319,12 +319,11 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
     bool IExecutionManager.IsFunclet(CodeBlockHandle codeInfoHandle)
     {
         // Interpreter code has no native unwind info and therefore no funclets.
-        TargetCodePointer startAddress = ((IExecutionManager)this).GetStartAddress(codeInfoHandle);
-        if (((IExecutionManager)this).GetCodeKind(startAddress) == CodeKind.Interpreter)
+        TargetPointer startAddress = ((IExecutionManager)this).GetStartAddress(codeInfoHandle);
+        if (((IExecutionManager)this).GetCodeKind(new TargetCodePointer(startAddress.Value)) == CodeKind.Interpreter)
             return false;
 
-        return startAddress !=
-               ((IExecutionManager)this).GetFuncletStartAddress(codeInfoHandle);
+        return startAddress != ((IExecutionManager)this).GetFuncletStartAddress(codeInfoHandle);
     }
 
     bool IExecutionManager.IsFilterFunclet(CodeBlockHandle codeInfoHandle)
@@ -337,7 +336,7 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
         if (!eman.IsFunclet(codeInfoHandle))
             return false;
 
-        TargetPointer funcletStartAddress = eman.GetFuncletStartAddress(codeInfoHandle).AsTargetPointer;
+        TargetPointer funcletStartAddress = eman.GetFuncletStartAddress(codeInfoHandle);
         uint funcletStartOffset = (uint)(funcletStartAddress - info.StartAddress);
 
         List<ExceptionClauseInfo> clauses = eman.GetExceptionClauses(codeInfoHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
@@ -19,8 +19,8 @@ public sealed class ExecutionManager_1 : IExecutionManager
 
     public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
     public TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetMethodDesc(codeInfoHandle);
-    public TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
-    public TargetCodePointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetFuncletStartAddress(codeInfoHandle);
+    public TargetPointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
+    public TargetPointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetFuncletStartAddress(codeInfoHandle);
     public void GetMethodRegionInfo(CodeBlockHandle codeInfoHandle, out uint hotSize, out TargetPointer coldStart, out uint coldSize) => _executionManagerCore.GetMethodRegionInfo(codeInfoHandle, out hotSize, out coldStart, out coldSize);
     public TargetPointer NonVirtualEntry2MethodDesc(TargetCodePointer entrypoint) => _executionManagerCore.NonVirtualEntry2MethodDesc(entrypoint);
     public bool IsFunclet(CodeBlockHandle codeInfoHandle) => _executionManagerCore.IsFunclet(codeInfoHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
@@ -19,8 +19,8 @@ public sealed class ExecutionManager_2 : IExecutionManager
 
     public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
     public TargetPointer GetMethodDesc(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetMethodDesc(codeInfoHandle);
-    public TargetCodePointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
-    public TargetCodePointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetFuncletStartAddress(codeInfoHandle);
+    public TargetPointer GetStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetStartAddress(codeInfoHandle);
+    public TargetPointer GetFuncletStartAddress(CodeBlockHandle codeInfoHandle) => _executionManagerCore.GetFuncletStartAddress(codeInfoHandle);
     public void GetMethodRegionInfo(CodeBlockHandle codeInfoHandle, out uint hotSize, out TargetPointer coldStart, out uint coldSize) => _executionManagerCore.GetMethodRegionInfo(codeInfoHandle, out hotSize, out coldStart, out coldSize);
     public TargetPointer NonVirtualEntry2MethodDesc(TargetCodePointer entrypoint) => _executionManagerCore.NonVirtualEntry2MethodDesc(entrypoint);
     public bool IsFunclet(CodeBlockHandle codeInfoHandle) => _executionManagerCore.IsFunclet(codeInfoHandle);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86/X86Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86/X86Unwinder.cs
@@ -58,8 +58,8 @@ public class X86Unwinder(Target target)
 
         eman.GetGCInfo(cbh, out TargetPointer gcInfoAddress, out uint gcInfoVersion);
         uint relOffset = (uint)eman.GetRelativeOffset(cbh).Value;
-        TargetPointer methodStart = eman.GetStartAddress(cbh).AsTargetPointer;
-        TargetPointer funcletStart = eman.GetFuncletStartAddress(cbh).AsTargetPointer;
+        TargetPointer methodStart = eman.GetStartAddress(cbh);
+        TargetPointer funcletStart = eman.GetFuncletStartAddress(cbh);
         bool isFunclet = eman.IsFunclet(cbh);
 
         GCInfo gcInfo = new(_target, gcInfoAddress, gcInfoVersion, relOffset);

--- a/src/native/managed/cdac/tests/CodeVersionsTests.cs
+++ b/src/native/managed/cdac/tests/CodeVersionsTests.cs
@@ -78,7 +78,7 @@ internal static class MockExtensions
         CodeBlockHandle handle = new CodeBlockHandle(block.StartAddress.AsTargetPointer);
         mock.Setup(e => e.GetCodeBlockHandle(It.Is<TargetCodePointer>(ip => ip >= block.StartAddress && ip < block.StartAddress + block.Length)))
             .Returns(handle);
-        mock.Setup(e => e.GetStartAddress(handle)).Returns(block.StartAddress);
+        mock.Setup(e => e.GetStartAddress(handle)).Returns(block.StartAddress.AsTargetPointer);
         mock.Setup(e => e.GetMethodDesc(handle)).Returns(block.MethodDesc.Address);
     }
 
@@ -153,6 +153,9 @@ public class CodeVersionsTests
         mockExecutionManager ??= new Mock<IExecutionManager>();
         mockRuntimeTypeSystem ??= new Mock<IRuntimeTypeSystem>();
 
+        Mock<IPlatformMetadata> mockPlatformMetadata = new Mock<IPlatformMetadata>();
+        mockPlatformMetadata.Setup(p => p.GetCodePointerFlags()).Returns(default(CodePointerFlags));
+
         return new TestPlaceholderTarget.Builder(arch)
             .UseReader(builder.Builder.GetMemoryContext().ReadFromTarget)
             .AddTypes(CreateContractTypes(builder))
@@ -160,6 +163,7 @@ public class CodeVersionsTests
             .AddMockContract(mockRuntimeTypeSystem)
             .AddMockContract(mockExecutionManager)
             .AddMockContract(mockLoader)
+            .AddMockContract(mockPlatformMetadata)
             .Build();
     }
 


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

## Problem

`runtime-diagnostics` build [1418267](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1418267) failed with:

```
Process terminated. Assertion failed.
GetNumLocations cDAC: 0, DAC: 1
   at Microsoft.Diagnostics.DataContractReader.Legacy.ClrDataValue...GetNumLocations(UInt32*)
```

The asserting frame was the `this` parameter of `ManualResetEventSlim.Wait` during `!ClrStack -a` against the WebApp3 dump.

## Root cause

`DebugInfo_2.GetMethodVarInfo` computed the IP -> codeOffset relative to `MethodDesc.NativeCode`. That field tracks only the most recently-compiled tier. With tiered compilation, an older-tier frame still on the stack gets the wrong base, no `varInfo` ranges match, and cDAC returns an empty location list while the legacy DAC finds the entry.

The legacy DAC (`src/coreclr/debug/daccess/daccess.cpp:5591`) instead uses `ExecutionManager::GetNativeCodeVersion(address).GetNativeCode()` -- the entry point of the specific NativeCodeVersion that owns the IP.

This bug has been latent since #125463. dotnet/diagnostics#5767 (merged 2026-05-12) rebuilt the debuggees with the .NET 11 test SDK, which increased the chance of hot methods like `ManualResetEventSlim.Wait` straddling tier boundaries at dump-capture time and surfaced the existing bug.

## Fix

Resolve the IP-specific `NativeCodeVersion` via the `ICodeVersions` contract (already mirrors `ExecutionManager::GetNativeCodeVersion` + `NativeCodeVersion::GetNativeCode` for versionable and non-versionable methods). Throw on an invalid `NativeCodeVersion`, matching the native DAC's `E_INVALIDARG` behavior.

### Type-correctness fix (uncovered while debugging an ARM32 regression)

While validating the fix above, an ARM32 regression in `IXCLRDataValueDumpTests.GetSize_ReturnsExpectedSizes` revealed a long-standing mistype:

- `IExecutionManager.GetStartAddress` / `GetFuncletStartAddress` declared `TargetCodePointer`, but the value stored in `CodeBlock` is the raw code-block start with no ARM32 thumb bit. That matches native -- `EECodeInfo::GetStartAddress` and `CodeHeader::GetCodeStartAddress` both return `TADDR` -- but the cdac type signature was lying about what the value represented.
- On ARM32, `CodeVersions_1.GetSpecificNativeCodeVersion` compared `MethodDesc.NativeCode` (a `PCODE` with the thumb bit set) against the raw `TADDR` from `GetStartAddress`, so the equality check never matched and `GetNativeCodeVersionForIP` returned `Invalid` -- which broke the new `GetMethodVarInfo` path on ARM32.

The first commit in this PR changes the return types to `TargetPointer` (matching native `TADDR` semantics), drops the now-redundant `AddressFromCodePointer` conversions at the callers, and at the one site that genuinely needs a `PCODE` for comparison uses `CodePointerFromAddress` (the cdac analogue of native `PINSTRToPCODE`). The second commit is the original `GetMethodVarInfo` change, now safe on ARM32.

## Validation

- Built cdac Contracts and Legacy projects: clean.
- `dotnet test` on the full cdac suite: 2133/2133 passed (16 unrelated skips).
- runtime-diagnostics CI will validate end-to-end behavior on x64 and ARM32.
