### PR TITLE
Test harness and assorted changes for R2R testing in Wasm

### DIFF
--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -315,6 +315,11 @@ namespace ILCompiler
             Console.WriteLine();
             Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--targetarch", String.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
             Console.WriteLine();
+
+            string[] ValidObjFormats = ["pe", "macho", "wasm"];
+            Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--obj-format", String.Join("', '", ValidObjFormats), "pe"));
+            Console.WriteLine();
+
             Console.WriteLine(String.Format(SR.SwitchWithDefaultHelp, "--type-validation", String.Join("', '", Enum.GetNames<TypeValidationRule>()), nameof(TypeValidationRule.Automatic)));
             Console.WriteLine();
 

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -414,6 +414,10 @@ namespace ILCompiler
                     string rtrHeaderSymbolName = Get(_command.ReadyToRunHeaderSymbolName);
 
                     ReadyToRunContainerFormat format = Get(_command.OutputFormat);
+                    if (format == ReadyToRunContainerFormat.PE && typeSystemContext.Target.Architecture == TargetArchitecture.Wasm32)
+                    {
+                        format = ReadyToRunContainerFormat.Wasm;
+                    }
                     if (!composite && format != ReadyToRunContainerFormat.PE && format != ReadyToRunContainerFormat.Wasm)
                     {
                         throw new Exception(string.Format(SR.ErrorContainerFormatRequiresComposite, format));

--- a/src/coreclr/tools/r2rtest/CommandLineOptions.cs
+++ b/src/coreclr/tools/r2rtest/CommandLineOptions.cs
@@ -34,6 +34,7 @@ namespace R2RTest
                     OutputDirectory,
                     Crossgen2Path,
                     TargetArch,
+                    TargetOs,
                     VerifyTypeAndFieldLayout,
                     NoJit,
                     NoCrossgen2,
@@ -72,6 +73,7 @@ namespace R2RTest
                     OutputDirectory,
                     Crossgen2Path,
                     TargetArch,
+                    TargetOs,
                     VerifyTypeAndFieldLayout,
                     NoJit,
                     NoCrossgen2,
@@ -107,6 +109,7 @@ namespace R2RTest
                 {
                     Crossgen2Path,
                     TargetArch,
+                    TargetOs,
                     VerifyTypeAndFieldLayout,
                     NoCrossgen2,
                     NoCleanup,
@@ -280,6 +283,9 @@ namespace R2RTest
         public Option<string> TargetArch { get; } =
             new("--target-arch") { Description = "Target architecture for crossgen2" };
 
+        public Option<string> TargetOs { get; } =
+            new("--target-os") { Description = "Target OS for crossgen2" };
+
         //
         // compile-nuget specific options
         //
@@ -306,6 +312,7 @@ namespace R2RTest
             Crossgen2Path = res.GetValue(cmd.Crossgen2Path);
             VerifyTypeAndFieldLayout = res.GetValue(cmd.VerifyTypeAndFieldLayout);
             TargetArch = res.GetValue(cmd.TargetArch);
+            TargetOs = res.GetValue(cmd.TargetOs);
             Exe = res.GetValue(cmd.Exe);
             NoJit = res.GetValue(cmd.NoJit);
             NoCrossgen2 = res.GetValue(cmd.NoCrossgen2);
@@ -345,6 +352,7 @@ namespace R2RTest
         public FileInfo Crossgen2Path { get; }
         public bool VerifyTypeAndFieldLayout { get; }
         public string TargetArch { get; }
+        public string TargetOs { get; }
         public bool Exe { get; }
         public bool NoJit { get; set; }
         public bool NoCrossgen2 { get; }

--- a/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
+++ b/src/coreclr/tools/r2rtest/Crossgen2Runner.cs
@@ -122,6 +122,11 @@ namespace R2RTest
                 yield return $"--targetarch={_options.TargetArch}";
             }
 
+            if (_options.TargetOs != null)
+            {
+                yield return $"--targetos={_options.TargetOs}";
+            }
+
             if (_options.VerifyTypeAndFieldLayout)
             {
                 yield return "--verify-type-and-field-layout";

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -174,6 +174,9 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
           if [ "$(CrossGen2OutputFormat)" == "macho" ]; then
               __CompositeExt=".o"
               __CompositeExtFinal=".dylib"
+          elif [ "$(CrossGen2OutputFormat)" == "wasm" ]; then
+              __CompositeExt=".wasm"
+              __CompositeExtFinal=".wasm"
           fi
           RunCrossgen2OnFiles "$PWD/composite-r2r${__CompositeExt}" "$PWD/composite-r2r${__CompositeExtFinal}" "$PWD/IL-CG2/*.dll"
       else
@@ -182,6 +185,9 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
           do
             echo $dllFile
             bareFileName="${dllFile##*/}"
+            if [ "$(CrossGen2OutputFormat)" == "wasm" ]; then
+                bareFileName="${bareFileName%.dll}.wasm"
+            fi
             RunCrossgen2OnFiles "$PWD/$bareFileName" "$PWD/$bareFileName" "$dllFile"
             if [ $__cg2ExitCode -ne 0 ]; then
               break
@@ -255,7 +261,11 @@ if defined RunCrossGen2 (
 
     if defined CompositeBuildMode (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! --composite
-        set __OutputFile=!scriptPath!\composite-r2r.dll
+        if "$(CrossGen2OutputFormat)"=="wasm" (
+            set __OutputFile=!scriptPath!\composite-r2r.wasm
+        ) else (
+            set __OutputFile=!scriptPath!\composite-r2r.dll
+        )
         set __PdbFile=!scriptPath!\composite-r2r.ni.pdb
         rem In composite mode, treat all dll's in the test folder as rooting inputs
         set __InputFile=!scriptPath!IL-CG2\*.dll
@@ -264,7 +274,11 @@ if defined RunCrossGen2 (
     ) else (
         set ExtraCrossGen2Args=!ExtraCrossGen2Args! -r:!scriptPath!IL-CG2\*.dll
         for %%I in (!scriptPath!IL-CG2\*.dll) do (
-            set __OutputFile=!scriptPath!%%~nI.dll
+            if "$(CrossGen2OutputFormat)"=="wasm" (
+                set __OutputFile=!scriptPath!%%~nI.wasm
+            ) else (
+                set __OutputFile=!scriptPath!%%~nI.dll
+            )
             set __PdbFile=!scriptPath!%%~nI.ni.pdb
             set __InputFile=%%I
             call :CompileOneFileCrossgen2
@@ -302,6 +316,9 @@ if defined RunCrossGen2 (
     echo --targetos:$(TargetOS)>>!__ResponseFile!
     echo --verify-type-and-field-layout>>!__ResponseFile!
     echo --method-layout:random>>!__ResponseFile!
+    if not "$(CrossGen2OutputFormat)"=="" (
+        echo -f:$(CrossGen2OutputFormat)>>!__ResponseFile!
+    )
     if defined CrossGen2SynthesizePgo (
         echo --synthesize-random-mibc>>!__ResponseFile!
         echo --embed-pgo-data>>!__ResponseFile!

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -270,8 +270,33 @@ fi
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun" $(CoreRunArgs)  ${__DotEnvArg}</CLRTestRunFile>
       <WatcherRunFile>"$CORE_ROOT/watchdog" $_WatcherTimeoutMins</WatcherRunFile>
 
-      <!-- Note that this overwrites CLRTestBashPreCommands rather than adding to it. -->
-      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
+      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' == 'coreclr'"><![CDATA[
+$(CLRTestBashPreCommands)
+if [ -z "${RunWithNodeJS:-}" ] ; then
+    if [ ! -z ${RunCrossGen2+x} ]%3B then
+      TakeLock
+    fi
+
+    # Build wasm app containing the test dll
+    __Command=""
+    if [ ! -z ${__TestDotNetCmd+x} ] %3B then
+      __Command+=" $__TestDotNetCmd"
+    else
+      __Command+=" dotnet"
+    fi
+
+    # workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
+    export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
+
+    $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=`pwd` $(CLRTestMSBuildArgs) || exit $?
+
+    if [ ! -z ${RunCrossGen2+x} ]%3B then
+      ReleaseLock
+    fi
+fi
+   ]]>
+      </CLRTestBashPreCommands>
+      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' != 'coreclr'"><![CDATA[
 if [ -z "${RunWithNodeJS:-}" ] ; then
     # Build wasm app containing the test dll
     __Command=""
@@ -329,7 +354,77 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
       ]]></BashCLRTestLaunchCmds>
-      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser'">
+      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' == 'coreclr'">
+      <![CDATA[
+run_with_timeout() {
+  local timeout_sec=%24(( $1 / 1000 ))
+  shift
+  local cmd=("$@")
+
+  # Start the command in the background
+  "${cmd[@]}" &
+  local pid=$!
+
+  # Start a watchdog that will kill the process if it exceeds timeout
+  (
+    sleep "$timeout_sec"
+    if [ $? -eq 0 ]; then
+      echo "Process $pid exceeded timeout of $timeout_sec seconds. Killing..."
+      if kill -0 "$pid" 2>/dev/null; then
+        kill -9 "$pid" 2>/dev/null
+      fi
+    fi
+  ) &
+  local watchdog=$!
+
+  # Wait for the command to finish
+  wait "$pid"
+  local exit_code=$?
+
+  # Kill watchdog and its children (sleep process) if still running
+  echo Kill watchdog with PID $watchdog
+  pkill -P "$watchdog" 2>/dev/null
+  kill "$watchdog" 2>/dev/null
+  wait "$watchdog" 2>/dev/null
+
+  # If the process was killed by SIGKILL (128+9 = 137), map to 99
+  if [ $exit_code -eq 137 ]; then
+    return 99
+  else
+    return $exit_code
+  fi
+}
+
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+  TakeLock
+fi
+
+if [ -z ${RunWithNodeJS+x} ] ; then
+    cd WasmApp
+    ./run-v8.sh
+else
+    if [ -z ${__TestTimeout+x} ]; then
+      __TestTimeout=300000
+    fi
+
+    echo Running with node
+    echo CORE_ROOT: ${CORE_ROOT}
+    echo ExePath: ${PWD}/${ExePath}
+    echo CLRTestExecutionArguments: ${CLRTestExecutionArguments[@]}
+    echo node version: `node -v`
+    echo Timeout in ms: $__TestTimeout
+    cmd=( node --stack-size=8192 "${CORE_ROOT}/corerun.js" -c "${CORE_ROOT}" "${PWD}/${ExePath}" "${CLRTestExecutionArguments[@]}" )
+    echo Running: "${cmd[@]}"
+    run_with_timeout $__TestTimeout "${cmd[@]}"
+fi
+CLRTestExitCode=$?
+
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+  ReleaseLock
+fi
+      ]]>
+      </BashCLRTestLaunchCmds>
+      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' != 'coreclr'">
       <![CDATA[
 run_with_timeout() {
   local timeout_sec=%24(( $1 / 1000 ))

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -270,8 +270,16 @@ fi
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun" $(CoreRunArgs)  ${__DotEnvArg}</CLRTestRunFile>
       <WatcherRunFile>"$CORE_ROOT/watchdog" $_WatcherTimeoutMins</WatcherRunFile>
 
-      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' == 'coreclr'"><![CDATA[
+      <!-- CoreCLR on browser defaults to running tests with Node.js -->
+      <BashDefaultRunWithNodeJS Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'"><![CDATA[
+if [ -z "${RunWithNodeJS:-}" ] ; then
+    export RunWithNodeJS=1
+fi
+]]></BashDefaultRunWithNodeJS>
+
+      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
 $(CLRTestBashPreCommands)
+$(BashDefaultRunWithNodeJS)
 if [ -z "${RunWithNodeJS:-}" ] ; then
     if [ ! -z ${RunCrossGen2+x} ]%3B then
       TakeLock
@@ -293,23 +301,6 @@ if [ -z "${RunWithNodeJS:-}" ] ; then
     if [ ! -z ${RunCrossGen2+x} ]%3B then
       ReleaseLock
     fi
-fi
-   ]]>
-      </CLRTestBashPreCommands>
-      <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' != 'coreclr'"><![CDATA[
-if [ -z "${RunWithNodeJS:-}" ] ; then
-    # Build wasm app containing the test dll
-    __Command=""
-    if [ ! -z ${__TestDotNetCmd+x} ] %3B then
-      __Command+=" $__TestDotNetCmd"
-    else
-      __Command+=" dotnet"
-    fi
-
-    # workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-    export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
-
-    $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=`pwd` $(CLRTestMSBuildArgs) || exit $?
 fi
    ]]>
       </CLRTestBashPreCommands>
@@ -354,7 +345,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
       ]]></BashCLRTestLaunchCmds>
-      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' == 'coreclr'">
+      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser'">
       <![CDATA[
 run_with_timeout() {
   local timeout_sec=%24(( $1 / 1000 ))
@@ -422,68 +413,6 @@ CLRTestExitCode=$?
 if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
-      ]]>
-      </BashCLRTestLaunchCmds>
-      <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' != 'coreclr'">
-      <![CDATA[
-run_with_timeout() {
-  local timeout_sec=%24(( $1 / 1000 ))
-  shift
-  local cmd=("$@")
-
-  # Start the command in the background
-  "${cmd[@]}" &
-  local pid=$!
-
-  # Start a watchdog that will kill the process if it exceeds timeout
-  (
-    sleep "$timeout_sec"
-    if [ $? -eq 0 ]; then
-      echo "Process $pid exceeded timeout of $timeout_sec seconds. Killing..."
-      if kill -0 "$pid" 2>/dev/null; then
-        kill -9 "$pid" 2>/dev/null
-      fi
-    fi
-  ) &
-  local watchdog=$!
-
-  # Wait for the command to finish
-  wait "$pid"
-  local exit_code=$?
-
-  # Kill watchdog and its children (sleep process) if still running
-  echo Kill watchdog with PID $watchdog
-  pkill -P "$watchdog" 2>/dev/null
-  kill "$watchdog" 2>/dev/null
-  wait "$watchdog" 2>/dev/null
-
-  # If the process was killed by SIGKILL (128+9 = 137), map to 99
-  if [ $exit_code -eq 137 ]; then
-    return 99
-  else
-    return $exit_code
-  fi
-}
-
-if [ -z ${RunWithNodeJS+x} ] ; then
-    cd WasmApp
-    ./run-v8.sh
-else
-    if [ -z ${__TestTimeout+x} ]; then
-      __TestTimeout=300000
-    fi
-
-    echo Running with node
-    echo CORE_ROOT: ${CORE_ROOT}
-    echo ExePath: ${PWD}/${ExePath}
-    echo CLRTestExecutionArguments: ${CLRTestExecutionArguments[@]}
-    echo node version: `node -v`
-    echo Timeout in ms: $__TestTimeout
-    cmd=( node --stack-size=8192 "${CORE_ROOT}/corerun.js" -c "${CORE_ROOT}" "${PWD}/${ExePath}" "${CLRTestExecutionArguments[@]}" )
-    echo Running: "${cmd[@]}"
-    run_with_timeout $__TestTimeout "${cmd[@]}"
-fi
-CLRTestExitCode=$?
       ]]>
       </BashCLRTestLaunchCmds>
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'android'">

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -280,11 +280,11 @@ fi
       <CLRTestBashPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
 $(CLRTestBashPreCommands)
 $(BashDefaultRunWithNodeJS)
-if [ -z "${RunWithNodeJS:-}" ] ; then
-    if [ ! -z ${RunCrossGen2+x} ]%3B then
-      TakeLock
-    fi
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+  TakeLock
+fi
 
+if [ -z "${RunWithNodeJS:-}" ] ; then
     # Build wasm app containing the test dll
     __Command=""
     if [ ! -z ${__TestDotNetCmd+x} ] %3B then
@@ -297,10 +297,10 @@ if [ -z "${RunWithNodeJS:-}" ] ; then
     export DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
 
     $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=`pwd` $(CLRTestMSBuildArgs) || exit $?
+fi
 
-    if [ ! -z ${RunCrossGen2+x} ]%3B then
-      ReleaseLock
-    fi
+if [ ! -z ${RunCrossGen2+x} ]%3B then
+  ReleaseLock
 fi
    ]]>
       </CLRTestBashPreCommands>

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -262,8 +262,38 @@ REM Local CoreShim requested - see MSBuild property 'CLRTestScriptLocalCoreShim'
 ECHO Copying '%CORE_ROOT%\CoreShim.dll'...
 COPY /y %CORE_ROOT%\CoreShim.dll .
       ]]></BatchCopyCoreShimLocalCmds>
-      <!-- Note that this overwrites CLRTestBatchPreCommands rather than adding to it. -->
-      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
+      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' == 'coreclr'"><![CDATA[
+$(CLRTestBatchPreCommands)
+IF NOT DEFINED RunWithNodeJS (
+    if defined RunCrossGen2 (
+      call :TakeLock
+    )
+
+    REM Build wasm app containing the test dll
+    IF DEFINED __TestDotNetCmd (
+        set __Command=%__TestDotNetCmd%
+    ) ELSE (
+        set __Command=dotnet
+    )
+
+    REM workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
+    set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
+
+    !__Command! msbuild %CORE_ROOT%\wasm-test-runner\WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=%%CD%% $(CLRTestMSBuildArgs)
+    IF NOT "!ERRORLEVEL!"=="0" (
+        if defined RunCrossGen2 (
+          call :ReleaseLock
+        )
+        popd
+        Exit /b !ERRORLEVEL!
+    )
+
+    if defined RunCrossGen2 (
+      call :ReleaseLock
+    )
+)
+      ]]></CLRTestBatchPreCommands>
+      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' != 'coreclr'"><![CDATA[
 IF NOT DEFINED RunWithNodeJS (
     REM Build wasm app containing the test dll
     IF DEFINED __TestDotNetCmd (
@@ -312,7 +342,50 @@ if defined RunCrossGen2 (
   call :ReleaseLock
 )
       ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser'">
+      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' == 'coreclr'">
+    <![CDATA[
+if defined RunCrossGen2 (
+  call :TakeLock
+)
+
+IF NOT DEFINED RunWithNodeJS (
+    ECHO V8 execution is not supported on Windows. Set RunWithNodeJS to use Node.
+    set CLRTestExitCode=1
+) ELSE (
+    if not defined __TestTimeout (
+      set __TestTimeout=300000
+    )
+
+    REM Convert Windows paths to Unix-style paths for Node.js
+    set "__CoreRootWin=%CORE_ROOT%"
+    set "__CoreRootUnix=%CORE_ROOT%"
+    set "__CoreRootUnix=!__CoreRootUnix:\=/!"
+    if "!__CoreRootUnix:~1,1!"==":" set "__CoreRootUnix=/!__CoreRootUnix:~3!"
+    
+    set "__ExePathUnix=!CD!\%ExePath%"
+    set "__ExePathUnix=!__ExePathUnix:\=/!"
+    if "!__ExePathUnix:~1,1!"==":" set "__ExePathUnix=/!__ExePathUnix:~3!"
+    
+    set "CORE_ROOT=!__CoreRootUnix!"
+    set "TestExclusionListPath=!__CoreRootUnix!/TestExclusionList.txt"
+    
+    ECHO Running with node
+    ECHO CORE_ROOT: !CORE_ROOT!
+    ECHO ExePath: !__ExePathUnix!
+    ECHO CLRTestExecutionArguments: %CLRTestExecutionArguments%
+    ECHO Timeout in ms: !__TestTimeout!
+    
+    set "__RunCmd=node --stack-size=8192 "!__CoreRootWin!\corerun.js" -c "!__CoreRootUnix!" "!__ExePathUnix!" %CLRTestExecutionArguments%"
+    ECHO Running: !__RunCmd!
+    call :RunWithTimeout !__TestTimeout!
+    set CLRTestExitCode=!ERRORLEVEL!
+)
+
+if defined RunCrossGen2 (
+  call :ReleaseLock
+)
+      ]]></BatchCLRTestLaunchCmds>
+      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' != 'coreclr'">
     <![CDATA[
 IF NOT DEFINED RunWithNodeJS (
     ECHO V8 execution is not supported on Windows. Set RunWithNodeJS to use Node.

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -272,11 +272,11 @@ COPY /y %CORE_ROOT%\CoreShim.dll .
       <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
 $(CLRTestBatchPreCommands)
 $(BatchDefaultRunWithNodeJS)
-IF NOT DEFINED RunWithNodeJS (
-    if defined RunCrossGen2 (
-      call :TakeLock
-    )
+if defined RunCrossGen2 (
+  call :TakeLock
+)
 
+IF NOT DEFINED RunWithNodeJS (
     REM Build wasm app containing the test dll
     IF DEFINED __TestDotNetCmd (
         set __Command=%__TestDotNetCmd%
@@ -295,10 +295,10 @@ IF NOT DEFINED RunWithNodeJS (
         popd
         Exit /b !ERRORLEVEL!
     )
+)
 
-    if defined RunCrossGen2 (
-      call :ReleaseLock
-    )
+if defined RunCrossGen2 (
+  call :ReleaseLock
 )
       ]]></CLRTestBatchPreCommands>
 

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -257,13 +257,21 @@ Exit /b !ERRORLEVEL!
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe" $(CoreRunArgs) %__DotEnvArg%</CLRTestRunFile>
       <WatcherRunFile>"%CORE_ROOT%\watchdog.exe" %_WatcherTimeoutMins%</WatcherRunFile>
 
+      <!-- CoreCLR on browser defaults to running tests with Node.js -->
+      <BatchDefaultRunWithNodeJS Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(TargetOS)' == 'browser'"><![CDATA[
+IF NOT DEFINED RunWithNodeJS (
+    set RunWithNodeJS=1
+)
+]]></BatchDefaultRunWithNodeJS>
+
       <BatchCopyCoreShimLocalCmds Condition="'$(CLRTestScriptLocalCoreShim)' == 'true'"><![CDATA[
 REM Local CoreShim requested - see MSBuild property 'CLRTestScriptLocalCoreShim'
 ECHO Copying '%CORE_ROOT%\CoreShim.dll'...
 COPY /y %CORE_ROOT%\CoreShim.dll .
       ]]></BatchCopyCoreShimLocalCmds>
-      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' == 'coreclr'"><![CDATA[
+      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm'"><![CDATA[
 $(CLRTestBatchPreCommands)
+$(BatchDefaultRunWithNodeJS)
 IF NOT DEFINED RunWithNodeJS (
     if defined RunCrossGen2 (
       call :TakeLock
@@ -290,25 +298,6 @@ IF NOT DEFINED RunWithNodeJS (
 
     if defined RunCrossGen2 (
       call :ReleaseLock
-    )
-)
-      ]]></CLRTestBatchPreCommands>
-      <CLRTestBatchPreCommands Condition="'$(CLRTestKind)' == 'BuildAndRun' and '$(TargetArchitecture)' == 'wasm' and '$(RuntimeFlavor)' != 'coreclr'"><![CDATA[
-IF NOT DEFINED RunWithNodeJS (
-    REM Build wasm app containing the test dll
-    IF DEFINED __TestDotNetCmd (
-        set __Command=%__TestDotNetCmd%
-    ) ELSE (
-        set __Command=dotnet
-    )
-
-    REM workaround msbuild issue - https://github.com/dotnet/runtime/issues/74328
-    set DOTNET_CLI_DO_NOT_USE_MSBUILD_SERVER=1
-
-    !__Command! msbuild %CORE_ROOT%\wasm-test-runner\WasmTestRunner.proj /p:NetCoreAppCurrent=$(NetCoreAppCurrent) /p:TestAssemblyFileName=$(MsBuildProjectName).dll /p:TestBinDir=%%CD%% $(CLRTestMSBuildArgs)
-    IF NOT "!ERRORLEVEL!"=="0" (
-        popd
-        Exit /b !ERRORLEVEL!
     )
 )
       ]]></CLRTestBatchPreCommands>
@@ -342,7 +331,7 @@ if defined RunCrossGen2 (
   call :ReleaseLock
 )
       ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' == 'coreclr'">
+      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser'">
     <![CDATA[
 if defined RunCrossGen2 (
   call :TakeLock
@@ -383,41 +372,6 @@ IF NOT DEFINED RunWithNodeJS (
 
 if defined RunCrossGen2 (
   call :ReleaseLock
-)
-      ]]></BatchCLRTestLaunchCmds>
-      <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser' And '$(RuntimeFlavor)' != 'coreclr'">
-    <![CDATA[
-IF NOT DEFINED RunWithNodeJS (
-    ECHO V8 execution is not supported on Windows. Set RunWithNodeJS to use Node.
-    set CLRTestExitCode=1
-) ELSE (
-    if not defined __TestTimeout (
-      set __TestTimeout=300000
-    )
-
-    REM Convert Windows paths to Unix-style paths for Node.js
-    set "__CoreRootWin=%CORE_ROOT%"
-    set "__CoreRootUnix=%CORE_ROOT%"
-    set "__CoreRootUnix=!__CoreRootUnix:\=/!"
-    if "!__CoreRootUnix:~1,1!"==":" set "__CoreRootUnix=/!__CoreRootUnix:~3!"
-    
-    set "__ExePathUnix=!CD!\%ExePath%"
-    set "__ExePathUnix=!__ExePathUnix:\=/!"
-    if "!__ExePathUnix:~1,1!"==":" set "__ExePathUnix=/!__ExePathUnix:~3!"
-    
-    set "CORE_ROOT=!__CoreRootUnix!"
-    set "TestExclusionListPath=!__CoreRootUnix!/TestExclusionList.txt"
-    
-    ECHO Running with node
-    ECHO CORE_ROOT: !CORE_ROOT!
-    ECHO ExePath: !__ExePathUnix!
-    ECHO CLRTestExecutionArguments: %CLRTestExecutionArguments%
-    ECHO Timeout in ms: !__TestTimeout!
-    
-    set "__RunCmd=node --stack-size=8192 "!__CoreRootWin!\corerun.js" -c "!__CoreRootUnix!" "!__ExePathUnix!" %CLRTestExecutionArguments%"
-    ECHO Running: !__RunCmd!
-    call :RunWithTimeout !__TestTimeout!
-    set CLRTestExitCode=!ERRORLEVEL!
 )
       ]]></BatchCLRTestLaunchCmds>
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'android'">

--- a/src/tests/Common/CoreRootArtifacts.targets
+++ b/src/tests/Common/CoreRootArtifacts.targets
@@ -63,7 +63,7 @@
       <RunTimeArtifactsIncludeFolders Include="IL/" TargetDir="IL/" />
 
       <!-- Used for Crossgen2 R2R tests -->
-      <RunTimeArtifactsIncludeFolders Include="crossgen2-published/" TargetDir="crossgen2/">
+      <RunTimeArtifactsIncludeFolders Condition="'$(CrossGen2HostArtifactsPath)' == ''" Include="crossgen2-published/" TargetDir="crossgen2/">
         <IncludeSubFolders>True</IncludeSubFolders>
       </RunTimeArtifactsIncludeFolders>
 
@@ -128,16 +128,24 @@
     </ItemGroup>
 
     <!-- Cross-architecture crossgen2 JIT libraries -->
-    <PropertyGroup>
+    <PropertyGroup Condition="'$(CrossGen2HostArtifactsPath)' == ''">
       <_Crossgen2Dir Condition="('$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64') or '$(EnableNativeSanitizers)' != ''">$(CoreCLRArtifactsPath)x64/crossgen2</_Crossgen2Dir>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_Crossgen2Dir)' != ''">
+    <ItemGroup Condition="'$(_Crossgen2Dir)' != '' and '$(CrossGen2HostArtifactsPath)' == ''">
       <_CoreRootArtifactSource
           Include="
             $(_Crossgen2Dir)/$(LibPrefix)clrjit_*$(LibSuffix);
             $(_Crossgen2Dir)/$(LibPrefix)jitinterface_*$(LibSuffix);
             $(_Crossgen2Dir)/$(LibPrefix)Microsoft.DiaSymReader.Native.*$(LibSuffix)"
+          TargetDir="crossgen2/" />
+    </ItemGroup>
+
+    <!-- When CrossGen2HostArtifactsPath is specified (e.g., wasm targets needing a host crossgen2),
+         copy crossgen2 from the host coreclr build instead of from the target's CoreCLRArtifactsPath. -->
+    <ItemGroup Condition="'$(CrossGen2HostArtifactsPath)' != ''">
+      <_CoreRootArtifactSource
+          Include="$(CrossGen2HostArtifactsPath)/crossgen2-published/**/*"
           TargetDir="crossgen2/" />
     </ItemGroup>
 

--- a/src/tests/Common/CoreRootArtifacts.targets
+++ b/src/tests/Common/CoreRootArtifacts.targets
@@ -63,7 +63,7 @@
       <RunTimeArtifactsIncludeFolders Include="IL/" TargetDir="IL/" />
 
       <!-- Used for Crossgen2 R2R tests -->
-      <RunTimeArtifactsIncludeFolders Condition="'$(CrossGen2HostArtifactsPath)' == ''" Include="crossgen2-published/" TargetDir="crossgen2/">
+      <RunTimeArtifactsIncludeFolders Include="crossgen2-published/" TargetDir="crossgen2/">
         <IncludeSubFolders>True</IncludeSubFolders>
       </RunTimeArtifactsIncludeFolders>
 
@@ -128,24 +128,16 @@
     </ItemGroup>
 
     <!-- Cross-architecture crossgen2 JIT libraries -->
-    <PropertyGroup Condition="'$(CrossGen2HostArtifactsPath)' == ''">
+    <PropertyGroup>
       <_Crossgen2Dir Condition="('$(TargetArchitecture)' != 'x64' and '$(BuildArchitecture)' == 'x64') or '$(EnableNativeSanitizers)' != ''">$(CoreCLRArtifactsPath)x64/crossgen2</_Crossgen2Dir>
     </PropertyGroup>
 
-    <ItemGroup Condition="'$(_Crossgen2Dir)' != '' and '$(CrossGen2HostArtifactsPath)' == ''">
+    <ItemGroup Condition="'$(_Crossgen2Dir)' != ''">
       <_CoreRootArtifactSource
           Include="
             $(_Crossgen2Dir)/$(LibPrefix)clrjit_*$(LibSuffix);
             $(_Crossgen2Dir)/$(LibPrefix)jitinterface_*$(LibSuffix);
             $(_Crossgen2Dir)/$(LibPrefix)Microsoft.DiaSymReader.Native.*$(LibSuffix)"
-          TargetDir="crossgen2/" />
-    </ItemGroup>
-
-    <!-- When CrossGen2HostArtifactsPath is specified (e.g., wasm targets needing a host crossgen2),
-         copy crossgen2 from the host coreclr build instead of from the target's CoreCLRArtifactsPath. -->
-    <ItemGroup Condition="'$(CrossGen2HostArtifactsPath)' != ''">
-      <_CoreRootArtifactSource
-          Include="$(CrossGen2HostArtifactsPath)/crossgen2-published/**/*"
           TargetDir="crossgen2/" />
     </ItemGroup>
 

--- a/src/tests/Common/CoreRootArtifacts.targets
+++ b/src/tests/Common/CoreRootArtifacts.targets
@@ -145,6 +145,14 @@
           TargetDir="crossgen2/" />
 
       <_CoreRootArtifactSource
+          Condition="'$(TargetArchitecture)' == 'wasm'"
+          Include="
+            $(_Crossgen2Dir)/$(HostLibPrefix)clrjit_*$(HostLibSuffix);
+            $(_Crossgen2Dir)/$(HostLibPrefix)jitinterface_*$(HostLibSuffix);
+            $(_Crossgen2Dir)/$(HostLibPrefix)Microsoft.DiaSymReader.Native.*$(HostLibSuffix)"
+          TargetDir="crossgen2/" />
+      <_CoreRootArtifactSource
+          Condition="'$(TargetArchitecture)' != 'wasm'"
           Include="
             $(_Crossgen2Dir)/$(LibPrefix)clrjit_*$(LibSuffix);
             $(_Crossgen2Dir)/$(LibPrefix)jitinterface_*$(LibSuffix);

--- a/src/tests/Common/CoreRootArtifacts.targets
+++ b/src/tests/Common/CoreRootArtifacts.targets
@@ -133,6 +133,17 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(_Crossgen2Dir)' != ''">
+      <!-- When crossgen2-published does not exist (e.g. wasm cross-targeting builds),
+           copy crossgen2 itself from the cross-architecture build output. -->
+      <_CoreRootArtifactSource
+          Include="$(_Crossgen2Dir)/crossgen2$(ExeSuffix)"
+          Condition="Exists('$(_Crossgen2Dir)/crossgen2$(ExeSuffix)') and !Exists('$(CoreCLRArtifactsPath)crossgen2-published/crossgen2$(ExeSuffix)')"
+          TargetDir="crossgen2/" />
+      <_CoreRootArtifactSource
+          Include="$(_Crossgen2Dir)/crossgen2.pdb"
+          Condition="Exists('$(_Crossgen2Dir)/crossgen2.pdb') and !Exists('$(CoreCLRArtifactsPath)crossgen2-published/crossgen2$(ExeSuffix)')"
+          TargetDir="crossgen2/" />
+
       <_CoreRootArtifactSource
           Include="
             $(_Crossgen2Dir)/$(LibPrefix)clrjit_*$(LibSuffix);

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -202,6 +202,7 @@
 
   <PropertyGroup Condition="'$(TargetOS)' == 'browser'">
     <CLRTestMSBuildArgs>/p:MSBuildEnableWorkloadResolver=false /p:Configuration=$(Configuration)</CLRTestMSBuildArgs>
+    <CrossGen2OutputFormat>wasm</CrossGen2OutputFormat>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestsCommonProject)' != 'true'">

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -70,8 +70,8 @@ if /i "%1" == "arm64"                    (set __BuildArch=arm64&set processedArg
 if /i "%1" == "wasm"                     (set __BuildArch=wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if /i "%1" == "os"                       (set __TargetOS=%2&set processedArgs=!processedArgs! %1&shift&shift&goto Arg_Loop)
-if /i "%1" == "browser"                  (set __TargetOS=browser&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%1" == "wasi"                     (set __TargetOS=wasi&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "browser"                  (set __TargetOS=browser&set __BuildArch=wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%1" == "wasi"                     (set __TargetOS=wasi&set __BuildArch=wasm&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"                    (set __BuildType=Debug&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%1" == "release"                  (set __BuildType=Release&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -361,8 +361,8 @@ echo.
 echo Build target OS options:
 echo     os ^<value^>: Set the target OS. Common values: windows ^(default^), linux, osx, android,
 echo         ios, iossimulator, tvos, tvossimulator, maccatalyst, browser, wasi.
-echo     browser: Shorthand for "os browser" ^(typically combine with "wasm", for example "wasm browser"^).
-echo     wasi: Shorthand for "os wasi" ^(typically combine with "wasm", for example "wasm wasi"^).
+echo     browser: Shorthand for "os browser" ^(also sets architecture to wasm^).
+echo     wasi: Shorthand for "os wasi" ^(also sets architecture to wasm^).
 echo.
 echo -Rebuild: Clean up all test artifacts prior to building tests.
 echo -SkipRestorePackages: Skip package restore.

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -54,6 +54,7 @@ set __Ninja=1
 set __CMakeArgs=
 set __EnableNativeSanitizers=
 set __Priority=0
+set __CrossGen2HostArtifactsPath=
 
 set __BuildNeedTargetArg=
 
@@ -106,6 +107,7 @@ if /i "%arg%" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipM
 if /i "%arg%" == "MSBuild"               (set __Ninja=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "crossgen2"             (set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "composite"             (set __CompositeBuildMode=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
+if /i "%arg%" == "crossgen2host"         (set __CrossGen2HostArtifactsPath=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%arg%" == "pdb"                   (set __CreatePdb=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "NativeAOT"             (set __TestBuildMode=nativeaot&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "Perfmap"               (set __CreatePerfmap=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -225,6 +227,22 @@ if "%__Mono%"=="1" (
   set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:RuntimeFlavor=mono"
 ) else (
   set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:RuntimeFlavor=coreclr"
+)
+
+REM Auto-detect CrossGen2HostArtifactsPath for wasm targets (crossgen2 is never available in wasm builds)
+if /i "%__BuildArch%" == "wasm" if "%__CrossGen2HostArtifactsPath%" == "" (
+    REM Prefer PROCESSOR_ARCHITEW6432 for WOW64 compatibility, then fall back to PROCESSOR_ARCHITECTURE
+    set "__HostProcArch=%PROCESSOR_ARCHITEW6432%"
+    if "!__HostProcArch!" == "" set "__HostProcArch=%PROCESSOR_ARCHITECTURE%"
+    set "__HostArch=x64"
+    if /i "!__HostProcArch!" == "ARM64" set "__HostArch=arm64"
+    if /i "!__HostProcArch!" == "x86" set "__HostArch=x86"
+    set "__CrossGen2HostArtifactsPath=%__RootBinDir%\bin\coreclr\windows.!__HostArch!.%__BuildType%"
+    echo %__MsgPrefix%Auto-detected CrossGen2HostArtifactsPath: !__CrossGen2HostArtifactsPath!
+)
+
+if not "%__CrossGen2HostArtifactsPath%" == "" (
+    set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:CrossGen2HostArtifactsPath=%__CrossGen2HostArtifactsPath%"
 )
 
 if %__Ninja% == 0 (
@@ -374,6 +392,7 @@ echo -CopyNativeOnly: Only copy the native test binaries to the managed output. 
 echo -GenerateLayoutOnly: Only generate the Core_Root layout without building managed or native test components.
 echo -MSBuild: Use MSBuild instead of Ninja.
 echo -Crossgen2: Precompiles the framework managed assemblies in coreroot using the Crossgen2 compiler.
+echo -Crossgen2Host ^<path^>: Override the path to the host coreclr artifacts used for crossgen2 when targeting wasm.
 echo -Composite: Use Crossgen2 composite mode (all framework gets compiled into a single native R2R library).
 echo -PDB: Create PDB files when precompiling the framework managed assemblies.
 echo -NativeAOT: Builds the tests for Native AOT compilation.

--- a/src/tests/build.cmd
+++ b/src/tests/build.cmd
@@ -54,7 +54,6 @@ set __Ninja=1
 set __CMakeArgs=
 set __EnableNativeSanitizers=
 set __Priority=0
-set __CrossGen2HostArtifactsPath=
 
 set __BuildNeedTargetArg=
 
@@ -107,7 +106,6 @@ if /i "%arg%" == "GenerateLayoutOnly"    (set __GenerateLayoutOnly=1&set __SkipM
 if /i "%arg%" == "MSBuild"               (set __Ninja=0&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "crossgen2"             (set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "composite"             (set __CompositeBuildMode=1&set __TestBuildMode=crossgen2&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
-if /i "%arg%" == "crossgen2host"         (set __CrossGen2HostArtifactsPath=%2&set processedArgs=!processedArgs! %1 %2&shift&shift&goto Arg_Loop)
 if /i "%arg%" == "pdb"                   (set __CreatePdb=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "NativeAOT"             (set __TestBuildMode=nativeaot&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
 if /i "%arg%" == "Perfmap"               (set __CreatePerfmap=1&set processedArgs=!processedArgs! %1&shift&goto Arg_Loop)
@@ -227,22 +225,6 @@ if "%__Mono%"=="1" (
   set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:RuntimeFlavor=mono"
 ) else (
   set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:RuntimeFlavor=coreclr"
-)
-
-REM Auto-detect CrossGen2HostArtifactsPath for wasm targets (crossgen2 is never available in wasm builds)
-if /i "%__BuildArch%" == "wasm" if "%__CrossGen2HostArtifactsPath%" == "" (
-    REM Prefer PROCESSOR_ARCHITEW6432 for WOW64 compatibility, then fall back to PROCESSOR_ARCHITECTURE
-    set "__HostProcArch=%PROCESSOR_ARCHITEW6432%"
-    if "!__HostProcArch!" == "" set "__HostProcArch=%PROCESSOR_ARCHITECTURE%"
-    set "__HostArch=x64"
-    if /i "!__HostProcArch!" == "ARM64" set "__HostArch=arm64"
-    if /i "!__HostProcArch!" == "x86" set "__HostArch=x86"
-    set "__CrossGen2HostArtifactsPath=%__RootBinDir%\bin\coreclr\windows.!__HostArch!.%__BuildType%"
-    echo %__MsgPrefix%Auto-detected CrossGen2HostArtifactsPath: !__CrossGen2HostArtifactsPath!
-)
-
-if not "%__CrossGen2HostArtifactsPath%" == "" (
-    set __CommonMSBuildArgs=!__CommonMSBuildArgs! "/p:CrossGen2HostArtifactsPath=%__CrossGen2HostArtifactsPath%"
 )
 
 if %__Ninja% == 0 (
@@ -392,7 +374,6 @@ echo -CopyNativeOnly: Only copy the native test binaries to the managed output. 
 echo -GenerateLayoutOnly: Only generate the Core_Root layout without building managed or native test components.
 echo -MSBuild: Use MSBuild instead of Ninja.
 echo -Crossgen2: Precompiles the framework managed assemblies in coreroot using the Crossgen2 compiler.
-echo -Crossgen2Host ^<path^>: Override the path to the host coreclr artifacts used for crossgen2 when targeting wasm.
 echo -Composite: Use Crossgen2 composite mode (all framework gets compiled into a single native R2R library).
 echo -PDB: Create PDB files when precompiling the framework managed assemblies.
 echo -NativeAOT: Builds the tests for Native AOT compilation.

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -291,6 +291,7 @@
       <CrossgenCmd>$(CrossgenCmd) --release</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) --nocleanup</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) --target-arch $(TargetArchitecture)</CrossgenCmd>
+      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' != ''">$(CrossgenCmd) --target-os $(TargetOS)</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) -dop $(NUMBER_OF_PROCESSORS)</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) -m "$(CORE_ROOT)\StandardOptimizationData.mibc"</CrossgenCmd>
 
@@ -300,7 +301,8 @@
       <CrossgenCmd Condition="'$(__CompositeBuildMode)' == ''">$(CrossgenCmd) --crossgen2-parallelism 1</CrossgenCmd>
 
       <CrossgenCmd>$(CrossgenCmd) --verify-type-and-field-layout</CrossgenCmd>
-      <CrossgenCmd>$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2$(ExeSuffix)"</CrossgenCmd>
+      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' == ''">$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2$(ExeSuffix)"</CrossgenCmd>
+      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' != ''">$(CrossgenCmd) --crossgen2-path "$(CrossGen2HostArtifactsPath)\crossgen2-published\crossgen2$(ExeSuffix)"</CrossgenCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(MsgPrefix)Compiling framework using Crossgen2: $(CrossgenCmd)" />

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -291,7 +291,6 @@
       <CrossgenCmd>$(CrossgenCmd) --release</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) --nocleanup</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) --target-arch $(TargetArchitecture)</CrossgenCmd>
-      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' != ''">$(CrossgenCmd) --target-os $(TargetOS)</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) -dop $(NUMBER_OF_PROCESSORS)</CrossgenCmd>
       <CrossgenCmd>$(CrossgenCmd) -m "$(CORE_ROOT)\StandardOptimizationData.mibc"</CrossgenCmd>
 
@@ -301,8 +300,7 @@
       <CrossgenCmd Condition="'$(__CompositeBuildMode)' == ''">$(CrossgenCmd) --crossgen2-parallelism 1</CrossgenCmd>
 
       <CrossgenCmd>$(CrossgenCmd) --verify-type-and-field-layout</CrossgenCmd>
-      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' == ''">$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2$(ExeSuffix)"</CrossgenCmd>
-      <CrossgenCmd Condition="'$(CrossGen2HostArtifactsPath)' != ''">$(CrossgenCmd) --crossgen2-path "$(CrossGen2HostArtifactsPath)\crossgen2-published\crossgen2$(ExeSuffix)"</CrossgenCmd>
+      <CrossgenCmd>$(CrossgenCmd) --crossgen2-path "$(__BinDir)\$(BuildArchitecture)\crossgen2\crossgen2$(ExeSuffix)"</CrossgenCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="$(MsgPrefix)Compiling framework using Crossgen2: $(CrossgenCmd)" />

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -141,6 +141,8 @@ usage_list+=("    target OS. Common values: linux (default on Linux), osx (defau
 usage_list+=("    ios, iossimulator, tvos, tvossimulator, maccatalyst, browser, wasi.")
 usage_list+=("    For mobile/device targets (android, ios, iossimulator, tvos, tvossimulator), this script")
 usage_list+=("    automatically skips building native test components.")
+usage_list+=("-browser - Shorthand for '-os browser' (also sets architecture to wasm).")
+usage_list+=("-wasi - Shorthand for '-os wasi' (also sets architecture to wasm).")
 usage_list+=("")
 usage_list+=("-rebuild - Clean up all test artifacts prior to building tests.")
 usage_list+=("-skiprestorepackages - Skip package restore.")
@@ -298,6 +300,16 @@ handle_arguments_local() {
             __Mono=0
             __MonoAot=0
             __MonoFullAot=0
+            ;;
+
+        browser|-browser)
+            __TargetOS=browser
+            __TargetArch=wasm
+            ;;
+
+        wasi|-wasi)
+            __TargetOS=wasi
+            __TargetArch=wasm
             ;;
 
         log*|-log*)

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -115,6 +115,9 @@ build_Tests()
     buildArgs+=("/maxcpucount")
     buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}" "${__msbuildBinLog}")
     buildArgs+=("/p:NUMBER_OF_PROCESSORS=${__NumProc}")
+    if [[ -n "$__CrossGen2HostArtifactsPath" ]]; then
+        buildArgs+=("/p:CrossGen2HostArtifactsPath=$__CrossGen2HostArtifactsPath")
+    fi
     buildArgs+=("${__UnprocessedBuildArgs[@]}")
 
     # Disable warnAsError - https://github.com/dotnet/runtime/issues/11077
@@ -152,6 +155,7 @@ usage_list+=("-copynativeonly - Only copy the native test binaries to the manage
 usage_list+=("-generatelayoutonly - Only generate the Core_Root layout without building managed or native test components.")
 usage_list+=("")
 usage_list+=("-crossgen2 - Precompiles the framework managed assemblies in coreroot using the Crossgen2 compiler.")
+usage_list+=("-crossgen2host:<path> - Override the path to the host coreclr artifacts used for crossgen2 when targeting wasm.")
 usage_list+=("-composite - Use Crossgen2 composite mode (all framework gets compiled into a single native R2R library).")
 usage_list+=("-nativeaot - Builds the tests for Native AOT compilation.")
 usage_list+=("-priority1 - Include priority=1 tests in the build.")
@@ -203,6 +207,17 @@ handle_arguments_local() {
         composite|-composite)
             __CompositeBuildMode=1
             __TestBuildMode=crossgen2
+            ;;
+
+        crossgen2host*|-crossgen2host*)
+            local arg="$1"
+            local parts=(${arg//:/ })
+            if [[ ${#parts[@]} -eq 1 ]]; then
+                __CrossGen2HostArtifactsPath="$2"
+                __ShiftArgs=1
+            else
+                __CrossGen2HostArtifactsPath="${parts[1]}"
+            fi
             ;;
 
         nativeaot|-nativeaot)
@@ -359,6 +374,7 @@ __Mono=0
 __MonoAot=0
 __MonoFullAot=0
 __BuildLogRootName="TestBuild"
+__CrossGen2HostArtifactsPath=
 CORE_ROOT=
 EnableNativeSanitizers=
 
@@ -408,6 +424,20 @@ __IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
 __TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
 __MonoBinDir="$__RootBinDir/bin/mono/$__OSPlatformConfig"
+
+# Auto-detect CrossGen2HostArtifactsPath for wasm targets (crossgen2 is never available in wasm builds)
+if [[ "$__TargetArch" == "wasm" && -z "$__CrossGen2HostArtifactsPath" ]]; then
+    # Determine the host OS name as used in artifact paths
+    if [[ "$platform" == "darwin" ]]; then
+        __HostOSName="osx"
+    elif [[ "$platform" == "freebsd" ]]; then
+        __HostOSName="freebsd"
+    else
+        __HostOSName="linux"
+    fi
+    __CrossGen2HostArtifactsPath="$__RootBinDir/bin/coreclr/$__HostOSName.$__HostArch.$__BuildType"
+    echo "${__MsgPrefix}Auto-detected CrossGen2HostArtifactsPath: $__CrossGen2HostArtifactsPath"
+fi
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to it.
 # This is needed by CLI to function.

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -115,9 +115,6 @@ build_Tests()
     buildArgs+=("/maxcpucount")
     buildArgs+=("${__msbuildLog}" "${__msbuildWrn}" "${__msbuildErr}" "${__msbuildBinLog}")
     buildArgs+=("/p:NUMBER_OF_PROCESSORS=${__NumProc}")
-    if [[ -n "$__CrossGen2HostArtifactsPath" ]]; then
-        buildArgs+=("/p:CrossGen2HostArtifactsPath=$__CrossGen2HostArtifactsPath")
-    fi
     buildArgs+=("${__UnprocessedBuildArgs[@]}")
 
     # Disable warnAsError - https://github.com/dotnet/runtime/issues/11077
@@ -155,7 +152,6 @@ usage_list+=("-copynativeonly - Only copy the native test binaries to the manage
 usage_list+=("-generatelayoutonly - Only generate the Core_Root layout without building managed or native test components.")
 usage_list+=("")
 usage_list+=("-crossgen2 - Precompiles the framework managed assemblies in coreroot using the Crossgen2 compiler.")
-usage_list+=("-crossgen2host:<path> - Override the path to the host coreclr artifacts used for crossgen2 when targeting wasm.")
 usage_list+=("-composite - Use Crossgen2 composite mode (all framework gets compiled into a single native R2R library).")
 usage_list+=("-nativeaot - Builds the tests for Native AOT compilation.")
 usage_list+=("-priority1 - Include priority=1 tests in the build.")
@@ -207,17 +203,6 @@ handle_arguments_local() {
         composite|-composite)
             __CompositeBuildMode=1
             __TestBuildMode=crossgen2
-            ;;
-
-        crossgen2host*|-crossgen2host*)
-            local arg="$1"
-            local parts=(${arg//:/ })
-            if [[ ${#parts[@]} -eq 1 ]]; then
-                __CrossGen2HostArtifactsPath="$2"
-                __ShiftArgs=1
-            else
-                __CrossGen2HostArtifactsPath="${parts[1]}"
-            fi
             ;;
 
         nativeaot|-nativeaot)
@@ -374,7 +359,6 @@ __Mono=0
 __MonoAot=0
 __MonoFullAot=0
 __BuildLogRootName="TestBuild"
-__CrossGen2HostArtifactsPath=
 CORE_ROOT=
 EnableNativeSanitizers=
 
@@ -424,20 +408,6 @@ __IntermediatesDir="$__RootBinDir/obj/coreclr/$__OSPlatformConfig"
 __TestIntermediatesDir="$__RootBinDir/tests/coreclr/obj/$__OSPlatformConfig"
 __CrossCompIntermediatesDir="$__IntermediatesDir/crossgen"
 __MonoBinDir="$__RootBinDir/bin/mono/$__OSPlatformConfig"
-
-# Auto-detect CrossGen2HostArtifactsPath for wasm targets (crossgen2 is never available in wasm builds)
-if [[ "$__TargetArch" == "wasm" && -z "$__CrossGen2HostArtifactsPath" ]]; then
-    # Determine the host OS name as used in artifact paths
-    if [[ "$platform" == "darwin" ]]; then
-        __HostOSName="osx"
-    elif [[ "$platform" == "freebsd" ]]; then
-        __HostOSName="freebsd"
-    else
-        __HostOSName="linux"
-    fi
-    __CrossGen2HostArtifactsPath="$__RootBinDir/bin/coreclr/$__HostOSName.$__HostArch.$__BuildType"
-    echo "${__MsgPrefix}Auto-detected CrossGen2HostArtifactsPath: $__CrossGen2HostArtifactsPath"
-fi
 
 # CI_SPECIFIC - On CI machines, $HOME may not be set. In such a case, create a subfolder and set the variable to it.
 # This is needed by CLI to function.

--- a/src/tests/readytorun/async-inline-thunks/async-inline-thunks.csproj
+++ b/src/tests/readytorun/async-inline-thunks/async-inline-thunks.csproj
@@ -9,6 +9,7 @@
     <CLRTestTargetUnsupported Condition="'$(EnableNativeSanitizers)' != ''">true</CLRTestTargetUnsupported>
     <!-- Disable on Mono which does not support runtime-async. -->
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'mono'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="helper/helper.csproj" />

--- a/src/tests/readytorun/determinism/crossgen2determinism.csproj
+++ b/src/tests/readytorun/determinism/crossgen2determinism.csproj
@@ -3,6 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, GCStressIncompatible, CrossGenTest -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'coreclr'">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'">true</CLRTestTargetUnsupported>
     <!-- We skip the ReadyToRun tests when sanitized due to build complexity -->
     <DisableProjectBuild Condition="'$(EnableNativeSanitizers)' != ''">true</DisableProjectBuild>
     <!-- Running Crossgen2 under GCStress takes too long -->

--- a/src/tests/readytorun/tests/mainv1.csproj
+++ b/src/tests/readytorun/tests/mainv1.csproj
@@ -7,6 +7,7 @@
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- This test launches crossgen2 with dotnet, so we would need a non-sanitzed jitinterface library. To simplify our infrastructure, we'll instead skip this test. -->
     <CLRTestTargetUnsupported Condition="'$(EnableNativeSanitizers)' != ''">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />

--- a/src/tests/readytorun/tests/mainv2.csproj
+++ b/src/tests/readytorun/tests/mainv2.csproj
@@ -7,6 +7,7 @@
     <IlasmRoundTripIncompatible>true</IlasmRoundTripIncompatible>
     <!-- This test launches crossgen2 with dotnet, so we would need a non-sanitzed jitinterface library. To simplify our infrastructure, we'll instead skip this test. -->
     <CLRTestTargetUnsupported Condition="'$(EnableNativeSanitizers)' != ''">true</CLRTestTargetUnsupported>
+    <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'wasm'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="fieldgetter.ilproj" />


### PR DESCRIPTION
- Add --help output for `--obj-format` switch to crossgen2.
- Minor tweak to R2RTest, if anyone is still using that
- Add support for the detail that R2R on wasm targets produces .wasm files instead of .dll files
- When tests are built with RuntimeFlavor=coreclr, then they will default to setting RunWithNodeJS to true
- Copy crossgen2 from a cross-build directory on Wasm
- Enable bash and batch precommands when building wasm tests
  - Disable a few tests that had problematic precommands for testing
  
When this PR and PR #127935 are merged, it will be straightforward enough to run tests.

The process will be something like:
```
Commands to run tests, starting from a fresh build

; Build runtime+libs
./build.sh clr+libs -rc debug -c release -os browser
; Build TestRoot
./src/tests/build.sh skipmanaged browser
; Build test project from the test tree
./dotnet.sh /p:TargetArchitecture=wasm /p:TargetOS=browser /p:RuntimeFlavor=coreclr src/tests/GC/API/GCSettings/InducedGen0GC.csproj

export CORE_ROOT=/home/davidwr/git/runtime/artifacts/tests/coreclr/browser.wasm.Debug/Tests/Core_Root
export RunCrossGen2=1
/home/davidwr/git/runtime/artifacts/tests/coreclr/browser.wasm.Debug/GC/API/GCSettings/InducedGen0GC/InducedGen0GC.sh
```
