### PR TITLE
Include cDAC exception details in HResult mismatch asserts

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -35,12 +35,49 @@ internal enum HResultValidationMode
 internal static class DebugExtensions
 {
 #if DEBUG
+    private const int LastExceptionRingSize = 4;
+
     [ThreadStatic]
-    private static Exception? t_lastException;
+    private static Exception?[]? _debugLastExceptions;
+
+    [ThreadStatic]
+    private static int _debugLastExceptionsNextIndex;
 
     static DebugExtensions()
     {
-        AppDomain.CurrentDomain.FirstChanceException += static (_, e) => t_lastException = e.Exception;
+        AppDomain.CurrentDomain.FirstChanceException += static (_, e) =>
+        {
+            Exception?[] ring = _debugLastExceptions ??= new Exception?[LastExceptionRingSize];
+            ring[_debugLastExceptionsNextIndex] = e.Exception;
+            _debugLastExceptionsNextIndex = (_debugLastExceptionsNextIndex + 1) % LastExceptionRingSize;
+        };
+    }
+
+    private static Exception? FindMatchingException(int hr)
+    {
+        Exception?[]? ring = _debugLastExceptions;
+        if (ring is null)
+            return null;
+
+        // Walk from newest to oldest.
+        int next = _debugLastExceptionsNextIndex;
+        for (int i = 0; i < LastExceptionRingSize; i++)
+        {
+            int idx = (next - 1 - i + LastExceptionRingSize) % LastExceptionRingSize;
+            Exception? ex = ring[idx];
+            if (ex is not null && ex.HResult == hr)
+                return ex;
+        }
+
+        return null;
+    }
+
+    private static void ClearLastExceptions()
+    {
+        Exception?[]? ring = _debugLastExceptions;
+        if (ring is not null)
+            Array.Clear(ring);
+        _debugLastExceptionsNextIndex = 0;
     }
 #endif
 
@@ -66,17 +103,20 @@ internal static class DebugExtensions
             {
                 string message = $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})";
 #if DEBUG
-                Exception? ex = t_lastException;
-                if (ex is not null && cdacHr < 0 && ex.HResult == cdacHr)
+                if (cdacHr < 0)
                 {
-                    message += $"{Environment.NewLine}cDAC exception:{Environment.NewLine}{ex}";
+                    Exception? ex = FindMatchingException(cdacHr);
+                    if (ex is not null)
+                    {
+                        message += $"{Environment.NewLine}cDAC exception:{Environment.NewLine}{ex}";
+                    }
                 }
 #endif
                 Debug.Assert(false, message);
             }
 
 #if DEBUG
-            t_lastException = null;
+            ClearLastExceptions();
 #endif
         }
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -108,7 +108,7 @@ internal static class DebugExtensions
                     Exception? ex = FindMatchingException(cdacHr);
                     if (ex is not null)
                     {
-                        message += $"{Environment.NewLine}cDAC exception:{Environment.NewLine}{ex}";
+                        message += $"{Environment.NewLine}---- cDAC exception ----{Environment.NewLine}{ex}{Environment.NewLine}---- end cDAC exception ----";
                     }
                 }
 #endif

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -33,6 +34,16 @@ internal enum HResultValidationMode
 
 internal static class DebugExtensions
 {
+#if DEBUG
+    [ThreadStatic]
+    private static Exception? t_lastException;
+
+    static DebugExtensions()
+    {
+        AppDomain.CurrentDomain.FirstChanceException += static (_, e) => t_lastException = e.Exception;
+    }
+#endif
+
     extension(Debug)
     {
         [Conditional("DEBUG")]
@@ -50,7 +61,23 @@ internal static class DebugExtensions
                 HResultValidationMode.AllowCdacSuccess => cdacHr == dacHr || (cdacHr < 0 && dacHr < 0) || (cdacHr >= 0 && dacHr < 0),
                 _ => cdacHr == dacHr,
             };
-            Debug.Assert(match, $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})");
+
+            if (!match)
+            {
+                string message = $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})";
+#if DEBUG
+                Exception? ex = t_lastException;
+                if (ex is not null && cdacHr < 0 && ex.HResult == cdacHr)
+                {
+                    message += $"{Environment.NewLine}cDAC exception:{Environment.NewLine}{ex}";
+                }
+#endif
+                Debug.Assert(false, message);
+            }
+
+#if DEBUG
+            t_lastException = null;
+#endif
         }
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with AI assistance (GitHub Copilot CLI).

When the cDAC and legacy DAC return mismatched HRESULTs, `Debug.ValidateHResult` previously asserted with only the two HRESULTs:

```
HResult mismatch - cDAC: 0xNNNNNNNN, DAC: 0xMMMMMMMM (File.cs:line)
```

That makes failures hard to triage -- you can see `E_FAIL` was returned but not what threw or where.

### Change

In `src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs`:

- Add a DEBUG-only thread-local ring (size 4) of recent first-chance exceptions, populated by an `AppDomain.CurrentDomain.FirstChanceException` handler registered from a static constructor.
- In `ValidateHResult`, when the HRESULTs do not match (and `cdacHr < 0`), scan the ring newest-to-oldest for an exception whose `HResult` equals `cdacHr`. If found, append `ex.ToString()` -- which includes the exception type, message, and full stack trace -- delimited by clear markers so it does not blur into `Debug.Fail`s own stack trace.
- Clear the ring on every `ValidateHResult` call to avoid stale attribution.

### Why this approach

cDAC entry points uniformly use `try { ... } catch (Exception ex) { hr = ex.HResult; }`, so the relevant exception is normally among the most recent throws on the thread before `ValidateHResult` runs. Filtering by `ex.HResult == cdacHr` guards against attribution mistakes if some intermediate contract helper threw-and-caught -- in that case we simply print nothing extra (same as today). Using a small ring (not a single slot) ensures exceptions thrown after the cDAC catch -- e.g. inside the validation block or during the legacy DAC call's managed marshaling -- do not displace the cDAC exception.

The big advantage: **no changes to the ~250 existing call sites or ~270 catch blocks** -- the diagnostic improvement is entirely contained to `DebugExtensions.cs`.

### Example output

Before:

```
Process terminated. Assertion failed.
HResult mismatch - cDAC: 0x80004001, DAC: 0x00000000 (SOSDacImpl.cs:1284)
   at System.Diagnostics.DebugProvider.Fail(String, String)
   at System.Diagnostics.Debug.Fail(String, String)
   at System.Diagnostics.Debug.Assert(Boolean, String, String)
   at System.Diagnostics.Debug.Assert(Boolean, String)
   at Microsoft.Diagnostics.DataContractReader.Legacy.DebugExtensions.ValidateHResult(...)
   at Microsoft.Diagnostics.DataContractReader.Legacy.SOSDacImpl.ISOSDacInterface.GetGCHeapData(...)
   at <...>...ABI_GetGCHeapData(...)
```

After:

```
Process terminated. Assertion failed.
HResult mismatch - cDAC: 0x80004001, DAC: 0x00000000 (SOSDacImpl.cs:1284)
---- cDAC exception ----
System.NotImplementedException: Contract 'IGC' is not supported by the target. Reason: Target does not support contract 'IGC'.
   at Microsoft.Diagnostics.DataContractReader.ContractRegistry.GetContract[TContract]()
   at Microsoft.Diagnostics.DataContractReader.ContractRegistry.get_GC()
   at Microsoft.Diagnostics.DataContractReader.Legacy.SOSDacImpl.ISOSDacInterface.GetGCHeapData(DacpGcHeapData*)
---- end cDAC exception ----
   at System.Diagnostics.DebugProvider.Fail(String, String)
   at System.Diagnostics.Debug.Fail(String, String)
   at System.Diagnostics.Debug.Assert(Boolean, String, String)
   at System.Diagnostics.Debug.Assert(Boolean, String)
   at Microsoft.Diagnostics.DataContractReader.Legacy.DebugExtensions.ValidateHResult(...)
   at Microsoft.Diagnostics.DataContractReader.Legacy.SOSDacImpl.ISOSDacInterface.GetGCHeapData(...)
   at <...>...ABI_GetGCHeapData(...)
```

### Testing

- `dotnet build` of the Legacy project: 0 warnings, 0 errors.
- `dotnet test Microsoft.Diagnostics.DataContractReader.Tests.csproj`: 2133 passed, 16 skipped, 0 failed.

### Notes

- DEBUG-only via `[Conditional("DEBUG")]` and `#if DEBUG` -- retail is unchanged.
- The `FirstChanceException` handler costs one ring write per thrown exception in DEBUG builds, which is negligible for a diagnostic-only tool.
