### PR TITLE
Fix createdump SIGSEGV on Heap dumps with interpreter active

### DIFF
--- a/src/coreclr/vm/common.h
+++ b/src/coreclr/vm/common.h
@@ -124,6 +124,7 @@ typedef DPTR(class DelegateEEClass)     PTR_DelegateEEClass;
 typedef VPTR(class EECodeManager)       PTR_EECodeManager;
 #ifdef FEATURE_INTERPRETER
 typedef VPTR(class InterpreterCodeManager) PTR_InterpreterCodeManager;
+typedef DPTR(struct InterpThreadContext) PTR_InterpThreadContext;
 #endif
 typedef DPTR(class RangeSectionMap)     PTR_RangeSectionMap;
 typedef DPTR(class EEConfig)            PTR_EEConfig;

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -921,7 +921,7 @@ public:
 
 #ifdef FEATURE_INTERPRETER
 public:
-    InterpThreadContext *m_pInterpThreadContext;
+    PTR_InterpThreadContext m_pInterpThreadContext;
     InterpThreadContext* GetInterpThreadContext();
     InterpThreadContext* GetOrCreateInterpThreadContext();
 #endif // FEATURE_INTERPRETER

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/InterpreterStack/InterpreterStack.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/InterpreterStack/InterpreterStack.csproj
@@ -1,9 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <!-- Full dumps only: Linux createdump segfaults during heap-dump region
-         enumeration when the interpreter is active. Tracked by
-         https://github.com/dotnet/runtime/issues/128044 — revisit once fixed. -->
-    <DumpTypes>Full</DumpTypes>
     <R2RModes>Jit</R2RModes>
     <!-- Selectively interpret MethodA/B/C while Main and CoreLib remain JIT'd,
          producing a mixed stack with InterpreterFrame transition boundaries.

--- a/src/native/managed/cdac/tests/DumpTests/InterpreterStackDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/InterpreterStackDumpTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class InterpreterStackDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "InterpreterStack";
-    protected override string DumpType => "full";
 
     private void SkipIfInterpreterNotAvailable()
     {


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

Fixes #128044.

## Problem

createdump SIGSEGVs on Linux when generating a Heap-type minidump for a
process running interpreted code. The crash reproduces locally with the
`InterpreterStack` DumpTests debuggee and matches the CI failure that
prompted `<DumpTypes>Full</DumpTypes>` to be added as a temporary workaround.

The faulting backtrace is:

```
#0  Thread::IsAddressInStack    threads.cpp:6741
#1  Thread::EnumMemoryRegionsWorker  threads.cpp:6909 (calls IsAddressInStack(currentSP))
#2  Thread::EnumMemoryRegions        threads.cpp
#3  ThreadStore::EnumMemoryRegions
#4  ClrDataAccess::EnumMemDumpAllThreadsStack
#5  ClrDataAccess::EnumMemoryRegionsWorkerHeap   (HEAP2-only path)
```

## Root cause

`Thread::m_pInterpThreadContext` was declared as a raw
`InterpThreadContext *`. In non-DAC code that's a normal host pointer, but in
DAC mode the field's value is a target-process address. When
`IsAddressInStack` (a DAC-callable helper) dereferenced
`m_pInterpThreadContext->pStackStart` it read from a target-process address
as if it were a host address, which faults inside createdump.

## Fix

Change the field type to `PTR_InterpThreadContext` (DPTR), matching the
treatment of other Thread fields like `m_pFrame`. In non-DAC builds
`DPTR(T)` is just `T*`, so there is no overhead or behavior change. In DAC
builds the read goes through `__DPtr<T>` and marshals correctly from the
target.

Also remove the `<DumpTypes>Full</DumpTypes>` workaround on the
`InterpreterStack` DumpTests debuggee so the Heap path that originally
failed is exercised again.

## Validation

Locally reproduced the original SIGSEGV on Linux x64 with the auto-dump
mechanism (`DOTNET_DbgMiniDumpType=2` + `DOTNET_Interpreter=MethodA`)
running the `InterpreterStack` debuggee. With this fix applied, createdump
produces a complete Heap dump (~74 MB) instead of crashing.
