### PR TITLE
Add ignore_global_json flag to hostfxr_resolve_sdk2

### DIFF
--- a/docs/design/features/hosting-layer-apis.md
+++ b/docs/design/features/hosting-layer-apis.md
@@ -68,6 +68,8 @@ enum hostfxr_resolve_sdk2_result_key_t
 {
     resolved_sdk_dir = 0,
     global_json_path = 1,
+    requested_version = 2,
+    global_json_state = 3,
 };
 
 typedef void (*hostfxr_resolve_sdk2_result_fn)(

--- a/docs/design/features/hosting-layer-apis.md
+++ b/docs/design/features/hosting-layer-apis.md
@@ -61,6 +61,7 @@ If the application is successfully executed, this value will return the exit cod
 enum hostfxr_resolve_sdk2_flags_t
 {
     disallow_prerelease = 0x1,
+    ignore_global_json = 0x2,
 };
 
 enum hostfxr_resolve_sdk2_result_key_t
@@ -85,6 +86,7 @@ Determine the directory location of the SDK, accounting for global.json and mult
 * `working_dir` - directory where the search for `global.json` will start and proceed upwards
 * `flags` - flags that influence resolution
   * `disallow_prerelease` - do not allow resolution to return a pre-release SDK version unless a pre-release version was specified via `global.json`
+  * `ignore_global_json` - do not search for or use `global.json` for resolution. Resolution behaves as if no `global.json` was found. When set, `result` will not be invoked with `global_json_path` or `requested_version` keys, and `global_json_state` will be reported as `not_found`.
 * `result` - callback invoked to return resolved values. The callback may be invoked more than once. Strings passed to the callback are valid only for the duration of the call.
 
 If resolution succeeds, `result` will be invoked with `resolved_sdk_dir` key and the value will hold the path to the resolved SDK directory. If resolution does not succeed, `result` will be invoked with `resolved_sdk_dir` key and the value will be `nullptr`.

--- a/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
+++ b/src/installer/tests/Assets/Projects/HostApiInvokerApp/HostFXR.cs
@@ -16,6 +16,7 @@ namespace HostApiInvokerApp
             internal enum hostfxr_resolve_sdk2_flags_t : int
             {
                 disallow_prerelease = 0x1,
+                ignore_global_json = 0x2,
             }
 
             internal enum hostfxr_resolve_sdk2_result_key_t : int

--- a/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
+++ b/src/installer/tests/HostActivation.Tests/NativeHostApis.cs
@@ -302,6 +302,59 @@ namespace HostActivation.Tests
         }
 
         [Fact]
+        public void Hostfxr_resolve_sdk2_IgnoreGlobalJson()
+        {
+            // With global.json requesting a specific SDK, but ignore_global_json flag set,
+            // pick latest SDK as if no global.json exists
+
+            var f = sharedTestState.SdkAndFrameworkFixture;
+            using (TestArtifact workingDir = TestArtifact.Create(nameof(Hostfxr_resolve_sdk2_IgnoreGlobalJson)))
+            {
+                string requestedVersion = "1.2.300";
+                GlobalJson.CreateWithVersion(workingDir.Location, requestedVersion);
+                string expectedData = string.Join(';', new[]
+                {
+                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, f.LocalSdks[^1])),
+                    ("global_json_state", "not_found"),
+                });
+
+                string api = ApiNames.hostfxr_resolve_sdk2;
+                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "ignore_global_json")
+                    .EnableTracingAndCaptureOutputs()
+                    .Execute()
+                    .Should().Pass()
+                    .And.ReturnStatusCode(api, Constants.ErrorCode.Success)
+                    .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
+            }
+        }
+
+        [Fact]
+        public void Hostfxr_resolve_sdk2_IgnoreGlobalJson_DisallowPrerelease()
+        {
+            // ignore_global_json combined with disallow_prerelease should pick latest non-preview
+
+            var f = sharedTestState.SdkAndFrameworkFixture;
+            using (TestArtifact workingDir = TestArtifact.Create(nameof(Hostfxr_resolve_sdk2_IgnoreGlobalJson_DisallowPrerelease)))
+            {
+                string requestedVersion = "5.6.700-preview";
+                GlobalJson.CreateWithVersion(workingDir.Location, requestedVersion);
+                string expectedData = string.Join(';', new[]
+                {
+                    ("resolved_sdk_dir", Path.Combine(f.LocalSdkDir, "1.2.300")),
+                    ("global_json_state", "not_found"),
+                });
+
+                string api = ApiNames.hostfxr_resolve_sdk2;
+                HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, api, f.ExeDir, workingDir.Location, "disallow_prerelease, ignore_global_json")
+                    .EnableTracingAndCaptureOutputs()
+                    .Execute()
+                    .Should().Pass()
+                    .And.ReturnStatusCode(api, Constants.ErrorCode.Success)
+                    .And.HaveStdOutContaining($"{api} data:[{expectedData}]");
+            }
+        }
+
+        [Fact]
         public void Hostfxr_corehost_set_error_writer_test()
         {
             HostTestContext.BuiltDotNet.Exec(sharedTestState.HostApiInvokerApp.AppDll, "Test_hostfxr_set_error_writer")

--- a/src/native/corehost/fxr/hostfxr.cpp
+++ b/src/native/corehost/fxr/hostfxr.cpp
@@ -166,6 +166,7 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk(
 enum hostfxr_resolve_sdk2_flags_t : int32_t
 {
     disallow_prerelease = 0x1,
+    ignore_global_json = 0x2,
 };
 
 enum class hostfxr_resolve_sdk2_result_key_t : int32_t
@@ -218,6 +219,9 @@ namespace
 //         disallow_prerelease (0x1)
 //           do not allow resolution to return a prerelease SDK version
 //           unless  prerelease version was specified via global.json.
+//         ignore_global_json (0x2)
+//           do not search for or use global.json for resolution.
+//           Resolution behaves as if no global.json was found.
 //
 //   result
 //      Callback invoked to return values. It can be invoked more
@@ -278,9 +282,11 @@ SHARED_API int32_t HOSTFXR_CALLTYPE hostfxr_resolve_sdk2(
         working_dir = _X("");
     }
 
-    auto resolver = sdk_resolver::from_nearest_global_file(
-        working_dir,
-        (flags & hostfxr_resolve_sdk2_flags_t::disallow_prerelease) == 0);
+    bool allow_prerelease = (flags & hostfxr_resolve_sdk2_flags_t::disallow_prerelease) == 0;
+
+    auto resolver = (flags & hostfxr_resolve_sdk2_flags_t::ignore_global_json) != 0
+        ? sdk_resolver::from_default_settings(allow_prerelease)
+        : sdk_resolver::from_nearest_global_file(working_dir, allow_prerelease);
 
     auto resolved_sdk_dir = resolver.resolve(exe_dir);
     if (!resolved_sdk_dir.empty())

--- a/src/native/corehost/fxr/sdk_resolver.cpp
+++ b/src/native/corehost/fxr/sdk_resolver.cpp
@@ -214,6 +214,13 @@ void sdk_resolver::print_resolution_error(const pal::string_t& dotnet_root, cons
         DOTNET_SDK_NOT_FOUND_URL);
 }
 
+sdk_resolver sdk_resolver::from_default_settings(bool allow_prerelease)
+{
+    sdk_resolver resolver{ allow_prerelease };
+    resolver.global_json.state = global_file_info::state::not_found;
+    return resolver;
+}
+
 sdk_resolver sdk_resolver::from_nearest_global_file(bool allow_prerelease)
 {
     pal::string_t cwd;

--- a/src/native/corehost/fxr/sdk_resolver.h
+++ b/src/native/corehost/fxr/sdk_resolver.h
@@ -72,6 +72,8 @@ public:
         const pal::string_t& cwd,
         bool allow_prerelease = true);
 
+    static sdk_resolver from_default_settings(bool allow_prerelease = true);
+
 private:
     explicit sdk_resolver(bool allow_prerelease = true);
     static sdk_roll_forward_policy to_policy(const pal::string_t& name);


### PR DESCRIPTION
This allows consumers such as the dotnet CLI to ignore global.json when
resolving the SDK version to use. This is useful for scenarios where
the user wants to use the latest SDK version regardless of what is
specified in global.json.

fix #128168