### PR TITLE
Handle Generic Context Arg in runtime implementation of signature key computation

### DIFF
--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -947,6 +947,13 @@ namespace
             pos++;
         }
 
+        if (sig.HasGenericContextArg())
+        {
+            if (pos < maxSize)
+                keyBuffer[pos] = 'i';
+            pos++;
+        }
+
         for (CorElementType argType = sig.NextArg();
             argType != ELEMENT_TYPE_END;
             argType = sig.NextArg())


### PR DESCRIPTION
> [!NOTE]
> PR description generated with AI assistance.

Fixes issue where methods with generic instantiation arguments cannot be called from managed code if they are called from R2R code.

The WASM signature key computation in `helpers.cpp` was not accounting for `HasGenericContextArg()`, which meant that methods requiring a generic instantiation context (hidden argument) would produce an incorrect signature key. This caused call mismatches when managed code invoked R2R-compiled methods with generic context.

The fix adds a check for `HasGenericContextArg()` and appends the appropriate `'i'` (integer/pointer) parameter to the signature key buffer, matching the actual calling convention.