### PR TITLE
[Wasm RyuJIT] Fix: Use passed in ig when possible for IF_CODE_SIZE in emitDispIns()

### DIFF
--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -1116,7 +1116,16 @@ void emitter::emitDispIns(
 
         case IF_CODE_SIZE:
         {
-            FuncInfoDsc* const func = m_compiler->funGetFunc(emitCurIG->igFuncIdx);
+            // We should either have a non-null ig parameter, or emitCurIG should be set
+            insGroup* curIG = ig;
+            if (curIG == nullptr)
+            {
+                curIG = emitCurIG;
+            }
+            assert(curIG != nullptr);
+
+            FuncInfoDsc* const func = m_compiler->funGetFunc(curIG->igFuncIdx);
+            assert(func != nullptr);
 
             emitLocation* const startLoc = func->startLoc;
             emitLocation* const endLoc   = func->endLoc;


### PR DESCRIPTION
We can't always rely on `emitCurIG` being set since `emitDispIns` can be called after codegen, so use the current passed in ig when possible in for `IF_CODE_SIZE` in `emitDispIns` for Wasm.