### PR TITLE
[mobile] Fix IL2007 in System.Runtime.Loader.Tests on non-iOS apple-mobile targets

### DIFF
--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleDevice.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.AppleDevice.xml
@@ -1,0 +1,4 @@
+<linker>
+  <assembly fullname="System.Runtime.Loader.Test.Assembly" />
+  <assembly fullname="System.Runtime.Loader.Test.Assembly2" />
+</linker>

--- a/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml
+++ b/src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml
@@ -2,6 +2,4 @@
   <assembly fullname="LoaderLinkTest.Dynamic" />
   <assembly fullname="ReferencedClassLib" />
   <assembly fullname="ReferencedClassLibNeutralIsSatellite" />
-  <assembly fullname="System.Runtime.Loader.Test.Assembly" />
-  <assembly fullname="System.Runtime.Loader.Test.Assembly2" />
 </linker>

--- a/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/libraries/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -102,6 +102,9 @@
   <ItemGroup Condition="'$(TargetOS)' == 'browser' or ('$(TargetsAppleMobile)' == 'true' and '$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true')">
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.xml" />
   </ItemGroup>
+  <ItemGroup Condition="('$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos') and '$(EnableAggressiveTrimming)' == 'true' and '$(UseNativeAotRuntime)' != 'true'">
+    <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)ILLink.Descriptors.AppleDevice.xml" />
+  </ItemGroup>
 
   <Target Name="PreserveEnCAssembliesFromLinking" Condition="'$(TargetOS)' == 'browser' and '$(EnableAggressiveTrimming)' == 'true'" BeforeTargets="PrepareForILLink">
     <ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.

## Description

Fixes IL2007 build failure in `System.Runtime.Loader.Tests` on every Apple-mobile target except iOS/tvOS device:

```
src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml(5,4):
  error IL2007: Could not resolve assembly 'System.Runtime.Loader.Test.Assembly'.
src/libraries/System.Runtime.Loader/tests/ILLink.Descriptors.xml(6,4):
  error IL2007: Could not resolve assembly 'System.Runtime.Loader.Test.Assembly2'.
```

Reproduces in `runtime-extra-platforms` legs `Build maccatalyst-arm64 Release AllSubsets_CoreCLR`, `maccatalyst-x64 Release AllSubsets_CoreCLR`, `iossimulator-arm64/x64 Release AllSubsets_CoreCLR`, `tvos-arm64 Release AllSubsets_CoreCLR_RuntimeTests`. First reproduction on `main`: build [1403076](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1403076) (commit `8f854afd60`, Apr 30); the build immediately before — [1401195](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1401195) (`9a6034a3ea`) — was clean.

## Cause

#127058 added two `<assembly>` entries to the shared `ILLink.Descriptors.xml`:

```xml
<assembly fullname="System.Runtime.Loader.Test.Assembly" />
<assembly fullname="System.Runtime.Loader.Test.Assembly2" />
```

But the corresponding `ProjectReference` in `System.Runtime.Loader.Tests.csproj` only deploys those two assemblies as separate files on iOS/tvOS:

```xml
<ProjectReference Condition="'$(TargetOS)' != 'ios' and '$(TargetOS)' != 'tvos'"
                  Include="System.Runtime.Loader.Test.Assembly\..."
                  ReferenceOutputAssembly="false" OutputItemType="EmbeddedResource" />
<ProjectReference Condition="'$(TargetOS)' == 'ios' or '$(TargetOS)' == 'tvos'"
                  Include="System.Runtime.Loader.Test.Assembly\..." />
```

On every other platform they are embedded resources, so ILLink can't resolve them as standalone assemblies and fails with IL2007 whenever the descriptor is included (i.e. with aggressive trimming).

## Fix

Split the two iOS/tvOS-only entries into a sibling `ILLink.Descriptors.AppleDevice.xml` and `<TrimmerRootDescriptor>` it only on `(TargetOS == 'ios' or TargetOS == 'tvos') && EnableAggressiveTrimming && !UseNativeAotRuntime`.
