### PR TITLE
Fix integer overflow in string.IndexOf range validation

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -127,7 +127,7 @@ namespace System
             ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, Length);
             ArgumentOutOfRangeException.ThrowIfNegative(count);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, Length - startIndex);
 
             int subIndex;
 
@@ -427,9 +427,10 @@ namespace System
         /// </returns>
         public unsafe int IndexOf(Rune value, int startIndex, int count, StringComparison comparisonType)
         {
-            ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 0);
-            ArgumentOutOfRangeException.ThrowIfLessThan(count, 0);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex + count, Length);
+            ArgumentOutOfRangeException.ThrowIfNegative(startIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(startIndex, Length);
+            ArgumentOutOfRangeException.ThrowIfNegative(count);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(count, Length - startIndex);
 
             // Convert value to span
             ReadOnlySpan<char> valueChars = value.AsSpan(stackalloc char[Rune.MaxUtf16CharsPerRune]);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/StringTests.cs
@@ -1346,6 +1346,35 @@ namespace System.Tests
             Assert.True(span == default);
         }
 
+        [Fact]
+        public static void IndexOf_Char_OrdinalIgnoreCase_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf('o', -1, 0, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf('o', 6, 0, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf('o', 0, -1, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf('o', 0, 6, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf('o', 3, 3, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf('o', 1, int.MaxValue, StringComparison.OrdinalIgnoreCase));
+        }
+
+        [Fact]
+        public static void IndexOf_Rune_StartIndexCount_ThrowsArgumentOutOfRangeException()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf(new Rune('o'), -1, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf(new Rune('o'), 6, 0));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 0, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 0, 6));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 3, 3));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 1, int.MaxValue));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf(new Rune('o'), -1, 0, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("startIndex", () => "Hello".IndexOf(new Rune('o'), 6, 0, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 0, -1, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 0, 6, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 3, 3, StringComparison.OrdinalIgnoreCase));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => "Hello".IndexOf(new Rune('o'), 1, int.MaxValue, StringComparison.OrdinalIgnoreCase));
+        }
+
         public static IEnumerable<object[]> IndexOf_SingleLetter_StringComparison_TestData()
         {
             yield return new object[] { "Hello", 'l', 0, int.MaxValue, StringComparison.Ordinal, null, 2 };


### PR DESCRIPTION
Closes #128192
This PR change `string.IndexOf` range validation from `count + startIndex > Length`  to `count > Length - startIndex` to avoid the overflow.
This ensures an `ArgumentOutOfRangeException` is thrown when `startIndex + count` exceeds `int.MaxValue` when comparisonType is `StringComparison.OrdinalIgnoreCase`.

Also applied the same fix to `IndexOf(Rune, int, int, StringComparison)` and updated it to use `ArgumentOutOfRangeException.ThrowIfNegative` and `ArgumentOutOfRangeException.ThrowIfGreaterThan` consistently with the char overload.