### PR TITLE
[Wasm] Workaround for release corerun.wasm not having exported stack pointer

### DIFF
--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -91,6 +91,12 @@ else()
                 -sENVIRONMENT=node,shell,web
                 -Wl,--error-limit=0)
 
+            # HACK: Workaround for bug in wasm-opt that strips __stack_pointer
+            # -g forces 'limited post-link optimizations'. I tried a dozen other workarounds and this is the only thing that worked.
+            # This bug may be fixed in latest emscripten.
+            target_link_options(corerun PRIVATE
+                -g)
+
             if (CORERUN_IN_BROWSER)
                 # Node.js doesn't have good support for WASM_BIGINT
                 # so it only is added when running in the browser.


### PR DESCRIPTION
emscripten's wasm-opt appears to have a bug that strips the stack pointer export from our runtime module, which prevents loading R2R'd wasm code in release builds. Passing `-g` to enable DWARF information for the runtime appears to work around this by forcing 'limited post-link optimizations'. I tried a bunch of other stuff and this was the only thing that worked.

Note that I can't reproduce this wasm-opt bug using latest emscripten on linux, so it's possible @pavelsavara 's emscripten bump will fix it for us.

See also https://github.com/dotnet/runtime/pull/128167 which handles this failure better.

EDIT: Repro steps using https://github.com/kg/wasm-ryujit-runner :

`dotnet run wasm-ryujit-runner.cs -- --auto-build --config Debug --checkout Z:\runtime --assembly Z:\wasm-test\bin\Debug\net10.0\wasm-test.dll --corerun`
works
`dotnet run wasm-ryujit-runner.cs -- --auto-build --config Release --checkout Z:\runtime --assembly Z:\wasm-test\bin\Debug\net10.0\wasm-test.dll --corerun`
broken due to missing `__stack_pointer`

cc @adamperlin @AndyAyersMS @davidwrighton 