### PR TITLE
Fix broken "See also" link in CoreCLR iOS build docs

### DIFF
--- a/docs/workflow/building/coreclr/ios.md
+++ b/docs/workflow/building/coreclr/ios.md
@@ -130,4 +130,4 @@ Native debugging is supported through Xcode. You can debug both the managed port
 
 ## See also
 
-- [Building CoreCLR on macOS](../macos.md)
+- [Building CoreCLR on macOS](README.md)


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the help of GitHub Copilot.

## Summary

Fix a broken cross-reference link in `docs/workflow/building/coreclr/ios.md`.

The "See also" section at line 133 linked to `../macos.md`, which resolves to the non-existent `docs/workflow/building/macos.md`. The correct target is `README.md` in the same directory (`docs/workflow/building/coreclr/README.md`), which is the CoreCLR build guide containing macOS instructions.

## Changes

- `docs/workflow/building/coreclr/ios.md`: Updated link from `../macos.md` → `README.md`

## Verification

- Confirmed `macos.md` does not exist at the resolved path
- Confirmed `README.md` exists and contains macOS build guidance
- Grepped the repo for other stale `macos.md` references — none found
