### PR TITLE
[cDAC] Reparse pending sub-descriptors on Flush

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -319,7 +319,7 @@ public abstract class Target
     /// Clear all cached data held by this target, including processed data and contract caches.
     /// Called when the target process state may have changed (e.g. on resume).
     /// </summary>
-    public void Flush()
+    public virtual void Flush()
     {
         ProcessedData.Clear();
         Contracts.Flush();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -11,6 +11,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Diagnostics.DataContractReader.Data;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using System.Collections.Frozen;
 
 namespace Microsoft.Diagnostics.DataContractReader;
 
@@ -33,12 +34,22 @@ public sealed unsafe class ContractDescriptorTarget : Target
         public int PointerSize { get; init; }
     }
 
-    private readonly Configuration _config;
+    private Configuration _config;
 
     private readonly DataTargetDelegates _dataTargetDelegates;
-    private readonly Dictionary<string, string> _contracts = [];
-    private readonly IReadOnlyDictionary<string, GlobalValue> _globals = new Dictionary<string, GlobalValue>();
-    private readonly Dictionary<string, Target.TypeInfo> _types = [];
+
+    private readonly List<Descriptor> _descriptors = [];
+
+    // Addresses of sub-descriptor pointer slots whose value was null the last time we read
+    // them. Re-checked on Flush. This relies on the following invariant: a sub-descriptor
+    // pointer slot only ever transitions null -> real-address. Once a slot holds a
+    // non-null sub-descriptor address it never changes again, so we never need to
+    // re-validate already-loaded sub-descriptors and we can safely drop a slot from this.
+    private readonly List<TargetPointer> _pendingSubDescriptors = [];
+
+    private IReadOnlyDictionary<string, string> _contracts = new Dictionary<string, string>();
+    private IReadOnlyDictionary<string, GlobalValue> _globals = new Dictionary<string, GlobalValue>();
+    private IReadOnlyDictionary<string, TypeInfo> _types = new Dictionary<string, TypeInfo>();
 
     public override ContractRegistry Contracts { get; }
     public override DataCache ProcessedData { get; }
@@ -72,12 +83,12 @@ public sealed unsafe class ContractDescriptorTarget : Target
         [NotNullWhen(true)] out ContractDescriptorTarget? target)
     {
         DataTargetDelegates dataTargetDelegates = new DataTargetDelegates(readFromTarget, writeToTarget, getThreadContext, allocVirtual);
-        if (TryReadAllContractDescriptors(
+        if (TryReadContractDescriptor(
             contractDescriptor,
             dataTargetDelegates,
-            out Descriptor[] descriptors))
+            out Descriptor descriptor))
         {
-            target = new ContractDescriptorTarget(descriptors, dataTargetDelegates, contractRegistrations);
+            target = new ContractDescriptorTarget(descriptor, dataTargetDelegates, contractRegistrations);
             return true;
         }
 
@@ -110,37 +121,93 @@ public sealed unsafe class ContractDescriptorTarget : Target
         Action<ContractRegistry>[]? contractRegistrations = null)
     {
         return new ContractDescriptorTarget(
-            [
-                new Descriptor
-                {
-                    Config = new Configuration { IsLittleEndian = isLittleEndian, PointerSize = pointerSize },
-                    ContractDescriptor = contractDescriptor,
-                    PointerData = globalPointerValues
-                }
-            ],
+            new Descriptor
+            {
+                Config = new Configuration { IsLittleEndian = isLittleEndian, PointerSize = pointerSize },
+                ContractDescriptor = contractDescriptor,
+                PointerData = globalPointerValues
+            },
             new DataTargetDelegates(readFromTarget, writeToTarget, getThreadContext, allocVirtual),
             contractRegistrations ?? []);
     }
 
-    private ContractDescriptorTarget(Descriptor[] descriptors, DataTargetDelegates dataTargetDelegates, Action<ContractRegistry>[] contractRegistrations)
+    private ContractDescriptorTarget(Descriptor mainDescriptor, DataTargetDelegates dataTargetDelegates, Action<ContractRegistry>[] contractRegistrations)
     {
         Contracts = new CachingContractRegistry(this, this.TryGetContractVersion, contractRegistrations);
         ProcessedData = new DataCache(this);
-        _config = descriptors[0].Config;
+
+        _config = mainDescriptor.Config;
         _dataTargetDelegates = dataTargetDelegates;
 
-        _contracts = [];
+        AddDescriptor(mainDescriptor);
+        BuildDescriptors(forceBuild: true);
+    }
+
+    public override void Flush()
+    {
+        base.Flush();
+
+        BuildDescriptors();
+    }
+
+    private void AddDescriptor(Descriptor descriptor)
+    {
+        _descriptors.Add(descriptor);
+        foreach (TargetPointer pSubDescriptor in GetSubDescriptors(descriptor))
+        {
+            if (pSubDescriptor == TargetPointer.Null)
+                continue;
+
+            _pendingSubDescriptors.Add(pSubDescriptor);
+        }
+    }
+
+    private void BuildDescriptors(bool forceBuild = false)
+    {
+        // First pass - find if we have any new descriptors
+        // if not, we can exit early without needing to rebuild
+        int initialDescriptorCount = _descriptors.Count;
+        int loopDescriptorCount;
+        do
+        {
+            loopDescriptorCount = _descriptors.Count;
+
+            for (int i = _pendingSubDescriptors.Count - 1; i >= 0; i--)
+            {
+                TargetPointer pendingSubDescriptor = _pendingSubDescriptors[i];
+                if (TryReadPointer(pendingSubDescriptor, out TargetPointer subDescriptorAddress)
+                    && subDescriptorAddress != TargetPointer.Null)
+                {
+                    _pendingSubDescriptors.RemoveAt(i);
+
+                    if (TryReadContractDescriptor(
+                        subDescriptorAddress.Value,
+                        _dataTargetDelegates,
+                        out Descriptor subDescriptor))
+                    {
+                        AddDescriptor(subDescriptor);
+                    }
+                }
+            }
+        } while (_descriptors.Count > loopDescriptorCount);
+
+        if (_descriptors.Count == initialDescriptorCount && !forceBuild)
+            // No new descriptors were found, and we're not forcing a build, so return early
+            return;
+
+
+        // Second pass - parse all descriptors and update contracts, globals, and types.
+        Dictionary<string, string> contracts = [];
+        Dictionary<string, GlobalValue> globals = [];
+        Dictionary<string, TypeInfo> types = [];
+
+        HashSet<string> seenTypeNames = [];
+        HashSet<string> seenGlobalNames = [];
 
         // Set pointer type size
-        _types[DataType.pointer.ToString()] = new TypeInfo { Size = (uint)_config.PointerSize };
+        types[DataType.pointer.ToString()] = new TypeInfo { Size = (uint)_config.PointerSize };
 
-        HashSet<string> seenTypeNames = new HashSet<string>();
-        HashSet<string> seenGlobalNames = new HashSet<string>();
-
-        Dictionary<string, GlobalValue> globalValues = [];
-
-
-        foreach (Descriptor descriptor in descriptors)
+        foreach (Descriptor descriptor in _descriptors)
         {
             if (descriptor.Config.IsLittleEndian != _config.IsLittleEndian ||
                 descriptor.Config.PointerSize != _config.PointerSize)
@@ -149,11 +216,11 @@ public sealed unsafe class ContractDescriptorTarget : Target
             // Read contracts and add to map
             foreach ((string name, string version) in descriptor.ContractDescriptor.Contracts ?? [])
             {
-                if (_contracts.ContainsKey(name))
+                if (contracts.ContainsKey(name))
                 {
                     throw new InvalidOperationException($"Duplicate contract name '{name}' found in contract descriptor.");
                 }
-                _contracts[name] = version;
+                contracts[name] = version;
             }
 
             // Read types and map to known data types
@@ -181,7 +248,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
                     }
                     seenTypeNames.Add(name);
 
-                    _types[name] = typeInfo;
+                    types[name] = typeInfo;
                 }
             }
 
@@ -200,7 +267,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
                         if (global.NumericValue.Value >= (ulong)descriptor.PointerData.Length)
                             throw new InvalidOperationException($"Invalid pointer data index {global.NumericValue.Value}.");
 
-                        globalValues[name] = new GlobalValue
+                        globals[name] = new GlobalValue
                         {
                             NumericValue = descriptor.PointerData[global.NumericValue.Value].Value,
                             StringValue = global.StringValue,
@@ -209,7 +276,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
                     }
                     else // direct
                     {
-                        globalValues[name] = new GlobalValue
+                        globals[name] = new GlobalValue
                         {
                             NumericValue = global.NumericValue,
                             StringValue = global.StringValue,
@@ -218,9 +285,11 @@ public sealed unsafe class ContractDescriptorTarget : Target
                     }
                 }
             }
-
-            _globals = globalValues.AsReadOnly();
         }
+
+        _contracts = contracts.ToFrozenDictionary();
+        _globals = globals.ToFrozenDictionary();
+        _types = types.ToFrozenDictionary();
     }
 
     private struct GlobalValue
@@ -249,42 +318,6 @@ public sealed unsafe class ContractDescriptorTarget : Target
                 yield return descriptor.PointerData[(int)subDescriptor.Value.NumericValue];
             }
         }
-    }
-
-    private static bool TryReadAllContractDescriptors(
-        ulong address,
-        DataTargetDelegates dataTargetDelegates,
-        out Descriptor[] descriptors)
-    {
-        if (!TryReadContractDescriptor(address, dataTargetDelegates, out Descriptor mainDescriptor))
-        {
-            descriptors = [];
-            return false;
-        }
-
-        List<Descriptor> allDescriptors = [mainDescriptor];
-
-        foreach (TargetPointer pSubDescriptor in GetSubDescriptors(mainDescriptor))
-        {
-            if (pSubDescriptor == TargetPointer.Null)
-                continue;
-
-            if (!TryReadPointer(pSubDescriptor.Value, mainDescriptor.Config, dataTargetDelegates, out TargetPointer subDescriptorAddress))
-                continue;
-
-            if (subDescriptorAddress == TargetPointer.Null)
-                continue;
-
-            TryReadAllContractDescriptors(
-                subDescriptorAddress.Value,
-                dataTargetDelegates,
-                out Descriptor[] subDescriptors);
-
-            allDescriptors.AddRange(subDescriptors);
-        }
-
-        descriptors = [.. allDescriptors];
-        return true;
     }
 
     // See docs/design/datacontracts/contract-descriptor.md

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -34,7 +34,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
         public int PointerSize { get; init; }
     }
 
-    private Configuration _config;
+    private readonly Configuration _config;
 
     private readonly DataTargetDelegates _dataTargetDelegates;
 


### PR DESCRIPTION
## Problem

When the cDAC attaches very early in the runtime's lifetime, for example when SOS uses the native host, the main contract descriptor symbol already exists, but the slots that subordinate modules (notably the GC) publish their own contract descriptor addresses into are still null. The initial sub-descriptor walk in `ContractDescriptorTarget`'s constructor therefore skips those sub-descriptors and the contracts / types / globals they contribute never make it into the registry. 

This is the root cause for the `SOS.StackAndOtherTests` failures against the in the runtime diagnostics pipeline

## Approach

While the actual `pointer_data` array is read only, the values they point to may change. Users re-read these values after flush, but the Target did not re-parse the sub descriptors. This PR modifies the Target to reparse the subdescriptors on flush (if any changes have occured).

We rely on the invariant that once a subdescriptor is set, it will not be changed, but it can be populated from null.

Restructured `ContractDescriptorTarget` around a two-pass build:

- **Pass 1** — walk the list of pending sub-descriptor slots; for any whose pointer has become non-null, load the sub-descriptor and append it to `_descriptors`. Loaded sub-descriptors contribute their own pending slots (any of their sub-descriptor pointers that are still null); the outer `do/while` loop drains those iteratively.
- **Pass 2** — rebuild `_contracts`, `_types`, `_globals` from the descriptor list as frozen dictionaries. Only runs when the descriptor set has actually grown (or on the construction path, via `forceBuild=true`).

## Testing

- `Microsoft.Diagnostics.DataContractReader.Tests`: **2133 passed, 0 failed, 16 skipped**.
- Manually verified with `cdb` + `!SetHostRuntime -none` + `DOTNET_ENABLE_CDAC=1` against a freshly-started runtime: sub-descriptor that was null at attach is picked up on the next `Flush`.

Draft because I want CI to confirm the no-fallback cDAC legs go green before review.
