### PR TITLE
[cDAC] Copy all debuggee project-reference DLLs/PDBs into Helix symbols dir

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -194,8 +194,13 @@
       <!-- Windows: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'mkdir %25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)')" />
+      <!-- Copy every DLL/PDB from the debuggee publish folder so that project
+           references (e.g. InterpreterStack/Trampoline.dll) are also available
+           for symbol resolution. -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
-          Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\%(Identity).dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
+          Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
+      <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
+          Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot; 2&gt;nul || (exit /b 0)')" />
 
       <!-- Unix: copy SPC from testhost shared framework -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
@@ -207,8 +212,13 @@
       <!-- Unix: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
+      <!-- Copy every DLL/PDB from the debuggee publish folder so that project
+           references (e.g. InterpreterStack/Trampoline.dll) are also available
+           for symbol resolution. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
-          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/%(Identity).dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
+          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
+      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
+          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.pdb $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ 2&gt;/dev/null || true')" />
     </ItemGroup>
 
     <!-- Test mode only: run xunit, capture exit code, propagate after archive. -->

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -194,12 +194,6 @@
       <!-- Windows: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'mkdir %25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)')" />
-      <!-- Copy every DLL from the debuggee publish folder so that project
-           references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for module resolution. cdac and ClrMD read ECMA-335 metadata from
-           the PE itself, so PDBs are not needed here. ``/Y`` keeps ``copy``
-           non-interactive if the destination file already exists (e.g. on a
-           retry that reuses the same payload directory). -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'copy /Y &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
 
@@ -213,10 +207,6 @@
       <!-- Unix: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
-      <!-- Copy every DLL from the debuggee publish folder so that project
-           references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for module resolution. cdac and ClrMD read ECMA-335 metadata from
-           the PE itself, so PDBs are not needed here. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
     </ItemGroup>

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -196,11 +196,12 @@
           Include="@(_UniqueDebuggee->'mkdir %25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)')" />
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. -->
+           for symbol resolution. PDB copy is guarded with `if exist` so that
+           a debuggee without PDBs doesn't fail the batch script. -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
-          Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot; 2&gt;nul || (exit /b 0)')" />
+          Include="@(_UniqueDebuggee->'if exist &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
 
       <!-- Unix: copy SPC from testhost shared framework -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
@@ -214,11 +215,13 @@
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. -->
+           for symbol resolution. PDB copy uses `find -exec ... +` so it's a
+           no-op when a debuggee has no PDBs (e.g. on net10.0 servicing dumps),
+           and avoids semicolons that would be split as Helix command separators. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
-          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.pdb $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ 2&gt;/dev/null || true')" />
+          Include="@(_UniqueDebuggee->'find $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity) -maxdepth 1 -name *.pdb -exec cp -t $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ {} +')" />
     </ItemGroup>
 
     <!-- Test mode only: run xunit, capture exit code, propagate after archive. -->

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -197,11 +197,13 @@
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
            for symbol resolution. PDB copy is guarded with `if exist` so that
-           a debuggee without PDBs doesn't fail the batch script. -->
+           a debuggee without PDBs doesn't fail the batch script. `/Y` keeps
+           `copy` non-interactive if the destination file already exists (e.g.
+           on a retry that reuses the same payload directory). -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
-          Include="@(_UniqueDebuggee->'copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
+          Include="@(_UniqueDebuggee->'copy /Y &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
-          Include="@(_UniqueDebuggee->'if exist &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; copy &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
+          Include="@(_UniqueDebuggee->'if exist &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; copy /Y &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
 
       <!-- Unix: copy SPC from testhost shared framework -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
@@ -215,13 +217,16 @@
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. PDB copy uses `find -exec ... +` so it's a
-           no-op when a debuggee has no PDBs (e.g. on net10.0 servicing dumps),
-           and avoids semicolons that would be split as Helix command separators. -->
+           for symbol resolution. PDB copy uses `find ... -exec cp {} <dest>/ +`
+           so it's a no-op when a debuggee has no PDBs, contains no semicolons
+           (which would be split by the Helix SDK SplitCommands), quotes the
+           pattern so the shell doesn't pre-expand it before find runs, and uses
+           the portable `cp <files> <dest>/` form rather than GNU-only `cp -t`
+           so it also works on macOS / BSD targets. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
-          Include="@(_UniqueDebuggee->'find $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity) -maxdepth 1 -name *.pdb -exec cp -t $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ {} +')" />
+          Include="@(_UniqueDebuggee->'find $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity) -maxdepth 1 -name &apos;*.pdb&apos; -exec cp {} $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ +')" />
     </ItemGroup>
 
     <!-- Test mode only: run xunit, capture exit code, propagate after archive. -->

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -194,16 +194,14 @@
       <!-- Windows: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'mkdir %25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)')" />
-      <!-- Copy every DLL/PDB from the debuggee publish folder so that project
+      <!-- Copy every DLL from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. PDB copy is guarded with `if exist` so that
-           a debuggee without PDBs doesn't fail the batch script. `/Y` keeps
-           `copy` non-interactive if the destination file already exists (e.g.
-           on a retry that reuses the same payload directory). -->
+           for module resolution. cdac and ClrMD read ECMA-335 metadata from
+           the PE itself, so PDBs are not needed here. ``/Y`` keeps ``copy``
+           non-interactive if the destination file already exists (e.g. on a
+           retry that reuses the same payload directory). -->
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
           Include="@(_UniqueDebuggee->'copy /Y &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.dll&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
-      <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
-          Include="@(_UniqueDebuggee->'if exist &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; copy /Y &quot;%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(Identity)\*.pdb&quot; &quot;%25HELIX_WORKITEM_PAYLOAD%25\dumps\local\symbols\debuggees\%(Identity)\&quot;')" />
 
       <!-- Unix: copy SPC from testhost shared framework -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
@@ -215,18 +213,12 @@
       <!-- Unix: copy each debuggee DLL -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
-      <!-- Copy every DLL/PDB from the debuggee publish folder so that project
+      <!-- Copy every DLL from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. The PDB copy uses ``cp <src>/*.pdb <dst>/``
-           with ``2>/dev/null || true``: the shell expands the glob, and when
-           a debuggee has no PDBs ``cp`` prints to stderr (silenced) and exits
-           non-zero (ignored). ``|| true`` is compatible with the dash shell
-           used inside Helix containers and does not affect the surrounding
-           script's control flow. -->
+           for module resolution. cdac and ClrMD read ECMA-335 metadata from
+           the PE itself, so PDBs are not needed here. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
-      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
-          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.pdb $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ 2&gt;/dev/null || true')" />
     </ItemGroup>
 
     <!-- Test mode only: run xunit, capture exit code, propagate after archive. -->

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -217,16 +217,17 @@
           Include="@(_UniqueDebuggee->'mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)')" />
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
-           for symbol resolution. PDB copy uses `find ... -exec cp {} <dest>/ +`
-           so it's a no-op when a debuggee has no PDBs, contains no semicolons
-           (which would be split by the Helix SDK SplitCommands), quotes the
-           pattern so the shell doesn't pre-expand it before find runs, and uses
-           the portable `cp <files> <dest>/` form rather than GNU-only `cp -t`
-           so it also works on macOS / BSD targets. -->
+           for symbol resolution. The PDB copy uses ``cp <src>/*.pdb <dst>/``
+           with ``2>/dev/null || true`` so the script keeps going when a
+           debuggee has no PDBs (the matching ``cp`` line for the JIT/AOT
+           debuggees on line ~123 uses the same ``|| true`` pattern, so this
+           works with the dash shell used inside Helix containers). The shell
+           expands the glob; if no PDB matches, ``cp`` errors out silently and
+           we ignore it. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
-          Include="@(_UniqueDebuggee->'find $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity) -maxdepth 1 -name &apos;*.pdb&apos; -exec cp {} $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ +')" />
+          Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.pdb $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/ 2&gt;/dev/null || true')" />
     </ItemGroup>
 
     <!-- Test mode only: run xunit, capture exit code, propagate after archive. -->

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -218,12 +218,11 @@
       <!-- Copy every DLL/PDB from the debuggee publish folder so that project
            references (e.g. InterpreterStack/Trampoline.dll) are also available
            for symbol resolution. The PDB copy uses ``cp <src>/*.pdb <dst>/``
-           with ``2>/dev/null || true`` so the script keeps going when a
-           debuggee has no PDBs (the matching ``cp`` line for the JIT/AOT
-           debuggees on line ~123 uses the same ``|| true`` pattern, so this
-           works with the dash shell used inside Helix containers). The shell
-           expands the glob; if no PDB matches, ``cp`` errors out silently and
-           we ignore it. -->
+           with ``2>/dev/null || true``: the shell expands the glob, and when
+           a debuggee has no PDBs ``cp`` prints to stderr (silenced) and exits
+           non-zero (ignored). ``|| true`` is compatible with the dash shell
+           used inside Helix containers and does not affect the surrounding
+           script's control flow. -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="@(_UniqueDebuggee->'cp $HELIX_WORKITEM_PAYLOAD/debuggees/%(Identity)/*.dll $HELIX_WORKITEM_PAYLOAD/dumps/local/symbols/debuggees/%(Identity)/')" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"


### PR DESCRIPTION
> [!NOTE]
> Drafted with Copilot CLI.

## Problem

The Helix symbol-prep step in `cdac-dump-helix.proj` copies only `<DebuggeeName>/<DebuggeeName>.dll` from each debuggee's publish output into the `dumps/local/symbols/debuggees/<DebuggeeName>/` directory that ClrMD uses as a symbol search path. DLLs contributed by `ProjectReference` (e.g. `InterpreterStack`'s `Trampoline.dll`, which lives next to `InterpreterStack.dll` in the publish folder) are silently dropped.

When the cDAC opens an x-plat Windows dump and ClrMD has to reload that module's metadata from disk (Windows mini-dump heap mode does not capture read-only image pages), the load fails with `VirtualReadException` in `EcmaMetadata_1.GetMetadataProvider`:

```
StackWalk_VerifyInterleavedStackLayout(config: local/jit (windows_x64)) [FAIL]
  VirtualReadException : Failed to read 2308 bytes at 0x7ff99f581610.
    at ContractDescriptorTarget.ReadBuffer
    at EcmaMetadata_1.GetMetadataProvider(ModuleHandle handle)
    at EcmaMetadata_1.GetMetadata(ModuleHandle handle)
```

This manifested as 3 failing `InterpreterStackDumpTests` on every host running the `windows-x64` and `windows-arm64` dumps in the `CdacXPlatDumpTests` stage of `runtime-diagnostics`. Linux dumps were unaffected because Linux core dumps include file-backed mappings, so ClrMD never had to fall back to disk.

## Fix

Broaden the per-debuggee copy step from `<DebuggeeName>.dll` to `*.dll` so project-reference outputs (e.g. `Trampoline.dll`) are also captured. cDAC and ClrMD read ECMA-335 metadata directly from the PE, so only DLLs need to be copied — no PDBs are required.

Also add `/Y` to the Windows `copy` command to keep it non-interactive on a retry that reuses the same payload directory.

The publish output is framework-dependent (`--no-self-contained`) so only user DLLs are present; the shared framework lives in the correlation payload and is not affected by this change.

## Testing

Validation requires a manual `runtime-diagnostics` xplat pipeline run — local repro requires Helix infrastructure.

[Build 1421241](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1421241) was an earlier validation run; a fresh run will be triggered on the latest commit before merging.
