### PR TITLE
Add support for generating pointers to funclets, and calling funclets by index

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -185,11 +185,8 @@ void CodeGen::genAllocLclFrame(unsigned frameSize, regNumber initReg, bool* pIni
         assert(m_compiler->lvaWasmFunctionIndex != BAD_VAR_NUM);
 
         // fp[0] == functionIndex
-        //
-        // TODO-WASM: Save the actual function index. For now we save a fixed constant
-        //
         GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-        GetEmitter()->emitIns_I(INS_I_const, EA_PTRSIZE, 0xBBBB);
+        GetEmitter()->emitFuncletAddressConstant(0 /* funcletId for main method */);
         GetEmitter()->emitIns_S(ins_Store(TYP_I_IMPL), EA_PTRSIZE, m_compiler->lvaWasmFunctionIndex, 0);
     }
 }

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -394,10 +394,8 @@ void CodeGen::genFuncletProlog(BasicBlock* block)
         GetEmitter()->emitIns(INS_I_sub);
         GetEmitter()->emitIns_I(INS_local_set, EA_PTRSIZE, GetStackPointerRegIndex());
 
-        // TODO-WASM: Save the funclet index. For now we save a fixed constant
-        //
         GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetStackPointerRegIndex());
-        GetEmitter()->emitIns_I(INS_I_const, EA_PTRSIZE, 0xAAAA);
+        GetEmitter()->emitFuncletAddressConstant((cnsval_ssize_t)funcletIndex);
         GetEmitter()->emitIns_I(ins_Store(TYP_I_IMPL), EA_PTRSIZE, 0);
     }
 }

--- a/src/coreclr/jit/emitfmtswasm.h
+++ b/src/coreclr/jit/emitfmtswasm.h
@@ -36,6 +36,8 @@ IF_DEF(FUNCIDX,       IS_NONE, NONE) // <opcode> <ULEB128 immediate (function in
 IF_DEF(SLEB128,       IS_NONE, NONE) // <opcode> <LEB128 immediate (signed)>
 IF_DEF(MEMADDR,       IS_NONE, NONE) // <opcode> <SLEB128 immediate (memory address reloc)>
 IF_DEF(FUNCPTR,       IS_NONE, NONE) // <opcode> <SLEB128 immediate (function pointer reloc)>
+IF_DEF(FUNCLETPTR,    IS_NONE, NONE) // <opcode> <SLEB128 immediate (funclet pointer reloc)>
+IF_DEF(FUNCLETIDX,    IS_NONE, NONE) // <opcode> <SLEB128 immediate (funclet index reloc)>
 IF_DEF(F32,           IS_NONE, NONE) // <opcode> <f32 immediate (stored as 64-bit integer constant)>
 IF_DEF(F64,           IS_NONE, NONE) // <opcode> <f64 immediate (stored as 64-bit integer constant)>
 IF_DEF(MEMARG,        IS_NONE, NONE) // <opcode> <memarg> (<align> <offset>)

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -157,10 +157,9 @@ void emitter::emitAddressConstant(void* address)
 }
 
 
-void emitter::emitFuncletAddressConstant(int64_t funcletId)
+void emitter::emitFuncletAddressConstant(cnsval_ssize_t funcletId)
 {
-    // Load our module base from __r2r_start, then load our address constant, then sum them.
-    // FIXME-WASM: Make this a named constant or a reloc that crossgen2 fills in.
+    // Load our table base, then load our function pointer offset, then sum them.
     emitIns_I(INS_global_get, EA_4BYTE, 2 /* __table_start */);
     emitIns_I(INS_i32_const_funcletptr, EA_PTRSIZE, (cnsval_ssize_t)funcletId);
     emitIns(INS_i32_add);
@@ -691,7 +690,7 @@ size_t emitter::emitOutputPaddedReloc(uint8_t* destination)
     return PADDED_RELOC_SIZE;
 }
 
-size_t emitter::emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType)
+size_t emitter::emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, CorInfoReloc relocType)
 {
     emitRecordRelocationWithAddlDelta(destination, emitCodeBlock, relocType, (int32_t)emitGetInsSC(id));
     return emitOutputPaddedReloc(destination);
@@ -775,13 +774,13 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         case IF_FUNCLETIDX:
         {
             dst += emitOutputOpcode(dst, ins);
-            dst += emitOutputConstantFunclet(dst, id, UNSIGNED, CorInfoReloc::WASM_FUNCTION_INDEX_LEB);
+            dst += emitOutputConstantFunclet(dst, id, CorInfoReloc::WASM_FUNCTION_INDEX_LEB);
             break;
         }
         case IF_FUNCLETPTR:
         {
             dst += emitOutputOpcode(dst, ins);
-            dst += emitOutputConstantFunclet(dst, id, SIGNED, CorInfoReloc::WASM_TABLE_INDEX_SLEB);
+            dst += emitOutputConstantFunclet(dst, id, CorInfoReloc::WASM_TABLE_INDEX_SLEB);
             break;
         }
         case IF_FUNCPTR:

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -156,6 +156,16 @@ void emitter::emitAddressConstant(void* address)
     emitIns(INS_i32_add);
 }
 
+
+void emitter::emitFuncletAddressConstant(int64_t funcletId)
+{
+    // Load our module base from __r2r_start, then load our address constant, then sum them.
+    // FIXME-WASM: Make this a named constant or a reloc that crossgen2 fills in.
+    emitIns_I(INS_global_get, EA_4BYTE, 2 /* __table_start */);
+    emitIns_I(INS_i32_const_funcletptr, EA_PTRSIZE, (cnsval_ssize_t)funcletId);
+    emitIns(INS_i32_add);
+}
+
 /*****************************************************************************
  *
  *  Add a call instruction (direct or indirect).
@@ -522,6 +532,10 @@ unsigned emitter::instrDesc::idCodeSize() const
         case IF_SLEB128:
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfSLEB128(emitGetInsSC(this));
             break;
+        case IF_FUNCLETPTR:
+        case IF_FUNCLETIDX:
+            size += PADDED_RELOC_SIZE; // funclet indices and pointers are always emitted as relocations
+            break;
         case IF_CALL_INDIRECT:
         {
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
@@ -677,6 +691,12 @@ size_t emitter::emitOutputPaddedReloc(uint8_t* destination)
     return PADDED_RELOC_SIZE;
 }
 
+size_t emitter::emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType)
+{
+    emitRecordRelocationWithAddlDelta(destination, emitCodeBlock, relocType, (int32_t)emitGetInsSC(id));
+    return emitOutputPaddedReloc(destination);
+}
+
 size_t emitter::emitOutputConstant(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType)
 {
     if (id->idIsCnsReloc())
@@ -750,6 +770,18 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             // TODO-WASM: The below reloc we're emitting here is specific to R2R and assumes the address we want
             // is an offset from __image_base
             dst += emitOutputConstant(dst, id, SIGNED, CorInfoReloc::WASM_MEMORY_ADDR_REL_SLEB);
+            break;
+        }
+        case IF_FUNCLETIDX:
+        {
+            dst += emitOutputOpcode(dst, ins);
+            dst += emitOutputConstantFunclet(dst, id, UNSIGNED, CorInfoReloc::WASM_FUNCTION_INDEX_LEB);
+            break;
+        }
+        case IF_FUNCLETPTR:
+        {
+            dst += emitOutputOpcode(dst, ins);
+            dst += emitOutputConstantFunclet(dst, id, SIGNED, CorInfoReloc::WASM_TABLE_INDEX_SLEB);
             break;
         }
         case IF_FUNCPTR:
@@ -1076,6 +1108,15 @@ void emitter::emitDispIns(
         }
         break;
 
+        case IF_FUNCLETPTR:
+        case IF_FUNCLETIDX:
+        {
+            cnsval_ssize_t imm = emitGetInsSC(id);
+            printf("funclet %lli", (int64_t)imm);
+            dispLclVarInfoIfAny();
+        }
+        break;
+
         case IF_F32:
         case IF_F64:
         {
@@ -1116,6 +1157,11 @@ void emitter::emitDispIns(
 
         case IF_CODE_SIZE:
         {
+            if (emitCurIG == nullptr)
+            {
+                printf(" <not yet determined>");
+                break;
+            }
             FuncInfoDsc* const func = m_compiler->funGetFunc(emitCurIG->igFuncIdx);
 
             emitLocation* const startLoc = func->startLoc;

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -1156,11 +1156,6 @@ void emitter::emitDispIns(
 
         case IF_CODE_SIZE:
         {
-            if (emitCurIG == nullptr)
-            {
-                printf(" <not yet determined>");
-                break;
-            }
             FuncInfoDsc* const func = m_compiler->funGetFunc(emitCurIG->igFuncIdx);
 
             emitLocation* const startLoc = func->startLoc;

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -156,10 +156,9 @@ void emitter::emitAddressConstant(void* address)
     emitIns(INS_i32_add);
 }
 
-
 void emitter::emitFuncletAddressConstant(cnsval_ssize_t funcletId)
 {
-    // Load our table base, then load our function pointer offset, then sum them.
+    // Load our table base, then load our funclet pointer offset, then sum them.
     emitIns_I(INS_global_get, EA_4BYTE, 2 /* __table_start */);
     emitIns_I(INS_i32_const_funcletptr, EA_PTRSIZE, (cnsval_ssize_t)funcletId);
     emitIns(INS_i32_add);

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -32,7 +32,7 @@ void emitIns_R_R(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2)
 void emitIns_S_R(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 
 void emitAddressConstant(void* address);
-void emitFuncletAddressConstant(int64_t funcletId);
+void emitFuncletAddressConstant(cnsval_ssize_t funcletId);
 
 static unsigned SizeOfULEB128(uint64_t value);
 static unsigned SizeOfSLEB128(int64_t value);
@@ -67,7 +67,7 @@ size_t emitRawBytes(uint8_t* destination, const void* source, size_t count);
 size_t emitOutputOpcode(BYTE* dst, instruction ins);
 size_t emitOutputPaddedReloc(uint8_t* destination);
 size_t emitOutputConstant(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType);
-size_t emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType);
+size_t emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, CorInfoReloc relocType);
 
 size_t emitOutputValtypeSig(uint8_t* destination, WasmValueType valtype);
 

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -32,6 +32,7 @@ void emitIns_R_R(instruction ins, emitAttr attr, regNumber reg1, regNumber reg2)
 void emitIns_S_R(instruction ins, emitAttr attr, regNumber ireg, int varx, int offs);
 
 void emitAddressConstant(void* address);
+void emitFuncletAddressConstant(int64_t funcletId);
 
 static unsigned SizeOfULEB128(uint64_t value);
 static unsigned SizeOfSLEB128(int64_t value);
@@ -66,6 +67,8 @@ size_t emitRawBytes(uint8_t* destination, const void* source, size_t count);
 size_t emitOutputOpcode(BYTE* dst, instruction ins);
 size_t emitOutputPaddedReloc(uint8_t* destination);
 size_t emitOutputConstant(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType);
+size_t emitOutputConstantFunclet(uint8_t* destination, const instrDesc* id, bool isSigned, CorInfoReloc relocType);
+
 size_t emitOutputValtypeSig(uint8_t* destination, WasmValueType valtype);
 
 void emitUpdateFuncletLocations();

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -50,6 +50,8 @@ INST(call,                 "call",                 0, IF_FUNCIDX,       0x10)
 INST(call_indirect,        "call_indirect",        0, IF_CALL_INDIRECT, 0x11)
 INST(return_call,          "return_call",          0, IF_FUNCIDX,       0x12)
 INST(return_call_indirect, "return_call_indirect", 0, IF_CALL_INDIRECT, 0x13)
+// Pseudo-instructions for relocations
+INST(call_funclet,         "call.funclet",         0, IF_FUNCLETIDX,    0x10)
 
 INST(drop,        "drop",        0, IF_OPCODE,  0x1A)
 INST(try_table,   "try_table",   0, IF_TRY_TABLE,   0x1F)
@@ -85,8 +87,9 @@ INST(i32_store16, "i32.store16", 0, IF_MEMARG,  0x3B)
 // Constants
 INST(i32_const,         "i32.const",         0, IF_SLEB128, 0x41)
 // Pseudo-instructions for relocations
-INST(i32_const_address, "i32.const_address", 0, IF_MEMADDR, 0x41)
-INST(i32_const_funcptr, "i32.const_funcptr", 0, IF_FUNCPTR, 0x41)
+INST(i32_const_address,    "i32.const_address",    0, IF_MEMADDR, 0x41)
+INST(i32_const_funcptr,    "i32.const_funcptr",    0, IF_FUNCPTR, 0x41)
+INST(i32_const_funcletptr, "i32.const_funcletptr", 0, IF_FUNCLETPTR, 0x41)
 // Constants, continued
 INST(i64_const,         "i64.const",         0, IF_SLEB128, 0x42)
 INST(f32_const,         "f32.const",         0, IF_F32,     0x43)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -969,7 +969,7 @@ namespace ILCompiler.ObjectWriter
                             // These will need to be fixed up by the runtime after load by adding tableBase
                             // except for WASM_TABLE_INDEX_REL_I32 and WASM_TABLE_INDEX_SLEB which are relative
                             // to the start of the table.
-                            Relocation.WriteValue(reloc.Type, pData, index);
+                            Relocation.WriteValue(reloc.Type, pData, index + addend);
                             break;
                         }
                         case RelocType.WASM_FUNCTION_INDEX_LEB:
@@ -979,7 +979,7 @@ namespace ILCompiler.ObjectWriter
 
                             // These are module-local function pointer indices, so we can simply write out the assigned function index
                             // for this particular symbol
-                            Relocation.WriteValue(reloc.Type, pData, index);
+                            Relocation.WriteValue(reloc.Type, pData, index + addend);
                             break;
                         }
                         default:


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

- Take advantage of relocation addend behavior, and pre-existing reloc logic to allow this
- Requires some followon work in the WasmObjectWriter to emit the funclets along with the primary method and adjust the function indices for the primary methods
- Pseudo instruction i32_const_funcletptr is known to work, I have not explicitly tested pseudo-instruction call_funclet
- Updates our current logic to setup the call chain with meaningful function pointers