### PR TITLE
[wasm][coreclr] Put generated callhelpers into libcoreclr_gen_static library

### DIFF
--- a/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt
@@ -187,6 +187,13 @@ if(FEATURE_INPROC_CRASHREPORT AND NOT CLR_CROSS_COMPONENTS_BUILD)
     target_sources(coreclr_static PRIVATE $<TARGET_OBJECTS:inproccrashreport>)
 endif()
 
+if (TARGET cee_wks_gen)
+    add_library_clr(coreclr_gen_static
+        STATIC
+        $<TARGET_OBJECTS:cee_wks_gen>
+    )
+endif()
+
 if (CLR_CMAKE_HOST_ANDROID)
     target_link_libraries(coreclr PUBLIC log)
 endif()
@@ -248,10 +255,16 @@ if(NOT CLR_CMAKE_HOST_ARCH_WASM)
     install_clr(TARGETS coreclr DESTINATIONS . sharedFramework COMPONENT runtime)
 else()
     install_clr(TARGETS coreclr_static DESTINATIONS . sharedFramework COMPONENT runtime)
+    if (TARGET coreclr_gen_static)
+        install_clr(TARGETS coreclr_gen_static DESTINATIONS . sharedFramework COMPONENT runtime)
+    endif()
 endif(NOT CLR_CMAKE_HOST_ARCH_WASM)
 
 if(CLR_CMAKE_HOST_MACCATALYST OR CLR_CMAKE_HOST_IOS OR CLR_CMAKE_HOST_TVOS OR CLR_CMAKE_HOST_ANDROID OR CLR_CMAKE_HOST_ARCH_WASM)
     install_clr(TARGETS coreclr_static DESTINATIONS . COMPONENT runtime)
+    if (TARGET coreclr_gen_static)
+        install_clr(TARGETS coreclr_gen_static DESTINATIONS . COMPONENT runtime)
+    endif()
 endif(CLR_CMAKE_HOST_MACCATALYST OR CLR_CMAKE_HOST_IOS OR CLR_CMAKE_HOST_TVOS OR CLR_CMAKE_HOST_ANDROID OR CLR_CMAKE_HOST_ARCH_WASM)
 
 # Enable profile guided optimization

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -55,6 +55,9 @@ else()
             System.IO.Compression.Native-Static
             System.Native-Static
             System.Native.TimeZoneData.Invariant)
+        if (TARGET coreclr_gen_static)
+            target_link_libraries(corerun PRIVATE coreclr_gen_static)
+        endif()
 
         # additional requirements for System.IO.Compression.Native
         include(${CLR_SRC_NATIVE_DIR}/libs/System.IO.Compression.Native/extra_libs.cmake)

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -943,13 +943,15 @@ elseif(CLR_CMAKE_TARGET_ARCH_WASM)
         ${ARCH_SOURCES_DIR}/calldescrworkerwasm.cpp
         ${ARCH_SOURCES_DIR}/profiler.cpp
         ${ARCH_SOURCES_DIR}/helpers.cpp
-        ${ARCH_SOURCES_DIR}/callhelpers-interp-to-managed.cpp
-        ${ARCH_SOURCES_DIR}/callhelpers-reverse.cpp
         exceptionhandling.cpp
         gcinfodecoder.cpp
     )
+    set(VM_SOURCES_WKS_GEN
+        ${ARCH_SOURCES_DIR}/callhelpers-interp-to-managed.cpp
+        ${ARCH_SOURCES_DIR}/callhelpers-reverse.cpp
+    )
     if (GEN_PINVOKE)
-        list(APPEND VM_SOURCES_WKS_ARCH
+        list(APPEND VM_SOURCES_WKS_GEN
             ${ARCH_SOURCES_DIR}/callhelpers-pinvoke.cpp
         )
     endif(GEN_PINVOKE)
@@ -1032,6 +1034,7 @@ if(CLR_CMAKE_TARGET_ARCH_I386)
 endif()
 
 convert_to_absolute_path(VM_SOURCES_WKS ${VM_SOURCES_WKS})
+convert_to_absolute_path(VM_SOURCES_WKS_GEN ${VM_SOURCES_WKS_GEN})
 convert_to_absolute_path(VM_SOURCES_WKS_ARCH_ASM ${VM_SOURCES_WKS_ARCH_ASM})
 convert_to_absolute_path(VM_SOURCES_DAC ${VM_SOURCES_DAC})
 convert_to_absolute_path(VM_SOURCES_WKS_SPECIAL ${VM_SOURCES_WKS_SPECIAL})

--- a/src/coreclr/vm/wks/CMakeLists.txt
+++ b/src/coreclr/vm/wks/CMakeLists.txt
@@ -8,9 +8,17 @@ add_library_clr(cee_wks_core OBJECT ${VM_SOURCES_WKS} ${VM_SOURCES_WKS_ARCH_ASM}
 add_library_clr(cee_wks OBJECT ${VM_SOURCES_WKS_SPECIAL})
 add_library_clr(cee_wks_mergeable OBJECT ${VM_SOURCES_WKS_SPECIAL})
 
+if (CLR_CMAKE_TARGET_ARCH_WASM AND VM_SOURCES_WKS_GEN)
+    add_library_clr(cee_wks_gen OBJECT ${VM_SOURCES_WKS_GEN})
+endif()
+
 target_precompile_headers(cee_wks_core PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks PRIVATE [["common.h"]])
 target_precompile_headers(cee_wks_mergeable PRIVATE [["common.h"]])
+
+if (TARGET cee_wks_gen)
+    target_precompile_headers(cee_wks_gen PRIVATE [["common.h"]])
+endif()
 
 if (MSVC)
     # corelib.cpp does not compile with precompiled header file
@@ -20,6 +28,10 @@ endif()
 add_dependencies(cee_wks_core eventing_headers)
 add_dependencies(cee_wks eventing_headers)
 add_dependencies(cee_wks_mergeable eventing_headers)
+
+if (TARGET cee_wks_gen)
+    add_dependencies(cee_wks_gen eventing_headers)
+endif()
 
 if (CLR_CMAKE_TARGET_WIN32)
   if(NOT CLR_CMAKE_HOST_ARCH_ARM AND NOT CLR_CMAKE_HOST_ARCH_ARM64)
@@ -45,6 +57,10 @@ add_custom_target(precompiled_asm DEPENDS ${VM_WKS_ARCH_ASM_OBJECTS})
 add_dependencies(cee_wks_core precompiled_asm)
 add_dependencies(cee_wks precompiled_asm)
 add_dependencies(cee_wks_mergeable precompiled_asm)
+
+if (TARGET cee_wks_gen)
+    add_dependencies(cee_wks_gen precompiled_asm)
+endif()
 
 target_compile_definitions(cee_wks_mergeable PUBLIC FEATURE_STATICALLY_LINKED)
 target_compile_definitions(cee_wks_mergeable PUBLIC CORECLR_EMBEDDED)

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -108,6 +108,7 @@
     <PlatformManifestFileEntry Include="libcoreclr.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclr.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclr_static.a" IsNative="true" />
+    <PlatformManifestFileEntry Include="libcoreclr_gen_static.a" IsNative="true" />
     <PlatformManifestFileEntry Include="clrgc.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrgc.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrgc.dylib" IsNative="true" />

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -345,14 +345,10 @@
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ManagedToNativeGenerator>
 
-    <!-- Add generated C++ files to compile list.
-         Note: reverse-pinvoke-table.cpp is NOT compiled separately because
-         libcoreclr_static.a already contains callhelpers-reverse.cpp.o with the
-         default reverse-thunk table. Compiling the app-generated version would
-         cause duplicate symbol errors when the archive object is pulled in for
-         other required symbols (e.g., SystemInteropJS_*). -->
     <ItemGroup>
       <_WasmSourceFileToCompile Include="$(_WasmPInvokeTablePath)"          ObjectFile="$(_WasmIntermediateOutputPath)pinvoke-table.o"
+                                                                            Dependencies="$(_WasmCompileRsp);$(_WasmIntermediateOutputPath)coreclr_compat.h" />
+      <_WasmSourceFileToCompile Include="$(_WasmReversePInvokeTablePath)"   ObjectFile="$(_WasmIntermediateOutputPath)reverse-pinvoke-table.o"
                                                                             Dependencies="$(_WasmCompileRsp);$(_WasmIntermediateOutputPath)coreclr_compat.h" />
       <_WasmSourceFileToCompile Include="$(_WasmInterpToNativeTablePath)"   ObjectFile="$(_WasmIntermediateOutputPath)wasm_m2n_invoke.o"
                                                                             Dependencies="$(_WasmCompileRsp);$(_WasmIntermediateOutputPath)coreclr_compat.h" />

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -58,6 +58,7 @@ set(SHARED_CLR_DESTINATION
 # CoreCLR runtime .a libraries
 LIST(APPEND NATIVE_LIBS
     ${SHARED_CLR_DESTINATION}/libcoreclr_static.a
+    ${SHARED_CLR_DESTINATION}/libcoreclr_gen_static.a
     ${SHARED_CLR_DESTINATION}/libnativeresourcestring.a
     ${SHARED_CLR_DESTINATION}/libgcinfo_unix_wasm.a
     ${SHARED_CLR_DESTINATION}/libcoreclrminipal.a


### PR DESCRIPTION
Move callhelpers-interp-to-managed.cpp, callhelpers-reverse.cpp, and
callhelpers-pinvoke.cpp out of cee_wks_core/coreclr_static into a new
cee_wks_gen object library and coreclr_gen_static static library.

This allows relinking with just libcoreclr_static plus newly generated
callhelper sources, without rebuilding the entire coreclr.

The new library is linked in all WASM/coreclr consumers: corerun,
browserhost, and installed alongside coreclr_static.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>