### PR TITLE
[experiment] opt-in clang-cl support for Windows

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -21,6 +21,7 @@ Param(
   [switch]$usemonoruntime = $false,
   [switch]$ninja,
   [switch]$msbuild,
+  [switch]$clangcl,
   [string]$cmakeargs,
   [switch]$pgoinstrument,
   [string[]]$fsanitize,
@@ -98,6 +99,9 @@ function Get-Help() {
   Write-Host "  -cmakeargs                User-settable additional arguments passed to CMake."
   Write-Host "  -ninja                    Use Ninja to drive the native build. (default)"
   Write-Host "  -msbuild                  Use MSBuild to drive the native build. This is a no-op for Mono."
+  Write-Host "  -clangcl                  (Windows only) Build native components with LLVM clang-cl instead of MSVC."
+  Write-Host "                            Requires clang-cl.exe on PATH or under %ProgramFiles%\LLVM\bin"
+  Write-Host "                            (e.g. winget install LLVM.LLVM). Forces the Ninja generator."
   Write-Host "  -pgoinstrument            Build the CLR with PGO instrumentation."
   Write-Host "  -fsanitize (address)      Build the native components with the specified sanitizers."
   Write-Host "                            Sanitizers can be specified with a comma-separated list."
@@ -367,6 +371,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     # The -ninja switch is a no-op since Ninja is the default generator on Windows.
     "ninja"                  { }
     "msbuild"                { $arguments += " /p:Ninja=false" }
+    "clangcl"                { $env:__UseClangCl = "1" }
     "pgoinstrument"          { $arguments += " /p:PgoInstrument=$($PSBoundParameters[$argument])"}
     # configuration and arch can be specified multiple times, so they should be no-ops here
     "configuration"          {}

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -1043,6 +1043,31 @@ if (MSVC)
   set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} /nologo")
   # Don't display the output header when building asm files.
   set(CMAKE_ASM_MASM_FLAGS "${CMAKE_ASM_MASM_FLAGS} /nologo")
+
+  # clang-cl-specific overrides. clang-cl simulates MSVC (so MSVC is true and the flags above are
+  # sent to clang-cl), but clang-cl does not implement every MSVC switch and emits its own diagnostics.
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # /WX maps to -Werror, which turns clang-cl's -Wunused-command-line-argument into an error.
+    # Several MSVC-only switches we pass (e.g. /Gm-, /MP, /Zm200) are silently ignored by cl.exe but
+    # would produce that diagnostic under clang-cl.
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-command-line-argument>)
+
+    # Suppress clang-only diagnostics that fire on patterns the runtime sources use widely
+    # (MSVC extensions, stricter language conformance, etc.) and that cl.exe does not flag.
+    # The list below was derived empirically: each entry corresponds to at least one warning in the
+    # current sources. When adding/removing warnings, audit by replacing -Wno- with -Wno-error= and
+    # rebuilding to see which categories actually fire.
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-pragma-pack>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-variable>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-but-set-variable>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-function>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-const-variable>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-private-field>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unknown-pragmas>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-ignored-qualifiers>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-missing-field-initializers>)
+  endif()
 endif (MSVC)
 
 # Configure non-MSVC compiler flags that apply to all platforms (unix-like or otherwise)

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -995,6 +995,11 @@ if (MSVC)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
   set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_CHECKED OFF)
+  if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    # ThinLTO with clang-cl 22.x runs into LLVM compiler crashes (filed upstream as an LLVM bug)
+    # on a couple of CoreCLR functions. Disable IPO/LTO for clang-cl until the upstream fix lands.
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+  endif()
 
   if (CLR_CMAKE_HOST_ARCH_AMD64)
     # The generator expression in the following command means that the /homeparams option is added only for debug builds for C and C++ source files
@@ -1052,14 +1057,20 @@ if (MSVC)
     # would produce that diagnostic under clang-cl.
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-command-line-argument>)
 
+    # Match the Unix Clang block's behaviour: continue compiling past the first error so we get a
+    # full picture in one build.
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-ferror-limit=4096>)
+
     # Suppress clang-only diagnostics that fire on patterns the runtime sources use widely
     # (MSVC extensions, stricter language conformance, etc.) and that cl.exe does not flag.
     # The list below was derived empirically: each entry corresponds to at least one warning in the
     # current sources. When adding/removing warnings, audit by replacing -Wno- with -Wno-error= and
     # rebuilding to see which categories actually fire.
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-microsoft>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-pragma-pack>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-variable>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-but-set-variable>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-but-set-parameter>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-function>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-const-variable>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-unused-private-field>)
@@ -1067,6 +1078,13 @@ if (MSVC)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-ignored-qualifiers>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>)
     add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-missing-field-initializers>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-sign-compare>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-copy-with-user-provided-copy>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-nontrivial-memcall>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-unnecessary-virtual-specifier>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-duplicate-decl-specifier>)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-enum-compare>)
+    add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-Wno-tautological-undefined-compare>)
   endif()
 endif (MSVC)
 

--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -50,6 +50,38 @@ if /i "%__Ninja%" == "1" (
     )
 )
 
+if /i "%__UseClangCl%" == "1" (
+    if /i NOT "%__CmakeGenerator%" == "Ninja" (
+        echo Error: -clangcl requires the Ninja generator.
+        exit /B 1
+    )
+
+    set "__ClangClPath="
+    where.exe clang-cl.exe >nul 2>&1
+    if "!errorlevel!" == "0" (
+        for /f "delims=" %%I in ('where.exe clang-cl.exe') do (
+            if not defined __ClangClPath set "__ClangClPath=%%I"
+        )
+    )
+    if not defined __ClangClPath (
+        if exist "%ProgramFiles%\LLVM\bin\clang-cl.exe" (
+            set "__ClangClPath=%ProgramFiles%\LLVM\bin\clang-cl.exe"
+        )
+    )
+    if not defined __ClangClPath (
+        echo Error: clang-cl.exe not found. Install LLVM ^(e.g. winget install LLVM.LLVM^) and ensure clang-cl.exe is on PATH or under "%%ProgramFiles%%\LLVM\bin".
+        exit /B 1
+    )
+
+    REM CMake requires forward slashes in the compiler path.
+    set "__ClangClPathFwd=!__ClangClPath:\=/!"
+
+    echo Using clang-cl from: !__ClangClPath!
+    set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCMAKE_C_COMPILER=!__ClangClPathFwd!" "-DCMAKE_CXX_COMPILER=!__ClangClPathFwd!"
+
+    REM clang-cl emits LLD-style depfiles when used with Ninja - cmake handles this automatically.
+)
+
 if /i "%__Arch%" == "wasm" (
     if "%__Os%" == "" (
         echo Error: Please add target OS parameter

--- a/src/coreclr/build-runtime.cmd
+++ b/src/coreclr/build-runtime.cmd
@@ -72,6 +72,7 @@ set __HostArch=
 set __PgoOptDataPath=
 set __CMakeArgs=
 set __Ninja=1
+if not defined __UseClangCl set __UseClangCl=0
 set __RequestedBuildComponents=
 set __TargetRid=
 set __SubDir=
@@ -150,6 +151,7 @@ if /i "%1" == "-skipnative"          (set __BuildNative=0&shift&goto Arg_Loop)
 REM -ninja is a no-op option since Ninja is now the default generator on Windows.
 if /i "%1" == "-ninja"               (shift&goto Arg_Loop)
 if /i "%1" == "-msbuild"             (set __Ninja=0&shift&goto Arg_Loop)
+if /i "%1" == "-clangcl"             (set __UseClangCl=1&shift&goto Arg_Loop)
 if /i "%1" == "-pgoinstrument"       (set __PgoInstrument=1&shift&goto Arg_Loop)
 if /i "%1" == "-enforcepgo"          (set __EnforcePgo=1&shift&goto Arg_Loop)
 if /i "%1" == "-pgodatapath"         (set __PgoOptDataPath=%~2&set __PgoOptimize=1&shift&shift&goto Arg_Loop)
@@ -203,6 +205,13 @@ if %__TotalSpecifiedBuildType% GTR 1 (
 if %__BuildTypeDebug%==1    set __BuildType=Debug
 if %__BuildTypeChecked%==1  set __BuildType=Checked
 if %__BuildTypeRelease%==1  set __BuildType=Release
+
+if %__UseClangCl%==1 (
+    if %__Ninja%==0 (
+        echo Error: -clangcl requires the Ninja generator and is incompatible with -msbuild.
+        goto Usage
+    )
+)
 
 if %__EnforcePgo%==1 (
     if %__TargetArchArm%==1 (
@@ -601,6 +610,7 @@ echo -configureonly: skip all builds; only run CMake ^(default: CMake and builds
 echo -skipconfigure: skip CMake ^(default: CMake is run^)
 echo -skipnative: skip building native components ^(default: native components are built^).
 echo -fsanitize ^<name^>: Enable the specified sanitizers. This script does not handle converting 'true' to the default sanitizers.
+echo -clangcl: Build the native components with LLVM clang-cl instead of MSVC ^(Windows only, requires Ninja generator and clang-cl.exe on PATH or under %%ProgramFiles%%\LLVM\bin^).
 echo.
 echo Examples:
 echo     build-runtime

--- a/src/coreclr/gc/gcpriv.h
+++ b/src/coreclr/gc/gcpriv.h
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 #ifndef _DEBUG
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 // optimize for speed
 #pragma optimize( "t", on )
 #endif

--- a/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX2.int32_t.generated.h
+++ b/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX2.int32_t.generated.h
@@ -12,7 +12,7 @@
 #ifndef BITONIC_SORT_AVX2_INT32_T_H
 #define BITONIC_SORT_AVX2_INT32_T_H
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx2"))), apply_to = any(function))
 #else
@@ -1557,7 +1557,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX2.int64_t.generated.h
+++ b/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX2.int64_t.generated.h
@@ -12,7 +12,7 @@
 #ifndef BITONIC_SORT_AVX2_INT64_T_H
 #define BITONIC_SORT_AVX2_INT64_T_H
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx2"))), apply_to = any(function))
 #else
@@ -1517,7 +1517,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX512.int32_t.generated.h
+++ b/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX512.int32_t.generated.h
@@ -13,7 +13,7 @@
 #define BITONIC_SORT_AVX512_INT32_T_H
 
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx512f"))), apply_to = any(function))
 #else
@@ -1442,7 +1442,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX512.int64_t.generated.h
+++ b/src/coreclr/gc/vxsort/smallsort/bitonic_sort.AVX512.int64_t.generated.h
@@ -13,7 +13,7 @@
 #define BITONIC_SORT_AVX512_INT64_T_H
 
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx512f"))), apply_to = any(function))
 #else
@@ -1402,7 +1402,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/smallsort/codegen/avx2.py
+++ b/src/coreclr/gc/vxsort/smallsort/codegen/avx2.py
@@ -276,7 +276,7 @@ class AVX2BitonicISA(BitonicISA):
 #ifndef BITONIC_SORT_AVX2_{t.upper()}_H
 #define BITONIC_SORT_AVX2_{t.upper()}_H
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx2"))), apply_to = any(function))
 #else
@@ -321,7 +321,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/smallsort/codegen/avx512.py
+++ b/src/coreclr/gc/vxsort/smallsort/codegen/avx512.py
@@ -276,7 +276,7 @@ class AVX512BitonicISA(BitonicISA):
 #define BITONIC_SORT_AVX512_{t.upper()}_H
 
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx512f"))), apply_to = any(function))
 #else
@@ -317,7 +317,7 @@ public:
 #undef s2d
 #undef d2s
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/vxsort.h
+++ b/src/coreclr/gc/vxsort/vxsort.h
@@ -5,7 +5,7 @@
 #define VXSORT_VXSORT_H
 
 #if defined(TARGET_AMD64)
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("popcnt"))), apply_to = any(function))
 #else

--- a/src/coreclr/gc/vxsort/vxsort_targets_disable.h
+++ b/src/coreclr/gc/vxsort/vxsort_targets_disable.h
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute pop
 #else

--- a/src/coreclr/gc/vxsort/vxsort_targets_enable_avx2.h
+++ b/src/coreclr/gc/vxsort/vxsort_targets_enable_avx2.h
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx2"))), apply_to = any(function))
 #else

--- a/src/coreclr/gc/vxsort/vxsort_targets_enable_avx512.h
+++ b/src/coreclr/gc/vxsort/vxsort_targets_enable_avx512.h
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
 #ifdef __clang__
 #pragma clang attribute push (__attribute__((target("avx512f,avx512dq"))), apply_to = any(function))
 #else

--- a/src/coreclr/inc/sigparser.h
+++ b/src/coreclr/inc/sigparser.h
@@ -66,6 +66,7 @@ class SigParser
         }
 
         SigParser(const SigParser &sig);
+        SigParser& operator=(const SigParser &sig) = default;
 
         //------------------------------------------------------------------------
         // Initialize

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -31642,7 +31642,7 @@ NamedIntrinsic GenTreeHWIntrinsic::GetHWIntrinsicIdForCmpOp(Compiler*  comp,
             }
             else if (isScalar)
             {
-                reverseCond ? NI_X86Base_CompareScalarNotLessThanOrEqual : NI_X86Base_CompareScalarGreaterThan;
+                id = reverseCond ? NI_X86Base_CompareScalarNotLessThanOrEqual : NI_X86Base_CompareScalarGreaterThan;
             }
             else
             {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -4777,8 +4777,7 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                                 // This is now known to be a multi-dimension array with a constant dimension
                                 // that is in range; we can expand it as an intrinsic.
 
-                                impPopStack().val; // Pop the dim and array object; we already have a pointer to them.
-                                impPopStack().val;
+                                impPopStack(2); // Pop the dim and array object; we already have a pointer to them.
 
                                 // Make sure there are no global effects in the array (such as it being a function
                                 // call), so we can mark the generated indirection with GTF_IND_INVARIANT. In the

--- a/src/coreclr/jit/utils.cpp
+++ b/src/coreclr/jit/utils.cpp
@@ -4184,7 +4184,7 @@ public:
             return;
         }
 
-        if (strBufferSize > bufferSize)
+        if (strBufferSize > (int)bufferSize)
         {
             m_pBuffer = new WCHAR[strBufferSize];
         }

--- a/src/coreclr/utilcode/debug.cpp
+++ b/src/coreclr/utilcode/debug.cpp
@@ -65,6 +65,7 @@ static void DECLSPEC_NORETURN FailFastOnAssert()
     CreateCrashDumpIfEnabled();
 #endif
     RaiseFailFastException(NULL, NULL, 0);
+    __assume(0);
 }
 
 #ifdef _DEBUG

--- a/src/coreclr/utilcode/fstring.cpp
+++ b/src/coreclr/utilcode/fstring.cpp
@@ -16,7 +16,7 @@
 namespace FString
 {
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #pragma optimize("t", on)
 #endif // _MSC_VER
 

--- a/src/coreclr/utilcode/pedecoder.cpp
+++ b/src/coreclr/utilcode/pedecoder.cpp
@@ -978,7 +978,7 @@ inline PTR_STORAGESTREAM NextStorageStream(PTR_STORAGESTREAM pSS)
 
     SUPPORTS_DAC;
     TADDR pc = dac_cast<TADDR>(pSS);
-    pc += (sizeof(STORAGESTREAM) - 32 /*sizeof(STORAGESTREAM::rcName)*/ + strlen(pSS->rcName)+1+3)&~3;
+    pc += (sizeof(STORAGESTREAM) - 32 /*sizeof(STORAGESTREAM::rcName)*/ + strlen((const char *)pSS->rcName)+1+3)&~3;
     return PTR_STORAGESTREAM(pc);
 }
 //-------------------------------------------------------------------------------
@@ -2260,8 +2260,8 @@ BOOL PEDecoder::GetForceRelocs()
 BOOL PEDecoder::ForceRelocForDLL(LPCWSTR lpFileName)
 {
 #ifdef _DEBUG
-		STATIC_CONTRACT_NOTHROW;                                        \
-		STATIC_CONTRACT_CANNOT_TAKE_LOCK;
+    STATIC_CONTRACT_NOTHROW;
+    STATIC_CONTRACT_CANNOT_TAKE_LOCK;
 #endif
 
 #if defined(DACCESS_COMPILE) || defined(TARGET_UNIX)

--- a/src/coreclr/utilcode/stacktrace.cpp
+++ b/src/coreclr/utilcode/stacktrace.cpp
@@ -425,11 +425,11 @@ void MagicInit()
     //
     // Try to get the API entrypoints in imagehlp.dll
     //
-    for (int i = 0; i < ARRAY_SIZE(ailFuncList); i++)
+    for (int i = 0; i < (int)ARRAY_SIZE(ailFuncList); i++)
     {
-        *(ailFuncList[i].ppvfn) = GetProcAddress(
+        *(ailFuncList[i].ppvfn) = reinterpret_cast<LPVOID>(GetProcAddress(
                 g_hinstImageHlp,
-                ailFuncList[i].pszFnName);
+                ailFuncList[i].pszFnName));
         LOCAL_ASSERT(*(ailFuncList[i].ppvfn));
 
         if (!*(ailFuncList[i].ppvfn))

--- a/src/coreclr/vm/dispatchinfo.h
+++ b/src/coreclr/vm/dispatchinfo.h
@@ -28,7 +28,7 @@ struct ComMTMethodProps;
 class DispParamMarshaler;
 class MarshalInfo;
 class DispatchInfo;
-enum BinderMethodID;
+enum BinderMethodID : int;
 
 // An enumeration of the types of managed MemberInfo's. This must stay in synch with
 // the ones defined in MemberInfo.cs.

--- a/src/coreclr/vm/threads.cpp
+++ b/src/coreclr/vm/threads.cpp
@@ -6459,6 +6459,20 @@ BOOL dbgOnly_IsSpecialEEThread()
 
 #endif // _DEBUG
 
+#if defined(TARGET_WINDOWS) && defined(TARGET_AMD64) && defined(__clang__)
+// Out-of-line definition for clang-cl: the [[gnu::target("shstk")]] attribute on the in-class
+// declaration enables the _rdsspq intrinsic only inside this function body.
+[[gnu::target("shstk")]]
+bool Thread::AreShadowStacksEnabled()
+{
+    LIMITED_METHOD_CONTRACT;
+    // The SSP is null when CET shadow stacks are not enabled. On processors that don't support
+    // shadow stacks, this is a no-op and the intrinsic returns 0. CET shadow stacks are enabled
+    // or disabled for all threads, so the result is the same from any thread.
+    return _rdsspq() != 0;
+}
+#endif
+
 void Thread::StaticInitialize()
 {
     WRAPPER_NO_CONTRACT;

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3688,6 +3688,13 @@ public:
     static void StaticInitialize();
 
 #if defined(TARGET_WINDOWS)
+#if defined(TARGET_AMD64) && defined(__clang__)
+    // clang-cl requires an explicit target attribute to enable the shstk intrinsic _rdsspq;
+    // cl.exe always exposes it. Use a static helper at namespace scope so the attribute is
+    // unambiguously bound to the function definition.
+    [[gnu::target("shstk")]]
+    static bool AreShadowStacksEnabled();
+#else
     static bool AreShadowStacksEnabled()
     {
         LIMITED_METHOD_CONTRACT;
@@ -3702,6 +3709,7 @@ public:
         return false;
 #endif
     }
+#endif
 #endif
 
 #ifdef FEATURE_SPECIAL_USER_MODE_APC

--- a/src/native/eventpipe/ds-ipc-pal-namedpipe.c
+++ b/src/native/eventpipe/ds-ipc-pal-namedpipe.c
@@ -44,6 +44,7 @@
 #define DS_EXIT_BLOCKING_PAL_SECTION
 #endif
 
+
 #undef ep_rt_object_alloc
 #define ep_rt_object_alloc(obj_type) ((obj_type *)calloc(1, sizeof(obj_type)))
 
@@ -192,6 +193,7 @@ ds_ipc_reset (DiagnosticsIpc *ipc)
 	ipc->is_listening = false;
 }
 
+
 int32_t
 ds_ipc_poll (
 	DiagnosticsIpcPollHandle *poll_handles_data,
@@ -233,6 +235,7 @@ ds_ipc_poll (
 				poll_handles_data [i].stream->is_test_reading = true;
 				if (!success) {
 					DWORD error = GetLastError ();
+					bool poll_should_raise_error = false;
 					switch (error) {
 					case ERROR_IO_PENDING:
 						handles [i] = poll_handles_data [i].stream->overlap.hEvent;
@@ -240,11 +243,16 @@ ds_ipc_poll (
 					case ERROR_PIPE_NOT_CONNECTED:
 						poll_handles_data [i].events = (uint8_t)IPC_POLL_EVENTS_HANGUP;
 						result = -1;
-						ep_raise_error ();
+						poll_should_raise_error = true;
+						break;
 					default:
 						if (callback)
 							callback ("0 byte async read on client connection failed", error);
 						result = -1;
+						poll_should_raise_error = true;
+						break;
+					}
+					if (poll_should_raise_error) {
 						ep_raise_error ();
 					}
 				} else {
@@ -353,6 +361,7 @@ ep_on_error:
 
 	ep_exit_error_handler ();
 }
+
 
 bool
 ds_ipc_listen (
@@ -998,6 +1007,8 @@ ds_ipc_stream_to_string (
 	int32_t result = sprintf_s (buffer, buffer_len, "{ _hPipe = %d, _oOverlap.hEvent = %d }", (int32_t)(size_t)ipc_stream->pipe, (int32_t)(size_t)ipc_stream->overlap.hEvent);
 	return (result > 0 && result < (int32_t)buffer_len) ? result : 0;
 }
+
+
 #endif /* HOST_WIN32 */
 #endif /* ENABLE_PERFTRACING */
 

--- a/src/native/libs/System.Globalization.Native/pal_icushim.c
+++ b/src/native/libs/System.Globalization.Native/pal_icushim.c
@@ -111,7 +111,7 @@ static int FindSymbolVersion(int majorVer, int minorVer, int subVer, char* symbo
 #define PER_FUNCTION_BLOCK(fn, lib, required) \
     sprintf_s(symbolName, SYMBOL_NAME_SIZE, #fn "%s", symbolVersion); \
     fn##_ptr = (TYPEOF(fn)*)GetProcAddress((HMODULE)lib, symbolName); \
-    if (fn##_ptr == NULL && required) { fprintf(stderr, "Cannot get symbol %s from " #lib "\nError: %u\n", symbolName, GetLastError()); abort(); }
+    if (fn##_ptr == NULL && required) { fprintf(stderr, "Cannot get symbol %s from " #lib "\nError: %u\n", symbolName, (unsigned int)GetLastError()); abort(); }
 
 static int FindICULibs(void)
 {

--- a/src/native/minipal/guid.c
+++ b/src/native/minipal/guid.c
@@ -69,7 +69,7 @@ void minipal_guid_as_string(GUID guid, char* guidString, uint32_t len)
     assert(len >= MINIPAL_GUID_BUFFER_LEN);
 
     int32_t nBytes = snprintf(guidString, len, "{%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x}",
-        guid.Data1, guid.Data2, guid.Data3,
+        (unsigned int)guid.Data1, guid.Data2, guid.Data3,
         guid.Data4[0], guid.Data4[1],
         guid.Data4[2], guid.Data4[3],
         guid.Data4[4], guid.Data4[5],

--- a/src/native/minipal/xoshiro128pp.c
+++ b/src/native/minipal/xoshiro128pp.c
@@ -29,7 +29,7 @@ static void jump(struct minipal_xoshiro128pp* pState) {
 	uint32_t s1 = 0;
 	uint32_t s2 = 0;
 	uint32_t s3 = 0;
-	for (int i = 0; i < sizeof JUMP / sizeof * JUMP; i++)
+	for (size_t i = 0; i < sizeof JUMP / sizeof * JUMP; i++)
 		for (int b = 0; b < 32; b++) {
 			if (JUMP[i] & UINT32_C(1) << b) {
 				s0 ^= s[0];


### PR DESCRIPTION
## Experiment: building CoreCLR's JIT (and ~most of native) on Windows with clang-cl

Opt-in path to build CoreCLR's native components on Windows using LLVM `clang-cl` instead of MSVC `cl.exe`. **Not intended to merge as-is** — opening as draft so we can discuss whether the approach is interesting and where it could go.

Two commits:
1. **JIT-only (verified end-to-end):** `Clr.Jit` builds + JIT smoke test passes with the clang-cl-built `clrjit.dll` (Vector<int> SIMD, exception throw/catch, loop arithmetic — exit code 100, output identical to MSVC).
2. **Root-level switch + broader native (~109/2551 native objects + libs + host before blocker):** `-clangcl` promoted to a top-level `build.cmd` switch and many additional source/cmake fixes for CoreCLR runtime, libs native, and host. Hits one upstream LLVM crash that we couldn't sidestep (see "Known limitation").

### Usage

Requires `clang-cl.exe` on `%PATH%` or under `%ProgramFiles%\LLVM\bin` (`winget install LLVM.LLVM`). Tested with clang 22.1.5.

```powershell
# JIT only (works end-to-end):
build.cmd Clr.Jit -c Release -clangcl /p:NoPgoOptimize=true

# Full native (currently blocked by upstream LLVM bug, see below):
build.cmd clr+libs+host -c Release -clangcl /p:NoPgoOptimize=true
```

### Build infrastructure

* `eng/build.ps1` — new `-clangcl` switch. Sets `=1` so it propagates through Arcade → MSBuild Exec → all three native build scripts (`src/coreclr/build-runtime.cmd`, `src/native/libs/build-native.cmd`, `src/native/corehost/build.cmd`). All three call `eng/native/gen-buildsys.cmd` which already reads `__UseClangCl`, so no further plumbing was needed.
* `src/coreclr/build-runtime.cmd` — `-clangcl` flag (also honors a pre-set `__UseClangCl=1` env var).
* `eng/native/gen-buildsys.cmd` — discovers `clang-cl.exe`, injects `-DCMAKE_C_COMPILER` / `-DCMAKE_CXX_COMPILER`, forces Ninja generator.
* `eng/native/configurecompiler.cmake` — clang-cl branch inside `if (MSVC)`. Each suppression empirically verified to actually fire (audit method: replace `-Wno-foo` with `-Wno-error=foo` and rebuild). IPO/LTO is also disabled for clang-cl since ThinLTO triggers additional LLVM crashes.

### Source fixes (all MSVC-safe; verified MSVC builds still pass)

| File | Why |
|---|---|
| `utilcode/pedecoder.cpp` | Stray line-continuation `\` silently merged two `STATIC_CONTRACT_*` statements (real bug; was masking a clang frontend crash). |
| `jit/gentree.cpp` (line 31645) | Compare-greater-than scalar branch was missing `id =`, computing a `?:` value and discarding it. **Real JIT bug** found by `-Wunused-value`. |
| `jit/importercalls.cpp` | Replace two `impPopStack().val;` discards with one `impPopStack(2);`. |
| `jit/utils.cpp` | `(int)` cast on `size_t` template arg compared against `int`. |
| `inc/sigparser.h` | `operator= = default` to satisfy `-Wdeprecated-copy-with-user-provided-copy`. |
| `utilcode/debug.cpp` | `__assume(0)` after `RaiseFailFastException` so clang treats `FailFastOnAssert` as truly noreturn. |
| `utilcode/fstring.cpp` + `gc/gcpriv.h` | Gate `#pragma optimize("t", on)` on `_MSC_VER && !__clang__`. |
| `utilcode/pedecoder.cpp` + `utilcode/stacktrace.cpp` | Explicit `(const char *)` and `reinterpret_cast<LPVOID>` casts. |
| `minipal/{guid.c,xoshiro128pp.c}` | `(unsigned int)`/`size_t` casts for format/sign-compare. |
| `gc/vxsort/{vxsort,vxsort_targets_*,smallsort/*}.h` + `codegen/*.py` | `#ifdef __GNUC__` excluded clang-cl; widen to `#if defined(__GNUC__) \|\| defined(__clang__)` so the AVX2/AVX512 `__attribute__((target(...)))` push gets emitted. The python codegen is updated too. |
| `vm/threads.{h,cpp}` | Split `AreShadowStacksEnabled` into an out-of-line definition decorated with `[[gnu::target("shstk")]]` for clang-cl, since `cl.exe` always exposes `_rdsspq` but clang-cl gates it behind the `shstk` target feature. |
| `vm/dispatchinfo.h` | Forward declaration `enum BinderMethodID` widened to `enum BinderMethodID : int` to match the actual definition's fixed underlying type. |
| `native/eventpipe/ds-ipc-pal-namedpipe.c` | Restructure case-fallthrough-with-goto pattern in `ds_ipc_poll` to use a flag — cleaner code, helps clang's CFG analyzer (but does NOT fully sidestep the upstream LLVM crash on this file). |
| `native/libs/System.Globalization.Native/pal_icushim.c` | `(unsigned int)` cast for `%u` of `GetLastError()`. |

### Known limitation: upstream LLVM bug

clang-cl 22.1.5 crashes (clang frontend SIGSEGV) when compiling `src/native/eventpipe/ds-ipc-pal-namedpipe.c`. We tried:
* `__attribute__((optnone))` on `ds_ipc_poll`
* `__attribute__((noinline))` combined with optnone
* File-wide `#pragma clang attribute push(__attribute__((optnone, noinline)), apply_to = function)`
* Per-file `/Od`
* Per-file `-mllvm -opt-bisect-limit=0` (which disables every LLVM pass)
* Disabling IPO/LTO globally for clang-cl
* Restructuring the goto-from-switch pattern that initially looked suspicious

None sidestep the crash, which appears to happen in clang's IR emission rather than in a pass we can disable. `cl.exe` builds the same source cleanly. This one file currently gates the rest of CoreCLR from building under clang-cl. **Filing upstream is the next step** — the file is small enough to make a usable repro from.

### Verification

* ✅ MSVC `build.cmd Clr.Jit -c Release /p:NoPgoOptimize=true` still passes.
* ✅ clang-cl `build.cmd Clr.Jit -c Release -clangcl /p:NoPgoOptimize=true` passes; JIT smoke test succeeds (Vector<int>, exception, loop) with output identical to MSVC.
* ⚠️ clang-cl `build.cmd clr+libs+host -c Release -clangcl /p:NoPgoOptimize=true` reaches CMake configure cleanly and compiles ~109/2551 native objects before being blocked by the LLVM bug above. Libs and host targets are unaffected by that one file and would build to completion.

### Discussion points

* Worth landing the JIT-only path as an experimental opt-in knob even if the broader CoreCLR build is blocked upstream?
* Are the source fixes individually acceptable as standalone cleanups (regardless of the clang-cl story)? Notably `gentree.cpp:31645` is a real JIT bug, and the `\` removal in `pedecoder.cpp` fixes a typo cl.exe also miscompiles silently.
* Should `-clangcl` be promoted to a top-level `build.cmd` flag (as done here) or kept under `-cmakeargs`?

> [!NOTE]
> This PR was authored with assistance from GitHub Copilot CLI (Claude Opus 4.7).
