### PR TITLE
Remove unused runtime_config_t::m_prop_keys and m_prop_values

### DIFF
--- a/src/native/corehost/runtime_config.h
+++ b/src/native/corehost/runtime_config.h
@@ -54,8 +54,6 @@ private:
     fx_reference_vector_t m_included_frameworks;
     settings_t m_default_settings;   // the default settings (Steps #0 and #1)
     settings_t m_override_settings;  // the settings that can't be changed (Step #5)
-    std::vector<std::string> m_prop_keys;
-    std::vector<std::string> m_prop_values;
     std::list<pal::string_t> m_probe_paths;
 
     pal::string_t m_tfm;


### PR DESCRIPTION
Removed unused property key and value vectors.

cc @dotnet/appmodel @AaronRobinsonMSFT 