### PR TITLE
Use bundle extraction path for CoreLib fallback in BindToSystem

### DIFF
--- a/src/coreclr/binder/assemblybindercommon.cpp
+++ b/src/coreclr/binder/assemblybindercommon.cpp
@@ -22,7 +22,6 @@
 #include "failurecache.hpp"
 #include "utils.hpp"
 #include "stringarraylist.h"
-#include "configuration.h"
 
 #if !defined(DACCESS_COMPILE)
 #include "defaultassemblybinder.h"
@@ -295,37 +294,16 @@ namespace BINDER_SPACE
 
         BinderTracing::PathProbed(sCoreLib, pathSource, hr);
 
-        if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND))
+        if (hr == HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND)
+            && Bundle::AppIsBundle()
+            && Bundle::AppBundle->HasExtractedFiles())
         {
-            // Try to find corelib in the TPA
-            StackSString sCoreLibSimpleName(CoreLibName_W);
-            StackSString sTrustedPlatformAssemblies = Configuration::GetKnobStringValue(W("TRUSTED_PLATFORM_ASSEMBLIES"));
-            sTrustedPlatformAssemblies.Normalize();
-
-            bool found = false;
-            for (SString::Iterator i = sTrustedPlatformAssemblies.Begin(); i != sTrustedPlatformAssemblies.End(); )
-            {
-                SString fileName;
-                SString simpleName;
-                HRESULT pathResult = S_OK;
-                IF_FAIL_GO(pathResult = GetNextTPAPath(sTrustedPlatformAssemblies, i, /*dllOnly*/ true, fileName, simpleName));
-                if (pathResult == S_FALSE)
-                {
-                    break;
-                }
-
-                if (simpleName.EqualsCaseInsensitive(sCoreLibSimpleName))
-                {
-                    sCoreLib = fileName;
-                    found = true;
-                    break;
-                }
-            }
-
-            if (!found)
-            {
-                GO_WITH_HRESULT(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
-            }
+            // For a single-file app with extracted contents (IncludeAllContentForSelfExtract),
+            // CoreCLR is statically linked into the host executable, so systemDirectory is the
+            // directory of the host executable. The extracted CoreLib lives in the bundle
+            // extraction directory rather than beside the host. Try to find it there.
+            sCoreLib.Set(Bundle::AppBundle->ExtractionPath());
+            CombinePath(sCoreLib, sCoreLibName, sCoreLib);
 
             hr = AssemblyBinderCommon::GetAssembly(sCoreLib,
                 TRUE /* fIsInTPA */,

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -445,6 +445,14 @@ static int run(const configuration& config)
     {
         // Use the external assembly probe to load assemblies from the app assembly paths.
         use_external_assembly_probe = true;
+    }
+    else
+    {
+        tpa_list = std::move(app_assemblies_env);
+    }
+
+    if (use_external_assembly_probe)
+    {
         if (!core_libs.empty())
         {
             pal::string_utf8_t core_libs_utf8 = pal::convert_to_utf8(core_libs.c_str());
@@ -458,10 +466,6 @@ static int run(const configuration& config)
             s_core_root_path = (char*)::malloc(core_root_utf8.length() + 1);
             ::strcpy(s_core_root_path, core_root_utf8.c_str());
         }
-    }
-    else
-    {
-        tpa_list = std::move(app_assemblies_env);
     }
 
     {


### PR DESCRIPTION
When the primary lookup of `System.Private.CoreLib.dll` in the system directory (the directory CoreCLR was loaded from) fails, the binder previously fell back to scanning the `TRUSTED_PLATFORM_ASSEMBLIES` value for a matching simple name. This fallback was originally added in #42435 specifically for the self-contained single-file app with extracted contents (`IncludeAllContentForSelfExtract=true`) case - CoreCLR is statically linked into the host executable, so `SystemDirectory` points at the host directory, but the extracted CoreLib lives in the bundle extraction directory.

Look directly in the bundle extraction directory in that case instead of scanning the TPA list.

cc @dotnet/appmodel @AaronRobinsonMSFT 

For a `Hello, World!` self-contained single-file app published with `IncludeAllContentForSelfExtract=true`, the framework's deps.json had `System.Private.CoreLib` at runtime asset position 98 of 182. Per process startup, the old fallback did:

| What | Allocations | Bytes |
|---|---|---|
| `StackSString` copy of the TPA list | 1 | ~26 KB |
| `outPath` SString per `GetNextTPAPath` iteration | 98 | ~14 KB |
| `simpleName` SString per iteration | 98 | ~5 KB |
| Incidentals (`Normalize`, comparisons, etc.) | ~12 | ~200 B |
| **Total** | **~209** | **~38 KB** |

Measured via a `DYLD_INSERT_LIBRARIES` malloc/calloc/realloc interposer over 5 fresh runs each (osx-arm64 Release):

| Variant | Total allocations | Total bytes allocated |
|---|---|---|
| Before | 25,425 ± 2 | ~9,022 KB |
| After  | 25,216 ± 2 | ~8,984 KB |
| **Saved** | **~209** | **~38 KB** |

The savings scale with TPA list size and CoreLib's position in it: roughly `1 large (TPA copy) + 2k small allocations` for k entries scanned before CoreLib.
