### PR TITLE
JIT: Transform SELECT to (folded) bitwise op

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3948,6 +3948,7 @@ public:
     GenTree* gtFoldExprSpecialFloating(GenTree* tree);
     GenTree* gtFoldBoxNullable(GenTree* tree);
     GenTree* gtFoldExprCompare(GenTree* tree);
+    GenTree* gtFoldAndOrXor(GenTree* tree);
     GenTree* gtFoldExprConditional(GenTree* tree);
     GenTree* gtFoldExprCall(GenTreeCall* call);
     GenTree* gtFoldTypeCompare(GenTree* tree);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15381,6 +15381,16 @@ GenTree* Compiler::gtFoldAndOrXor(GenTree* tree)
 
         GenTree* op1 = tree->gtGetOp1();
         GenTree* op2 = tree->gtGetOp2();
+
+        auto supportedOp = [](GenTree* op) {
+            return op->OperIsAnyLocal() || op->OperIsConst();
+        };
+        if (!supportedOp(op1->gtGetOp1()) || !supportedOp(op1->gtGetOp2()) || !supportedOp(op2->gtGetOp1()) ||
+            !supportedOp(op2->gtGetOp2()))
+        {
+            return tree;
+        }
+
         if (!op1->OperIs(GT_EQ))
         {
             std::swap(op1, op2);
@@ -15399,8 +15409,8 @@ GenTree* Compiler::gtFoldAndOrXor(GenTree* tree)
             }
         }
 
-        if (fusedCmp != GT_NONE && GenTree::Compare(op1->gtGetOp1(), op2->gtGetOp1()) &&
-            GenTree::Compare(op1->gtGetOp2(), op2->gtGetOp2()))
+        if (fusedCmp != GT_NONE && GenTree::Compare(op1->gtGetOp2(), op2->gtGetOp2()) &&
+            GenTree::Compare(op1->gtGetOp1(), op2->gtGetOp1()))
         {
             return gtNewOperNode(fusedCmp, tree->TypeGet(), op1->gtGetOp1(), op1->gtGetOp2());
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -15102,6 +15102,10 @@ GenTree* Compiler::gtFoldExprBinary(GenTreeOp* tree)
         // comparisons of two local variables can sometimes be folded
         return gtFoldExprCompare(tree);
     }
+    else if (tree->OperIs(GT_AND, GT_OR, GT_XOR))
+    {
+        return gtFoldAndOrXor(tree);
+    }
 
     return tree;
 }
@@ -15355,6 +15359,54 @@ GenTree* Compiler::gtFoldExprCompare(GenTree* tree)
     DISPTREE(cons);
 
     return cons;
+}
+
+//-----------------------------------------------------------------------------
+// gtFoldAndOrXor: Try various transformations on AND/OR/XOR tree
+//
+// Arguments:
+//     tree - The AND/OR/XOR tree
+//
+// Return Value:
+//     New tree if optimization was done, otherwise input tree.
+//
+GenTree* Compiler::gtFoldAndOrXor(GenTree* tree)
+{
+    assert(tree->OperIs(GT_AND, GT_OR, GT_XOR));
+
+    if (tree->OperIs(GT_OR))
+    {
+        // (x == 3) | (x > 3) -> x >= 3
+        // (x == 3) | (x < 3) -> x <= 3
+
+        GenTree* op1 = tree->gtGetOp1();
+        GenTree* op2 = tree->gtGetOp2();
+        if (!op1->OperIs(GT_EQ))
+        {
+            std::swap(op1, op2);
+        }
+
+        genTreeOps fusedCmp = GT_NONE;
+        if (op1->OperIs(GT_EQ))
+        {
+            if (op2->OperIs(GT_GT))
+            {
+                fusedCmp = GT_GE;
+            }
+            if (op2->OperIs(GT_LT))
+            {
+                fusedCmp = GT_LE;
+            }
+        }
+
+        if (fusedCmp != GT_NONE && GenTree::Compare(op1->gtGetOp1(), op2->gtGetOp1()) &&
+            GenTree::Compare(op1->gtGetOp2(), op2->gtGetOp2()))
+        {
+            return gtNewOperNode(fusedCmp, tree->TypeGet(), op1->gtGetOp1(), op1->gtGetOp2());
+        }
+    }
+
+    return tree;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -983,7 +983,7 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
 
 //-----------------------------------------------------------------------------
 // TrySelectToBitwiseOp: Try to optimize:
-// SELECT(x !=  3,  x > 3, 1) -> (x ==  3) | (x > 3)
+// SELECT(x !=  3,  x > 3, 1) -> (x ==  3) | (x >  3)
 // SELECT(x == 13, y == 4, 0) -> (x == 13) & (y == 4)
 //
 // Arguments:
@@ -1003,8 +1003,8 @@ GenTree* OptIfConversionDsc::TrySelectToBitwiseOp(GenTreeConditional* select)
         return nullptr;
     }
 
-    int64_t trueVal = falseInput->AsIntConCommon()->IntegralValue();
-    genTreeOps bitOp = (trueVal == 1) ? GT_OR : ((trueVal == 0) ? GT_AND : GT_NONE);
+    int64_t    trueVal = falseInput->AsIntConCommon()->IntegralValue();
+    genTreeOps bitOp   = (trueVal == 1) ? GT_OR : ((trueVal == 0) ? GT_AND : GT_NONE);
     if (bitOp == GT_NONE)
     {
         return nullptr;
@@ -1012,6 +1012,8 @@ GenTree* OptIfConversionDsc::TrySelectToBitwiseOp(GenTreeConditional* select)
 
     if (bitOp == GT_OR)
     {
+        // Need to reverse for OR because of:
+        // SELECT(x != 3, x > 3, 1) -> (x == 3) | (x > 3)
         cond = m_compiler->gtReverseCond(cond);
     }
 

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -56,6 +56,7 @@ private:
     GenTree* TrySelectToCnsOpCond(GenTreeConditional* select);
     GenTree* TrySelectToLclOpCond(GenTreeConditional* select);
     GenTree* TrySelectToCondOpLcl(GenTreeConditional* select);
+    GenTree* TrySelectToBitwiseOp(GenTreeConditional* select);
 
 #ifdef DEBUG
     void IfConvertDump();
@@ -721,6 +722,20 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
 //
 GenTree* OptIfConversionDsc::TryOptimizeSelect(GenTreeConditional* select)
 {
+    // Canonicalize
+    if (select->gtCond->OperIsCompare())
+    {
+        // SELECT(cnd, cns, op) -> SELECT(cnd, op, cns)
+        if (select->gtOp1->OperIsConst() && !select->gtOp2->OperIsConst())
+        {
+            if (m_compiler->gtCanSwapOrder(select->gtOp1, select->gtOp2))
+            {
+                std::swap(select->gtOp1, select->gtOp2);
+                select->gtCond = m_compiler->gtReverseCond(select->gtCond);
+            }
+        }
+    }
+
     GenTree* opt = TrySelectToCnsOpCond(select);
     if (opt != nullptr)
     {
@@ -734,6 +749,12 @@ GenTree* OptIfConversionDsc::TryOptimizeSelect(GenTreeConditional* select)
     }
 
     opt = TrySelectToCondOpLcl(select);
+    if (opt != nullptr)
+    {
+        return opt;
+    }
+
+    opt = TrySelectToBitwiseOp(select);
     if (opt != nullptr)
     {
         return opt;
@@ -958,6 +979,44 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
     }
 #endif // TARGET_RISCV64
     return nullptr;
+}
+
+//-----------------------------------------------------------------------------
+// TrySelectToBitwiseOp: Try to optimize:
+// SELECT(x !=  3,  x > 3, 1) -> (x ==  3) | (x > 3)
+// SELECT(x == 13, y == 4, 0) -> (x == 13) & (y == 4)
+//
+// Arguments:
+//     select - The SELECT node
+//
+// Return Value:
+//     Optimized node, otherwise nullptr.
+//
+GenTree* OptIfConversionDsc::TrySelectToBitwiseOp(GenTreeConditional* select)
+{
+    GenTree* cond       = select->gtCond;
+    GenTree* trueInput  = select->gtOp1;
+    GenTree* falseInput = select->gtOp2;
+
+    if (!cond->OperIsCompare() || !trueInput->OperIsCompare() || !falseInput->IsIntegralConst())
+    {
+        return nullptr;
+    }
+
+    int64_t trueVal = falseInput->AsIntConCommon()->IntegralValue();
+    genTreeOps bitOp = (trueVal == 1) ? GT_OR : ((trueVal == 0) ? GT_AND : GT_NONE);
+    if (bitOp == GT_NONE)
+    {
+        return nullptr;
+    }
+
+    if (bitOp == GT_OR)
+    {
+        cond = m_compiler->gtReverseCond(cond);
+    }
+
+    GenTree* bitwiseOp = m_compiler->gtNewOperNode(bitOp, select->TypeGet(), cond, trueInput);
+    return m_compiler->gtFoldExpr(bitwiseOp);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Fix #123291

1. Add canonicalization of CNS to right: `SELECT(x == 0, 1, x > 0)` -> `SELECT(x != 0, x > 0, 1)`
2. Add transform to bitwise op: `SELECT(x != 0, x > 0, 1)` -> `(x == 0) | (x > 0)`
3. Add  `gtFoldAndOrXor` to fuse cmps: `(x == 0) | (x > 0)` -> `x >= 0`

This overlaps with work that optimizeBools does already. But I think handling it in if-conversion like this is overall better. Perhaps in the future (with the help of this PR and more...) we don't need optimizeBools at all.

I added a general `gtFoldAndOrXor` to `gtFoldExpr` to fuse the cmps. I didn't add it to morph (e.g `fgOptimizeCommutativeArithmetic`) because 1. I am not allowed to call that from if-conversion and 2. my understanding of @EgorBo is that we are moving things like this to `gtFoldExpr` anyway.

Diffs on XARCH look worse because of https://discord.com/channels/143867839282020352/312132327348240384/1502728076243767439

Note the current costing leads to us frequently rejecting cases, for example:
`return x == 3 && y == 3;` would be transformed to `(x == 3 & y == 3)` which optimizeBools doesnt do either, but we get:
`Skipping if-conversion that will evaluate RHS unconditionally at costs 8,1` - it only allows up to 7.