### PR TITLE
[Expirement] intrinsify span.slice

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -1594,8 +1594,13 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr, IL_OFFSET codeSize, Fixed
                     else if (ni != NI_Illegal)
                     {
                         // Otherwise note "intrinsic" (most likely will be lowered as single instructions)
-                        // except Math where only a few intrinsics won't end up as normal calls
-                        if (!IsMathIntrinsic(ni) || IsTargetIntrinsic(ni))
+                        // except Math where only a few intrinsics won't end up as normal calls.
+                        // Span.Slice(int) / ReadOnlySpan.Slice(int) are tagged [Intrinsic] only so the
+                        // JIT can replace their managed bodies with a GT_BOUNDS_CHECK + byref form;
+                        // they are not lowered to a single instruction, so excluding them here keeps
+                        // the caller's inlining profitability identical to the pre-[Intrinsic] world.
+                        if ((!IsMathIntrinsic(ni) || IsTargetIntrinsic(ni)) && (ni != NI_System_Span_Slice) &&
+                            (ni != NI_System_ReadOnlySpan_Slice))
                         {
                             compInlineResult->Note(InlineObservation::CALLEE_INTRINSIC);
                         }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3447,8 +3447,10 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
             case NI_System_String_get_Length:
             case NI_System_Span_get_Item:
             case NI_System_Span_get_Length:
+            case NI_System_Span_Slice:
             case NI_System_ReadOnlySpan_get_Item:
             case NI_System_ReadOnlySpan_get_Length:
+            case NI_System_ReadOnlySpan_Slice:
             case NI_System_BitConverter_DoubleToInt64Bits:
             case NI_System_BitConverter_Int32BitsToSingle:
             case NI_System_BitConverter_Int64BitsToDouble:
@@ -3882,6 +3884,132 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                 result->SetHasOrderingSideEffect();
                 retNode = gtNewOperNode(GT_COMMA, resultType, boundsCheck, result);
 
+                break;
+            }
+
+            case NI_System_Span_Slice:
+            case NI_System_ReadOnlySpan_Slice:
+            {
+                optMethodFlags |= OMF_HAS_ARRAYREF;
+
+                // Have start, stack pointer-to Span<T> s on the stack. Expand to:
+                //
+                // For Span<T>
+                //   BoundsCheck(start, s->_length + 1)                  // ArgumentOutOfRange on failure
+                //   tmp._reference = s->_reference + (nuint)(uint)start * sizeof(T)
+                //   tmp._length    = s->_length - start
+                //   tmp
+                //
+                // For ReadOnlySpan<T> -- same expansion, the only difference is the result type.
+                //
+                // Signature should show one class type parameter, which
+                // we need to examine.
+                assert(sig->sigInst.classInstCount == 1);
+                assert(sig->numArgs == 1);
+                CORINFO_CLASS_HANDLE spanElemHnd = sig->sigInst.classInst[0];
+                const unsigned       elemSize    = info.compCompHnd->getClassSize(spanElemHnd);
+                assert(elemSize > 0);
+
+                const bool isReadOnly = (ni == NI_System_ReadOnlySpan_Slice);
+
+                JITDUMP("\nimpIntrinsic: Expanding %sSpan<T>.Slice(int), T=%s, sizeof(T)=%u\n",
+                        isReadOnly ? "ReadOnly" : "", eeGetClassName(spanElemHnd), elemSize);
+
+                GenTree* start          = impPopStack().val;
+                GenTree* ptrToSpan      = impPopStack().val;
+                GenTree* startClone     = nullptr;
+                GenTree* ptrToSpanClone = nullptr;
+                assert(genActualType(start) == TYP_INT);
+                assert(ptrToSpan->TypeIs(TYP_BYREF, TYP_I_IMPL));
+
+#if defined(DEBUG)
+                if (verbose)
+                {
+                    printf("with ptr-to-span\n");
+                    gtDispTree(ptrToSpan);
+                    printf("and start\n");
+                    gtDispTree(start);
+                }
+#endif // defined(DEBUG)
+
+                // We need 'start' three times (bounds check, byref offset, new length),
+                // so spill it once and clone the resulting LclVar reads as needed.
+                start = impCloneExpr(start, &startClone, CHECK_SPILL_ALL, nullptr DEBUGARG("Span.Slice start"));
+                GenTree* startClone2 = gtCloneExpr(startClone);
+
+                if (impIsAddressInLocal(ptrToSpan))
+                {
+                    ptrToSpanClone = gtCloneExpr(ptrToSpan);
+                }
+                else
+                {
+                    ptrToSpan = impCloneExpr(ptrToSpan, &ptrToSpanClone, CHECK_SPILL_ALL,
+                                             nullptr DEBUGARG("Span.Slice ptrToSpan"));
+                }
+
+                // Read input length.
+                CORINFO_FIELD_HANDLE lengthHnd    = info.compCompHnd->getFieldInClass(clsHnd, 1);
+                const unsigned       lengthOffset = info.compCompHnd->getFieldOffset(lengthHnd);
+
+                GenTreeFieldAddr* lengthFieldAddr = gtNewFieldAddrNode(lengthHnd, ptrToSpan, lengthOffset);
+                GenTree*          length          = gtNewIndir(TYP_INT, lengthFieldAddr);
+                lengthFieldAddr->SetIsSpanLength(true);
+
+                // Length is needed twice: once for the bounds check (as length + 1)
+                // and once for the new length (length - start).
+                GenTree* lengthClone = nullptr;
+                length = impCloneExpr(length, &lengthClone, CHECK_SPILL_ALL, nullptr DEBUGARG("Span.Slice length"));
+
+                // Bounds check: throw ArgumentOutOfRangeException if (uint)start > (uint)length,
+                // which is equivalent to (uint)start >= (uint)(length + 1).
+                //
+                // Use TYP_INT (not widened to TYP_LONG) so that downstream range-check
+                // elimination (rangecheck.cpp) can actually reason about the bound -- it bails on
+                // TYP_LONG. The (length + 1) addition is in TYP_INT and would wrap to int.MinValue
+                // when _length == int.MaxValue; codegen still does the comparison unsigned and
+                // produces the correct result, but assertion-prop / range-check passes lose some
+                // information at that boundary (a Span<byte> with int.MaxValue elements is the
+                // only case that could be affected).
+                GenTree* boundInt    = gtNewOperNode(GT_ADD, TYP_INT, length, gtNewIconNode(1));
+                GenTree* boundsCheck =
+                    new (this, GT_BOUNDS_CHECK) GenTreeBoundsChk(start, boundInt, SCK_ARG_RNG_EXCPN);
+
+                // Read input reference.
+                CORINFO_FIELD_HANDLE ptrHnd        = info.compCompHnd->getFieldInClass(clsHnd, 0);
+                const unsigned       ptrOffset     = info.compCompHnd->getFieldOffset(ptrHnd);
+                GenTreeFieldAddr*    dataFieldAddr = gtNewFieldAddrNode(ptrHnd, ptrToSpanClone, ptrOffset);
+                GenTree*             oldRef        = gtNewIndir(TYP_BYREF, dataFieldAddr);
+
+                // newRef = oldRef + (nuint)(uint)start * sizeof(T)
+                GenTree* offset = impImplicitIorI4Cast(startClone, TYP_I_IMPL, /* zeroExtend */ true);
+                if (elemSize != 1)
+                {
+                    GenTree* sizeofNode = gtNewIconNode(static_cast<ssize_t>(elemSize), TYP_I_IMPL);
+                    offset              = gtNewOperNode(GT_MUL, TYP_I_IMPL, offset, sizeofNode);
+                }
+                GenTree* newRef = gtNewOperNode(GT_ADD, TYP_BYREF, oldRef, offset);
+
+                // newLength = length - start
+                GenTree* newLength = gtNewOperNode(GT_SUB, TYP_INT, lengthClone, startClone2);
+
+                // Allocate a temp local for the result Span and initialize its fields.
+                CORINFO_CLASS_HANDLE retSpanHnd  = sig->retTypeClass;
+                unsigned             spanTempNum = lvaGrabTemp(true DEBUGARG("Span<T> for Slice"));
+                lvaSetStruct(spanTempNum, retSpanHnd, false);
+
+                GenTree* lengthFieldStore =
+                    gtNewStoreLclFldNode(spanTempNum, TYP_INT, OFFSETOF__CORINFO_Span__length, newLength);
+                GenTree* dataFieldStore =
+                    gtNewStoreLclFldNode(spanTempNum, TYP_BYREF, OFFSETOF__CORINFO_Span__reference, newRef);
+
+                // Statements are appended in order, and GT_BOUNDS_CHECK carries GTF_EXCEPT, so the
+                // check executes before any of the temp-span field stores. Match the field-store
+                // order used by impCreateSpanIntrinsic (length, then reference).
+                impAppendTree(boundsCheck, CHECK_SPILL_NONE, impCurStmtDI);
+                impAppendTree(lengthFieldStore, CHECK_SPILL_NONE, impCurStmtDI);
+                impAppendTree(dataFieldStore, CHECK_SPILL_NONE, impCurStmtDI);
+
+                retNode = impCreateLocalNode(spanTempNum DEBUGARG(0));
                 break;
             }
 
@@ -10672,6 +10800,18 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         {
                             result = NI_System_ReadOnlySpan_get_Length;
                         }
+                        else if (strcmp(methodName, "Slice") == 0)
+                        {
+                            // Only the single-argument Slice(int) overload is intrinsic; the
+                            // two-argument Slice(int, int) overload shares the same method name
+                            // but is not [Intrinsic] and must not be matched here.
+                            CORINFO_SIG_INFO sliceSig;
+                            info.compCompHnd->getMethodSig(method, &sliceSig);
+                            if (sliceSig.numArgs == 1)
+                            {
+                                result = NI_System_ReadOnlySpan_Slice;
+                            }
+                        }
                     }
                     else if (strcmp(className, "RuntimeType") == 0)
                     {
@@ -10709,6 +10849,18 @@ NamedIntrinsic Compiler::lookupNamedIntrinsic(CORINFO_METHOD_HANDLE method)
                         else if (strcmp(methodName, "get_Length") == 0)
                         {
                             result = NI_System_Span_get_Length;
+                        }
+                        else if (strcmp(methodName, "Slice") == 0)
+                        {
+                            // Only the single-argument Slice(int) overload is intrinsic; the
+                            // two-argument Slice(int, int) overload shares the same method name
+                            // but is not [Intrinsic] and must not be matched here.
+                            CORINFO_SIG_INFO sliceSig;
+                            info.compCompHnd->getMethodSig(method, &sliceSig);
+                            if (sliceSig.numArgs == 1)
+                            {
+                                result = NI_System_Span_Slice;
+                            }
                         }
                     }
                     else if (strcmp(className, "SpanHelpers") == 0)

--- a/src/coreclr/jit/namedintrinsiclist.h
+++ b/src/coreclr/jit/namedintrinsiclist.h
@@ -147,11 +147,13 @@ enum NamedIntrinsic : unsigned short
     NI_System_String_EndsWith,
     NI_System_Span_get_Item,
     NI_System_Span_get_Length,
+    NI_System_Span_Slice,
     NI_System_SpanHelpers_ClearWithoutReferences,
     NI_System_SpanHelpers_Fill,
     NI_System_SpanHelpers_SequenceEqual,
     NI_System_ReadOnlySpan_get_Item,
     NI_System_ReadOnlySpan_get_Length,
+    NI_System_ReadOnlySpan_Slice,
 
     NI_System_MemoryExtensions_AsSpan,
     NI_System_MemoryExtensions_Equals,

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1232,6 +1232,25 @@ void RangeCheck::MergeEdgeAssertionsWorker(Compiler*                        comp
             {
                 cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
                 limit   = Limit(Limit::keBinOpArray, boundVN, boundCns);
+
+                // If the assertion's bound VN differs from preferredBoundVN but they are
+                // related by a small constant, normalize the limit to use preferredBoundVN.
+                // This commonly arises with the Span.Slice(int) intrinsic, which emits
+                // BOUNDS_CHECK(start, length + 1) -- so preferredBoundVN is "length + 1"
+                // while loop assertions decompose against "length" itself.
+                // Without normalization, TightenLimit's "prefer preferredBound" heuristic
+                // would pick a looser non-asserted limit over this tighter assertion.
+                ValueNum addOpVN;
+                int      addOpCns;
+                if ((boundVN != preferredBoundVN) && (preferredBoundVN != ValueNumStore::NoVN) &&
+                    (boundCns > INT32_MIN) &&
+                    comp->vnStore->IsVNBinFuncWithConst(preferredBoundVN, VNF_ADD, &addOpVN, &addOpCns) &&
+                    (addOpVN == boundVN) && (addOpCns == 1))
+                {
+                    // preferredBoundVN = boundVN + 1, so "boundVN + boundCns" is equivalent to
+                    // "preferredBoundVN + (boundCns - 1)".
+                    limit = Limit(Limit::keBinOpArray, preferredBoundVN, boundCns - 1);
+                }
             }
             else if (normalLclVNMatchesOp2)
             {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -13348,6 +13348,18 @@ void Compiler::fgValueNumberTree(GenTree* tree)
                         if ((lengthVN != ValueNumStore::NoVN) && !vnStore->IsVNConstant(lengthVN))
                         {
                             vnStore->SetVNIsCheckedBound(lengthVN);
+
+                            // If the bound is "X + 1" (e.g. emitted by the Span.Slice(int) intrinsic to encode
+                            // "throw if start > X" as BOUNDS_CHECK(start, X + 1)), also register X as a checked
+                            // bound so the assertion creator decomposes "(i + k) <= X - m" against X rather than
+                            // falling back to an opaque RelopVN that range-check elimination cannot see through.
+                            ValueNum innerVN;
+                            int      addCns;
+                            if (vnStore->IsVNBinFuncWithConst(lengthVN, VNF_ADD, &innerVN, &addCns) &&
+                                (addCns == 1) && !vnStore->IsVNConstant(innerVN))
+                            {
+                                vnStore->SetVNIsCheckedBound(innerVN);
+                            }
                         }
                     }
                     break;

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -125,8 +125,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal ReadOnlySpan(ref T reference, int length)
         {
-            Debug.Assert(length >= 0);
-
             _reference = ref reference;
             _length = length;
         }
@@ -369,6 +367,7 @@ namespace System
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;Length).
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Intrinsic]
         public ReadOnlySpan<T> Slice(int start)
         {
             if ((uint)start > (uint)_length)

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -130,8 +130,6 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal Span(ref T reference, int length)
         {
-            Debug.Assert(length >= 0);
-
             _reference = ref reference;
             _length = length;
         }
@@ -393,6 +391,7 @@ namespace System
         /// Thrown when the specified <paramref name="start"/> index is not in range (&lt;0 or &gt;Length).
         /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Intrinsic]
         public Span<T> Slice(int start)
         {
             if ((uint)start > (uint)_length)


### PR DESCRIPTION
```csharp
void Foo(Span<int> src)
{
    int i = 0;
    for (; i <= src.Length - Vector128<int>.Count; i += Vector128<int>.Count)
    {
        Vector128.Create(42).CopyTo(src.Slice(i));
    }
}
```

```diff
 ; Assembly listing for method Program:Foo(System.Span`1[int]) (FullOpts)
-; 0 inlinees with PGO data; 2 single block inlinees; 2 inlinees without PGO data
+; 0 inlinees with PGO data; 1 single block inlinees; 1 inlinees without PGO data
 ;
 ; Lcl frame size = 40
 
 G_M28304_IG01:
        sub      rsp, 40
 G_M28304_IG02:
        mov      rax, bword ptr [rcx]
        mov      ecx, dword ptr [rcx+0x08]
        xor      edx, edx
        lea      r8d, [rcx-0x04]
        test     r8d, r8d
        jl       SHORT G_M28304_IG04
        align    [0 bytes for IG03]
 G_M28304_IG03:
-       cmp      edx, ecx
-       ja       SHORT G_M28304_IG05
-       mov      r10d, edx
-       lea      r10, bword ptr [rax+4*r10]
-       mov      r9d, ecx
-       sub      r9d, edx
-       cmp      r9d, 4
-       jl       SHORT G_M28304_IG06
+       mov      r10d, ecx
+       sub      r10d, edx
+       lea      r9, bword ptr [rax+4*rdx]
+       cmp      r10d, 4
+       jl       SHORT G_M28304_IG05
        vbroadcastss xmm0, dword ptr [reloc @RWD00]
-       vmovups  xmmword ptr [r10], xmm0
+       vmovups  xmmword ptr [r9], xmm0
        add      edx, 4
        cmp      edx, r8d
        jle      SHORT G_M28304_IG03
 G_M28304_IG04:
        add      rsp, 40
        ret
 G_M28304_IG05:
-       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException()]
-       int3
-G_M28304_IG06:
        call     [System.ThrowHelper:ThrowArgumentException_DestinationTooShort()]
        int3
 RWD00   dd      0000002Ah               ; 5.88545e-44
 
-; Total bytes of code 85, prolog size 4, PerfScore 40.50, instruction count 27
+; Total bytes of code 71, prolog size 4, PerfScore 34.50, instruction count 22
```
