### PR TITLE
Pre-size intermediate Dictionary in ToFrozenDictionary

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -133,8 +133,6 @@ namespace System.Collections.Frozen
             {
                 int capacity = source switch
                 {
-                    IDictionary<TKey, TValue> dictionary => dictionary.Count,
-                    IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.Count,
                     ICollection<KeyValuePair<TKey, TValue>> collection => collection.Count,
                     IReadOnlyCollection<KeyValuePair<TKey, TValue>> readOnlyCollection => readOnlyCollection.Count,
                     _ => 0,

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -135,6 +135,8 @@ namespace System.Collections.Frozen
                 {
                     IDictionary<TKey, TValue> dictionary => dictionary.Count,
                     IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.Count,
+                    ICollection<KeyValuePair<TKey, TValue>> collection => collection.Count,
+                    IReadOnlyCollection<KeyValuePair<TKey, TValue>> readOnlyCollection => readOnlyCollection.Count,
                     _ => 0,
                 };
                 newDictionary = new Dictionary<TKey, TValue>(capacity, comparer);

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -131,7 +131,8 @@ namespace System.Collections.Frozen
             newDictionary = source as Dictionary<TKey, TValue>;
             if (newDictionary is null || (newDictionary.Count != 0 && !newDictionary.Comparer.Equals(comparer)))
             {
-                newDictionary = new Dictionary<TKey, TValue>(comparer);
+                int capacity = source is ICollection<KeyValuePair<TKey, TValue>> collection ? collection.Count : 0;
+                newDictionary = new Dictionary<TKey, TValue>(capacity, comparer);
                 foreach (KeyValuePair<TKey, TValue> pair in source)
                 {
                     // Dictionary's constructor uses Add, which will throw on duplicates.

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -131,12 +131,7 @@ namespace System.Collections.Frozen
             newDictionary = source as Dictionary<TKey, TValue>;
             if (newDictionary is null || (newDictionary.Count != 0 && !newDictionary.Comparer.Equals(comparer)))
             {
-                int capacity = source switch
-                {
-                    ICollection<KeyValuePair<TKey, TValue>> collection => collection.Count,
-                    IReadOnlyCollection<KeyValuePair<TKey, TValue>> readOnlyCollection => readOnlyCollection.Count,
-                    _ => 0,
-                };
+                int capacity = (source as ICollection<KeyValuePair<TKey, TValue>>)?.Count ?? 0;
                 newDictionary = new Dictionary<TKey, TValue>(capacity, comparer);
                 foreach (KeyValuePair<TKey, TValue> pair in source)
                 {

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenDictionary.cs
@@ -131,7 +131,12 @@ namespace System.Collections.Frozen
             newDictionary = source as Dictionary<TKey, TValue>;
             if (newDictionary is null || (newDictionary.Count != 0 && !newDictionary.Comparer.Equals(comparer)))
             {
-                int capacity = source is ICollection<KeyValuePair<TKey, TValue>> collection ? collection.Count : 0;
+                int capacity = source switch
+                {
+                    IDictionary<TKey, TValue> dictionary => dictionary.Count,
+                    IReadOnlyDictionary<TKey, TValue> readOnlyDictionary => readOnlyDictionary.Count,
+                    _ => 0,
+                };
                 newDictionary = new Dictionary<TKey, TValue>(capacity, comparer);
                 foreach (KeyValuePair<TKey, TValue> pair in source)
                 {


### PR DESCRIPTION
`ToFrozenDictionary` builds an intermediate `Dictionary<,>` to deduplicate keys when the source isn't already a matching `Dictionary<,>`. It used the default-capacity constructor, so a known-size source pays `log2(N)` resizes and ~`2N` rehashes for nothing.

Helps most where the early `source as Dictionary<,>` reuse path doesn't fire: `ConcurrentDictionary<,>`, `SortedDictionary<,>`, `ImmutableDictionary<,>`, `ReadOnlyDictionary<,>`, plus arrays and `List<KVP>` from LINQ.

Sizing-only change — `Dictionary<,>` capacity is contractually behavior-invariant, so existing `MultipleValuesSameKey_LastInSourceWins` already covers the shared `foreach { d[k] = v; }` body.