### PR TITLE
JIT: Canonicalize loop backedges to a single latch block

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7495,6 +7495,8 @@ public:
     bool optCanonicalizeExits(FlowGraphNaturalLoop* loop);
     bool optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit);
 
+    bool optCanonicalizeBackedges(FlowGraphNaturalLoop* loop);
+
     template <typename TFunc>
     bool optLoopComplexityExceeds(FlowGraphNaturalLoop* loop, unsigned limit, TFunc getTreeComplexity);
 

--- a/src/coreclr/jit/fgdiagnostic.cpp
+++ b/src/coreclr/jit/fgdiagnostic.cpp
@@ -4808,6 +4808,10 @@ void Compiler::fgDebugCheckLoops()
             assert(loop->EntryEdge(0)->getSourceBlock()->KindIs(BBJ_ALWAYS));
             assert(!bbIsTryBeg(loop->GetHeader()));
 
+            // After canonicalization a natural loop has a single backedge.
+            //
+            assert(loop->BackEdges().size() == 1);
+
             loop->VisitRegularExitBlocks([=](BasicBlock* exit) {
                 for (BasicBlock* pred : exit->PredBlocks())
                 {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2852,23 +2852,40 @@ bool Compiler::optCanonicalizeBackedges(FlowGraphNaturalLoop* loop)
 
     BasicBlock* const header = loop->GetHeader();
 
-    // The latch will live in the same EH region as the header. That placement
-    // is only safe when every backedge source is in the same EH region as the
-    // header: if a source is outside the header's region, its original branch
-    // is legal only because the header is an EH-region entry, and the new
-    // latch (a non-entry block in the header's region) cannot be the target
-    // of such a branch.
+    // Determine the EH region for the latch. Mirror the logic in
+    // optCreatePreheader: if every backedge source is within the header's
+    // try region, the latch can live in the same try region as the header;
+    // otherwise it must live in the header's true enclosing try region (which
+    // is only legal when the header itself is a try-region entry, since that
+    // is the only way the original out-of-region backedges could be legal).
     //
-    for (FlowEdge* const backEdge : loop->BackEdges())
+    unsigned latchEHRegion        = EHblkDsc::NO_ENCLOSING_INDEX;
+    bool     inSameRegionAsHeader = true;
+    if (header->hasTryIndex())
     {
-        BasicBlock* const source = backEdge->getSourceBlock();
-        if (!BasicBlock::sameEHRegion(source, header))
+        latchEHRegion = header->getTryIndex();
+        for (FlowEdge* const backEdge : loop->BackEdges())
         {
-            JITDUMP("Skip backedge canonicalization for " FMT_LP ": backedge source " FMT_BB
-                    " is not in the same EH region as header " FMT_BB "\n",
-                    loop->GetIndex(), source->bbNum, header->bbNum);
-            return false;
+            BasicBlock* const source = backEdge->getSourceBlock();
+            if (!bbInTryRegions(latchEHRegion, source))
+            {
+                latchEHRegion        = ehTrueEnclosingTryIndex(latchEHRegion);
+                inSameRegionAsHeader = false;
+                break;
+            }
         }
+    }
+
+    if (!inSameRegionAsHeader && !bbIsTryBeg(header))
+    {
+        // The original out-of-region backedges can only have been legal if the
+        // header was a try-region entry. If it is not, something is unusual;
+        // skip canonicalization rather than risk introducing illegal edges.
+        //
+        JITDUMP("Skip backedge canonicalization for " FMT_LP ": header " FMT_BB
+                " is not a try entry but has backedge sources outside its try region\n",
+                loop->GetIndex(), header->bbNum);
+        return false;
     }
 
     // Snapshot the backedge sources before any redirection mutates the
@@ -2880,19 +2897,31 @@ bool Compiler::optCanonicalizeBackedges(FlowGraphNaturalLoop* loop)
         sources.Push(backEdge->getSourceBlock());
     }
 
-    // Create the latch in the same EH region as the header. Any block that can
-    // branch to the header can also branch to a block in the header's EH
-    // region, so this placement is always legal for backedge sources.
+    // Create the latch in the appropriate EH region. For the same-region case,
+    // fgNewBBinRegion will place the latch within the header's region (after
+    // the region's entry block, if the header is the entry). For the
+    // enclosing-region case, place the latch physically before the header and
+    // let fgSetEHRegionForNewPreheaderOrExit recognize that the header is a
+    // try-region entry and assign the latch to the enclosing region.
     //
-    BasicBlock* const latch = fgNewBBinRegion(BBJ_ALWAYS, header);
+    BasicBlock* latch;
+    if (inSameRegionAsHeader)
+    {
+        latch = fgNewBBinRegion(BBJ_ALWAYS, header);
+    }
+    else
+    {
+        latch = fgNewBBbefore(BBJ_ALWAYS, header, /* extendRegion */ false);
+        fgSetEHRegionForNewPreheaderOrExit(latch);
+    }
     latch->SetFlags(BBF_INTERNAL);
     latch->bbCodeOffs = header->bbCodeOffs;
 
     FlowEdge* const newEdge = fgAddRefPred(header, latch);
     latch->SetTargetEdge(newEdge);
 
-    JITDUMP("Created new latch " FMT_BB " for " FMT_LP " to merge %u backedges\n", latch->bbNum, loop->GetIndex(),
-            (unsigned)sources.Height());
+    JITDUMP("Created new latch " FMT_BB " for " FMT_LP " in %s EH region to merge %u backedges\n", latch->bbNum,
+            loop->GetIndex(), inSameRegionAsHeader ? "header's" : "header's enclosing", (unsigned)sources.Height());
 
     // Redirect each backedge through the new latch.
     //

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2381,6 +2381,17 @@ bool Compiler::optCanonicalizeLoops()
         changed |= optCreatePreheader(loop);
     }
 
+    // After preheader creation, canonicalize backedges so that every loop has
+    // at most one backedge. Running this before exit canonicalization avoids
+    // operating on stale BackEdges lists that exit canonicalization can
+    // invalidate (e.g., when an inner-loop exit is also an outer-loop
+    // backedge).
+    //
+    for (FlowGraphNaturalLoop* loop : m_loops->InReversePostOrder())
+    {
+        changed |= optCanonicalizeBackedges(loop);
+    }
+
     // At this point we've created preheaders. That means we are working with
     // stale loop and DFS data. However, we can do exit canonicalization even
     // on the stale data; this relies on the fact that exiting blocks do not
@@ -2818,6 +2829,83 @@ bool Compiler::optCanonicalizeExit(FlowGraphNaturalLoop* loop, BasicBlock* exit)
 
     JITDUMP("Created new exit " FMT_BB " to replace " FMT_BB " exit for " FMT_LP "\n", newExit->bbNum, exit->bbNum,
             loop->GetIndex());
+    return true;
+}
+
+//-----------------------------------------------------------------------------
+// optCanonicalizeBackedges: If a loop has more than one backedge, redirect all
+// backedge sources through a single new "latch" block that branches to the
+// loop header.
+//
+// Parameters:
+//   loop - The loop
+//
+// Returns:
+//   True if a new latch block was created.
+//
+bool Compiler::optCanonicalizeBackedges(FlowGraphNaturalLoop* loop)
+{
+    if (loop->BackEdges().size() <= 1)
+    {
+        return false;
+    }
+
+    BasicBlock* const header = loop->GetHeader();
+
+    // The latch will live in the same EH region as the header. That placement
+    // is only safe when every backedge source is in the same EH region as the
+    // header: if a source is outside the header's region, its original branch
+    // is legal only because the header is an EH-region entry, and the new
+    // latch (a non-entry block in the header's region) cannot be the target
+    // of such a branch.
+    //
+    for (FlowEdge* const backEdge : loop->BackEdges())
+    {
+        BasicBlock* const source = backEdge->getSourceBlock();
+        if (!BasicBlock::sameEHRegion(source, header))
+        {
+            JITDUMP("Skip backedge canonicalization for " FMT_LP ": backedge source " FMT_BB
+                    " is not in the same EH region as header " FMT_BB "\n",
+                    loop->GetIndex(), source->bbNum, header->bbNum);
+            return false;
+        }
+    }
+
+    // Snapshot the backedge sources before any redirection mutates the
+    // predecessor lists.
+    //
+    ArrayStack<BasicBlock*> sources(getAllocator(CMK_LoopOpt));
+    for (FlowEdge* const backEdge : loop->BackEdges())
+    {
+        sources.Push(backEdge->getSourceBlock());
+    }
+
+    // Create the latch in the same EH region as the header. Any block that can
+    // branch to the header can also branch to a block in the header's EH
+    // region, so this placement is always legal for backedge sources.
+    //
+    BasicBlock* const latch = fgNewBBinRegion(BBJ_ALWAYS, header);
+    latch->SetFlags(BBF_INTERNAL);
+    latch->bbCodeOffs = header->bbCodeOffs;
+
+    FlowEdge* const newEdge = fgAddRefPred(header, latch);
+    latch->SetTargetEdge(newEdge);
+
+    JITDUMP("Created new latch " FMT_BB " for " FMT_LP " to merge %u backedges\n", latch->bbNum, loop->GetIndex(),
+            (unsigned)sources.Height());
+
+    // Redirect each backedge through the new latch.
+    //
+    for (int i = 0; i < sources.Height(); i++)
+    {
+        BasicBlock* const source = sources.Bottom(i);
+        JITDUMP("  Backedge " FMT_BB " -> " FMT_BB " becomes " FMT_BB " -> " FMT_BB "\n", source->bbNum, header->bbNum,
+                source->bbNum, latch->bbNum);
+        fgReplaceJumpTarget(source, header, latch);
+    }
+
+    optSetWeightForPreheaderOrExit(loop, latch);
+
     return true;
 }
 


### PR DESCRIPTION
Adds optCanonicalizeBackedges, run during optCanonicalizeLoops between preheader creation and exit canonicalization. For any natural loop with more than one backedge, create a new block that branches to the header and redirect every backedge source to the block. 
