### PR TITLE
[mono] Fix aot profiler buffer resizing

### DIFF
--- a/src/mono/mono/profiler/aot.c
+++ b/src/mono/mono/profiler/aot.c
@@ -409,8 +409,12 @@ mono_profiler_init_aot (const char *desc)
 static void
 make_room (MonoProfiler *prof, int n)
 {
-	if (prof->buf_pos + n >= prof->buf_len) {
+	int new_needed_len = prof->buf_pos + n;
+	if (new_needed_len >= prof->buf_len) {
 		int new_len = prof->buf_len * 2;
+		while (new_needed_len >= new_len)
+			new_len *= 2;
+
 		guint8 *new_buf = g_malloc0 (new_len);
 		memcpy (new_buf, prof->buf, prof->buf_pos);
 		g_free (prof->buf);


### PR DESCRIPTION
Fixes scenario where the new needed size is greater than double of the previous size