### PR TITLE
Prioritize setTgtPref for the op1 use

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3083,22 +3083,9 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, SingleTypeRegSet dstCandidates,
     }
 
 #ifndef TARGET_ARM
-    // Some paths can have multiple operands as the tgtPref
-    // but we only want to track one of them and to preference
-    // the first use as that improves CQ the most.
-
-    if (tgtPrefUse != nullptr)
-    {
-        setTgtPref(interval, tgtPrefUse);
-    }
-    else if (tgtPrefUse2 != nullptr)
-    {
-        setTgtPref(interval, tgtPrefUse2);
-    }
-    else if (tgtPrefUse3 != nullptr)
-    {
-        setTgtPref(interval, tgtPrefUse3);
-    }
+    setTgtPref(interval, tgtPrefUse);
+    setTgtPref(interval, tgtPrefUse2);
+    setTgtPref(interval, tgtPrefUse3);
 #endif // !TARGET_ARM
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -3083,9 +3083,22 @@ RefPosition* LinearScan::BuildDef(GenTree* tree, SingleTypeRegSet dstCandidates,
     }
 
 #ifndef TARGET_ARM
-    setTgtPref(interval, tgtPrefUse);
-    setTgtPref(interval, tgtPrefUse2);
-    setTgtPref(interval, tgtPrefUse3);
+    // Some paths can have multiple operands as the tgtPref
+    // but we only want to track one of them and to preference
+    // the first use as that improves CQ the most.
+
+    if (tgtPrefUse != nullptr)
+    {
+        setTgtPref(interval, tgtPrefUse);
+    }
+    else if (tgtPrefUse2 != nullptr)
+    {
+        setTgtPref(interval, tgtPrefUse2);
+    }
+    else if (tgtPrefUse3 != nullptr)
+    {
+        setTgtPref(interval, tgtPrefUse3);
+    }
 #endif // !TARGET_ARM
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -967,13 +967,6 @@ int LinearScan::BuildSelect(GenTreeOp* select)
         srcCount++;
     }
 
-    if ((tgtPrefUse != nullptr) && (tgtPrefUse2 != nullptr))
-    {
-        // CQ analysis shows that it's best to always prefer only the 'true'
-        // val here.
-        tgtPrefUse2 = nullptr;
-    }
-
     // Codegen will emit something like:
     //
     // mov dstReg, falseVal


### PR DESCRIPTION
Checking TP/CQ for a case that BuildSelect indicates produces much better codegen.