### PR TITLE
[cDAC] Implement DacDbi GetNativeCodeInfo / GetNativeCodeInfoForAddr

### DIFF
--- a/docs/design/datacontracts/EnC.md
+++ b/docs/design/datacontracts/EnC.md
@@ -1,0 +1,89 @@
+# Contract EnC
+
+This contract reports Edit and Continue (EnC) function version numbers for jitted
+managed methods. EnC function versions are 1-based monotonically increasing counters
+that the runtime assigns to each `EnC`-emitted instance of a method body.
+
+## APIs of contract
+
+``` csharp
+// Returns the latest EnC version number associated with the method identified by
+// (module, methodDef). If no EnC-jitted instance exists for that method, returns
+// the default EnC function version (1).
+TargetNUInt GetLatestEnCVersion(TargetPointer module, uint methodDef);
+
+// Returns the EnC version number for the specific jitted instance of the method
+// identified by (module, methodDef) whose hot region starts at the given native
+// code address. If no matching jitted instance exists (for example, the method
+// was never EnC-edited), returns the default EnC function version (1).
+TargetNUInt GetEnCVersion(TargetPointer module, uint methodDef, TargetCodePointer nativeCodeAddress);
+```
+
+## Version 1
+
+Data descriptors used:
+| Data Descriptor Name | Field | Type | Purpose |
+| --- | --- | --- | --- |
+| `Module` | `EnCDataList` | nuint | Head of the singly linked list of `EnCData` entries for jitted EnC-versioned methods in this module |
+| `EnCData` | `AddrOfCode` | nuint | Native code start (TADDR) for the jitted instance |
+| `EnCData` | `Token` | uint32 | `mdMethodDef` token of the method |
+| `EnCData` | `EnCVersion` | nuint | EnC function version number for this jitted instance |
+| `EnCData` | `Next` | nuint | Next entry in the module's `EnCData` list, or null |
+
+Global variables used:
+| Global Name | Type | Purpose |
+| --- | --- | --- |
+| `CorDBDefaultEnCFunctionVersion` | nuint | Default EnC function version reported for methods that have never been EnC-edited (matches `CorDB_DEFAULT_ENC_FUNCTION_VERSION` in `src/coreclr/inc/cordbpriv.h`) |
+
+Contracts used: none
+
+``` csharp
+// Returns the address of the first EnCData entry on module's EnCDataList whose Token
+// matches methodDef and (when addrOrZero is non-null) whose AddrOfCode matches
+// addrOrZero. Returns TargetPointer.Null if no entry matches.
+TargetPointer FindEnCDataEntry(TargetPointer module, uint methodDef,
+                               TargetPointer addrOrZero)
+{
+    TargetPointer cur = _target.ReadPointer(module + /* Module::EnCDataList offset */);
+    while (cur != TargetPointer.Null)
+    {
+        uint token = _target.Read<uint>(cur + /* EnCData::Token offset */);
+        TargetPointer addrOfCode = _target.ReadPointer(cur + /* EnCData::AddrOfCode offset */);
+        if (token == methodDef &&
+            (addrOrZero == TargetPointer.Null || addrOfCode == addrOrZero))
+        {
+            return cur;
+        }
+        cur = _target.ReadPointer(cur + /* EnCData::Next offset */);
+    }
+    return TargetPointer.Null;
+}
+```
+
+``` csharp
+TargetNUInt GetLatestEnCVersion(TargetPointer module, uint methodDef)
+{
+    TargetPointer entry = FindEnCDataEntry(module, methodDef, TargetPointer.Null);
+    if (entry == TargetPointer.Null)
+        return new TargetNUInt(/* CorDBDefaultEnCFunctionVersion global */);
+
+    return _target.ReadNUInt(entry + /* EnCData::EnCVersion offset */);
+}
+```
+
+``` csharp
+TargetNUInt GetEnCVersion(TargetPointer module, uint methodDef,
+                          TargetCodePointer nativeCodeAddress)
+{
+    if (nativeCodeAddress.Value == 0)
+        return new TargetNUInt(/* CorDBDefaultEnCFunctionVersion global */);
+
+    TargetPointer entry = FindEnCDataEntry(module, methodDef,
+                                           new TargetPointer(nativeCodeAddress.Value));
+    if (entry == TargetPointer.Null)
+        return new TargetNUInt(/* CorDBDefaultEnCFunctionVersion global */);
+
+    return _target.ReadNUInt(entry + /* EnCData::EnCVersion offset */);
+}
+```
+

--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -721,7 +721,7 @@ TargetPointer GetModuleLookupMapElement(TargetPointer table, uint token, out Tar
 
 // Returns the MethodDesc pointer for the given mdMemberRef token, or TargetPointer.Null
 // if the entry is a FieldDesc (flagged with IS_FIELD_MEMBER_REF) or not present.
-TargetPointer LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken);
+TargetPointer LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken)
 {
     ModuleLookupTables tables = GetLookupTables(handle);
     TargetPointer ptr = GetModuleLookupMapElement(tables.MemberRefToDesc, memberRefToken, out TargetNUInt flags);

--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -103,6 +103,7 @@ TargetPointer GetILBase(ModuleHandle handle);
 TargetPointer GetAssemblyLoadContext(ModuleHandle handle);
 ModuleLookupTables GetLookupTables(ModuleHandle handle);
 TargetPointer GetModuleLookupMapElement(TargetPointer table, uint token, out TargetNUInt flags);
+TargetPointer LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken);
 IEnumerable<(TargetPointer, uint)> EnumerateModuleLookupMap(TargetPointer table);
 bool IsCollectible(ModuleHandle handle);
 bool IsDynamic(ModuleHandle handle);
@@ -254,6 +255,7 @@ enum ClrModifiableAssemblies : uint
 | `MaxWebcilSections` | ushort | Maximum number of COFF sections supported in a Webcil image (must stay in sync with native `WEBCIL_MAX_SECTIONS`) | `16` |
 | `DebuggerInfoMask` | uint | Mask for the debugger info bits within the Module's transient flags | `0x0000FC00` |
 | `DebuggerInfoShift` | int | Bit shift for the debugger info bits within the Module's transient flags | `10` |
+| `IS_FIELD_MEMBER_REF` | TADDR (target pointer-sized unsigned int) | Flag on `MemberRefToDescMap` entries indicating the entry is a FieldDesc, not a MethodDesc | `0x00000002` |
 | `DEBUGGER_ALLOW_JIT_OPTS_PRIV` | uint | Debugger allows JIT optimizations (shifted in transient flags) | `0x00000800` |
 
 Contracts used:
@@ -715,6 +717,15 @@ TargetPointer GetModuleLookupMapElement(TargetPointer table, uint token, out Tar
         }
     } while (table != TargetPointer.Null);
     return TargetPointer.Null;
+}
+
+// Returns the MethodDesc pointer for the given mdMemberRef token, or TargetPointer.Null
+// if the entry is a FieldDesc (flagged with IS_FIELD_MEMBER_REF) or not present.
+TargetPointer LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken);
+{
+    ModuleLookupTables tables = GetLookupTables(handle);
+    TargetPointer ptr = GetModuleLookupMapElement(tables.MemberRefToDesc, memberRefToken, out TargetNUInt flags);
+    return (flags.Value & /* IS_FIELD_MEMBER_REF */) != 0 ? TargetPointer.Null : ptr;
 }
 
 IEnumerable<(TargetPointer, uint)> EnumerateModuleLookupMap(TargetPointer table)

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -244,6 +244,10 @@ partial interface IRuntimeTypeSystem : IContract
     // Return true if the method is an async thunk method.
     public virtual bool IsAsyncThunkMethod(MethodDescHandle methodDesc);
 
+    // Return the async variant MethodDesc for the given method, or null if not found.
+    // Mirrors the no-create path of native MethodDesc::GetAsyncVariantNoCreate.
+    public virtual MethodDescHandle? GetAsyncVariant(MethodDescHandle methodDesc);
+
     // Return true if the method is a wrapper stub (unboxing or instantiating).
     public virtual bool IsWrapperStub(MethodDescHandle methodDesc);
 
@@ -1212,8 +1216,11 @@ And the following enumeration definitions
     [Flags]
     internal enum AsyncMethodFlags : uint
     {
-        None = 0,
-        Thunk = 16,
+        None = 0x0,
+        AsyncCall = 0x1,
+        IsAsyncVariant = 0x4,
+        Thunk = 0x10,
+        ReturnDroppingThunk = 0x20,
     }
 
     [Flags]
@@ -1695,6 +1702,42 @@ Determining if a method is a wrapper stub (unboxing or instantiating):
     {
         MethodDesc md = _methodDescs[methodDescHandle.Address];
         return md.IsUnboxingStub || IsInstantiatingStub(md);
+    }
+```
+
+Resolving the async variant of an async thunk method (no-create):
+
+```csharp
+    // Helper: matches native MatchesAsyncVariantLookup(AsyncVariantLookup::Async).
+    private bool IsAsyncVariantMethod(MethodDesc md)
+    {
+        if (!md.HasAsyncMethodData)
+            return false;
+
+        Data.AsyncMethodData asyncData = // Read AsyncMethodData from the async method data optional slot
+        AsyncMethodFlags flags = (AsyncMethodFlags)asyncData.Flags;
+        return flags.HasFlag(AsyncMethodFlags.IsAsyncVariant) && !flags.HasFlag(AsyncMethodFlags.ReturnDroppingThunk);
+    }
+
+    public MethodDescHandle? GetAsyncVariant(MethodDescHandle methodDescHandle)
+    {
+        MethodDesc md = _methodDescs[methodDescHandle.Address];
+        uint token = md.Token;
+        TypeHandle typeHandle = GetTypeHandle(GetMethodTable(methodDescHandle));
+
+        // For typical method definitions (non-generic or generic-with-formal-vars), native's
+        // FindOrCreateAssociatedMethodDesc returns the result of MethodTable::GetParallelMethodDesc
+        // directly. The canonical MethodTable holds the chunk of sibling MethodDescs that share
+        // a token; one of them carries the async-variant flag combination.
+        TypeHandle canonMT = GetTypeHandle(GetCanonicalMethodTable(typeHandle));
+        foreach (MethodDescHandle candidate in GetIntroducedMethods(canonMT))
+        {
+            MethodDesc candidateMd = _methodDescs[candidate.Address];
+            if (candidateMd.Token == token && IsAsyncVariantMethod(candidateMd))
+                return candidate;
+        }
+
+        return null;
     }
 ```
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1255,8 +1255,7 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_Assembly 
             if (pCodeInfo->m_rgCodeRegions[kHot].pAddress != (CORDB_ADDRESS)NULL)
             {
                 pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
-                LookupEnCVersions(pModule,
-                                  pCodeInfo->vmNativeCodeMethodDescToken,
+                LookupEnCVersions(pCodeInfo->vmNativeCodeMethodDescToken,
                                   functionToken,
                                   pCodeInfo->m_rgCodeRegions[kHot].pAddress,
                                   &(pCodeInfo->encVersion));
@@ -1337,11 +1336,10 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_AD
         pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
         pCodeInfo->vmNativeCodeMethodDescToken = vmMethodDesc;
 
-        SIZE_T unusedLatestEncVersion;
+        ULONG64 unusedLatestEncVersion;
         Module * pModule = pMethodDesc->GetModule();
         _ASSERTE(pModule != NULL);
-        LookupEnCVersions(pModule,
-                          vmMethodDesc,
+        LookupEnCVersions(vmMethodDesc,
                           pMethodDesc->GetMemberDef(),
                           codeStartAddr,
                           &unusedLatestEncVersion, //unused by caller
@@ -5602,60 +5600,23 @@ HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetPartialUserState(VMPTR_Thread 
 //    thinking is that some of the RS data structures will remain, most likely in a reduced form.
 //
 
-void DacDbiInterfaceImpl::LookupEnCVersions(Module*          pModule,
-                                            VMPTR_MethodDesc vmMethodDesc,
+void DacDbiInterfaceImpl::LookupEnCVersions(VMPTR_MethodDesc vmMethodDesc,
                                             mdMethodDef      mdMethod,
                                             CORDB_ADDRESS    pNativeStartAddress,
-                                            SIZE_T *         pLatestEnCVersion,
-                                            SIZE_T *         pJittedInstanceEnCVersion /* = NULL */)
+                                            ULONG64 *        pLatestEnCVersion,
+                                            ULONG64 *        pJittedInstanceEnCVersion /* = NULL */)
 {
-    MethodDesc * pMD     = vmMethodDesc.GetDacPtr();
-
-    // make sure the vmMethodDesc and mdMethod match
-    _ASSERTE(pMD->GetMemberDef() == mdMethod);
-
+    MethodDesc * pMD = vmMethodDesc.GetDacPtr();
     _ASSERTE(pLatestEnCVersion != NULL);
 
-    // @dbgtodo  inspection - once we do EnC, stop using DMIs.
-    // If the method wasn't EnCed, DMIs may not exist. And since this is DAC, we can't create them.
-
-    // We may not have the memory for the DebuggerMethodInfos in a minidump.
-    // When dump debugging EnC information isn't very useful so just fallback
-    // to default version.
-    DebuggerMethodInfo * pDMI = NULL;
-    DebuggerJitInfo * pDJI = NULL;
-    EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
+    Module* pLoaderModule = pMD->GetLoaderModule();
+    PTR_EnCData pEnCData = pLoaderModule->FindEncData(mdMethod, CORDB_ADDRESS_TO_TADDR(pNativeStartAddress));
+    PTR_EnCData pLatestEncData = pLoaderModule->FindLatestEncData(mdMethod);
+    if (pJittedInstanceEnCVersion != NULL)
     {
-        if (g_pDebugger != NULL)
-        {
-            pDMI = g_pDebugger->GetOrCreateMethodInfo(pModule, mdMethod);
-            if (pDMI != NULL)
-            {
-                pDJI = pDMI->FindJitInfo(pMD, CORDB_ADDRESS_TO_TADDR(pNativeStartAddress));
-            }
-        }
+        *pJittedInstanceEnCVersion = (pEnCData != NULL) ? pEnCData->encVersion : CorDB_DEFAULT_ENC_FUNCTION_VERSION;
     }
-    EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
-    if (pDJI != NULL)
-    {
-        if (pJittedInstanceEnCVersion != NULL)
-        {
-            *pJittedInstanceEnCVersion = pDJI->m_encVersion;
-        }
-        *pLatestEnCVersion = pDMI->GetCurrentEnCVersion();
-    }
-    else
-    {
-        // If we have no DMI/DJI, then we must never have EnCed. So we can use default EnC info
-        // Several cases where we don't have a DMI/DJI:
-        // - LCG methods
-        // - method was never "touched" by debugger. (DJIs are created lazily).
-        if (pJittedInstanceEnCVersion != NULL)
-        {
-            *pJittedInstanceEnCVersion = CorDB_DEFAULT_ENC_FUNCTION_VERSION;
-        }
-        *pLatestEnCVersion = CorDB_DEFAULT_ENC_FUNCTION_VERSION;
-    }
+    *pLatestEnCVersion = (pLatestEncData != NULL) ? pLatestEncData->encVersion : CorDB_DEFAULT_ENC_FUNCTION_VERSION;
 }
 
 // Get the address of the Debugger control block on the helper thread

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5608,7 +5608,16 @@ void DacDbiInterfaceImpl::LookupEnCVersions(VMPTR_MethodDesc vmMethodDesc,
 {
     MethodDesc * pMD = vmMethodDesc.GetDacPtr();
     _ASSERTE(pLatestEnCVersion != NULL);
-
+#ifdef FEATURE_METADATA_UPDATER
+    if (pJittedInstanceEnCVersion != NULL)
+    {
+        *pJittedInstanceEnCVersion = CorDB_DEFAULT_ENC_FUNCTION_VERSION;
+    }
+    if (pLatestEnCVersion != NULL)
+    {
+        *pLatestEnCVersion = CorDB_DEFAULT_ENC_FUNCTION_VERSION;
+    }
+#else
     Module* pLoaderModule = pMD->GetLoaderModule();
     PTR_EnCData pEnCData = pLoaderModule->FindEncData(mdMethod, CORDB_ADDRESS_TO_TADDR(pNativeStartAddress));
     PTR_EnCData pLatestEncData = pLoaderModule->FindLatestEncData(mdMethod);
@@ -5617,6 +5626,7 @@ void DacDbiInterfaceImpl::LookupEnCVersions(VMPTR_MethodDesc vmMethodDesc,
         *pJittedInstanceEnCVersion = (pEnCData != NULL) ? pEnCData->encVersion : CorDB_DEFAULT_ENC_FUNCTION_VERSION;
     }
     *pLatestEnCVersion = (pLatestEncData != NULL) ? pLatestEncData->encVersion : CorDB_DEFAULT_ENC_FUNCTION_VERSION;
+#endif // FEATURE_METADATA_UPDATER
 }
 
 // Get the address of the Debugger control block on the helper thread

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5608,7 +5608,7 @@ void DacDbiInterfaceImpl::LookupEnCVersions(VMPTR_MethodDesc vmMethodDesc,
 {
     MethodDesc * pMD = vmMethodDesc.GetDacPtr();
     _ASSERTE(pLatestEnCVersion != NULL);
-#ifdef FEATURE_METADATA_UPDATER
+#ifndef FEATURE_METADATA_UPDATER
     if (pJittedInstanceEnCVersion != NULL)
     {
         *pJittedInstanceEnCVersion = CorDB_DEFAULT_ENC_FUNCTION_VERSION;

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -883,12 +883,11 @@ private:
     BOOL UnwindRuntimeStackFrame(StackFrameIterator * pIter);
 
     // Look up the EnC version number of a particular jitted instance of a managed method.
-    void LookupEnCVersions(Module*          pModule,
-                           VMPTR_MethodDesc vmMethodDesc,
+    void LookupEnCVersions(VMPTR_MethodDesc vmMethodDesc,
                            mdMethodDef      mdMethod,
                            CORDB_ADDRESS    pNativeStartAddress,
-                           SIZE_T *         pLatestEnCVersion,
-                           SIZE_T *         pJittedInstanceEnCVersion = NULL);
+                           ULONG64 *        pLatestEnCVersion,
+                           ULONG64 *        pJittedInstanceEnCVersion = NULL);
 
     // @dbgtodo - This method should be removed once CordbFunctionBreakpoint and SetIP are moved OOP and
     // no longer use nativeCodeJITInfoToken.

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -2718,7 +2718,7 @@ HRESULT CordbObjectValue::GetFunctionHelper(ICorDebugFunction **ppFunction)
         IfFailThrow(pDAC->GetNativeCodeInfo(functionAssembly, functionMethodDef, &nativeCodeForDelFunc));
 
         RSSmartPtr<CordbModule> funcModule(GetAppDomain()->LookupOrCreateModule(functionAssembly));
-        func.Assign(funcModule->LookupOrCreateFunction(functionMethodDef, nativeCodeForDelFunc.encVersion));
+        func.Assign(funcModule->LookupOrCreateFunction(functionMethodDef, (SIZE_T)nativeCodeForDelFunc.encVersion));
     }
 
     *ppFunction = static_cast<ICorDebugFunction*> (func.GetValue());

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -3902,7 +3902,7 @@ HRESULT CordbVariableHome::GetOffset(LONG *pOffset)
 CordbNativeCode::CordbNativeCode(CordbFunction *                pFunction,
                                  const NativeCodeFunctionData * pJitData,
                                  BOOL                           fIsInstantiatedGeneric)
-  : CordbCode(pFunction, (UINT_PTR)pJitData->m_rgCodeRegions[kHot].pAddress, pJitData->encVersion, FALSE),
+  : CordbCode(pFunction, (UINT_PTR)pJitData->m_rgCodeRegions[kHot].pAddress, (SIZE_T)pJitData->encVersion, FALSE),
     m_vmNativeCodeMethodDescToken(pJitData->vmNativeCodeMethodDescToken),
     m_fCodeAvailable(TRUE),
     m_fIsInstantiatedGeneric(fIsInstantiatedGeneric != FALSE)
@@ -5093,7 +5093,7 @@ CordbNativeCode * CordbModule::LookupOrCreateNativeCode(mdMethodDef methodToken,
              codeInfo.m_rgCodeRegions[kHot].cbSize));
 
         // Lookup the function object that this code should be bound to
-        CordbFunction* pFunction = CordbModule::LookupOrCreateFunction(methodToken, codeInfo.encVersion);
+        CordbFunction* pFunction = CordbModule::LookupOrCreateFunction(methodToken, (SIZE_T)codeInfo.encVersion);
         _ASSERTE(pFunction != NULL);
 
         // There are bugs with the on-demand class load performed by CordbFunction in some cases. The old stack

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1226,6 +1226,15 @@ void DebuggerJitInfo::Init(TADDR newAddress)
     this->m_sizeOfCode =  this->m_codeRegionInfo.getSizeOfTotalCode();
 
     this->m_encVersion = this->m_methodInfo->GetCurrentEnCVersion();
+    if (this->m_encVersion != CorDB_DEFAULT_ENC_FUNCTION_VERSION)
+    {
+        Module* pModule = this->m_pLoaderModule;
+        EnCData* pEnCData = (EnCData*)(void*)pModule->GetLoaderAllocator()->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(EnCData)));
+        pEnCData->addrOfCode = this->m_addrOfCode;
+        pEnCData->token = this->m_methodInfo->m_token;
+        pEnCData->encVersion = this->m_encVersion;
+        pModule->AddEncData(pEnCData);
+    }
 
     this->InitFuncletAddress();
 

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1231,7 +1231,7 @@ void DebuggerJitInfo::Init(TADDR newAddress)
     {
         Module* pModule = this->m_pLoaderModule;
         EnCData* pEnCData = (EnCData*)(void*)pModule->GetLoaderAllocator()->GetLowFrequencyHeap()->AllocMem(S_SIZE_T(sizeof(EnCData)));
-        pEnCData->addrOfCode = this->m_addrOfCode;
+        pEnCData->addrOfCode = (TADDR)this->m_addrOfCode;
         pEnCData->token = this->m_methodInfo->m_token;
         pEnCData->encVersion = this->m_encVersion;
         pModule->AddEncData(pEnCData);

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -1226,6 +1226,7 @@ void DebuggerJitInfo::Init(TADDR newAddress)
     this->m_sizeOfCode =  this->m_codeRegionInfo.getSizeOfTotalCode();
 
     this->m_encVersion = this->m_methodInfo->GetCurrentEnCVersion();
+#ifdef FEATURE_METADATA_UPDATER
     if (this->m_encVersion != CorDB_DEFAULT_ENC_FUNCTION_VERSION)
     {
         Module* pModule = this->m_pLoaderModule;
@@ -1235,6 +1236,7 @@ void DebuggerJitInfo::Init(TADDR newAddress)
         pEnCData->encVersion = this->m_encVersion;
         pModule->AddEncData(pEnCData);
     }
+#endif // FEATURE_METADATA_UPDATER
 
     this->InitFuncletAddress();
 

--- a/src/coreclr/debug/inc/dacdbistructures.h
+++ b/src/coreclr/debug/inc/dacdbistructures.h
@@ -509,7 +509,7 @@ public:
     VMPTR_MethodDesc vmNativeCodeMethodDescToken;
 
     // EnC version number of the function
-    SIZE_T           encVersion;
+    ULONG64          encVersion;
 };
 
 //----------------------------------------------------------------------------------

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -62,6 +62,15 @@ class JITInlineTrackingMap;
 
 #ifdef FEATURE_METADATA_UPDATER
 class EnCEEClassData;
+struct EnCData;
+typedef DPTR(struct EnCData) PTR_EnCData;
+struct EnCData
+{
+    TADDR addrOfCode;
+    mdMethodDef token;
+    SIZE_T encVersion;
+    PTR_EnCData pNext;
+};
 #endif // FEATURE_METADATA_UPDATER
 
 // Hash table parameter of available classes (name -> module/class) hash
@@ -326,7 +335,7 @@ typedef DPTR(class MemberRef) PTR_MemberRef;
 
 
 // flag used to mark member ref pointers to field descriptors in the member ref cache
-#define IS_FIELD_MEMBER_REF ((TADDR)0x00000002)
+#define IS_FIELD_MEMBER_REF ((TADDR)0x00000002) // [cDAC] [Loader]: Contract depends on this value.
 
 
 //
@@ -949,6 +958,48 @@ protected:
 #ifdef FEATURE_METADATA_UPDATER
     // Holds a table of EnCEEClassData object for classes in this module that have been modified
     CUnorderedArray<EnCEEClassData*, 5> m_ClassList;
+
+    PTR_EnCData m_pEnCDataList = nullptr;
+
+public:
+    void AddEncData(EnCData* pData)
+    {
+        LIMITED_METHOD_CONTRACT;
+        pData->pNext = m_pEnCDataList;
+        m_pEnCDataList = dac_cast<PTR_EnCData>(pData);
+    }
+
+    PTR_EnCData FindEncData(mdMethodDef token, TADDR addrOfCode)
+    {
+        LIMITED_METHOD_CONTRACT;
+        SUPPORTS_DAC;
+        for (PTR_EnCData pCur = m_pEnCDataList; pCur != nullptr; pCur = pCur->pNext)
+        {
+            if (pCur->token == token && pCur->addrOfCode == addrOfCode)
+            {
+                return pCur;
+            }
+        }
+
+        return nullptr;
+    }
+
+    PTR_EnCData FindLatestEncData(mdMethodDef token)
+    {
+        LIMITED_METHOD_CONTRACT;
+        SUPPORTS_DAC;
+        for (PTR_EnCData pCur = m_pEnCDataList; pCur != nullptr; pCur = pCur->pNext)
+        {
+            if (pCur->token == token)
+            {
+                return pCur;
+            }
+        }
+
+        return nullptr;
+    }
+
+protected:
 #endif // FEATURE_METADATA_UPDATER
 
 private:
@@ -1728,6 +1779,9 @@ struct cdac_data<Module>
     static constexpr size_t MethodDefToILCodeVersioningStateMap = offsetof(Module, m_ILCodeVersioningStateMap);
 #endif // FEATURE_CODE_VERSIONING
     static constexpr size_t DynamicILBlobTable = offsetof(Module, m_debuggerSpecificData.m_pDynamicILBlobTable);
+#ifdef FEATURE_METADATA_UPDATER
+    static constexpr size_t EnCDataList = offsetof(Module, m_pEnCDataList);
+#endif // FEATURE_METADATA_UPDATER
 };
 
 //

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -277,7 +277,20 @@ CDAC_TYPE_FIELD(Module, T_POINTER, TypeRefToMethodTableMap, cdac_data<Module>::T
 CDAC_TYPE_FIELD(Module, T_POINTER, MethodDefToILCodeVersioningStateMap, cdac_data<Module>::MethodDefToILCodeVersioningStateMap)
 #endif // FEATURE_CODE_VERSIONING
 CDAC_TYPE_FIELD(Module, T_POINTER, DynamicILBlobTable, cdac_data<Module>::DynamicILBlobTable)
+#ifdef FEATURE_METADATA_UPDATER
+CDAC_TYPE_FIELD(Module, T_POINTER, EnCDataList, cdac_data<Module>::EnCDataList)
+#endif // FEATURE_METADATA_UPDATER
 CDAC_TYPE_END(Module)
+
+#ifdef FEATURE_METADATA_UPDATER
+CDAC_TYPE_BEGIN(EnCData)
+CDAC_TYPE_INDETERMINATE(EnCData)
+CDAC_TYPE_FIELD(EnCData, T_POINTER, AddrOfCode, offsetof(EnCData, addrOfCode))
+CDAC_TYPE_FIELD(EnCData, T_UINT32, Token, offsetof(EnCData, token))
+CDAC_TYPE_FIELD(EnCData, T_NUINT, EnCVersion, offsetof(EnCData, encVersion))
+CDAC_TYPE_FIELD(EnCData, T_POINTER, Next, offsetof(EnCData, pNext))
+CDAC_TYPE_END(EnCData)
+#endif // FEATURE_METADATA_UPDATER
 
 CDAC_TYPE_BEGIN(ModuleLookupMap)
 CDAC_TYPE_FIELD(ModuleLookupMap, T_POINTER, TableData, offsetof(LookupMapBase, pTable))
@@ -1520,6 +1533,7 @@ CDAC_GLOBAL(DirectorySeparator, T_UINT8, (uint8_t)DIRECTORY_SEPARATOR_CHAR_A)
 CDAC_GLOBAL(HashMapSlotsPerBucket, T_UINT32, SLOTS_PER_BUCKET)
 CDAC_GLOBAL(HashMapValueMask, T_UINT64, VALUE_MASK)
 CDAC_GLOBAL(MethodDescAlignment, T_UINT64, MethodDesc::ALIGNMENT)
+CDAC_GLOBAL(CorDBDefaultEnCFunctionVersion, T_NUINT, CorDB_DEFAULT_ENC_FUNCTION_VERSION)
 CDAC_GLOBAL(ArrayBaseSize, T_UINT32, ARRAYBASE_BASESIZE)
 CDAC_GLOBAL(SyncBlockValueToObjectOffset, T_UINT16, OBJHEADER_SIZE - cdac_data<ObjHeader>::SyncBlockValue)
 CDAC_GLOBAL(StubCodeBlockLast, T_UINT8, STUB_CODE_BLOCK_LAST)
@@ -1622,6 +1636,9 @@ CDAC_GLOBAL_CONTRACT(Debugger, c1)
 #endif // DEBUGGING_SUPPORTED && !TARGET_WASM
 CDAC_GLOBAL_CONTRACT(DebugInfo, c2)
 CDAC_GLOBAL_CONTRACT(EcmaMetadata, c1)
+#ifdef FEATURE_METADATA_UPDATER
+CDAC_GLOBAL_CONTRACT(EnC, c1)
+#endif // FEATURE_METADATA_UPDATER
 CDAC_GLOBAL_CONTRACT(Exception, c1)
 CDAC_GLOBAL_CONTRACT(ExecutionManager, c2)
 CDAC_GLOBAL_CONTRACT(GCInfo, c1)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -62,6 +62,10 @@ public abstract class ContractRegistry
     /// </summary>
     public virtual IReJIT ReJIT => GetContract<IReJIT>();
     /// <summary>
+    /// Gets an instance of the EnC contract for the target.
+    /// </summary>
+    public virtual IEnC EnC => GetContract<IEnC>();
+    /// <summary>
     /// Gets an instance of the StackWalk contract for the target.
     /// </summary>
     public virtual IStackWalk StackWalk => GetContract<IStackWalk>();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IEnC.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IEnC.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+public interface IEnC : IContract
+{
+    static string IContract.Name { get; } = nameof(EnC);
+    TargetNUInt GetLatestEnCVersion(TargetPointer module, uint methodDef) => throw new NotImplementedException();
+    TargetNUInt GetEnCVersion(TargetPointer module, uint methodDef, TargetCodePointer nativeCodeAddress) => throw new NotImplementedException();
+}
+
+public readonly struct EnC : IEnC
+{
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -126,6 +126,7 @@ public interface ILoader : IContract
     TargetPointer GetAssemblyLoadContext(ModuleHandle handle) => throw new NotImplementedException();
     ModuleLookupTables GetLookupTables(ModuleHandle handle) => throw new NotImplementedException();
     TargetPointer GetModuleLookupMapElement(TargetPointer table, uint token, out TargetNUInt flags) => throw new NotImplementedException();
+    TargetPointer LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken) => throw new NotImplementedException();
     IEnumerable<(TargetPointer, uint)> EnumerateModuleLookupMap(TargetPointer table) => throw new NotImplementedException();
     bool IsCollectible(ModuleHandle handle) => throw new NotImplementedException();
     bool IsDynamic(ModuleHandle handle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -251,6 +251,11 @@ public interface IRuntimeTypeSystem : IContract
 
     bool IsAsyncThunkMethod(MethodDescHandle methodDesc) => throw new NotImplementedException();
 
+    // Given an async thunk method, find its async variant counterpart (the MethodDesc with the real async body).
+    // Returns null if the variant is not found (not yet loaded).
+    // Mirrors native GetAsyncVariantNoCreate().
+    MethodDescHandle? GetAsyncVariant(MethodDescHandle methodDesc) => throw new NotImplementedException();
+
     bool IsWrapperStub(MethodDescHandle methodDesc) => throw new NotImplementedException();
     #endregion MethodDesc inspection APIs
     #region FieldDesc inspection APIs

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
@@ -30,6 +30,7 @@ public static class Constants
         public const string ObjectToMethodTableUnmask = nameof(ObjectToMethodTableUnmask);
         public const string SOSBreakingChangeVersion = nameof(SOSBreakingChangeVersion);
         public const string RecommendedReaderVersion = nameof(RecommendedReaderVersion);
+        public const string CorDBDefaultEnCFunctionVersion = nameof(CorDBDefaultEnCFunctionVersion);
 
         public const string ContinuationMethodTable = nameof(ContinuationMethodTable);
         public const string ExceptionMethodTable = nameof(ExceptionMethodTable);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EnC_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EnC_1.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.Diagnostics.DataContractReader.Contracts;
+
+internal readonly struct EnC_1 : IEnC
+{
+    private readonly Target _target;
+    private readonly ulong _defaultEnCFunctionVersion;
+
+    public EnC_1(Target target)
+    {
+        _target = target;
+        _defaultEnCFunctionVersion = target.ReadGlobal<ulong>(Constants.Globals.CorDBDefaultEnCFunctionVersion);
+    }
+
+    TargetNUInt IEnC.GetLatestEnCVersion(TargetPointer module, uint methodDef)
+    {
+        Data.EnCData? entry = FindFirstByToken(module, methodDef);
+        return entry is null
+            ? new TargetNUInt(_defaultEnCFunctionVersion)
+            : entry.EnCVersion;
+    }
+
+    TargetNUInt IEnC.GetEnCVersion(TargetPointer module, uint methodDef, TargetCodePointer nativeCodeAddress)
+    {
+        if (nativeCodeAddress.Value == 0)
+        {
+            return new TargetNUInt(_defaultEnCFunctionVersion);
+        }
+
+        // EnCData entries store native code start addresses as TADDR (already stripped of any thumb bit).
+        TargetPointer addr = new TargetPointer(nativeCodeAddress.Value);
+
+        Data.Module moduleData = _target.ProcessedData.GetOrAdd<Data.Module>(module);
+        TargetPointer cur = moduleData.EnCDataList;
+        while (cur != TargetPointer.Null)
+        {
+            Data.EnCData entry = _target.ProcessedData.GetOrAdd<Data.EnCData>(cur);
+            if (entry.Token == methodDef && entry.AddrOfCode == addr)
+            {
+                return entry.EnCVersion;
+            }
+            cur = entry.Next;
+        }
+
+        return new TargetNUInt(_defaultEnCFunctionVersion);
+    }
+
+    private Data.EnCData? FindFirstByToken(TargetPointer module, uint methodDef)
+    {
+        Data.Module moduleData = _target.ProcessedData.GetOrAdd<Data.Module>(module);
+        TargetPointer cur = moduleData.EnCDataList;
+        while (cur != TargetPointer.Null)
+        {
+            Data.EnCData entry = _target.ProcessedData.GetOrAdd<Data.EnCData>(cur);
+            if (entry.Token == methodDef)
+            {
+                return entry;
+            }
+            cur = entry.Next;
+        }
+
+        return null;
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -31,6 +31,9 @@ internal readonly struct Loader_1 : ILoader
 
     private const uint DEBUGGER_ALLOW_JIT_OPTS_PRIV = 0x00000800;
 
+    // Flag on MemberRefToDescMap entries indicating the entry is a FieldDesc, not a MethodDesc.
+    private const ulong IS_FIELD_MEMBER_REF = 0x00000002;
+
     private enum PEImageFlags : uint
     {
         FLAG_MAPPED = 0x01, // the file is mapped/hydrated (vs. the raw disk layout)
@@ -544,6 +547,14 @@ internal readonly struct Loader_1 : ILoader
         (TargetPointer rval, uint _) = IterateModuleLookupMap(table, rid, SearchLookupMap).FirstOrDefault();
         flags = new TargetNUInt(rval & supportedFlagsMask);
         return rval & ~supportedFlagsMask;
+    }
+
+    TargetPointer ILoader.LookupMemberRefAsMethod(ModuleHandle handle, uint memberRefToken)
+    {
+        ILoader self = this;
+        ModuleLookupTables tables = self.GetLookupTables(handle);
+        TargetPointer ptr = self.GetModuleLookupMapElement(tables.MemberRefToDesc, memberRefToken, out TargetNUInt flags);
+        return (flags.Value & IS_FIELD_MEMBER_REF) != 0 ? TargetPointer.Null : ptr;
     }
 
     IEnumerable<(TargetPointer, uint)> ILoader.EnumerateModuleLookupMap(TargetPointer table)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -154,9 +154,11 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     [Flags]
     internal enum AsyncMethodFlags : uint
     {
-        None = 0,
+        None = 0x0,
         AsyncCall = 0x1,
-        Thunk = 16,
+        IsAsyncVariant = 0x4,
+        Thunk = 0x10,
+        ReturnDroppingThunk = 0x20,
     }
 
     [Flags]
@@ -1921,6 +1923,42 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
         Data.AsyncMethodData asyncData = _target.ProcessedData.GetOrAdd<Data.AsyncMethodData>(md.GetAddressOfAsyncMethodData());
         return ((AsyncMethodFlags)asyncData.Flags).HasFlag(AsyncMethodFlags.Thunk);
+    }
+
+    /// <summary>
+    /// Returns true if the method matches <c>MatchesAsyncVariantLookup(AsyncVariantLookup::Async)</c>,
+    /// i.e. it has the <c>IsAsyncVariant</c> flag set and is not a <c>ReturnDroppingThunk</c>.
+    /// </summary>
+    private bool IsAsyncVariantMethod(MethodDesc md)
+    {
+        if (!md.HasAsyncMethodData)
+            return false;
+
+        Data.AsyncMethodData asyncData = _target.ProcessedData.GetOrAdd<Data.AsyncMethodData>(md.GetAddressOfAsyncMethodData());
+        AsyncMethodFlags flags = (AsyncMethodFlags)asyncData.Flags;
+        return flags.HasFlag(AsyncMethodFlags.IsAsyncVariant) && !flags.HasFlag(AsyncMethodFlags.ReturnDroppingThunk);
+    }
+
+    public MethodDescHandle? GetAsyncVariant(MethodDescHandle methodDescHandle)
+    {
+        MethodDesc md = _methodDescs[methodDescHandle.Address];
+        uint token = md.Token;
+        TargetPointer mtAddr = GetMethodTable(methodDescHandle);
+        TypeHandle typeHandle = GetTypeHandle(mtAddr);
+
+        // Iterate the introduced methods on the canonical MethodTable looking for a sibling
+        // with the same token that matches AsyncVariantLookup::Async (IsAsyncVariant set and
+        // ReturnDroppingThunk clear). Mirrors MethodTable::GetParallelMethodDesc's slow-path
+        // IntroducedMethodIterator loop.
+        TypeHandle canonMT = GetTypeHandle(GetCanonicalMethodTable(typeHandle));
+        foreach (MethodDescHandle candidate in GetIntroducedMethods(canonMT))
+        {
+            MethodDesc candidateMd = _methodDescs[candidate.Address];
+            if (candidateMd.Token == token && IsAsyncVariantMethod(candidateMd))
+                return candidate;
+        }
+
+        return null;
     }
 
     public bool IsWrapperStub(MethodDescHandle methodDescHandle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/CoreCLRContracts.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/CoreCLRContracts.cs
@@ -51,6 +51,8 @@ public static class CoreCLRContracts
 
         registry.Register<IReJIT>("c1", static t => new ReJIT_1(t));
 
+        registry.Register<IEnC>("c1", static t => new EnC_1(t));
+
         registry.Register<IGC>("c1", static t => new GC_1(t));
 
         registry.Register<IGCInfo>("c1", static t =>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EnCData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/EnCData.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader.Data;
+
+internal sealed class EnCData : IData<EnCData>
+{
+    static EnCData IData<EnCData>.Create(Target target, TargetPointer address)
+        => new EnCData(target, address);
+
+    public EnCData(Target target, TargetPointer address)
+    {
+        Target.TypeInfo type = target.GetTypeInfo(DataType.EnCData);
+
+        AddrOfCode = target.ReadPointerField(address, type, nameof(AddrOfCode));
+        Token = target.ReadField<uint>(address, type, nameof(Token));
+        EnCVersion = target.ReadNUInt(address + (ulong)type.Fields[nameof(EnCVersion)].Offset);
+        Next = target.ReadPointerField(address, type, nameof(Next));
+    }
+
+    public TargetPointer AddrOfCode { get; init; }
+    public uint Token { get; init; }
+    public TargetNUInt EnCVersion { get; init; }
+    public TargetPointer Next { get; init; }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Module.cs
@@ -37,6 +37,10 @@ internal sealed class Module : IData<Module>
         TypeRefToMethodTableMap = address + (ulong)type.Fields[nameof(TypeRefToMethodTableMap)].Offset;
         MethodDefToILCodeVersioningStateMap = address + (ulong)type.Fields[nameof(MethodDefToILCodeVersioningStateMap)].Offset;
         DynamicILBlobTable = target.ReadPointerField(address, type, nameof(DynamicILBlobTable));
+
+        EnCDataList = type.Fields.ContainsKey(nameof(EnCDataList))
+            ? target.ReadPointerField(address, type, nameof(EnCDataList))
+            : TargetPointer.Null;
     }
 
     private readonly TargetPointer _address;
@@ -71,4 +75,6 @@ internal sealed class Module : IData<Module>
     public TargetPointer TypeRefToMethodTableMap { get; init; }
     public TargetPointer MethodDefToILCodeVersioningStateMap { get; init; }
     public TargetPointer DynamicILBlobTable { get; init; }
+
+    public TargetPointer EnCDataList { get; init; }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/DataType.cs
@@ -145,6 +145,7 @@ public enum DataType
     EETypeHashTable,
     InstMethodHashTable,
     DynamicILBlobTable,
+    EnCData,
     EEJitManager,
     PatchpointInfo,
     PortableEntryPoint,

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/EcmaMetadataUtils.cs
@@ -22,6 +22,7 @@ public static class EcmaMetadataUtils
         mdtTypeDef = 0x02 << 24,
         mdtFieldDef = 0x04 << 24,
         mdtMethodDef = 0x06 << 24,
+        mdtMemberRef = 0x0a << 24,
     }
 
     public const uint TokenTypeMask = 0xff000000;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -18,6 +18,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 {
     private readonly Target _target;
     private readonly IDacDbiInterface? _legacy;
+    private readonly ulong _corDBDefaultEnCFunctionVersion;
 
     // IStringHolder is a native C++ abstract class (not COM) with a single virtual method:
     //   virtual HRESULT AssignCopy(const WCHAR* psz) = 0;
@@ -54,6 +55,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     {
         _target = target;
         _legacy = legacyObj as IDacDbiInterface;
+        _corDBDefaultEnCFunctionVersion = target.ReadGlobal<ulong>(Constants.Globals.CorDBDefaultEnCFunctionVersion);
     }
 
     public int CheckDbiVersion(DbiVersion* pVersion)
@@ -1275,11 +1277,242 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     public int GetILCodeAndSig(ulong vmAssembly, uint functionToken, DacDbiTargetBuffer* pTargetBuffer, uint* pLocalSigToken)
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetILCodeAndSig(vmAssembly, functionToken, pTargetBuffer, pLocalSigToken) : HResults.E_NOTIMPL;
 
-    public int GetNativeCodeInfo(ulong vmAssembly, uint functionToken, nint pJitManagerList)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetNativeCodeInfo(vmAssembly, functionToken, pJitManagerList) : HResults.E_NOTIMPL;
+    public int GetNativeCodeInfo(ulong vmAssembly, uint functionToken, NativeCodeFunctionData* pCodeInfo)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (pCodeInfo == null)
+                throw new ArgumentException("Output buffer cannot be null.", nameof(pCodeInfo));
 
-    public int GetNativeCodeInfoForAddr(ulong codeAddress, nint pCodeInfo, ulong* pVmModule, uint* pFunctionToken)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetNativeCodeInfoForAddr(codeAddress, pCodeInfo, pVmModule, pFunctionToken) : HResults.E_NOTIMPL;
+            *pCodeInfo = default;
+            pCodeInfo->encVersion = _corDBDefaultEnCFunctionVersion;
+            Contracts.ILoader loader = _target.Contracts.Loader;
+            Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+
+            Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromAssemblyPtr(new TargetPointer(vmAssembly));
+            Contracts.ModuleLookupTables tables = loader.GetLookupTables(moduleHandle);
+
+            TargetPointer mdAddr;
+            uint tokenType = functionToken & EcmaMetadataUtils.TokenTypeMask;
+            if (tokenType == (uint)EcmaMetadataUtils.TokenType.mdtMethodDef)
+            {
+                mdAddr = loader.GetModuleLookupMapElement(tables.MethodDefToDesc, functionToken, out _);
+            }
+            else if (tokenType == (uint)EcmaMetadataUtils.TokenType.mdtMemberRef)
+            {
+                mdAddr = loader.LookupMemberRefAsMethod(moduleHandle, functionToken);
+            }
+            else
+                throw new ArgumentException("Invalid function token type.", nameof(functionToken));
+
+            if (mdAddr != TargetPointer.Null)
+            {
+                Contracts.MethodDescHandle md = rts.GetMethodDescHandle(mdAddr);
+
+                // If this is an async thunk, unwrap to the real async variant.
+                // Mirrors native: pMethodDesc->GetAsyncVariantNoCreate().
+                if (rts.IsAsyncThunkMethod(md))
+                {
+                    Contracts.MethodDescHandle? asyncVariant = rts.GetAsyncVariant(md);
+                    if (asyncVariant is not null)
+                    {
+                        md = asyncVariant.Value;
+                        mdAddr = md.Address;
+                    }
+                }
+
+                TargetCodePointer nativeCode = rts.GetNativeCode(md);
+                if (nativeCode.Value != 0)
+                {
+                    FillRegionInfoAndGenericInstantiation(rts, md, nativeCode, pCodeInfo);
+
+                    // Look up EnC version on the method desc's loader module.
+                    TargetPointer loaderModule = GetLoaderModule(rts, md);
+                    if (_target.Contracts.TryGetContract<Contracts.IEnC>(out Contracts.IEnC enc))
+                    {
+                        pCodeInfo->encVersion = enc.GetEnCVersion(loaderModule, functionToken, nativeCode).Value;
+                    }
+                }
+            }
+            pCodeInfo->vmNativeCodeMethodDescToken = mdAddr.Value;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            NativeCodeFunctionData dataLocal = default;
+            int hrLocal = _legacy.GetNativeCodeInfo(vmAssembly, functionToken, &dataLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                AssertNativeCodeFunctionDataEqual(pCodeInfo, &dataLocal);
+            }
+        }
+#endif
+        return hr;
+    }
+
+    public int GetNativeCodeInfoForAddr(ulong codeAddress, NativeCodeFunctionData* pCodeInfo, ulong* pVmModule, uint* pFunctionToken)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (pCodeInfo == null)
+                throw new ArgumentException("Output buffer cannot be null.", nameof(pCodeInfo));
+
+            *pCodeInfo = default;
+            if (pVmModule != null)
+                *pVmModule = 0;
+            if (pFunctionToken != null)
+                *pFunctionToken = 0;
+
+            // codeAddress == 0 is not an error: clear output and report success
+            // (matches legacy DacDbiInterfaceImpl::GetNativeCodeInfoForAddr).
+            if (codeAddress != 0)
+            {
+                Contracts.IExecutionManager em = _target.Contracts.ExecutionManager;
+                Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+
+                Contracts.CodeBlockHandle? cbh = em.GetCodeBlockHandle(new TargetCodePointer(codeAddress));
+                if (cbh is null)
+                    throw new ArgumentException("No code block found for the given address.", nameof(codeAddress));
+                TargetPointer mdAddr = em.GetMethodDesc(cbh.Value);
+
+                Contracts.MethodDescHandle md = rts.GetMethodDescHandle(mdAddr);
+                TargetCodePointer hotStart = new TargetCodePointer(em.GetStartAddress(cbh.Value).Value);
+
+                FillRegionInfoAndGenericInstantiation(rts, md, hotStart, pCodeInfo);
+                pCodeInfo->vmNativeCodeMethodDescToken = mdAddr.Value;
+
+                uint methodToken = rts.GetMethodToken(md);
+
+                TargetPointer loaderModule = GetLoaderModule(rts, md);
+                if (_target.Contracts.TryGetContract<Contracts.IEnC>(out Contracts.IEnC enc))
+                {
+                    pCodeInfo->encVersion = enc.GetEnCVersion(loaderModule, methodToken, hotStart).Value;
+                }
+                else
+                {
+                    pCodeInfo->encVersion = _corDBDefaultEnCFunctionVersion;
+                }
+
+                if (pFunctionToken != null)
+                    *pFunctionToken = methodToken;
+
+                if (pVmModule != null)
+                {
+                    TargetPointer mt = rts.GetMethodTable(md);
+                    Contracts.TypeHandle th = rts.GetTypeHandle(mt);
+                    *pVmModule = rts.GetModule(th).Value;
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            NativeCodeFunctionData dataLocal = default;
+            ulong moduleLocal = 0;
+            uint tokenLocal = 0;
+            int hrLocal = _legacy.GetNativeCodeInfoForAddr(
+                codeAddress,
+                &dataLocal,
+                pVmModule != null ? &moduleLocal : null,
+                pFunctionToken != null ? &tokenLocal : null);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+            {
+                AssertNativeCodeFunctionDataEqual(pCodeInfo, &dataLocal);
+                if (pVmModule != null)
+                    Debug.Assert(*pVmModule == moduleLocal, $"pVmModule: cDAC: {*pVmModule:x}, DAC: {moduleLocal:x}");
+                if (pFunctionToken != null)
+                    Debug.Assert(*pFunctionToken == tokenLocal, $"pFunctionToken: cDAC: {*pFunctionToken:x}, DAC: {tokenLocal:x}");
+            }
+        }
+#endif
+        return hr;
+    }
+
+    // Helper: fill the hot/cold region info and the isInstantiatedGeneric flag.
+    // pOut->hotRegion.pAddress == 0 when the method has no jitted code; in that case
+    // the cold region and isInstantiatedGeneric remain zero (cleared on entry).
+    private void FillRegionInfoAndGenericInstantiation(
+        Contracts.IRuntimeTypeSystem rts,
+        Contracts.MethodDescHandle md,
+        TargetCodePointer hotStart,
+        NativeCodeFunctionData* pCodeInfo)
+    {
+        if (hotStart.Value == 0)
+            return;
+
+        Contracts.IExecutionManager em = _target.Contracts.ExecutionManager;
+
+        // Look up the code block to obtain hot region size and any cold region.
+        Contracts.CodeBlockHandle? cbh = em.GetCodeBlockHandle(hotStart);
+        uint hotSize = 0;
+        TargetPointer coldStart = TargetPointer.Null;
+        uint coldSize = 0;
+        if (cbh is not null)
+        {
+            em.GetMethodRegionInfo(cbh.Value, out hotSize, out coldStart, out coldSize);
+        }
+
+        pCodeInfo->hotRegion.pAddress = hotStart.Value;
+        pCodeInfo->hotRegion.cbSize = hotSize;
+        pCodeInfo->coldRegion.pAddress = coldStart.Value;
+        pCodeInfo->coldRegion.cbSize = coldSize;
+
+        // isInstantiatedGeneric mirrors MethodDesc::HasClassOrMethodInstantiation():
+        // either the owning type is instantiated, or the method has its own instantiation.
+        bool hasClassInst = false;
+        TargetPointer mt = rts.GetMethodTable(md);
+        if (mt != TargetPointer.Null)
+        {
+            Contracts.TypeHandle th = rts.GetTypeHandle(mt);
+            hasClassInst = rts.GetInstantiation(th).Length > 0;
+        }
+        bool hasMethodInst = rts.GetGenericMethodInstantiation(md).Length > 0;
+        pCodeInfo->isInstantiatedGeneric = (hasClassInst || hasMethodInst) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+    }
+
+    // Returns MethodDesc::GetLoaderModule(): the module that owns the loader heap
+    // for this method desc. For non-generic methods this equals the metadata
+    // module; for instantiations they may differ.
+    private static TargetPointer GetLoaderModule(Contracts.IRuntimeTypeSystem rts, Contracts.MethodDescHandle md)
+    {
+        TargetPointer mt = rts.GetMethodTable(md);
+        if (mt == TargetPointer.Null)
+            return TargetPointer.Null;
+        Contracts.TypeHandle th = rts.GetTypeHandle(mt);
+        return rts.GetLoaderModule(th);
+    }
+
+#if DEBUG
+    private static void AssertNativeCodeFunctionDataEqual(NativeCodeFunctionData* cdac, NativeCodeFunctionData* legacy)
+    {
+        Debug.Assert(cdac->hotRegion.pAddress == legacy->hotRegion.pAddress,
+            $"hotRegion.pAddress: cDAC: {cdac->hotRegion.pAddress:x}, DAC: {legacy->hotRegion.pAddress:x}");
+        Debug.Assert(cdac->hotRegion.cbSize == legacy->hotRegion.cbSize,
+            $"hotRegion.cbSize: cDAC: {cdac->hotRegion.cbSize}, DAC: {legacy->hotRegion.cbSize}");
+        Debug.Assert(cdac->coldRegion.pAddress == legacy->coldRegion.pAddress,
+            $"coldRegion.pAddress: cDAC: {cdac->coldRegion.pAddress:x}, DAC: {legacy->coldRegion.pAddress:x}");
+        Debug.Assert(cdac->coldRegion.cbSize == legacy->coldRegion.cbSize,
+            $"coldRegion.cbSize: cDAC: {cdac->coldRegion.cbSize}, DAC: {legacy->coldRegion.cbSize}");
+        Debug.Assert(cdac->isInstantiatedGeneric == legacy->isInstantiatedGeneric,
+            $"isInstantiatedGeneric: cDAC: {cdac->isInstantiatedGeneric}, DAC: {legacy->isInstantiatedGeneric}");
+        Debug.Assert(cdac->vmNativeCodeMethodDescToken == legacy->vmNativeCodeMethodDescToken,
+            $"vmNativeCodeMethodDescToken: cDAC: {cdac->vmNativeCodeMethodDescToken:x}, DAC: {legacy->vmNativeCodeMethodDescToken:x}");
+        Debug.Assert(cdac->encVersion == legacy->encVersion,
+            $"encVersion: cDAC: {cdac->encVersion}, DAC: {legacy->encVersion}");
+    }
+#endif
 
     public int IsValueType(ulong vmTypeHandle, Interop.BOOL* pResult)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1325,7 +1325,16 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                 TargetCodePointer nativeCode = rts.GetNativeCode(md);
                 if (nativeCode.Value != 0)
                 {
-                    FillRegionInfoAndGenericInstantiation(rts, md, nativeCode, pCodeInfo);
+                    // GetNativeCode can return an interpreter precode. Resolve to the
+                    // actual interpreter/jitted code address before asking for region info,
+                    // matching native GetMethodRegionInfo's GetCodeForInterpreterOrJitted path.
+                    TargetCodePointer regionCode = rts.GetCodeForInterpreterOrJitted(md);
+                    if (regionCode.Value == 0)
+                    {
+                        regionCode = nativeCode;
+                    }
+
+                    FillRegionInfoAndGenericInstantiation(rts, md, regionCode, pCodeInfo);
 
                     // Look up EnC version on the method desc's loader module.
                     TargetPointer loaderModule = GetLoaderModule(rts, md);
@@ -1377,7 +1386,10 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                 Contracts.IExecutionManager em = _target.Contracts.ExecutionManager;
                 Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
 
-                Contracts.CodeBlockHandle? cbh = em.GetCodeBlockHandle(new TargetCodePointer(codeAddress));
+                TargetCodePointer lookupAddress = new TargetCodePointer(codeAddress);
+                lookupAddress = PrecodeStubs.GetInterpreterCodeFromInterpreterPrecodeIfPresent(_target, lookupAddress);
+
+                Contracts.CodeBlockHandle? cbh = em.GetCodeBlockHandle(lookupAddress);
                 if (cbh is null)
                     throw new ArgumentException("No code block found for the given address.", nameof(codeAddress));
                 TargetPointer mdAddr = em.GetMethodDesc(cbh.Value);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1328,11 +1328,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                     // GetNativeCode can return an interpreter precode. Resolve to the
                     // actual interpreter/jitted code address before asking for region info,
                     // matching native GetMethodRegionInfo's GetCodeForInterpreterOrJitted path.
-                    TargetCodePointer regionCode = rts.GetCodeForInterpreterOrJitted(md);
-                    if (regionCode.Value == 0)
-                    {
-                        regionCode = nativeCode;
-                    }
+                    TargetCodePointer regionCode = _target.Contracts.PrecodeStubs.GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCode);
 
                     FillRegionInfoAndGenericInstantiation(rts, md, regionCode, pCodeInfo);
 
@@ -1387,7 +1383,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                 Contracts.IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
 
                 TargetCodePointer lookupAddress = new TargetCodePointer(codeAddress);
-                lookupAddress = PrecodeStubs.GetInterpreterCodeFromInterpreterPrecodeIfPresent(_target, lookupAddress);
+                lookupAddress = _target.Contracts.PrecodeStubs.GetInterpreterCodeFromInterpreterPrecodeIfPresent(lookupAddress);
 
                 Contracts.CodeBlockHandle? cbh = em.GetCodeBlockHandle(lookupAddress);
                 if (cbh is null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1336,11 +1336,11 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 
                     FillRegionInfoAndGenericInstantiation(rts, md, regionCode, pCodeInfo);
 
-                    // Look up EnC version on the method desc's loader module.
+                    // Look up the latest EnC version on the method desc's loader module.
                     TargetPointer loaderModule = GetLoaderModule(rts, md);
                     if (_target.Contracts.TryGetContract<Contracts.IEnC>(out Contracts.IEnC enc))
                     {
-                        pCodeInfo->encVersion = enc.GetEnCVersion(loaderModule, functionToken, nativeCode).Value;
+                        pCodeInfo->encVersion = enc.GetLatestEnCVersion(loaderModule, functionToken).Value;
                     }
                 }
             }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -33,8 +33,6 @@ public struct DacDbiTargetBuffer
     public uint cbSize;
 }
 
-// Mirrors the native NativeCodeFunctionData class defined in
-// src/coreclr/debug/inc/dacdbistructures.h.
 [StructLayout(LayoutKind.Sequential)]
 public struct NativeCodeFunctionData
 {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -33,6 +33,18 @@ public struct DacDbiTargetBuffer
     public uint cbSize;
 }
 
+// Mirrors the native NativeCodeFunctionData class defined in
+// src/coreclr/debug/inc/dacdbistructures.h.
+[StructLayout(LayoutKind.Sequential)]
+public struct NativeCodeFunctionData
+{
+    public DacDbiTargetBuffer hotRegion;
+    public DacDbiTargetBuffer coldRegion;
+    public Interop.BOOL isInstantiatedGeneric;
+    public ulong vmNativeCodeMethodDescToken;
+    public ulong encVersion;
+}
+
 [StructLayout(LayoutKind.Sequential)]
 public struct DacDbiAssemblyInfo
 {
@@ -372,10 +384,10 @@ public unsafe partial interface IDacDbiInterface
     int GetILCodeAndSig(ulong vmAssembly, uint functionToken, DacDbiTargetBuffer* pTargetBuffer, uint* pLocalSigToken);
 
     [PreserveSig]
-    int GetNativeCodeInfo(ulong vmAssembly, uint functionToken, nint pJitManagerList);
+    int GetNativeCodeInfo(ulong vmAssembly, uint functionToken, NativeCodeFunctionData* pCodeInfo);
 
     [PreserveSig]
-    int GetNativeCodeInfoForAddr(ulong codeAddress, nint pCodeInfo, ulong* pVmModule, uint* pFunctionToken);
+    int GetNativeCodeInfoForAddr(ulong codeAddress, NativeCodeFunctionData* pCodeInfo, ulong* pVmModule, uint* pFunctionToken);
 
     [PreserveSig]
     int IsValueType(ulong vmTypeHandle, Interop.BOOL* pResult);

--- a/src/native/managed/cdac/tests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/DacDbiImplTests.cs
@@ -23,7 +23,11 @@ public unsafe class DacDbiImplTests
         MockTarget.Architecture arch,
         Action<MockLoaderBuilder, TestPlaceholderTarget.Builder> configure)
     {
-        var (_, target) = LoaderTests.CreateLoaderContractWithTarget(arch, configure);
+        var (_, target) = LoaderTests.CreateLoaderContractWithTarget(arch, (loader, builder) =>
+        {
+            builder.AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, 1));
+            configure(loader, builder);
+        });
         var dacDbi = new DacDbiImpl(target, legacyObj: null);
         return (dacDbi, target);
     }
@@ -262,6 +266,7 @@ public unsafe class DacDbiImplTests
     {
         var target = new TestPlaceholderTarget.Builder(arch)
             .UseReader((_, _) => -1)
+            .AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, 1))
             .AddMockContract(mockLoader)
             .Build();
         return new DacDbiImpl(target, legacyObj: null);
@@ -396,5 +401,144 @@ public unsafe class DacDbiImplTests
 
         Assert.Equal(System.HResults.S_OK, hr);
         Assert.Empty(assemblies);
+    }
+
+    private static DacDbiImpl CreateDacDbiWithMocks(
+        MockTarget.Architecture arch,
+        Mock<ILoader> mockLoader,
+        Mock<IRuntimeTypeSystem> mockRuntimeTypeSystem,
+        Mock<IExecutionManager> mockExecutionManager,
+        Mock<IPrecodeStubs> mockPrecodeStubs,
+        Mock<IEnC>? mockEnc = null,
+        ulong defaultEncVersion = 1)
+    {
+        var builder = new TestPlaceholderTarget.Builder(arch)
+            .UseReader((_, _) => -1)
+            .AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, defaultEncVersion))
+            .AddMockContract(mockLoader)
+            .AddMockContract(mockRuntimeTypeSystem)
+            .AddMockContract(mockExecutionManager)
+            .AddMockContract(mockPrecodeStubs);
+
+        if (mockEnc is not null)
+            builder.AddMockContract(mockEnc);
+
+        var target = builder.Build();
+        return new DacDbiImpl(target, legacyObj: null);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetNativeCodeInfo_UsesLatestEnCVersion(MockTarget.Architecture arch)
+    {
+        const ulong vmAssembly = 0x1000;
+        uint functionToken = EcmaMetadataUtils.CreateMethodDef(0x123);
+        TargetPointer moduleAddr = new(0x2000);
+        TargetPointer methodDescAddr = new(0x3000);
+        TargetPointer methodLoaderModuleAddr = TargetPointer.Null;
+        TargetCodePointer nativeCodeAddr = new(0x6000);
+        TargetCodePointer resolvedCodeAddr = TargetCodePointer.Null;
+        const ulong expectedEncVersion = 42;
+
+        var mockLoader = new Mock<ILoader>();
+        var mockRuntimeTypeSystem = new Mock<IRuntimeTypeSystem>();
+        var mockExecutionManager = new Mock<IExecutionManager>();
+        var mockPrecodeStubs = new Mock<IPrecodeStubs>();
+        var mockEnc = new Mock<IEnC>();
+
+        Contracts.ModuleHandle moduleHandle = new(moduleAddr);
+        TargetPointer methodDefToDescTable = new(0x9000);
+        TargetNUInt mapFlags = default;
+        MethodDescHandle methodDescHandle = new(methodDescAddr);
+
+        mockLoader.Setup(l => l.GetModuleHandleFromAssemblyPtr(new TargetPointer(vmAssembly))).Returns(moduleHandle);
+        mockLoader.Setup(l => l.GetLookupTables(moduleHandle)).Returns(new ModuleLookupTables { MethodDefToDesc = methodDefToDescTable });
+        mockLoader.Setup(l => l.GetModuleLookupMapElement(methodDefToDescTable, functionToken, out mapFlags)).Returns(methodDescAddr);
+
+        mockRuntimeTypeSystem.Setup(r => r.GetMethodDescHandle(methodDescAddr)).Returns(methodDescHandle);
+        mockRuntimeTypeSystem.Setup(r => r.IsAsyncThunkMethod(methodDescHandle)).Returns(false);
+        mockRuntimeTypeSystem.Setup(r => r.GetNativeCode(methodDescHandle)).Returns(nativeCodeAddr);
+        mockRuntimeTypeSystem.Setup(r => r.GetMethodTable(methodDescHandle)).Returns(TargetPointer.Null);
+
+        mockPrecodeStubs.Setup(p => p.GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCodeAddr)).Returns(resolvedCodeAddr);
+
+        mockEnc.Setup(e => e.GetLatestEnCVersion(methodLoaderModuleAddr, functionToken)).Returns(new TargetNUInt(expectedEncVersion));
+
+        DacDbiImpl dacDbi = CreateDacDbiWithMocks(
+            arch,
+            mockLoader,
+            mockRuntimeTypeSystem,
+            mockExecutionManager,
+            mockPrecodeStubs,
+            mockEnc);
+
+        NativeCodeFunctionData codeInfo = default;
+        int hr = dacDbi.GetNativeCodeInfo(vmAssembly, functionToken, &codeInfo);
+
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(expectedEncVersion, codeInfo.encVersion);
+        Assert.Equal(methodDescAddr.Value, codeInfo.vmNativeCodeMethodDescToken);
+        Assert.Equal(0ul, codeInfo.hotRegion.pAddress);
+        Assert.Equal(0u, codeInfo.hotRegion.cbSize);
+        Assert.Equal(0ul, codeInfo.coldRegion.pAddress);
+        Assert.Equal(0u, codeInfo.coldRegion.cbSize);
+        mockEnc.Verify(e => e.GetLatestEnCVersion(methodLoaderModuleAddr, functionToken), Times.Once);
+        mockEnc.Verify(e => e.GetEnCVersion(It.IsAny<TargetPointer>(), It.IsAny<uint>(), It.IsAny<TargetCodePointer>()), Times.Never);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetNativeCodeInfoForAddr_UsesAddressSpecificEnCVersion(MockTarget.Architecture arch)
+    {
+        TargetCodePointer requestedAddress = new(0x1000);
+        TargetCodePointer resolvedAddress = new(0x1008);
+        CodeBlockHandle codeBlockHandle = new(new TargetPointer(0x2000));
+        TargetPointer methodDescAddr = new(0x3000);
+        MethodDescHandle methodDescHandle = new(methodDescAddr);
+        TargetCodePointer hotStartAddr = TargetCodePointer.Null;
+        TargetPointer loaderModuleAddr = TargetPointer.Null;
+        uint methodToken = EcmaMetadataUtils.CreateMethodDef(0x111);
+        const ulong expectedEncVersion = 97;
+
+        var mockLoader = new Mock<ILoader>();
+        var mockRuntimeTypeSystem = new Mock<IRuntimeTypeSystem>();
+        var mockExecutionManager = new Mock<IExecutionManager>();
+        var mockPrecodeStubs = new Mock<IPrecodeStubs>();
+        var mockEnc = new Mock<IEnC>();
+
+        mockPrecodeStubs.Setup(p => p.GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedAddress)).Returns(resolvedAddress);
+
+        mockExecutionManager.Setup(e => e.GetCodeBlockHandle(resolvedAddress)).Returns(codeBlockHandle);
+        mockExecutionManager.Setup(e => e.GetMethodDesc(codeBlockHandle)).Returns(methodDescAddr);
+        mockExecutionManager.Setup(e => e.GetStartAddress(codeBlockHandle)).Returns(hotStartAddr.AsTargetPointer);
+
+        mockRuntimeTypeSystem.Setup(r => r.GetMethodDescHandle(methodDescAddr)).Returns(methodDescHandle);
+        mockRuntimeTypeSystem.Setup(r => r.GetMethodToken(methodDescHandle)).Returns(methodToken);
+        mockRuntimeTypeSystem.Setup(r => r.GetMethodTable(methodDescHandle)).Returns(TargetPointer.Null);
+
+        mockEnc.Setup(e => e.GetEnCVersion(loaderModuleAddr, methodToken, hotStartAddr)).Returns(new TargetNUInt(expectedEncVersion));
+
+        DacDbiImpl dacDbi = CreateDacDbiWithMocks(
+            arch,
+            mockLoader,
+            mockRuntimeTypeSystem,
+            mockExecutionManager,
+            mockPrecodeStubs,
+            mockEnc);
+
+        NativeCodeFunctionData codeInfo = default;
+        uint functionToken = 0;
+        int hr = dacDbi.GetNativeCodeInfoForAddr(requestedAddress.Value, &codeInfo, null, &functionToken);
+
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(expectedEncVersion, codeInfo.encVersion);
+        Assert.Equal(methodDescAddr.Value, codeInfo.vmNativeCodeMethodDescToken);
+        Assert.Equal(0ul, codeInfo.hotRegion.pAddress);
+        Assert.Equal(0u, codeInfo.hotRegion.cbSize);
+        Assert.Equal(0ul, codeInfo.coldRegion.pAddress);
+        Assert.Equal(0u, codeInfo.coldRegion.cbSize);
+        Assert.Equal(methodToken, functionToken);
+        mockEnc.Verify(e => e.GetEnCVersion(loaderModuleAddr, methodToken, hotStartAddr), Times.Once);
+        mockEnc.Verify(e => e.GetLatestEnCVersion(It.IsAny<TargetPointer>(), It.IsAny<uint>()), Times.Never);
     }
 }

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -11,7 +11,7 @@ public class EnCContractTests
 {
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetLatestEnCVersion_ReturnsLatestVersionForKnownToken_DefaultForUnknownToken(MockTarget.Architecture arch)
+    public void GetLatestEnCVersion_ReturnsLatestVersion_DefaultsForUnregisteredToken(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;
@@ -33,7 +33,7 @@ public class EnCContractTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetEnCVersion_ReturnsVersionForMatchingAddress_DefaultForNonMatchingOrNullAddress(MockTarget.Architecture arch)
+    public void GetEnCVersion_ReturnsMatchingVersion_DefaultsForMismatchOrNull(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;
@@ -67,7 +67,7 @@ public class EnCContractTests
 
         MockLoaderModuleWithEnCDataList module = moduleLayout.Create(allocator.Allocate((ulong)moduleLayout.Size, "Module"));
 
-        ulong next = 0;
+        ulong headAddress = 0;
         for (int i = entries.Count - 1; i >= 0; i--)
         {
             var entry = entries[i];
@@ -75,11 +75,11 @@ public class EnCContractTests
             node.AddrOfCode = entry.AddrOfCode;
             node.Token = entry.Token;
             node.EnCVersion = entry.EnCVersion;
-            node.Next = next;
-            next = node.Address;
+            node.Next = headAddress;
+            headAddress = node.Address;
         }
 
-        module.EnCDataList = next;
+        module.EnCDataList = headAddress;
 
         targetBuilder
             .AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, defaultVersion))

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -11,7 +11,7 @@ public class EnCContractTests
 {
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetLatestEnCVersion_ReturnsFirstEntryForTokenAndDefaultForMissingToken(MockTarget.Architecture arch)
+    public void GetLatestEnCVersion_ReturnsLatestVersionForKnownToken_DefaultForUnknownToken(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;
@@ -33,7 +33,7 @@ public class EnCContractTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetEnCVersion_ReturnsVersionForMatchingAddressOrDefaultForMismatch(MockTarget.Architecture arch)
+    public void GetEnCVersion_ReturnsVersionForMatchingAddress_DefaultForNonMatchingOrNullAddress(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -65,9 +65,9 @@ public class EnCContractTests
         Layout<MockLoaderModuleWithEnCDataList> moduleLayout = MockLoaderModuleWithEnCDataList.CreateLayout(arch);
         Layout<MockEnCDataNode> encDataLayout = MockEnCDataNode.CreateLayout(arch);
 
-        MockLoaderModuleWithEnCDataList module = moduleLayout.Create(allocator.Allocate((ulong)moduleLayout.Size, "Module"));
+        MockLoaderModuleWithEnCDataList moduleInstance = moduleLayout.Create(allocator.Allocate((ulong)moduleLayout.Size, "Module"));
 
-        ulong headAddress = 0;
+        ulong headAddress = TargetPointer.Null.Value;
         for (int i = entries.Count - 1; i >= 0; i--)
         {
             var entry = entries[i];
@@ -79,7 +79,7 @@ public class EnCContractTests
             headAddress = node.Address;
         }
 
-        module.EnCDataList = headAddress;
+        moduleInstance.EnCDataList = headAddress;
 
         targetBuilder
             .AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, defaultVersion))
@@ -91,7 +91,7 @@ public class EnCContractTests
             .AddContract<IEnC>("c1");
 
         TestPlaceholderTarget target = targetBuilder.Build();
-        return (target.Contracts.EnC, new TargetPointer(module.Address));
+        return (target.Contracts.EnC, new TargetPointer(moduleInstance.Address));
     }
 
     private sealed class MockLoaderModuleWithEnCDataList : TypedView

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -1,0 +1,161 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public class EnCContractTests
+{
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetLatestEnCVersion_ReturnsFirstMatchingEntryAndDefault(MockTarget.Architecture arch)
+    {
+        const ulong defaultVersion = 1;
+        const uint methodToken = 0x06000042;
+        const uint missingToken = 0x06000043;
+        const ulong latestVersion = 7;
+
+        var (enc, module) = CreateEnCContract(
+            arch,
+            defaultVersion,
+            [
+                (methodToken, 0x1000ul, latestVersion),
+                (methodToken, 0x2000ul, 6ul),
+                (missingToken, 0x3000ul, 9ul),
+            ]);
+
+        Assert.Equal(latestVersion, enc.GetLatestEnCVersion(module, methodToken).Value);
+        Assert.Equal(defaultVersion, enc.GetLatestEnCVersion(module, 0x06000044).Value);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetEnCVersion_ReturnsAddressMatchAndDefault(MockTarget.Architecture arch)
+    {
+        const ulong defaultVersion = 1;
+        const uint methodToken = 0x06000042;
+        const ulong matchingAddress = 0x2000;
+        const ulong expectedVersion = 6;
+
+        var (enc, module) = CreateEnCContract(
+            arch,
+            defaultVersion,
+            [
+                (methodToken, 0x1000ul, 7ul),
+                (methodToken, matchingAddress, expectedVersion),
+                (0x06000043u, 0x3000ul, 9ul),
+            ]);
+
+        Assert.Equal(expectedVersion, enc.GetEnCVersion(module, methodToken, new TargetCodePointer(matchingAddress)).Value);
+        Assert.Equal(defaultVersion, enc.GetEnCVersion(module, methodToken, new TargetCodePointer(0x4000)).Value);
+        Assert.Equal(defaultVersion, enc.GetEnCVersion(module, methodToken, TargetCodePointer.Null).Value);
+    }
+
+    private static (IEnC Contract, TargetPointer ModuleAddress) CreateEnCContract(
+        MockTarget.Architecture arch,
+        ulong defaultVersion,
+        IReadOnlyList<(uint Token, ulong AddrOfCode, ulong EnCVersion)> entries)
+    {
+        var targetBuilder = new TestPlaceholderTarget.Builder(arch);
+        MockMemorySpace.BumpAllocator allocator = targetBuilder.MemoryBuilder.CreateAllocator(0x0010_0000, 0x0011_0000);
+
+        Layout<MockLoaderModuleWithEnCDataList> moduleLayout = MockLoaderModuleWithEnCDataList.CreateLayout(arch);
+        Layout<MockEnCDataNode> encDataLayout = MockEnCDataNode.CreateLayout(arch);
+
+        MockLoaderModuleWithEnCDataList module = moduleLayout.Create(allocator.Allocate((ulong)moduleLayout.Size, "Module"));
+
+        ulong next = 0;
+        for (int i = entries.Count - 1; i >= 0; i--)
+        {
+            var entry = entries[i];
+            MockEnCDataNode node = encDataLayout.Create(allocator.Allocate((ulong)encDataLayout.Size, "EnCData"));
+            node.AddrOfCode = entry.AddrOfCode;
+            node.Token = entry.Token;
+            node.EnCVersion = entry.EnCVersion;
+            node.Next = next;
+            next = node.Address;
+        }
+
+        module.EnCDataList = next;
+
+        targetBuilder
+            .AddGlobals((Constants.Globals.CorDBDefaultEnCFunctionVersion, defaultVersion))
+            .AddTypes(new Dictionary<DataType, Target.TypeInfo>
+            {
+                [DataType.Module] = TargetTestHelpers.CreateTypeInfo(moduleLayout),
+                [DataType.EnCData] = TargetTestHelpers.CreateTypeInfo(encDataLayout),
+            })
+            .AddContract<IEnC>("c1");
+
+        TestPlaceholderTarget target = targetBuilder.Build();
+        return (target.Contracts.EnC, new TargetPointer(module.Address));
+    }
+
+    private sealed class MockLoaderModuleWithEnCDataList : TypedView
+    {
+        public static Layout<MockLoaderModuleWithEnCDataList> CreateLayout(MockTarget.Architecture architecture)
+            => new SequentialLayoutBuilder("Module", architecture)
+                .AddPointerField("Assembly")
+                .AddPointerField("PEAssembly")
+                .AddPointerField("Base")
+                .AddUInt32Field("Flags")
+                .AddPointerField("LoaderAllocator")
+                .AddPointerField("DynamicMetadata")
+                .AddPointerField("SimpleName")
+                .AddPointerField("Path")
+                .AddPointerField("FileName")
+                .AddPointerField("ReadyToRunInfo")
+                .AddPointerField("GrowableSymbolStream")
+                .AddPointerField("AvailableTypeParams")
+                .AddPointerField("InstMethodHashTable")
+                .AddPointerField("FieldDefToDescMap")
+                .AddPointerField("ManifestModuleReferencesMap")
+                .AddPointerField("MemberRefToDescMap")
+                .AddPointerField("MethodDefToDescMap")
+                .AddPointerField("TypeDefToMethodTableMap")
+                .AddPointerField("TypeRefToMethodTableMap")
+                .AddPointerField("MethodDefToILCodeVersioningStateMap")
+                .AddPointerField("DynamicILBlobTable")
+                .AddPointerField("EnCDataList")
+                .Build<MockLoaderModuleWithEnCDataList>();
+
+        public ulong EnCDataList
+        {
+            set => WritePointerField("EnCDataList", value);
+        }
+    }
+
+    private sealed class MockEnCDataNode : TypedView
+    {
+        public static Layout<MockEnCDataNode> CreateLayout(MockTarget.Architecture architecture)
+            => new SequentialLayoutBuilder("EnCData", architecture)
+                .AddPointerField("AddrOfCode")
+                .AddUInt32Field("Token")
+                .AddNUIntField("EnCVersion")
+                .AddPointerField("Next")
+                .Build<MockEnCDataNode>();
+
+        public ulong AddrOfCode
+        {
+            set => WritePointerField("AddrOfCode", value);
+        }
+
+        public uint Token
+        {
+            set => WriteUInt32Field("Token", value);
+        }
+
+        public ulong EnCVersion
+        {
+            set => WritePointerField("EnCVersion", value);
+        }
+
+        public ulong Next
+        {
+            set => WritePointerField("Next", value);
+        }
+    }
+}

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -11,7 +11,7 @@ public class EnCContractTests
 {
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetLatestEnCVersion_ReturnsFirstMatchingEntryAndDefault(MockTarget.Architecture arch)
+    public void GetLatestEnCVersion_ReturnsFirstEntryForTokenAndDefaultForMissingToken(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;
@@ -33,7 +33,7 @@ public class EnCContractTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void GetEnCVersion_ReturnsAddressMatchAndDefault(MockTarget.Architecture arch)
+    public void GetEnCVersion_ReturnsVersionForMatchingAddressOrDefaultForMismatch(MockTarget.Architecture arch)
     {
         const ulong defaultVersion = 1;
         const uint methodToken = 0x06000042;

--- a/src/native/managed/cdac/tests/EnCContractTests.cs
+++ b/src/native/managed/cdac/tests/EnCContractTests.cs
@@ -134,7 +134,7 @@ public class EnCContractTests
             => new SequentialLayoutBuilder("EnCData", architecture)
                 .AddPointerField("AddrOfCode")
                 .AddUInt32Field("Token")
-                .AddNUIntField("EnCVersion")
+                .AddPointerField("EnCVersion")
                 .AddPointerField("Next")
                 .Build<MockEnCDataNode>();
 


### PR DESCRIPTION
* Restructures debugger-side lookup of EnC version data. Previously we had to walk through a hash table of all the `DebuggerMethodInfo`s and then the `DebuggerJitInfo`s to get this data. It was noted that this is quite heavy just to get this one piece of data. We don't have that many EnC versions, so we now have a linked list of these stored on the `Module`.
* Introduces EnC contract to get EnC-related data. 
```csharp
    TargetNUInt GetLatestEnCVersion(TargetPointer module, uint methodDef);
    TargetNUInt GetEnCVersion(TargetPointer module, uint methodDef, TargetCodePointer nativeCodeAddress);
```
* Implements cDAC DacDbi APIs `GetNativeCodeInfo` and `GetNativeCodeInfoForAddr`.

note to ccr: do not talk about changing com interface compatibility or compatibility with older datadescriptors.

