### PR TITLE
[release/10.0] Fix heap_segment_used watermark after compaction

### DIFF
--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -12638,6 +12638,11 @@ size_t gc_heap::decommit_heap_segment_pages_worker (heap_segment* seg,
 void gc_heap::decommit_heap_segment (heap_segment* seg)
 {
 #ifdef USE_REGIONS
+    if (use_large_pages_p)
+    {
+        return;
+    }
+
     if (!dt_high_memory_load_p())
     {
         return;
@@ -38000,6 +38005,21 @@ void gc_heap::compact_phase (int condemned_gen_number,
     }
 
     recover_saved_pinned_info();
+
+#ifdef USE_REGIONS
+    for (int i = 0; i <= min (condemned_gen_number + 1, (int)max_generation); i++)
+    {
+        generation* gen = generation_of (i);
+        for (heap_segment* region = generation_start_segment_rw (gen);
+             region != nullptr;
+             region = heap_segment_next_rw (region))
+        {
+            uint8_t* plan_allocated = heap_segment_plan_allocated (region);
+            if (plan_allocated > heap_segment_used (region))
+                heap_segment_used (region) = plan_allocated;
+        }
+    }
+#endif //USE_REGIONS
 
     concurrent_print_time_delta ("compact end");
 


### PR DESCRIPTION
Backport of #128217 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

GC with large pages enabled in regions mode can lead to intermittent crashes due to non-zeroed memory being returned for an allocation request that expects the memory to be zeroed.

## Regression
- [x] Yes, introduced when GC regions were enabled
- [ ] No

## Testing
CI tests, local testing using targeted repro app from the customer, GC tests

## Risk
Low. It adds maintaining `heap_segment_used` watermark after compaction so that it covers all the touched memory in a region. Before this change, it was stale (lower) for regions that receive relocated objects.
