### PR TITLE
[browser] Skip boot json generation in nested publish

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -680,9 +680,14 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!-- Write the boot JSON file for the build.
        This target is incremental: when all inputs (assemblies, static web assets, VFS files,
-       config files, extensions, property stamp) are older than the output, the target is skipped. -->
+       config files, extensions, property stamp) are older than the output, the target is skipped.
+       Skipped during nested publish: the nested publish runs the full Build chain which would
+       create the boot JSON without VFS entries (LinkContentToWwwroot is skipped). If we wrote
+       it here, the outer build's Inputs/Outputs check would find the stale output and skip
+       regeneration, leaving the final boot JSON without VFS content files. -->
   <Target Name="_WriteBuildWasmBootJsonFile"
     DependsOnTargets="_WriteWasmBootJsonBuildPropertyStamp"
+    Condition="'$(WasmBuildingForNestedPublish)' != 'true'"
     Inputs="@(IntermediateAssembly);@(WasmStaticWebAsset);@(_WasmJsModuleCandidatesForBuild);@(_WasmFilesToIncludeInFileSystemStaticWebAsset);@(_WasmJsConfigStaticWebAsset);@(_WasmDotnetJsForBuild);@(WasmBootConfigExtension);$(ProjectRuntimeConfigFilePath);$(MSBuildProjectFullPath);$(MSBuildThisFileFullPath);$(_WebAssemblySdkTasksAssembly);$(IntermediateOutputPath)wasm-bootjson-build.stamp"
     Outputs="$(_WasmBuildBootJsonPath)">
 
@@ -733,8 +738,10 @@ Copyright (c) .NET Foundation. All rights reserved.
   </Target>
 
   <!-- Define the boot config file as a static web asset and create endpoints.
-       This target always runs to ensure items are populated even when _WriteBuildWasmBootJsonFile is skipped. -->
-  <Target Name="_GenerateBuildWasmBootJson" DependsOnTargets="_WriteBuildWasmBootJsonFile">
+       This target always runs to ensure items are populated even when _WriteBuildWasmBootJsonFile is skipped.
+       Skipped during nested publish (same reason as _WriteBuildWasmBootJsonFile). -->
+  <Target Name="_GenerateBuildWasmBootJson" DependsOnTargets="_WriteBuildWasmBootJsonFile"
+    Condition="'$(WasmBuildingForNestedPublish)' != 'true'">
 
     <ItemGroup>
       <!-- Track boot JSON for clean operations even when _WriteBuildWasmBootJsonFile was skipped -->


### PR DESCRIPTION
Skip `_WriteBuildWasmBootJsonFile` and `_GenerateBuildWasmBootJson` during nested publish to prevent writing a stale boot JSON without VFS entries.

During CoreCLR WASM nested publish, the new incrementalism (Inputs/Outputs) on `_WriteBuildWasmBootJsonFile` caused it to be skipped in the outer build after the nested publish wrote the boot JSON without VFS content. This resulted in `DirectoryNotFoundException` for content files like `testdataset1.xml`.

Regression from https://github.com/dotnet/runtime/pull/125367
Relates to https://github.com/dotnet/runtime/issues/128293