### PR TITLE
Revert MemoryStream breaking change

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -310,7 +310,7 @@ namespace System.IO
                 ArgumentOutOfRangeException.ThrowIfNegative(value);
                 EnsureNotClosed();
 
-                if (value > MemStreamMaxLength - _origin)
+                if (value > int.MaxValue - _origin)
                     throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
                 _position = _origin + (int)value;
             }
@@ -523,7 +523,7 @@ namespace System.IO
 
         private long SeekCore(long offset, int loc)
         {
-            if (offset > MemStreamMaxLength - loc)
+            if (offset > int.MaxValue - loc)
                 throw new ArgumentOutOfRangeException(nameof(offset), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
             int tempPosition = unchecked(loc + (int)offset);
             if (unchecked(loc + offset) < _origin || tempPosition < _origin)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -34,8 +34,6 @@ namespace System.IO
 
         private CachedCompletedInt32Task _lastReadTask; // The last successful task returned from ReadAsync
 
-        private static int MemStreamMaxLength => Array.MaxLength;
-
         public MemoryStream()
             : this(0)
         {
@@ -536,13 +534,13 @@ namespace System.IO
 
         // Sets the length of the stream to a given value.  The new
         // value must be nonnegative and less than the space remaining in
-        // the array, MemStreamMaxLength - origin
+        // the array, int.MaxValue - origin
         // Origin is 0 in all cases other than a MemoryStream created on
         // top of an existing array and a specific starting offset was passed
         // into the MemoryStream constructor.  The upper bounds prevents any
         // situations where a stream may be created on top of an array then
         // the stream is made longer than the maximum possible length of the
-        // array (MemStreamMaxLength).
+        // array (int.MaxValue).
         //
         public override void SetLength(long value)
         {
@@ -552,7 +550,6 @@ namespace System.IO
             EnsureWriteable();
 
             // Origin wasn't publicly exposed above.
-            Debug.Assert(MemStreamMaxLength == Array.MaxLength);  // Check parameter validation logic in this method if this fails.
             if (value > (int.MaxValue - _origin))
                 throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -546,15 +546,15 @@ namespace System.IO
         //
         public override void SetLength(long value)
         {
-            if (value < 0)
+            if (value < 0 || value > int.MaxValue)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
 
             EnsureWriteable();
 
             // Origin wasn't publicly exposed above.
             Debug.Assert(MemStreamMaxLength == Array.MaxLength);  // Check parameter validation logic in this method if this fails.
-            if (value > (MemStreamMaxLength - _origin))
-                throw new OutOfMemoryException();
+            if (value > (int.MaxValue - _origin))
+                throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
 
             int newLength = _origin + (int)value;
             bool allocatedNewArray = EnsureCapacity(newLength);

--- a/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/MemoryStream.cs
@@ -44,7 +44,6 @@ namespace System.IO
         public MemoryStream(int capacity)
         {
             ArgumentOutOfRangeException.ThrowIfNegative(capacity);
-            ArgumentOutOfRangeException.ThrowIfGreaterThan(capacity, MemStreamMaxLength);
 
             _buffer = capacity != 0 ? new byte[capacity] : [];
             _capacity = capacity;
@@ -547,7 +546,7 @@ namespace System.IO
         //
         public override void SetLength(long value)
         {
-            if (value < 0 || value > MemStreamMaxLength)
+            if (value < 0)
                 throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
 
             EnsureWriteable();
@@ -555,7 +554,7 @@ namespace System.IO
             // Origin wasn't publicly exposed above.
             Debug.Assert(MemStreamMaxLength == Array.MaxLength);  // Check parameter validation logic in this method if this fails.
             if (value > (MemStreamMaxLength - _origin))
-                throw new ArgumentOutOfRangeException(nameof(value), SR.Format(SR.ArgumentOutOfRange_StreamLength, Array.MaxLength));
+                throw new OutOfMemoryException();
 
             int newLength = _origin + (int)value;
             bool allocatedNewArray = EnsureCapacity(newLength);

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStream.ConstructorTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStream.ConstructorTests.cs
@@ -36,7 +36,7 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => new MemoryStream(-1));
             if (PlatformDetection.IsNotIntMaxValueArrayIndexSupported)
             {
-                Assert.Throws<ArgumentOutOfRangeException>(() => new MemoryStream(int.MaxValue));
+                Assert.Throws<OutOfMemoryException>(() => new MemoryStream(int.MaxValue));
             }
         }
     }

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -160,9 +160,9 @@ namespace System.IO.Tests
                 ms.Capacity = MaxSupportedLength;
                 Assert.Equal(MaxSupportedLength, ms.Capacity);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = MaxSupportedLength + 1);
+                Assert.Throws<OutOfMemoryException>(() => ms.Capacity = MaxSupportedLength + 1);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = int.MaxValue);
+                Assert.Throws<OutOfMemoryException>(() => ms.Capacity = int.MaxValue);
             }
         }
 

--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -105,8 +105,8 @@ namespace System.IO.Tests
             byte[] buffer = new byte[bufferSize];
             using (MemoryStream ms = new MemoryStream(buffer, origin, buffer.Length - origin, true))
             {
-                Seek(mode, ms, Array.MaxLength - origin);
-                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)Array.MaxLength - origin + 1));
+                Seek(mode, ms, int.MaxValue - origin);
+                Assert.Throws<ArgumentOutOfRangeException>(() => Seek(mode, ms, (long)int.MaxValue - origin + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MinValue + 1));
                 Assert.ThrowsAny<Exception>(() => Seek(mode, ms, long.MaxValue - 1));
             }


### PR DESCRIPTION
Revert Memorystream breaking change mentioned here: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/11/memorystream-max-capacity#affected-apis 
Base discussion here: https://github.com/dotnet/runtime/pull/123709
Fixes #123440 