### PR TITLE
Reject negative PAX size values when reading TAR headers

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -155,7 +155,7 @@ namespace System.Formats.Tar
                 {
                     throw new InvalidDataException(SR.Format(SR.TarSizeFieldNegative));
                 }
-                
+
                 _size = size;
             }
 

--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -151,6 +151,11 @@ namespace System.Formats.Tar
             // The 'size' header field only fits 12 bytes, so the data section length that surpases that limit needs to be retrieved
             if (TarHelpers.TryGetStringAsBaseTenLong(ExtendedAttributes, PaxEaSize, out long size))
             {
+                if (size < 0)
+                {
+                    throw new InvalidDataException(SR.Format(SR.TarSizeFieldNegative));
+                }
+                
                 _size = size;
             }
 


### PR DESCRIPTION
This change adds a validation check while applying extended attributes in TarHeader.Read.cs so that a negative size value from PAX metadata now throws InvalidDataException instead of being accepted.