### PR TITLE
[R2R] Add discovery of generic virtual methods 

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -94,16 +94,14 @@ namespace ILCompiler.DependencyAnalysis
                 // to make the type check as cheap as possible we check for specific
                 // *sealed* types instead of doing `entry is EETypeNode` which has
                 // to walk the whole class hierarchy for the non matching nodes.
-                if (entry is not ConstructedEETypeNode constructedEETypeNode)
+                if (entry is not ConstructedEETypeNode typeNode)
                     continue;
-
-                TypeDesc potentialOverrideType = constructedEETypeNode.Type;
 #else
                 if (entry is not InheritedVirtualMethodsNode typeNode)
                     continue;
+#endif
 
                 TypeDesc potentialOverrideType = typeNode.Type;
-#endif
                 if (!potentialOverrideType.IsDefType || potentialOverrideType.IsInterface)
                     continue;
 

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -7,6 +7,10 @@ using System.Collections.Generic;
 using ILCompiler.DependencyAnalysisFramework;
 using Internal.TypeSystem;
 
+#if READYTORUN
+using ILCompiler.DependencyAnalysis.ReadyToRun;
+#endif
+
 namespace ILCompiler.DependencyAnalysis
 {
     /// <summary>
@@ -42,13 +46,16 @@ namespace ILCompiler.DependencyAnalysis
         {
             if (!_method.IsAbstract)
             {
-                yield return new DependencyListEntry(factory.GenericVirtualMethodImpl(_method), "Implementation of the generic virtual method");
+                DependencyNodeCore<NodeFactory> node = GetVirtualMethodImplNode(factory, _method);
+                if (node != null)
+                    yield return new DependencyListEntry(node, "Implementation of the generic virtual method");
             }
-
+#if !READYTORUN
             if (!_method.OwningType.IsInterface)
             {
                 yield return new DependencyListEntry(factory.TypeGVMEntries(_method.OwningType.GetTypeDefinition()), "Resolution metadata");
             }
+#endif
         }
 
         public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
@@ -80,19 +87,23 @@ namespace ILCompiler.DependencyAnalysis
             for (int i = firstNode; i < markedNodes.Count; i++)
             {
                 DependencyNodeCore<NodeFactory> entry = markedNodes[i];
-                EETypeNode entryAsEETypeNode;
 
+#if !READYTORUN
                 // This method is often called with a long list of ScannedMethodNode
                 // or MethodCodeNode nodes. We are not interested in those. In order
                 // to make the type check as cheap as possible we check for specific
                 // *sealed* types instead of doing `entry is EETypeNode` which has
                 // to walk the whole class hierarchy for the non matching nodes.
-                if (entry is ConstructedEETypeNode constructedEETypeNode)
-                    entryAsEETypeNode = constructedEETypeNode;
-                else
+                if (entry is not ConstructedEETypeNode constructedEETypeNode)
                     continue;
 
-                TypeDesc potentialOverrideType = entryAsEETypeNode.Type;
+                TypeDesc potentialOverrideType = constructedEETypeNode.Type;
+#else
+                if (entry is not InheritedVirtualMethodsNode typeNode)
+                    continue;
+
+                TypeDesc potentialOverrideType = typeNode.Type;
+#endif
                 if (!potentialOverrideType.IsDefType || potentialOverrideType.IsInterface)
                     continue;
 
@@ -102,11 +113,12 @@ namespace ILCompiler.DependencyAnalysis
                     potentialOverrideType.ConvertToCanonForm(CanonicalFormKind.Specific) != potentialOverrideType)
                     continue;
 
+#if !READYTORUN
                 bool foundImpl = false;
-
+#endif
                 // If this is an interface gvm, look for types that implement the interface
-                // and other instantantiations that have the same canonical form.
-                // This ensure the various slot numbers remain equivalent across all types where there is an equivalence
+                // and other instantiations that have the same canonical form.
+                // This ensures the various slot numbers remain equivalent across all types where there is an equivalence
                 // relationship in the vtable.
                 if (methodOwningType.IsInterface)
                 {
@@ -149,17 +161,29 @@ namespace ILCompiler.DependencyAnalysis
                                     .MakeInstantiatedMethod(_method.Instantiation)
                                     .InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
 
+                                MethodDesc canonImpl = implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific);
+
                                 // Static virtuals cannot be further overridden so this is an impl use. Otherwise it's a virtual slot use.
                                 if (implementingMethodInstantiation.Signature.IsStatic)
-                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GenericVirtualMethodImpl(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
+                                {
+                                    DependencyNodeCore<NodeFactory> node = GetVirtualMethodImplNode(factory, canonImpl);
+                                    if (node != null)
+                                        dynamicDependencies.Add(new CombinedDependencyListEntry(node, null, "ImplementingMethodInstantiation"));
+                                }
                                 else
-                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(implementingMethodInstantiation.GetCanonMethodTarget(CanonicalFormKind.Specific)), null, "ImplementingMethodInstantiation"));
+                                {
+                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(canonImpl), null, "ImplementingMethodInstantiation"));
+                                }
 
+#if !READYTORUN
                                 TypeSystemEntity origin = (implementingMethodInstantiation.OwningType != potentialOverrideType) ? potentialOverrideType : null;
                                 factory.MetadataManager.NoteOverridingMethod(_method, implementingMethodInstantiation, origin);
+#endif
                             }
 
+#if !READYTORUN
                             foundImpl = true;
+#endif
                         }
                     }
                 }
@@ -168,8 +192,8 @@ namespace ILCompiler.DependencyAnalysis
                     // This is not an interface GVM. Check whether the current type overrides the virtual method.
                     // We might need to change what virtual method we ask about - consider:
                     //
-                    // class Base<T> { virtual Method(); }
-                    // class Derived : Base<string> { override Method(); }
+                    // class Base<T> { virtual Method<U>(); }
+                    // class Derived : Base<string> { override Method<U>(); }
                     //
                     // We need to resolve Base<__Canon>.Method on Derived, but if we were to ask the virtual
                     // method resolution algorithm, the answer would be "does not override" because Base<__Canon>
@@ -207,15 +231,18 @@ namespace ILCompiler.DependencyAnalysis
                         .GetCanonMethodTarget(CanonicalFormKind.Specific);
                     if (instantiatedTargetMethod != _method)
                     {
-                        dynamicDependencies.Add(new CombinedDependencyListEntry(
-                            factory.GenericVirtualMethodImpl(instantiatedTargetMethod), null, "DerivedMethodInstantiation"));
-
+                        DependencyNodeCore<NodeFactory> node = GetVirtualMethodImplNode(factory, instantiatedTargetMethod);
+                        if (node != null)
+                            dynamicDependencies.Add(new CombinedDependencyListEntry(node, null, "DerivedMethodInstantiation"));
+#if !READYTORUN
                         factory.MetadataManager.NoteOverridingMethod(_method, instantiatedTargetMethod);
 
                         foundImpl = true;
+#endif
                     }
                 }
 
+#if !READYTORUN
                 if (foundImpl)
                 {
                     TypeDesc currentType = potentialOverrideType;
@@ -226,9 +253,30 @@ namespace ILCompiler.DependencyAnalysis
                     }
                     while (currentType != null);
                 }
+#endif
             }
 
             return dynamicDependencies;
+        }
+
+        private static DependencyNodeCore<NodeFactory> GetVirtualMethodImplNode(NodeFactory factory, MethodDesc method)
+        {
+#if !READYTORUN
+            return factory.GenericVirtualMethodImpl(method);
+#else
+            if (!factory.CompilationModuleGroup.ContainsMethodBody(method, false))
+                return null;
+
+            try
+            {
+                factory.DetectGenericCycles(method, method);
+                return factory.CompiledMethodNode(method);
+            }
+            catch (TypeSystemException)
+            {
+                return null;
+            }
+#endif
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -145,10 +145,9 @@ namespace ILCompiler.DependencyAnalysis
 
                             if (slotDecl != null)
                             {
-                                TypeDesc[] openInstantiation = new TypeDesc[_method.Instantiation.Length];
-                                for (int instArg = 0; instArg < openInstantiation.Length; instArg++)
-                                    openInstantiation[instArg] = context.GetSignatureVariable(instArg, method: true);
-                                MethodDesc implementingMethodInstantiation = slotDecl.MakeInstantiatedMethod(openInstantiation).InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
+                                MethodDesc implementingMethodInstantiation = slotDecl
+                                    .MakeInstantiatedMethod(_method.Instantiation)
+                                    .InstantiateSignature(potentialOverrideType.Instantiation, _method.Instantiation);
 
                                 // Static virtuals cannot be further overridden so this is an impl use. Otherwise it's a virtual slot use.
                                 if (implementingMethodInstantiation.Signature.IsStatic)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -301,6 +301,7 @@
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\AssemblyStubNode.cs" Link="Compiler\DependencyAnalysis\AssemblyStubNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\CompilerComparer.cs" Link="Compiler\DependencyAnalysis\CompilerComparer.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\EmbeddedDataContainerNode.cs" Link="Compiler\DependencyAnalysis\EmbeddedDataContainerNode.cs" />
+    <Compile Include="..\..\Common\Compiler\DependencyAnalysis\GVMDependenciesNode.cs" Link="Compiler\DependencyAnalysis\GVMDependenciesNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\IMethodBodyNode.cs" Link="Compiler\DependencyAnalysis\IMethodBodyNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\IMethodNode.cs" Link="Compiler\DependencyAnalysis\IMethodNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\INodeWithCodeInfo.cs" Link="Compiler\DependencyAnalysis\INodeWithCodeInfo.cs" />
@@ -546,7 +547,6 @@
     <Compile Include="Compiler\DependencyAnalysis\GenericVirtualMethodTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\InterfaceGenericVirtualMethodTableNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\TypeGVMEntriesNode.cs" />
-    <Compile Include="Compiler\DependencyAnalysis\GVMDependenciesNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ReflectionFieldMapNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutInfoNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\NativeLayoutVertexNode.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/InheritedVirtualMethodsNode.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using ILCompiler.DependencyAnalysisFramework;
+using Internal.TypeSystem;
+
+namespace ILCompiler.DependencyAnalysis.ReadyToRun
+{
+    /// <summary>
+    /// Type discovery marker node for virtual dispatch dependency analysis.
+    ///
+    /// Marked InterestingForDynamicDependencyAnalysis so that GVMDependenciesNode
+    /// can iterate on these type nodes to discover new virtual method targets to include in compilation.
+    /// </summary>
+    public class InheritedVirtualMethodsNode : DependencyNodeCore<NodeFactory>
+    {
+        private readonly TypeDesc _type;
+
+        public InheritedVirtualMethodsNode(TypeDesc type)
+        {
+            Debug.Assert(type.IsDefType && !type.IsInterface);
+            _type = type;
+        }
+
+        public TypeDesc Type => _type;
+
+        public override bool InterestingForDynamicDependencyAnalysis => true;
+        public override bool HasDynamicDependencies => false;
+        public override bool HasConditionalStaticDependencies => false;
+        public override bool StaticDependenciesAreComputed => true;
+
+        public override IEnumerable<CombinedDependencyListEntry> GetConditionalStaticDependencies(NodeFactory context) => null;
+        public override IEnumerable<CombinedDependencyListEntry> SearchDynamicDependencies(List<DependencyNodeCore<NodeFactory>> markedNodes, int firstNode, NodeFactory context) => null;
+        public override IEnumerable<DependencyListEntry> GetStaticDependencies(NodeFactory context) => null;
+
+        protected override string GetName(NodeFactory factory) => $"Inherited virtual methods on {_type}";
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -54,15 +54,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         protected override DependencyList ComputeNonRelocationBasedDependencies(NodeFactory factory)
         {
             DependencyList list = base.ComputeNonRelocationBasedDependencies(factory);
+            MethodDesc canonMethod = Method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             if (_fixupKind == ReadyToRunFixupKind.VirtualEntry &&
                 !Method.IsAbstract &&
                 !Method.HasInstantiation &&
-                Method.GetCanonMethodTarget(CanonicalFormKind.Specific) is var canonMethod &&
                 !factory.CompilationModuleGroup.VersionsWithMethodBody(canonMethod) &&
                 factory.CompilationModuleGroup.CrossModuleCompileable(canonMethod) &&
                 factory.CompilationModuleGroup.ContainsMethodBody(canonMethod, false))
             {
-                list = list ?? new DependencyAnalysisFramework.DependencyNodeCore<NodeFactory>.DependencyList();
+                list = list ?? new DependencyList();
                 try
                 {
                     factory.DetectGenericCycles(_method.Method, canonMethod);
@@ -73,7 +73,37 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
             }
 
+            // For generic virtual method calls, create a virtual dependency node that will
+            // dynamically discover implementations on types as they are added to the graph.
+            if (_fixupKind == ReadyToRunFixupKind.VirtualEntry &&
+                Method.IsVirtual &&
+                Method.HasInstantiation &&
+                !Method.IsFinal &&
+                !Method.IsGenericMethodDefinition &&
+                !Method.OwningType.IsGenericDefinition &&
+                (Method.OwningType.IsInterface || !Method.OwningType.IsSealed()))
+            {
+                // Because methods with generic parameters are already compiled in their canonical form, we are only interested in finding
+                // instantiations of virtual methods that have at least one non-canonical argument (aka a valuetype).
+                if (HasNonCanonicalInstantiationArguments(canonMethod))
+                {
+                    list = list ?? new DependencyList();
+                    list.Add(factory.GVMDependencies(Method), "Virtual dispatch dependency");
+                }
+            }
+
             return list;
+        }
+
+        private static bool HasNonCanonicalInstantiationArguments(MethodDesc canonMethod)
+        {
+            TypeDesc canonType = canonMethod.Context.CanonType;
+            foreach (TypeDesc arg in canonMethod.Instantiation)
+            {
+                if (arg != canonType)
+                    return true;
+            }
+            return false;
         }
 
         public override ObjectData GetData(NodeFactory factory, bool relocsOnly = false)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -213,11 +213,33 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 dependencies.Add(factory.AllMethodsOnType(_typeDesc), "Methods on generic type instantiation");
             }
 
+            // We record the usage of this type, so that GVM dependency analysis can resolve all implementations.
+            if (!_typeDesc.IsGenericDefinition &&
+                !_typeDesc.IsInterface &&
+                _typeDesc.IsDefType &&
+                (factory.CompilationCurrentPhase == 0) &&
+                factory.CompilationModuleGroup.VersionsWithType(_typeDesc) &&
+                TypeHasGVMSlots(_typeDesc))
+            {
+                dependencies.Add(factory.InheritedVirtualMethods(_typeDesc), "Inherited virtual/interface methods on type");
+            }
+
             if (_fixupKind == ReadyToRunFixupKind.TypeHandle)
             {
                 AddDependenciesForAsyncStateMachineBox(ref dependencies, factory, _typeDesc);
             }
             return dependencies;
+        }
+
+        private static bool TypeHasGVMSlots(TypeDesc type)
+        {
+            foreach (MethodDesc method in type.EnumAllVirtualSlots())
+            {
+                if (method.HasInstantiation)
+                    return true;
+            }
+
+            return false;
         }
 
         public static void AddDependenciesForAsyncStateMachineBox(ref DependencyList dependencies, NodeFactory factory, TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeFixupSignature.cs
@@ -233,10 +233,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private static bool TypeHasGVMSlots(TypeDesc type)
         {
-            foreach (MethodDesc method in type.EnumAllVirtualSlots())
+            TypeDesc currentType = type;
+            while (currentType != null)
             {
-                if (method.HasInstantiation)
-                    return true;
+                foreach (MethodDesc method in currentType.GetVirtualMethods())
+                {
+                    if (method.HasInstantiation)
+                        return true;
+                }
+                currentType = currentType.BaseType;
             }
 
             return false;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -141,6 +141,23 @@ namespace ILCompiler.DependencyAnalysis
             return _allMethodsOnType.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
         }
 
+        private NodeCache<TypeDesc, InheritedVirtualMethodsNode> _inheritedVirtualMethods;
+
+        public InheritedVirtualMethodsNode InheritedVirtualMethods(TypeDesc type)
+        {
+            return _inheritedVirtualMethods.GetOrAdd(type.ConvertToCanonForm(CanonicalFormKind.Specific));
+        }
+
+        private NodeCache<MethodDesc, GVMDependenciesNode> _gvmDependenciesNode;
+
+        public GVMDependenciesNode GVMDependencies(MethodDesc method)
+        {
+            Debug.Assert(method.IsVirtual);
+            MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
+            canonMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(canonMethod);
+            return _gvmDependenciesNode.GetOrAdd(canonMethod);
+        }
+
         private NodeCache<ReadyToRunGenericHelperKey, ISymbolNode> _genericReadyToRunHelpersFromDict;
 
         public ISymbolNode ReadyToRunHelperFromDictionaryLookup(ReadyToRunHelperId id, Object target, TypeSystemEntity dictionaryOwner)
@@ -261,6 +278,16 @@ namespace ILCompiler.DependencyAnalysis
             _allMethodsOnType = new NodeCache<TypeDesc, AllMethodsOnTypeNode>(type =>
             {
                 return new AllMethodsOnTypeNode(type);
+            });
+
+            _inheritedVirtualMethods = new NodeCache<TypeDesc, InheritedVirtualMethodsNode>(type =>
+            {
+                return new InheritedVirtualMethodsNode(type);
+            });
+
+            _gvmDependenciesNode = new NodeCache<MethodDesc, GVMDependenciesNode>(method =>
+            {
+                return new GVMDependenciesNode(method);
             });
 
             _genericReadyToRunHelpersFromDict = new NodeCache<ReadyToRunGenericHelperKey, ISymbolNode>(helperKey =>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -82,6 +82,7 @@
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\AssemblyStubNode.cs" Link="Compiler\DependencyAnalysis\AssemblyStubNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\CompilerComparer.cs" Link="Compiler\DependencyAnalysis\CompilerComparer.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\EmbeddedDataContainerNode.cs" Link="Compiler\DependencyAnalysis\EmbeddedDataContainerNode.cs" />
+    <Compile Include="..\..\Common\Compiler\DependencyAnalysis\GVMDependenciesNode.cs" Link="Compiler\DependencyAnalysis\GVMDependenciesNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\IMethodBodyNode.cs" Link="Compiler\DependencyAnalysis\IMethodBodyNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\IMethodNode.cs" Link="Compiler\DependencyAnalysis\IMethodNode.cs" />
     <Compile Include="..\..\Common\Compiler\DependencyAnalysis\INodeWithCodeInfo.cs" Link="Compiler\DependencyAnalysis\INodeWithCodeInfo.cs" />
@@ -226,6 +227,7 @@
     <Compile Include="Compiler\CompositeImageSettings.cs" />
     <Compile Include="Compiler\CryptographicHashProvider.cs" />
     <Compile Include="Compiler\DependencyAnalysis\AllMethodsOnTypeNode.cs" />
+    <Compile Include="Compiler\DependencyAnalysis\InheritedVirtualMethodsNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedDataNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\ArrayOfEmbeddedPointersNode.cs" />
     <Compile Include="Compiler\DependencyAnalysis\EmbeddedObjectNode.cs" />


### PR DESCRIPTION
Called methods are obtained from MethodFixupSignature and are stored into GVMDependenciesNode. These will be nodes that HasDynamicDependencies so the dependency analysis will do additional iterations for these nodes on the newly added nodes that are InterestingForDynamicDependencyAnalysis. These will be InheritedVirtualMethodsNode added as part of TypeFixupSignature, which represent types used by the application. We resolve the target method for calling the virtual/interface method on the existing types.

GVMDependenciesNode is moved from NativeAOT sources so that it is shared with ReadyToRun, with just a few minor tweaks guarded by ReadyToRun define (we don't report back via NoteOverridingMethod and we don't need to add TypeGVMEntries).