### PR TITLE
[Wasm RyuJit] emit virtual IP ranges in the unwind info

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -38,7 +38,9 @@ void CodeGenInterface::setFramePointerRequiredEH(bool value)
 {
     m_cgFramePointerRequired = value;
 
-#ifndef JIT32_GCENCODER
+#if defined(JIT32_GCENCODER) || defined(TARGET_WASM)
+    // No impact on GC reporting for x86 or Wasm
+#else
     if (value)
     {
         // EnumGcRefs will only enumerate slots in aborted frames
@@ -55,7 +57,7 @@ void CodeGenInterface::setFramePointerRequiredEH(bool value)
 
         m_cgInterruptible = true;
     }
-#endif // JIT32_GCENCODER
+#endif // defined(JIT32_GCENCODER) || defined(TARGET_WASM)
 }
 
 #if HAS_FIXED_REGISTER_SET

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3452,17 +3452,17 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
         GcInfoEncoder(m_compiler->info.compCompHnd, m_compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder != nullptr);
 
-    // For Wasm, encode the max Virtual IP as the code size, and use zero for the prolog size.
-    // Note code size cannot be zero per GC info. So we start at 1.
+    // Encode the max Virtual IP as the code size, and use 1 for the prolog size.
     //
-    unsigned maxVirtualIP = 1;
+    unsigned maxVirtualIP = 0;
     for (FuncInfoDsc* const func : m_compiler->Funcs())
     {
         maxVirtualIP = max(maxVirtualIP, func->endVirtualIP);
     }
+    maxVirtualIP++;
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).
-    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, maxVirtualIP, /* prologSize */ 0);
+    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, maxVirtualIP, /* prologSize */ 1);
 
     // We keep the call count for the second call to gcMakeRegPtrTable() below.
     unsigned callCnt = 0;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3459,7 +3459,6 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
     {
         maxVirtualIP = max(maxVirtualIP, func->endVirtualIP);
     }
-    maxVirtualIP++;
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).
     gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, maxVirtualIP, /* prologSize */ 1);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3452,7 +3452,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
         GcInfoEncoder(m_compiler->info.compCompHnd, m_compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder != nullptr);
 
-    // Encode the max Virtual IP as the code size, and use 1 for the prolog size.
+    // Find the max Virtual IP.
     //
     unsigned maxVirtualIP = 0;
     for (FuncInfoDsc* const func : m_compiler->Funcs())
@@ -3461,6 +3461,7 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
     }
 
     // Runtime wants us to report twice the actual Virtual IP range as code size.
+    // Use 1 as the prolog size.
     //
     codeSize   = 2 * maxVirtualIP;
     prologSize = 1;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3460,7 +3460,9 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
         maxVirtualIP = max(maxVirtualIP, func->endVirtualIP);
     }
 
-    codeSize   = maxVirtualIP;
+    // Runtime wants us to report twice the actual Virtual IP range as code size.
+    //
+    codeSize   = 2 * maxVirtualIP;
     prologSize = 1;
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3452,8 +3452,17 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
         GcInfoEncoder(m_compiler->info.compCompHnd, m_compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder != nullptr);
 
+    // For Wasm, encode the max Virtual IP as the code size, and use zero for the prolog size.
+    // Note code size cannot be zero per GC info. So we start at 1.
+    //
+    unsigned maxVirtualIP = 1;
+    for (FuncInfoDsc* const func : m_compiler->Funcs())
+    {
+        maxVirtualIP = max(maxVirtualIP, func->endVirtualIP);
+    }
+
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).
-    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, codeSize, prologSize);
+    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, maxVirtualIP, /* prologSize */ 0);
 
     // We keep the call count for the second call to gcMakeRegPtrTable() below.
     unsigned callCnt = 0;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3460,8 +3460,11 @@ void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, un
         maxVirtualIP = max(maxVirtualIP, func->endVirtualIP);
     }
 
+    codeSize   = maxVirtualIP;
+    prologSize = 1;
+
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).
-    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, maxVirtualIP, /* prologSize */ 1);
+    gcInfo.gcInfoBlockHdrSave(gcInfoEncoder, codeSize, prologSize);
 
     // We keep the call count for the second call to gcMakeRegPtrTable() below.
     unsigned callCnt = 0;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1778,6 +1778,8 @@ struct FuncInfoDsc
     bool needsUnwindableFrame;
     emitLocation* startLoc;
     emitLocation* endLoc;
+    unsigned startVirtualIP;
+    unsigned endVirtualIP;
 
     void ensureUnwindableFrame(Compiler* comp);
 #endif // defined(TARGET_WASM)

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2716,6 +2716,22 @@ PhaseStatus Compiler::fgWasmVirtualIP()
             JITDUMP(" Handler [%04u..%04u)\n", clauses[clauseIndex].clause.HandlerOffset,
                     clauses[clauseIndex].clause.HandlerLength);
         }
+
+        // Verify that funclet Virtual IP ranges are disjoint.
+        //
+        for (FuncInfoDsc* const func1 : Funcs())
+        {
+            for (FuncInfoDsc* const func2 : Funcs())
+            {
+                if (func1 == func2)
+                {
+                    break;
+                }
+
+                assert((func1->endVirtualIP <= func2->startVirtualIP) ||
+                       (func2->endVirtualIP <= func1->startVirtualIP));
+            }
+        }
     }
 #endif // DEBUG
 

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2590,9 +2590,9 @@ PhaseStatus Compiler::fgWasmVirtualIP()
         if (func->IsMethod())
         {
             // We use Virtual IP as length, and need a value to represent
-            // the prolog, so bump by 2 before we get to any EH or GC point.
+            // the prolog, so bump by 1 before we get to any EH or GC point.
             //
-            virtualIP += 2;
+            virtualIP += 1;
         }
 
         for (BasicBlock* const block : func->Blocks(this))
@@ -2696,6 +2696,11 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 // Filter length is implicit
                 virtualIP++;
             }
+        }
+
+        if (func->IsMethod())
+        {
+            virtualIP += 1;
         }
 
         func->endVirtualIP = virtualIP;

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2585,6 +2585,8 @@ PhaseStatus Compiler::fgWasmVirtualIP()
 
     for (FuncInfoDsc* const func : Funcs())
     {
+        func->startVirtualIP = virtualIP;
+
         for (BasicBlock* const block : func->Blocks(this))
         {
             EHblkDsc* const hndDsc = ehGetBlockHndDsc(block);
@@ -2687,6 +2689,8 @@ PhaseStatus Compiler::fgWasmVirtualIP()
                 virtualIP++;
             }
         }
+
+        func->endVirtualIP = virtualIP;
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -2587,6 +2587,14 @@ PhaseStatus Compiler::fgWasmVirtualIP()
     {
         func->startVirtualIP = virtualIP;
 
+        if (func->IsMethod())
+        {
+            // We use Virtual IP as length, and need a value to represent
+            // the prolog, so bump by 2 before we get to any EH or GC point.
+            //
+            virtualIP += 2;
+        }
+
         for (BasicBlock* const block : func->Blocks(this))
         {
             EHblkDsc* const hndDsc = ehGetBlockHndDsc(block);

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -4154,8 +4154,17 @@ PhaseStatus Compiler::fgSetBlockOrder()
 
     if (fgHasCycleWithoutGCSafePoint())
     {
+#if defined(TARGET_WASM)
+        // TODO-WASM: insert GC polls for loops, and arrange it so the
+        // polling overhead is tolerable.
+        //
+        JITDUMP("NOTE: Method requires GC polls -- Wasm does not insert these yet\n");
+#else
+
         JITDUMP("Marking method as fully interruptible\n");
         SetInterruptible(true);
+
+#endif // defined(TARGET_WASM)
     }
 
     for (BasicBlock* const block : Blocks())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14462,6 +14462,12 @@ void Compiler::fgMergeBlockReturn(BasicBlock* block)
 
 void Compiler::fgSetOptions()
 {
+#if defined(TARGET_WASM)
+    // Wasm requires GC polls, and only supports partially interruptible GC reporting.
+    optMethodFlags |= OMF_NEEDS_GCPOLLS;
+    assert(!GetInterruptible());
+#else
+
 #ifdef DEBUG
     /* Should we force fully interruptible code ? */
     if (JitConfig.JitFullyInt() || compStressCompile(STRESS_GENERIC_VARN, 30))
@@ -14471,11 +14477,6 @@ void Compiler::fgSetOptions()
     }
 #endif
 
-#if defined(TARGET_WASM)
-    // Wasm requires GC polls, and only supports partially interruptible GC reporting.
-    optMethodFlags |= OMF_NEEDS_GCPOLLS;
-    assert(!GetInterruptible());
-#else
     if (opts.compDbgCode)
     {
         assert(!codeGen->isGCTypeFixed());

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -14471,11 +14471,17 @@ void Compiler::fgSetOptions()
     }
 #endif
 
+#if defined(TARGET_WASM)
+    // Wasm requires GC polls, and only supports partially interruptible GC reporting.
+    optMethodFlags |= OMF_NEEDS_GCPOLLS;
+    assert(!GetInterruptible());
+#else
     if (opts.compDbgCode)
     {
         assert(!codeGen->isGCTypeFixed());
         SetInterruptible(true); // debugging is easier this way ...
     }
+#endif // defined(TARGET_WASM)
 
     /* Assume we won't need an explicit stack frame if this is allowed */
 

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -58,9 +58,10 @@ void Compiler::unwindReserve()
 //
 void Compiler::unwindReserveFunc(FuncInfoDsc* func)
 {
-    bool  isFunclet   = func->IsFunclet();
-    bool  isColdCode  = false;
-    ULONG encodedSize = emitter::SizeOfULEB128(func->funWasmFrameSize) + emitter::SizeOfULEB128(func->startVirtualIP) +
+    bool isFunclet  = func->IsFunclet();
+    bool isColdCode = false;
+    assert(func->endVirtualIP > func->startVirtualIP);
+    ULONG encodedSize = emitter::SizeOfULEB128(func->funWasmFrameSize) +
                         emitter::SizeOfULEB128(func->endVirtualIP - func->startVirtualIP);
 
     eeReserveUnwindInfo(isFunclet, isColdCode, encodedSize);
@@ -95,7 +96,7 @@ void Compiler::unwindEmit(void* pHotCode, void* pColdCode)
 //
 // Notes:
 //   For Wasm the unwind extent describes the entire span of Wasm code for the method or funclet,
-//   and the virtual IP range (encoded as start, delta).
+//   and the virtual IP "length" for the method or funclet.
 //
 void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode)
 {
@@ -106,14 +107,13 @@ void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode
     //
     pColdCode = nullptr;
 
-    // Unwind info is the frame size and the virtual IP range (start, delta).
+    // Unwind info is the frame size and the virtual IP length.
     // All values encoded via ULEB128.
     //
-    uint8_t buffer[15];
+    uint8_t buffer[10];
     size_t  index = 0;
-    assert(func->endVirtualIP >= func->startVirtualIP);
-    index += GetEmitter()->emitOutputULEB128(buffer, func->funWasmFrameSize);
-    index += GetEmitter()->emitOutputULEB128(buffer + index, func->startVirtualIP);
+    assert(func->endVirtualIP > func->startVirtualIP);
+    index += GetEmitter()->emitOutputULEB128(buffer + index, func->funWasmFrameSize);
     index += GetEmitter()->emitOutputULEB128(buffer + index, func->endVirtualIP - func->startVirtualIP);
     assert(index <= sizeof(buffer));
 

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -93,7 +93,8 @@ void Compiler::unwindEmit(void* pHotCode, void* pColdCode)
 //    pColdCode - Pointer to the beginning of the memory with the function and funclet cold code.
 //
 // Notes:
-//   For Wasm the unwind extent describes the entire span of Wasm code for the method or funclet.
+//   For Wasm the unwind extent describes the entire span of Wasm code for the method or funclet,
+//   and the virtual IP range (encoded as start, delta).
 //
 void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode)
 {
@@ -104,13 +105,20 @@ void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode
     //
     pColdCode = nullptr;
 
-    // Unwind info is just the frame size.
-    // Record frame size with ULEB128 compression.
+    // Unwind info is the frame size and the virtual IP range (start, delta).
+    // All values encoded via ULEB128.
     //
-    uint8_t buffer[5];
-    ULONG   encodedSize = (ULONG)GetEmitter()->emitOutputULEB128(buffer, func->funWasmFrameSize);
-    assert(encodedSize <= sizeof(buffer));
+    uint8_t buffer[15];
+    size_t  index = 0;
+    assert(func->endVirtualIP >= func->startVirtualIP);
+    index += GetEmitter()->emitOutputULEB128(buffer, func->funWasmFrameSize);
+    index += GetEmitter()->emitOutputULEB128(buffer + index, func->startVirtualIP);
+    index += GetEmitter()->emitOutputULEB128(buffer + index, func->endVirtualIP - func->startVirtualIP);
+    assert(index <= sizeof(buffer));
 
-    eeAllocUnwindInfo((BYTE*)pHotCode, (BYTE*)pColdCode, startOffset, endOffset, encodedSize, (BYTE*)&buffer,
+    JITDUMP("Unwind info for %s %u: VIP range [%u, %u); frame size %u\n", func->IsFunclet() ? "funclet" : "main",
+            func->GetFuncletIdx(this), func->startVirtualIP, func->endVirtualIP, func->funWasmFrameSize);
+
+    eeAllocUnwindInfo((BYTE*)pHotCode, (BYTE*)pColdCode, startOffset, endOffset, (ULONG)index, (BYTE*)&buffer,
                       (CorJitFuncKind)func->funKind);
 }

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -60,7 +60,8 @@ void Compiler::unwindReserveFunc(FuncInfoDsc* func)
 {
     bool  isFunclet   = func->IsFunclet();
     bool  isColdCode  = false;
-    ULONG encodedSize = emitter::SizeOfULEB128(func->funWasmFrameSize);
+    ULONG encodedSize = emitter::SizeOfULEB128(func->funWasmFrameSize) + emitter::SizeOfULEB128(func->startVirtualIP) +
+                        emitter::SizeOfULEB128(func->endVirtualIP - func->startVirtualIP);
 
     eeReserveUnwindInfo(isFunclet, isColdCode, encodedSize);
 }


### PR DESCRIPTION
Extend the per-funclet unwind info to record the length of the virtual IP range. The lowest Virtual IP for a funclet can be found by summing the lengths of all the prior funclets.

The unwind info previously just recorded the size of the fixed part of the frame.

Virtual IP ranges for funclets (and main method) are disjoint.

Data is encoded as ULEB128.