### PR TITLE
Localize libunwind symbols in NativeAOT to avoid duplicate symbol errors

### DIFF
--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -179,8 +179,9 @@ else()
 
   include(${CLR_SRC_NATIVE_DIR}/external/llvm-libunwind.cmake)
 
-  list(APPEND FULL_RUNTIME_SOURCES ${LLVM_LIBUNWIND_SOURCES})
-  set(RUNTIME_SOURCES_ARCH_ASM ${LLVM_LIBUNWIND_ASM_SOURCES})
+  # Store libunwind sources separately so Full/CMakeLists.txt can build them
+  # as an OBJECT library and localize their hidden symbols.
+  set(LLVM_LIBUNWIND_ALL_SOURCES ${LLVM_LIBUNWIND_SOURCES} ${LLVM_LIBUNWIND_ASM_SOURCES})
 
   set(ASM_SUFFIX S)
 endif()

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -30,31 +30,32 @@ add_library(Runtime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOU
 add_dependencies(Runtime.ServerGC aot_eventing_headers)
 target_link_libraries(Runtime.ServerGC PRIVATE aotminipal nativeaot_cdac_contract_descriptor nativeaot_gc_wks_descriptor nativeaot_gc_svr_descriptor)
 
-# Localize hidden symbols in the libunwind object files to avoid duplicate
-# symbol errors when linking against another copy of libunwind (e.g. Android
-# NDK r29). This converts GLOBAL HIDDEN symbols to LOCAL without affecting
-# the runtime's own symbols.
+# Build the bundled libunwind as a separate OBJECT library and localize its
+# hidden symbols to avoid duplicate symbol errors when linking against another
+# copy of libunwind (e.g. Android NDK r29's libunwind.a).
 # See: https://github.com/dotnet/runtime/issues/121172
-if(LLVM_LIBUNWIND_ALL_SOURCES AND CMAKE_OBJCOPY)
+if(LLVM_LIBUNWIND_ALL_SOURCES)
   add_library(libunwind_objects OBJECT ${LLVM_LIBUNWIND_ALL_SOURCES})
-
-  # Run objcopy --localize-hidden on each libunwind object file.
-  set(LOCALIZE_COMMANDS)
-  foreach(src ${LLVM_LIBUNWIND_ALL_SOURCES})
-    file(RELATIVE_PATH rel_src "/" "${src}")
-    set(obj_file "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/libunwind_objects.dir/./${rel_src}.o")
-    list(APPEND LOCALIZE_COMMANDS COMMAND ${CMAKE_OBJCOPY} --localize-hidden ${obj_file})
-  endforeach()
-
-  add_custom_target(localize_libunwind_symbols
-    ${LOCALIZE_COMMANDS}
-    DEPENDS libunwind_objects
-    COMMENT "Localizing hidden symbols in libunwind objects"
-  )
-  add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
-  add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
   target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
   target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)
+
+  if(CMAKE_OBJCOPY)
+    set(LOCALIZE_STAMP "${CMAKE_CURRENT_BINARY_DIR}/libunwind_localized.stamp")
+    add_custom_command(
+      OUTPUT ${LOCALIZE_STAMP}
+      COMMAND ${CMAKE_COMMAND}
+        -DOBJCOPY=${CMAKE_OBJCOPY}
+        "-DOBJECT_FILES=$<TARGET_OBJECTS:libunwind_objects>"
+        -P ${NATIVEAOT_RUNTIME_DIR}/localize-hidden-symbols.cmake
+      COMMAND ${CMAKE_COMMAND} -E touch ${LOCALIZE_STAMP}
+      DEPENDS libunwind_objects
+      COMMENT "Localizing hidden symbols in libunwind objects"
+      VERBATIM
+    )
+    add_custom_target(localize_libunwind_symbols DEPENDS ${LOCALIZE_STAMP})
+    add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
+    add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
+  endif()
 endif()
 
 add_library(standalonegc-disabled STATIC ${STANDALONEGC_DISABLED_SOURCES})

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(Runtime.ServerGC PRIVATE aotminipal nativeaot_cdac_contrac
 # hidden symbols to avoid duplicate symbol errors when linking against another
 # copy of libunwind (e.g. Android NDK r29's libunwind.a).
 # See: https://github.com/dotnet/runtime/issues/121172
-if(LLVM_LIBUNWIND_ALL_SOURCES)
+if(NOT WIN32)
   add_library(libunwind_objects OBJECT ${LLVM_LIBUNWIND_ALL_SOURCES})
   target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
   target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -37,38 +37,33 @@ target_link_libraries(Runtime.ServerGC PRIVATE aotminipal nativeaot_cdac_contrac
 if(NOT WIN32)
   add_library(libunwind_objects OBJECT ${LLVM_LIBUNWIND_ALL_SOURCES})
 
-  if(CMAKE_OBJCOPY)
-    # Copy the compiled objects and run objcopy --localize-hidden on the copies.
-    # We must not modify the originals in-place because that changes their mtime,
-    # invalidating Ninja's deps log and causing always-dirty incremental builds.
-    set(LOCALIZE_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/libunwind_localized")
-    set(LOCALIZED_OBJECTS)
-    foreach(src ${LLVM_LIBUNWIND_ALL_SOURCES})
-      get_filename_component(obj_name "${src}" NAME)
-      list(APPEND LOCALIZED_OBJECTS "${LOCALIZE_OUTPUT_DIR}/${obj_name}.o")
-    endforeach()
+  # Copy the compiled objects and run objcopy --localize-hidden on the copies.
+  # We must not modify the originals in-place because that changes their mtime,
+  # invalidating Ninja's deps log and causing always-dirty incremental builds.
+  set(LOCALIZE_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/libunwind_localized")
+  set(LOCALIZED_OBJECTS)
+  foreach(src ${LLVM_LIBUNWIND_ALL_SOURCES})
+    get_filename_component(obj_name "${src}" NAME)
+    list(APPEND LOCALIZED_OBJECTS "${LOCALIZE_OUTPUT_DIR}/${obj_name}.o")
+  endforeach()
 
-    add_custom_command(
-      OUTPUT ${LOCALIZED_OBJECTS}
-      COMMAND ${CMAKE_COMMAND}
-        -DOBJCOPY=${CMAKE_OBJCOPY}
-        "-DOBJECT_FILES=$<TARGET_OBJECTS:libunwind_objects>"
-        -DOUTPUT_DIR=${LOCALIZE_OUTPUT_DIR}
-        -P ${NATIVEAOT_RUNTIME_DIR}/localize-hidden-symbols.cmake
-      DEPENDS $<TARGET_OBJECTS:libunwind_objects>
-      COMMENT "Localizing hidden symbols in libunwind objects"
-      VERBATIM
-    )
-    add_custom_target(localize_libunwind_symbols DEPENDS ${LOCALIZED_OBJECTS})
-    add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
-    add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
-    target_sources(Runtime.WorkstationGC PRIVATE ${LOCALIZED_OBJECTS})
-    target_sources(Runtime.ServerGC PRIVATE ${LOCALIZED_OBJECTS})
-    set_source_files_properties(${LOCALIZED_OBJECTS} PROPERTIES EXTERNAL_OBJECT TRUE GENERATED TRUE)
-  else()
-    target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
-    target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)
-  endif()
+  add_custom_command(
+    OUTPUT ${LOCALIZED_OBJECTS}
+    COMMAND ${CMAKE_COMMAND}
+      -DOBJCOPY=${CMAKE_OBJCOPY}
+      "-DOBJECT_FILES=$<TARGET_OBJECTS:libunwind_objects>"
+      -DOUTPUT_DIR=${LOCALIZE_OUTPUT_DIR}
+      -P ${NATIVEAOT_RUNTIME_DIR}/localize-hidden-symbols.cmake
+    DEPENDS $<TARGET_OBJECTS:libunwind_objects>
+    COMMENT "Localizing hidden symbols in libunwind objects"
+    VERBATIM
+  )
+  add_custom_target(localize_libunwind_symbols DEPENDS ${LOCALIZED_OBJECTS})
+  add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
+  add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
+  target_sources(Runtime.WorkstationGC PRIVATE ${LOCALIZED_OBJECTS})
+  target_sources(Runtime.ServerGC PRIVATE ${LOCALIZED_OBJECTS})
+  set_source_files_properties(${LOCALIZED_OBJECTS} PROPERTIES EXTERNAL_OBJECT TRUE GENERATED TRUE)
 endif()
 
 add_library(standalonegc-disabled STATIC ${STANDALONEGC_DISABLED_SOURCES})

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -36,25 +36,38 @@ target_link_libraries(Runtime.ServerGC PRIVATE aotminipal nativeaot_cdac_contrac
 # See: https://github.com/dotnet/runtime/issues/121172
 if(NOT WIN32)
   add_library(libunwind_objects OBJECT ${LLVM_LIBUNWIND_ALL_SOURCES})
-  target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
-  target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)
 
   if(CMAKE_OBJCOPY)
-    set(LOCALIZE_STAMP "${CMAKE_CURRENT_BINARY_DIR}/libunwind_localized.stamp")
+    # Copy the compiled objects and run objcopy --localize-hidden on the copies.
+    # We must not modify the originals in-place because that changes their mtime,
+    # invalidating Ninja's deps log and causing always-dirty incremental builds.
+    set(LOCALIZE_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/libunwind_localized")
+    set(LOCALIZED_OBJECTS)
+    foreach(src ${LLVM_LIBUNWIND_ALL_SOURCES})
+      get_filename_component(obj_name "${src}" NAME)
+      list(APPEND LOCALIZED_OBJECTS "${LOCALIZE_OUTPUT_DIR}/${obj_name}.o")
+    endforeach()
+
     add_custom_command(
-      OUTPUT ${LOCALIZE_STAMP}
+      OUTPUT ${LOCALIZED_OBJECTS}
       COMMAND ${CMAKE_COMMAND}
         -DOBJCOPY=${CMAKE_OBJCOPY}
         "-DOBJECT_FILES=$<TARGET_OBJECTS:libunwind_objects>"
+        -DOUTPUT_DIR=${LOCALIZE_OUTPUT_DIR}
         -P ${NATIVEAOT_RUNTIME_DIR}/localize-hidden-symbols.cmake
-      COMMAND ${CMAKE_COMMAND} -E touch ${LOCALIZE_STAMP}
-      DEPENDS libunwind_objects
+      DEPENDS $<TARGET_OBJECTS:libunwind_objects>
       COMMENT "Localizing hidden symbols in libunwind objects"
       VERBATIM
     )
-    add_custom_target(localize_libunwind_symbols DEPENDS ${LOCALIZE_STAMP})
+    add_custom_target(localize_libunwind_symbols DEPENDS ${LOCALIZED_OBJECTS})
     add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
     add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
+    target_sources(Runtime.WorkstationGC PRIVATE ${LOCALIZED_OBJECTS})
+    target_sources(Runtime.ServerGC PRIVATE ${LOCALIZED_OBJECTS})
+    set_source_files_properties(${LOCALIZED_OBJECTS} PROPERTIES EXTERNAL_OBJECT TRUE GENERATED TRUE)
+  else()
+    target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
+    target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)
   endif()
 endif()
 

--- a/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/Full/CMakeLists.txt
@@ -30,6 +30,33 @@ add_library(Runtime.ServerGC STATIC ${COMMON_RUNTIME_SOURCES} ${FULL_RUNTIME_SOU
 add_dependencies(Runtime.ServerGC aot_eventing_headers)
 target_link_libraries(Runtime.ServerGC PRIVATE aotminipal nativeaot_cdac_contract_descriptor nativeaot_gc_wks_descriptor nativeaot_gc_svr_descriptor)
 
+# Localize hidden symbols in the libunwind object files to avoid duplicate
+# symbol errors when linking against another copy of libunwind (e.g. Android
+# NDK r29). This converts GLOBAL HIDDEN symbols to LOCAL without affecting
+# the runtime's own symbols.
+# See: https://github.com/dotnet/runtime/issues/121172
+if(LLVM_LIBUNWIND_ALL_SOURCES AND CMAKE_OBJCOPY)
+  add_library(libunwind_objects OBJECT ${LLVM_LIBUNWIND_ALL_SOURCES})
+
+  # Run objcopy --localize-hidden on each libunwind object file.
+  set(LOCALIZE_COMMANDS)
+  foreach(src ${LLVM_LIBUNWIND_ALL_SOURCES})
+    file(RELATIVE_PATH rel_src "/" "${src}")
+    set(obj_file "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/libunwind_objects.dir/./${rel_src}.o")
+    list(APPEND LOCALIZE_COMMANDS COMMAND ${CMAKE_OBJCOPY} --localize-hidden ${obj_file})
+  endforeach()
+
+  add_custom_target(localize_libunwind_symbols
+    ${LOCALIZE_COMMANDS}
+    DEPENDS libunwind_objects
+    COMMENT "Localizing hidden symbols in libunwind objects"
+  )
+  add_dependencies(Runtime.WorkstationGC localize_libunwind_symbols)
+  add_dependencies(Runtime.ServerGC localize_libunwind_symbols)
+  target_link_libraries(Runtime.WorkstationGC PRIVATE libunwind_objects)
+  target_link_libraries(Runtime.ServerGC PRIVATE libunwind_objects)
+endif()
+
 add_library(standalonegc-disabled STATIC ${STANDALONEGC_DISABLED_SOURCES})
 add_dependencies(standalonegc-disabled aot_eventing_headers)
 add_library(standalonegc-enabled STATIC ${STANDALONEGC_ENABLED_SOURCES})

--- a/src/coreclr/nativeaot/Runtime/localize-hidden-symbols.cmake
+++ b/src/coreclr/nativeaot/Runtime/localize-hidden-symbols.cmake
@@ -1,0 +1,9 @@
+# CMake script to run objcopy --localize-hidden on a list of object files.
+# Invoked via: cmake -DOBJCOPY=<path> -DOBJECT_FILES=<semicolon-separated-list> -P localize-hidden-symbols.cmake
+
+foreach(obj_file ${OBJECT_FILES})
+  execute_process(COMMAND ${OBJCOPY} --localize-hidden ${obj_file} RESULT_VARIABLE result)
+  if(NOT result EQUAL 0)
+    message(FATAL_ERROR "objcopy --localize-hidden failed on ${obj_file}")
+  endif()
+endforeach()

--- a/src/coreclr/nativeaot/Runtime/localize-hidden-symbols.cmake
+++ b/src/coreclr/nativeaot/Runtime/localize-hidden-symbols.cmake
@@ -1,9 +1,14 @@
-# CMake script to run objcopy --localize-hidden on a list of object files.
-# Invoked via: cmake -DOBJCOPY=<path> -DOBJECT_FILES=<semicolon-separated-list> -P localize-hidden-symbols.cmake
+# CMake script to copy object files and run objcopy --localize-hidden on the copies.
+# Invoked via: cmake -DOBJCOPY=<path> -DOBJECT_FILES=<semicolon-separated-list> -DOUTPUT_DIR=<dir> -P localize-hidden-symbols.cmake
+
+file(MAKE_DIRECTORY ${OUTPUT_DIR})
 
 foreach(obj_file ${OBJECT_FILES})
-  execute_process(COMMAND ${OBJCOPY} --localize-hidden ${obj_file} RESULT_VARIABLE result)
+  get_filename_component(obj_name "${obj_file}" NAME)
+  set(output_file "${OUTPUT_DIR}/${obj_name}")
+  file(COPY_FILE "${obj_file}" "${output_file}")
+  execute_process(COMMAND ${OBJCOPY} --localize-hidden ${output_file} RESULT_VARIABLE result)
   if(NOT result EQUAL 0)
-    message(FATAL_ERROR "objcopy --localize-hidden failed on ${obj_file}")
+    message(FATAL_ERROR "objcopy --localize-hidden failed on ${output_file}")
   endif()
 endforeach()


### PR DESCRIPTION
## Description

When NativeAOT is statically linked alongside another copy of libunwind (e.g. the Android NDK r29's `libunwind.a`), the `__unw_*` symbols in `libRuntime.WorkstationGC.a` clash with those in the NDK's archive, causing `ld.lld` duplicate symbol errors.

These symbols are `GLOBAL HIDDEN` — hidden visibility prevents export from the final `.so` but does not prevent duplicate detection during static linking. This PR builds the libunwind sources as a separate OBJECT library and runs `objcopy --localize-hidden` on those objects before they are archived into the runtime static libraries. This converts `GLOBAL HIDDEN` symbols to `LOCAL` in only the libunwind objects, without affecting the runtime's own `GLOBAL HIDDEN` symbols (like `RhInitialize`, `RhpNewFast`, etc.) that must remain globally visible for cross-object resolution.

Fixes #121172

> [!NOTE]
> This PR was created with assistance from AI.