### PR TITLE
Replace small stackallocs with collection literals

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.RSA.cs
+++ b/src/libraries/Common/src/Interop/Windows/BCrypt/Interop.BCryptEncryptDecrypt.RSA.cs
@@ -52,7 +52,7 @@ internal static partial class Interop
             BCryptEncryptFlags dwFlags)
         {
             // BCryptEncrypt does not accept null/0, only non-null/0.
-            ReadOnlySpan<byte> notNull = stackalloc byte[1];
+            ReadOnlySpan<byte> notNull = [0];
             scoped ReadOnlySpan<byte> effectiveSource;
 
             if (source.IsEmpty)

--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -464,7 +464,7 @@ namespace System
             // Adjust represents the number of characters over the formatting e.g. format string is "0000" and you are trying to
             // format 100000 (6 digits). Means adjust will be 2. On the other hand if you are trying to format 10 adjust will be
             // -2 and we'll need to fixup these digits with 0 padding if we have 0 formatting as in this example.
-            Span<int> thousandsSepPos = stackalloc int[4];
+            Span<int> thousandsSepPos = [0, 0, 0, 0];
             int thousandsSepCtr = -1;
 
             if (thousandSeps)

--- a/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLDecimal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/SQLTypes/SQLDecimal.cs
@@ -477,7 +477,7 @@ namespace System.Data.SqlTypes
             _data4 = s_uiZero;
         }
 
-        public unsafe SqlDecimal(decimal value)
+        public SqlDecimal(decimal value)
         {
             // set the null bit
             _bStatus = s_bNotNull;
@@ -490,7 +490,7 @@ namespace System.Data.SqlTypes
             // m_data1 = *pInt++; // lo part
             // m_data2 = *pInt++; // mid part
 
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.GetBits(value, bits);
             uint sgnscl;
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.cs
@@ -234,7 +234,7 @@ namespace System.Diagnostics
         ///  - '|a000b421-5d183ab6.1.8e2d4c28_' - Id of the grand child activity. It was started in another process and ends with '_'<para />
         /// 'a000b421-5d183ab6' is a <see cref="RootId"/> for the first Activity and all its children
         /// </example>
-        public unsafe string? Id
+        public string? Id
         {
             get
             {
@@ -243,7 +243,7 @@ namespace System.Diagnostics
                 if (_id == null && _spanId != null)
                 {
                     // Convert flags to binary.
-                    Span<char> flagsChars = stackalloc char[2];
+                    Span<char> flagsChars = ['\0', '\0'];
                     HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _w3CIdFlags), flagsChars, 0, HexConverter.Casing.Lower);
                     string id =
 #if NET
@@ -266,7 +266,7 @@ namespace System.Diagnostics
         /// <para/>
         /// See <see href="https://github.com/dotnet/runtime/blob/main/src/libraries/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md#id-format"/> for more details
         /// </summary>
-        public unsafe string? ParentId
+        public string? ParentId
         {
             get
             {
@@ -275,7 +275,7 @@ namespace System.Diagnostics
                 {
                     if (_parentSpanId != null)
                     {
-                        Span<char> flagsChars = stackalloc char[2];
+                        Span<char> flagsChars = ['\0', '\0'];
                         HexConverter.ToCharsBuffer((byte)((~ActivityTraceFlagsIsSet) & _parentTraceFlags), flagsChars, 0, HexConverter.Casing.Lower);
                         string parentId =
 #if NET
@@ -2019,12 +2019,12 @@ namespace System.Diagnostics
         /// This is exposed as CreateFromUtf8String, but we are modifying fields, so the code needs to be in a constructor.
         /// </summary>
         /// <param name="idData"></param>
-        private unsafe ActivityTraceId(ReadOnlySpan<byte> idData)
+        private ActivityTraceId(ReadOnlySpan<byte> idData)
         {
             if (idData.Length != 32)
                 throw new ArgumentOutOfRangeException(nameof(idData));
 
-            Span<ulong> span = stackalloc ulong[2];
+            Span<ulong> span = [0, 0];
 
             if (!Utf8Parser.TryParse(idData.Slice(0, 16), out span[0], out _, 'x'))
             {

--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.Tag.cs
@@ -142,7 +142,7 @@ namespace System.Formats.Cbor
             /// deconstructs a decimal value into its signed integral component and negative base-10 exponent
             public static void Deconstruct(decimal value, out decimal mantissa, out byte scale)
             {
-                Span<int> buf = stackalloc int[4];
+                Span<int> buf = [0, 0, 0, 0];
                 CborHelpers.GetBitsFromDecimal(value, buf);
 
                 int flags = buf[3];
@@ -154,7 +154,7 @@ namespace System.Formats.Cbor
             /// reconstructs a decimal value out of a signed integral component and a negative base-10 exponent
             private static decimal ReconstructFromNegativeScale(decimal mantissa, byte scale)
             {
-                Span<int> buf = stackalloc int[4];
+                Span<int> buf = [0, 0, 0, 0];
                 CborHelpers.GetBitsFromDecimal(mantissa, buf);
 
                 int flags = buf[3];

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/Zstandard/ZstandardStream.Decompress.cs
@@ -261,9 +261,9 @@ namespace System.IO.Compression
         /// <exception cref="InvalidDataException">The data is in an invalid format.</exception>
         /// <exception cref="ObjectDisposedException">The stream is disposed.</exception>
         /// <exception cref="IOException">Failed to decompress data from the underlying stream.</exception>
-        public override unsafe int ReadByte()
+        public override int ReadByte()
         {
-            Span<byte> singleByte = stackalloc byte[1];
+            Span<byte> singleByte = [0];
             int bytesRead = Read(singleByte);
             return bytesRead > 0 ? singleByte[0] : -1;
         }

--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/PipeReaderStream.cs
@@ -55,9 +55,9 @@ namespace System.IO.Pipelines
             return ReadInternal(new Span<byte>(buffer, offset, count));
         }
 
-        public override unsafe int ReadByte()
+        public override int ReadByte()
         {
-            Span<byte> oneByte = stackalloc byte[1];
+            Span<byte> oneByte = [0];
             return ReadInternal(oneByte) == 0 ? -1 : oneByte[0];
         }
 

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -973,9 +973,9 @@ namespace System.Linq.Expressions.Compiler
 
         #region Support for emitting constants
 
-        private static unsafe void EmitDecimal(this ILGenerator il, decimal value)
+        private static void EmitDecimal(this ILGenerator il, decimal value)
         {
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.GetBits(value, bits);
 
             int scale = (bits[3] & int.MaxValue) >> 16;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.cs
@@ -503,7 +503,7 @@ namespace System.Globalization
             // Change span to lower and convert to rune
             if (valueChars.Length == 2)
             {
-                Span<char> lowerChars = stackalloc char[2];
+                Span<char> lowerChars = ['\0', '\0'];
                 ToLower(valueChars, lowerChars);
                 return new Rune(lowerChars[0], lowerChars[1]);
             }
@@ -525,7 +525,7 @@ namespace System.Globalization
             // Change span to upper and convert to rune
             if (valueChars.Length == 2)
             {
-                Span<char> upperChars = stackalloc char[2];
+                Span<char> upperChars = ['\0', '\0'];
                 ToUpper(valueChars, upperChars);
                 return new Rune(upperChars[0], upperChars[1]);
             }
@@ -713,7 +713,7 @@ namespace System.Globalization
             return inputIndex;
         }
 
-        private unsafe int AddTitlecaseLetter(ref StringBuilder result, ref string input, int inputIndex, int charLen)
+        private int AddTitlecaseLetter(ref StringBuilder result, ref string input, int inputIndex, int charLen)
         {
             Debug.Assert(charLen == 1 || charLen == 2, "[TextInfo.AddTitlecaseLetter] CharUnicodeInfo.InternalGetUnicodeCategory returned an unexpected charLen!");
 
@@ -729,7 +729,7 @@ namespace System.Globalization
                 }
                 else
                 {
-                    Span<char> dst = stackalloc char[2];
+                    Span<char> dst = ['\0', '\0'];
                     ChangeCaseToUpper(src, dst);
                     result.Append(dst);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/UnmanagedMemoryAccessor.cs
@@ -460,7 +460,7 @@ namespace System.IO
         {
             EnsureSafeToWrite(position, sizeof(decimal));
 
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.TryGetBits(value, bits, out int intsWritten);
             Debug.Assert(intsWritten == 4);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/AssemblyName.cs
@@ -321,10 +321,10 @@ namespace System.Reflection
             return result;
         }
 
-        internal static unsafe void EscapeStringToBuilder(scoped ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder vsb)
+        internal static void EscapeStringToBuilder(scoped ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder vsb)
         {
             // Allocate enough stack space to hold any Rune's UTF8 encoding.
-            Span<byte> utf8Bytes = stackalloc byte[4];
+            Span<byte> utf8Bytes = [0, 0, 0, 0];
 
             while (!stringToEscape.IsEmpty)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Resources/ResourceReader.cs
@@ -554,7 +554,7 @@ namespace System.Resources
             }
         }
 
-        private unsafe object? _LoadObjectV1(int pos)
+        private object? _LoadObjectV1(int pos)
         {
             Debug.Assert(Monitor.IsEntered(this)); // uses _store
 
@@ -602,7 +602,7 @@ namespace System.Resources
 #if RESOURCES_EXTENSIONS
                 int[] bits = new int[4];
 #else
-                Span<int> bits = stackalloc int[4];
+                Span<int> bits = [0, 0, 0, 0];
 #endif
                 for (int i = 0; i < bits.Length; i++)
                     bits[i] = _store.ReadInt32();

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.cs
@@ -137,7 +137,7 @@ namespace System.Buffers
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && PackedSpanHelpers.PackedIndexOfIsSupported &&
                 maxInclusive < 128 && values.Length == 4 && minInclusive > 0)
             {
-                Span<char> copy = stackalloc char[4];
+                Span<char> copy = ['\0', '\0', '\0', '\0'];
                 values.CopyTo(copy);
                 copy.Sort();
 

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
@@ -326,13 +326,13 @@ namespace System.Buffers
             return result;
         }
 
-        private static unsafe void SurrogateToUpperNLS(char h, char l, out char hr, out char lr)
+        private static void SurrogateToUpperNLS(char h, char l, out char hr, out char lr)
         {
             Debug.Assert(char.IsHighSurrogate(h));
             Debug.Assert(char.IsLowSurrogate(l));
 
             ReadOnlySpan<char> chars = [h, l];
-            Span<char> destination = stackalloc char[2];
+            Span<char> destination = ['\0', '\0'];
 
             int written = Ordinal.ToUpperOrdinal(chars, destination);
             Debug.Assert(written == 2);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
@@ -219,7 +219,7 @@ namespace System.Text
             _leftoverByteCount = 0;
         }
 
-        internal unsafe int DrainLeftoverDataForGetCharCount(ReadOnlySpan<byte> bytes, out int bytesConsumed)
+        internal int DrainLeftoverDataForGetCharCount(ReadOnlySpan<byte> bytes, out int bytesConsumed)
         {
             // Quick check: we _should not_ have leftover fallback data from a previous invocation,
             // as we'd end up consuming any such data and would corrupt whatever Convert call happens
@@ -231,7 +231,7 @@ namespace System.Text
             // Copy the existing leftover data plus as many bytes as possible of the new incoming data
             // into a temporary concated buffer, then get its char count by decoding it.
 
-            Span<byte> combinedBuffer = stackalloc byte[4];
+            Span<byte> combinedBuffer = [0, 0, 0, 0];
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(GetLeftoverData(), bytes, combinedBuffer));
             int charCount = 0;
 
@@ -275,7 +275,7 @@ namespace System.Text
             return charCount;
         }
 
-        internal unsafe int DrainLeftoverDataForGetChars(ReadOnlySpan<byte> bytes, Span<char> chars, out int bytesConsumed)
+        internal int DrainLeftoverDataForGetChars(ReadOnlySpan<byte> bytes, Span<char> chars, out int bytesConsumed)
         {
             // Quick check: we _should not_ have leftover fallback data from a previous invocation,
             // as we'd end up consuming any such data and would corrupt whatever Convert call happens
@@ -287,7 +287,7 @@ namespace System.Text
             // Copy the existing leftover data plus as many bytes as possible of the new incoming data
             // into a temporary concated buffer, then transcode it from bytes to chars.
 
-            Span<byte> combinedBuffer = stackalloc byte[4];
+            Span<byte> combinedBuffer = [0, 0, 0, 0];
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(GetLeftoverData(), bytes, combinedBuffer));
             int charsWritten = 0;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.Internal.cs
@@ -97,14 +97,14 @@ namespace System.Text
         /// Returns <see langword="false"/> if the <see cref="Rune"/> cannot be represented in the
         /// current <see cref="Encoding"/>.
         /// </summary>
-        internal virtual unsafe bool TryGetByteCount(Rune value, out int byteCount)
+        internal virtual bool TryGetByteCount(Rune value, out int byteCount)
         {
             // Any production-quality type would override this method and provide a real
             // implementation, so we won't provide a base implementation. However, a
             // non-shipping slow reference implementation is provided below for convenience.
 
 #if false
-            Span<byte> bytes = stackalloc byte[4]; // max 4 bytes per input scalar
+            Span<byte> bytes = [0, 0, 0, 0]; // max 4 bytes per input scalar
 
             OperationStatus opStatus = EncodeRune(value, bytes, out byteCount);
             Debug.Assert(opStatus == OperationStatus.Done || opStatus == OperationStatus.InvalidData, "Unexpected return value.");

--- a/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
+++ b/src/libraries/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryWriter.cs
@@ -766,7 +766,7 @@ namespace System.Xml
             }
         }
 
-        public override unsafe void WriteDecimalText(decimal d)
+        public override void WriteDecimalText(decimal d)
         {
             if (BitConverter.IsLittleEndian)
             {
@@ -774,7 +774,7 @@ namespace System.Xml
             }
             else
             {
-                Span<int> bits = stackalloc int[4];
+                Span<int> bits = [0, 0, 0, 0];
                 decimal.TryGetBits(d, bits, out int intsWritten);
                 Debug.Assert(intsWritten == 4);
 
@@ -946,7 +946,7 @@ namespace System.Xml
             }
         }
 
-        public unsafe void WriteDecimalArray(ReadOnlySpan<decimal> items)
+        public void WriteDecimalArray(ReadOnlySpan<decimal> items)
         {
             if (BitConverter.IsLittleEndian)
             {
@@ -954,7 +954,7 @@ namespace System.Xml
             }
             else
             {
-                Span<int> bits = stackalloc int[4];
+                Span<int> bits = [0, 0, 0, 0];
                 WriteArrayInfo(XmlBinaryNodeType.DecimalTextWithEndElement, items.Length);
                 foreach (ref readonly decimal d in items)
                 {

--- a/src/libraries/System.Private.Uri/src/System/IriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IriHelper.cs
@@ -71,9 +71,9 @@ namespace System
 
         // IRI normalization for strings containing characters that are not allowed or
         // escaped characters that should be unescaped in the context of the specified Uri component.
-        public static unsafe void EscapeUnescapeIri(ref ValueStringBuilder dest, scoped ReadOnlySpan<char> span, bool isQuery)
+        public static void EscapeUnescapeIri(ref ValueStringBuilder dest, scoped ReadOnlySpan<char> span, bool isQuery)
         {
-            Span<byte> maxUtf8EncodedSpan = stackalloc byte[4];
+            Span<byte> maxUtf8EncodedSpan = [0, 0, 0, 0];
 
             for (int i = 0; (uint)i < (uint)span.Length; i++)
             {

--- a/src/libraries/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriHelper.cs
@@ -246,14 +246,14 @@ namespace System
             }
         }
 
-        private static unsafe void EscapeStringToBuilder(
+        private static void EscapeStringToBuilder(
             scoped ReadOnlySpan<char> stringToEscape, ref ValueStringBuilder vsb,
             SearchValues<char> noEscape, bool checkExistingEscaped)
         {
             Debug.Assert(!stringToEscape.IsEmpty && !noEscape.Contains(stringToEscape[0]));
 
             // Allocate enough stack space to hold any Rune's UTF8 encoding.
-            Span<byte> utf8Bytes = stackalloc byte[4];
+            Span<byte> utf8Bytes = [0, 0, 0, 0];
 
             while (!stringToEscape.IsEmpty)
             {

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/DecimalUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/DecimalUtilities.cs
@@ -5,10 +5,10 @@ namespace System.Reflection.Internal
 {
     internal static class DecimalUtilities
     {
-        public static unsafe int GetScale(this decimal value)
+        public static int GetScale(this decimal value)
         {
 #if NET
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.GetBits(value, bits);
             return unchecked((byte)(bits[3] >> 16));
 #else
@@ -16,10 +16,10 @@ namespace System.Reflection.Internal
 #endif
         }
 
-        public static unsafe void GetBits(this decimal value, out bool isNegative, out byte scale, out uint low, out uint mid, out uint high)
+        public static void GetBits(this decimal value, out bool isNegative, out byte scale, out uint low, out uint mid, out uint high)
         {
 #if NET
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.GetBits(value, bits);
 #else
             int[] bits = decimal.GetBits(value);

--- a/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
+++ b/src/libraries/System.Runtime.Numerics/src/System/Numerics/BigInteger.cs
@@ -249,10 +249,10 @@ namespace System.Numerics
             AssertValid();
         }
 
-        public unsafe BigInteger(decimal value)
+        public BigInteger(decimal value)
         {
             // First truncate to get scale to 0 and extract bits
-            Span<int> bits = stackalloc int[4];
+            Span<int> bits = [0, 0, 0, 0];
             decimal.GetBits(decimal.Truncate(value), bits);
 
             Debug.Assert(bits.Length == 4 && (bits[3] & DecimalScaleFactorMask) == 0);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHash.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/LiteHash.Windows.cs
@@ -113,7 +113,7 @@ namespace System.Security.Cryptography
             // does a reset.
             if ((_finishFlags & BCRYPT_HASH_DONT_RESET_FLAG) == BCRYPT_HASH_DONT_RESET_FLAG)
             {
-                Span<byte> buffer = stackalloc byte[1];
+                Span<byte> buffer = [0];
                 CheckStatus(Interop.BCrypt.BCryptFinishHash(_hashHandle, buffer, 0, dwFlags: 0));
             }
         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedNameBuilder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedNameBuilder.cs
@@ -204,7 +204,7 @@ namespace System.Security.Cryptography.X509Certificates
         /// will be normalized to upper case characters.
         /// </para>
         /// </remarks>
-        public unsafe void AddCountryOrRegion(string twoLetterCode)
+        public void AddCountryOrRegion(string twoLetterCode)
         {
             // ITU T-REC X.520 Annex A:
             // id-at-countryName
@@ -226,7 +226,7 @@ namespace System.Security.Cryptography.X509Certificates
                 throw new ArgumentException(SR.Argument_X500_InvalidCountryOrRegion, nameof(twoLetterCode));
             }
 
-            Span<char> fixupTwoLetterCode = stackalloc char[2];
+            Span<char> fixupTwoLetterCode = ['\0', '\0'];
             int written = twoLetterCodeSpan.ToUpperInvariant(fixupTwoLetterCode);
             Debug.Assert(written == 2);
 

--- a/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Writer/Utf8JsonWriter.WriteValues.StringSegment.cs
@@ -61,14 +61,14 @@ namespace System.Text.Json
             }
         }
 
-        private unsafe void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<char> value, bool isFinalSegment)
+        private void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<char> value, bool isFinalSegment)
         {
             Debug.Assert(HasPartialStringData);
             Debug.Assert(_enclosingContainer == EnclosingContainerType.Utf16StringSequence);
 
             scoped ReadOnlySpan<char> partialStringDataBuffer = PartialUtf16StringData;
 
-            Span<char> combinedBuffer = stackalloc char[2];
+            Span<char> combinedBuffer = ['\0', '\0'];
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, value, combinedBuffer));
 
             switch (Rune.DecodeFromUtf16(combinedBuffer, out _, out int charsConsumed))
@@ -229,14 +229,14 @@ namespace System.Text.Json
             }
         }
 
-        private unsafe void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<byte> utf8Value, bool isFinalSegment)
+        private void WriteStringSegmentWithLeftover(scoped ReadOnlySpan<byte> utf8Value, bool isFinalSegment)
         {
             Debug.Assert(HasPartialStringData);
             Debug.Assert(_enclosingContainer == EnclosingContainerType.Utf8StringSequence);
 
             scoped ReadOnlySpan<byte> partialStringDataBuffer = PartialUtf8StringData;
 
-            Span<byte> combinedBuffer = stackalloc byte[4];
+            Span<byte> combinedBuffer = [0, 0, 0, 0];
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, utf8Value, combinedBuffer));
 
             switch (Rune.DecodeFromUtf8(combinedBuffer, out _, out int bytesConsumed))
@@ -396,14 +396,14 @@ namespace System.Text.Json
             }
         }
 
-        private unsafe void WriteBase64StringSegmentWithLeftover(scoped ReadOnlySpan<byte> bytes, bool isFinalSegment)
+        private void WriteBase64StringSegmentWithLeftover(scoped ReadOnlySpan<byte> bytes, bool isFinalSegment)
         {
             Debug.Assert(HasPartialStringData);
             Debug.Assert(_enclosingContainer == EnclosingContainerType.Base64StringSequence);
 
             scoped ReadOnlySpan<byte> partialStringDataBuffer = PartialBase64StringData;
 
-            Span<byte> combinedBuffer = stackalloc byte[3];
+            Span<byte> combinedBuffer = [0, 0, 0];
             combinedBuffer = combinedBuffer.Slice(0, ConcatInto(partialStringDataBuffer, bytes, combinedBuffer));
             if (combinedBuffer.Length is 3)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -5951,7 +5951,7 @@ namespace System.Text.RegularExpressions
             // we get smaller code), and it's what we'd do for the fallback (which we get to avoid generating) as part of CharInClass.
             // Unlike the source generator, however, we only handle the case of a single UnicodeCategory: the source generator is able
             // to rely on C# compiler optimizations to handle dealing with multiple values efficiently.
-            Span<UnicodeCategory> categories = stackalloc UnicodeCategory[1]; // handle the case of one and only one category
+            Span<UnicodeCategory> categories = [default]; // handle the case of one and only one category
             if (RegexCharClass.TryGetOnlyCategories(charClass, categories, out int numCategories, out bool negated))
             {
                 // char.GetUnicodeCategory(ch) == category
@@ -5969,7 +5969,7 @@ namespace System.Text.RegularExpressions
 
             // Next, if there's only 2 or 3 chars in the set (fairly common due to the sets we create for prefixes),
             // it's cheaper and smaller to compare against each than it is to use a lookup table.
-            Span<char> setChars = stackalloc char[3];
+            Span<char> setChars = ['\0', '\0', '\0'];
             int numChars = RegexCharClass.GetSetChars(charClass, setChars);
             if (numChars is 2 or 3)
             {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -1379,7 +1379,7 @@ namespace System.Text.RegularExpressions
             // by sets that can be merged.  Third, it reduces the amount of duplicated comparisons required
             // if we end up backtracking into subsequent branches.
             // e.g. abc|ade => a(?bc|de)
-            static unsafe RegexNode ExtractCommonPrefixText(RegexNode alternation)
+            static RegexNode ExtractCommonPrefixText(RegexNode alternation)
             {
                 Debug.Assert(alternation.Kind == RegexNodeKind.Alternate);
                 Debug.Assert(alternation.Children is List<RegexNode> { Count: >= 2 });
@@ -1398,7 +1398,7 @@ namespace System.Text.RegularExpressions
                     return alternation;
                 }
 
-                Span<char> scratchChar = stackalloc char[1];
+                Span<char> scratchChar = ['\0'];
                 for (int startingIndex = 0; startingIndex < children.Count - 1; startingIndex++)
                 {
                     // Process the first branch to get the maximum possible common string.
@@ -3107,7 +3107,7 @@ namespace System.Text.RegularExpressions
             var vsb = new ValueStringBuilder(stackalloc char[32]);
 
             // We're looking in particular for sets of ASCII characters, so we focus only on sets with two characters in them, e.g. [Aa].
-            Span<char> twoChars = stackalloc char[2];
+            Span<char> twoChars = ['\0', '\0'];
 
             // Iterate from the child index to the exclusive upper bound.
             int i = childIndex;


### PR DESCRIPTION
Replace very small stackallocs with collection literals (since stackallocs require unsafe context).