### PR TITLE
Fix utf8 conversions for s390x

### DIFF
--- a/src/coreclr/pal/src/locale/unicode.cpp
+++ b/src/coreclr/pal/src/locale/unicode.cpp
@@ -61,6 +61,7 @@ MultiByteToWideChar(
         IN int cchWideChar)
 {
     INT retval =0;
+    dwFlags |= MINIPAL_TREAT_AS_LITTLE_ENDIAN;
 
     PERF_ENTRY(MultiByteToWideChar);
     ENTRY("MultiByteToWideChar(CodePage=%u, dwFlags=%#x, lpMultiByteStr=%p (%s),"
@@ -68,7 +69,7 @@ MultiByteToWideChar(
     CodePage, dwFlags, lpMultiByteStr?lpMultiByteStr:"NULL", lpMultiByteStr?lpMultiByteStr:"NULL",
     cbMultiByte, lpWideCharStr, cchWideChar);
 
-    if (dwFlags & ~(MB_ERR_INVALID_CHARS | MB_PRECOMPOSED))
+    if (dwFlags & ~(MB_ERR_INVALID_CHARS | MB_PRECOMPOSED | MINIPAL_TREAT_AS_LITTLE_ENDIAN))
     {
         ASSERT("Error dwFlags(0x%x) parameter is invalid\n", dwFlags);
         SetLastError(ERROR_INVALID_FLAGS);
@@ -137,6 +138,7 @@ WideCharToMultiByte(
     INT retval =0;
     char defaultChar = '?';
     BOOL usedDefaultChar = FALSE;
+    dwFlags |= MINIPAL_TREAT_AS_LITTLE_ENDIAN;
 
     PERF_ENTRY(WideCharToMultiByte);
     ENTRY("WideCharToMultiByte(CodePage=%u, dwFlags=%#x, lpWideCharStr=%p (%S), "
@@ -146,7 +148,7 @@ WideCharToMultiByte(
           cchWideChar, lpMultiByteStr, cbMultiByte,
           lpDefaultChar, lpUsedDefaultChar);
 
-    if (dwFlags & ~WC_NO_BEST_FIT_CHARS)
+    if (dwFlags & ~(WC_NO_BEST_FIT_CHARS | MINIPAL_TREAT_AS_LITTLE_ENDIAN))
     {
         ERROR("dwFlags %d invalid\n", dwFlags);
         SetLastError(ERROR_INVALID_FLAGS);

--- a/src/native/minipal/utf8.c
+++ b/src/native/minipal/utf8.c
@@ -620,14 +620,14 @@ static size_t GetCharCount(UTF8Encoding* self, unsigned char* bytes, size_t coun
         LongCodeWithMask32 :
 #if BIGENDIAN
         // be careful about the sign extension
-        if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
+        if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
         else
 #endif
         ch &= 0xFF;
 
         LongCodeWithMask16:
 #if BIGENDIAN
-        if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 8);
+        if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 8);
         else
 #endif
         ch &= 0xFF;
@@ -1061,7 +1061,7 @@ static size_t GetChars(UTF8Encoding* self, unsigned char* bytes, size_t byteCoun
 
                 // Unfortunately, this is endianness sensitive
 #if BIGENDIAN
-                if (!self->treatAsLE)
+                if (self->treatAsLE)
                 {
                     *pTarget = (CHAR16_T)((ch >> 8) & 0x7F);
                     pSrc += 2;
@@ -1093,7 +1093,7 @@ static size_t GetChars(UTF8Encoding* self, unsigned char* bytes, size_t byteCoun
 
                 // Unfortunately, this is endianness sensitive
 #if BIGENDIAN
-                if (!self->treatAsLE)
+                if (self->treatAsLE)
                 {
                     *pTarget = (CHAR16_T)((ch >> 24) & 0x7F);
                     *(pTarget + 1) = (CHAR16_T)((ch >> 16) & 0x7F);
@@ -1126,14 +1126,14 @@ static size_t GetChars(UTF8Encoding* self, unsigned char* bytes, size_t byteCoun
             LongCodeWithMask32 :
 #if BIGENDIAN
             // be careful about the sign extension
-            if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
+            if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
             else
 #endif
             ch &= 0xFF;
 
             LongCodeWithMask16:
 #if BIGENDIAN
-            if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 8);
+            if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 8);
             else
 #endif
             ch &= 0xFF;
@@ -1599,7 +1599,7 @@ static size_t GetBytes(UTF8Encoding* self, CHAR16_T* chars, size_t charCount, un
 
                 // Unfortunately, this is endianness sensitive
 #if BIGENDIAN
-                if (!self->treatAsLE)
+                if (self->treatAsLE)
                 {
                     *pTarget = (unsigned char)(ch >> 16);
                     *(pTarget + 1) = (unsigned char)ch;
@@ -1624,7 +1624,7 @@ static size_t GetBytes(UTF8Encoding* self, CHAR16_T* chars, size_t charCount, un
         LongCodeWithMask:
 #if BIGENDIAN
         // be careful about the sign extension
-        if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
+        if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
         else
 #endif
         ch = (CHAR16_T)ch;
@@ -2002,7 +2002,7 @@ static size_t GetByteCount(UTF8Encoding* self, CHAR16_T *chars, size_t count)
         LongCodeWithMask:
 #if BIGENDIAN
         // be careful about the sign extension
-        if (!self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
+        if (self->treatAsLE) ch = (int)(((unsigned int)ch) >> 16);
         else
 #endif
         ch = (CHAR16_T)ch;


### PR DESCRIPTION
while adding eventpipe support for s390x in microsoft/perfview I came across some bugs where string utf8_to_utf16 convertsion file was incorrect in the .nettrace file for s390x.
 
here we set the MINIPAL_TREAT_AS_LITTLE_ENDIAN flags 
https://github.com/dotnet/runtime/blob/99f87de9b1deedd54f89389ffdbddaa709d5d18e/src/native/eventpipe/ep-string.c#L13-L41

and here we invalidate the flag even if the flag is set.
https://github.com/dotnet/runtime/blob/main/src/native/minipal/utf8.c#L1095-L1110