### PR TITLE
Use cached continuation in Await as well when used with ValueTaskSource

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -378,7 +378,6 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(vtsCont);
         }
 
-        // same as above, but with continuation context capture.
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         private static unsafe void AwaitValueTaskSource(object source, short token)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -400,9 +400,9 @@ namespace System.Runtime.CompilerServices
             vtsCont.Initialize(source, token);
             vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
-            // capture continuation context. (this is the difference from the transparent helper)
-            // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
-            CaptureContinuationContext(ref vtsCont.ContinuationContext, ref vtsCont.Flags);
+            // We only need to capture flags.
+            // When needed, VTS will take the scheduling context captured in the "state".
+            CaptureContinuationContextFlags(ref vtsCont.Flags);
 
             sentinelContinuation.Next = vtsCont;
             state.StackState->ValueTaskContinuation = vtsCont;
@@ -459,8 +459,9 @@ namespace System.Runtime.CompilerServices
             vtsCont.Initialize<T>(source, token);
             vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
-            // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
-            CaptureContinuationContext(ref vtsCont.ContinuationContext, ref vtsCont.Flags);
+            // We only need to capture flags.
+            // When needed, VTS will take the scheduling context captured in the "state".
+            CaptureContinuationContextFlags(ref vtsCont.Flags);
 
             sentinelContinuation.Next = vtsCont;
             state.StackState->ValueTaskContinuation = vtsCont;
@@ -1200,6 +1201,26 @@ namespace System.Runtime.CompilerServices
             {
                 flags |= ContinuationFlags.ContinueOnCapturedTaskScheduler;
                 continuationContext = sched;
+                return;
+            }
+
+            flags |= ContinuationFlags.ContinueOnThreadPool;
+        }
+
+        // Same as above, but only captures flags
+        private static void CaptureContinuationContextFlags(ref ContinuationFlags flags)
+        {
+            SynchronizationContext? syncCtx = Thread.CurrentThreadAssumedInitialized._synchronizationContext;
+            if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))
+            {
+                flags |= ContinuationFlags.ContinueOnCapturedSynchronizationContext;
+                return;
+            }
+
+            TaskScheduler? sched = TaskScheduler.InternalCurrent;
+            if (sched != null && sched != TaskScheduler.Default)
+            {
+                flags |= ContinuationFlags.ContinueOnCapturedTaskScheduler;
                 return;
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -378,6 +378,38 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(vtsCont);
         }
 
+        // same as above, but with continuation context capture.
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        private static unsafe void AwaitValueTaskSource(object source, short token)
+        {
+            ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
+            Continuation? sentinelContinuation = state.SentinelContinuation ??= new Continuation();
+
+            ValueTaskContinuation? vtsCont = state.CachedValueTaskContinuation;
+            if (vtsCont != null)
+            {
+                state.CachedValueTaskContinuation = null;
+            }
+            else
+            {
+                vtsCont = new ValueTaskContinuation();
+            }
+
+            Debug.Assert(source != null);
+            vtsCont.Initialize(source, token);
+
+            // capture continuation context. (this is the difference from the transparent helper)
+            // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
+            CaptureContinuationContext(ref vtsCont.ContinuationContext, ref vtsCont.Flags);
+
+            sentinelContinuation.Next = vtsCont;
+            state.StackState->ValueTaskContinuation = vtsCont;
+
+            state.CaptureContexts();
+            AsyncSuspend(vtsCont);
+        }
+
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         private static unsafe void TransparentAwaitValueTaskOfT<T>(ValueTask<T> valueTask)
@@ -397,6 +429,36 @@ namespace System.Runtime.CompilerServices
 
             Debug.Assert(valueTask._obj != null);
             vtsCont.Initialize<T>(valueTask._obj, valueTask._token);
+
+            sentinelContinuation.Next = vtsCont;
+            state.StackState->ValueTaskContinuation = vtsCont;
+
+            state.CaptureContexts();
+            AsyncSuspend(vtsCont);
+        }
+
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        private static unsafe void AwaitValueTaskSourceOfT<T>(object source, short token)
+        {
+            ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
+            Continuation? sentinelContinuation = state.SentinelContinuation ??= new Continuation();
+
+            ValueTaskContinuation? vtsCont = state.CachedValueTaskContinuation;
+            if (vtsCont != null)
+            {
+                state.CachedValueTaskContinuation = null;
+            }
+            else
+            {
+                vtsCont = new ValueTaskContinuation();
+            }
+
+            Debug.Assert(source != null);
+            vtsCont.Initialize<T>(source, token);
+
+            // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
+            CaptureContinuationContext(ref vtsCont.ContinuationContext, ref vtsCont.Flags);
 
             sentinelContinuation.Next = vtsCont;
             state.StackState->ValueTaskContinuation = vtsCont;
@@ -493,12 +555,12 @@ namespace System.Runtime.CompilerServices
 
                 // Head continuation should be the result of async call to AwaitAwaiter or UnsafeAwaitAwaiter.
                 // These never have special continuation context handling.
+                // Except for the scenario with ValueTaskContinuation that wraps ValueTaskSource
+                // which can capture continuation context.
                 const ContinuationFlags continueFlags =
                     ContinuationFlags.ContinueOnCapturedSynchronizationContext |
                     ContinuationFlags.ContinueOnThreadPool |
                     ContinuationFlags.ContinueOnCapturedTaskScheduler;
-
-                Debug.Assert((headContinuation.Flags & continueFlags) == 0);
 
                 SetContinuationState(headContinuation);
 
@@ -506,10 +568,12 @@ namespace System.Runtime.CompilerServices
                 {
                     if (stackState->CriticalNotifier is { } critNotifier)
                     {
+                        Debug.Assert((headContinuation.Flags & continueFlags) == 0);
                         critNotifier.UnsafeOnCompleted(GetContinuationAction());
                     }
                     else if (stackState->TaskNotifier is { } taskNotifier)
                     {
+                        Debug.Assert((headContinuation.Flags & continueFlags) == 0);
                         // Runtime async callable wrapper for task returning
                         // method. This implements the context transparent
                         // forwarding and makes these wrappers minimal cost.
@@ -525,6 +589,7 @@ namespace System.Runtime.CompilerServices
                         Debug.Assert(source != null);
                         if (source is Task t)
                         {
+                            Debug.Assert((headContinuation.Flags & continueFlags) == 0);
                             if (!t.TryAddCompletionAction(this))
                             {
                                 ThreadPool.UnsafeQueueUserWorkItemInternal(this, preferLocal: true);
@@ -541,17 +606,17 @@ namespace System.Runtime.CompilerServices
                             // the continuation chain builds from the innermost frame out and at the time when the
                             // notifier is created we do not know yet if the caller wants to continue on a context.
 
-                            // Skip to a nontransparent/user continuation. Such continuaton must exist.
+                            // Skip to a nontransparent/user continuation. Such continuation must exist.
                             // Since we see a VTS notifier, something was directly or indirectly
                             // awaiting an async thunk for a ValueTask-returning method.
                             // That can only happen in nontransparent/user code.
-                            Continuation nextUserContinuation = valueTaskSourceCont.Next!;
-                            while ((nextUserContinuation.Flags & continueFlags) == 0 && nextUserContinuation.Next != null)
+                            Continuation contWithContinueFlags = valueTaskSourceCont;
+                            while ((contWithContinueFlags.Flags & continueFlags) == 0 && contWithContinueFlags.Next != null)
                             {
-                                nextUserContinuation = nextUserContinuation.Next;
+                                contWithContinueFlags = contWithContinueFlags.Next;
                             }
 
-                            ContinuationFlags continuationFlags = nextUserContinuation.Flags;
+                            ContinuationFlags continuationFlags = contWithContinueFlags.Flags;
                             const ContinuationFlags continueOnContextFlags =
                                 ContinuationFlags.ContinueOnCapturedSynchronizationContext |
                                 ContinuationFlags.ContinueOnCapturedTaskScheduler;
@@ -564,7 +629,7 @@ namespace System.Runtime.CompilerServices
                             }
 
                             // Clear continuation flags, so that continuation runs transparently
-                            nextUserContinuation.Flags &= ~continueFlags;
+                            contWithContinueFlags.Flags &= ~continueFlags;
 
                             valueTaskSourceCont.OnCompletedValueTaskSource(
                                 source,
@@ -576,6 +641,7 @@ namespace System.Runtime.CompilerServices
                     }
                     else
                     {
+                        Debug.Assert((headContinuation.Flags & continueFlags) == 0);
                         Debug.Assert(stackState->Notifier != null);
                         stackState->Notifier!.OnCompleted(GetContinuationAction());
                     }
@@ -1117,7 +1183,7 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        private static void CaptureContinuationContext(ref object continuationContext, ref ContinuationFlags flags)
+        private static void CaptureContinuationContext(ref object? continuationContext, ref ContinuationFlags flags)
         {
             SynchronizationContext? syncCtx = Thread.CurrentThreadAssumedInitialized._synchronizationContext;
             if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -380,7 +380,7 @@ namespace System.Runtime.CompilerServices
 
         [BypassReadyToRun]
         [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
-        private static unsafe void TransparentAwaitValueTaskOfT<T>(ValueTask<T?> valueTask)
+        private static unsafe void TransparentAwaitValueTaskOfT<T>(ValueTask<T> valueTask)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
             Continuation? sentinelContinuation = state.SentinelContinuation ??= new Continuation();

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -398,11 +398,10 @@ namespace System.Runtime.CompilerServices
 
             Debug.Assert(source != null);
             vtsCont.Initialize(source, token);
-            vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
             // We only need to capture flags.
-            // When needed, VTS will take the scheduling context captured in the "state".
-            CaptureContinuationContextFlags(ref vtsCont.Flags);
+            // If needed, VTS will use the scheduling context captured in the "state".
+            CaptureContinuationContextFlags(ref vtsCont.Flags, state.CurrentThread!);
 
             sentinelContinuation.Next = vtsCont;
             state.StackState->ValueTaskContinuation = vtsCont;
@@ -457,11 +456,10 @@ namespace System.Runtime.CompilerServices
 
             Debug.Assert(source != null);
             vtsCont.Initialize<T>(source, token);
-            vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
             // We only need to capture flags.
-            // When needed, VTS will take the scheduling context captured in the "state".
-            CaptureContinuationContextFlags(ref vtsCont.Flags);
+            // If needed, VTS will use the scheduling context captured in the "state".
+            CaptureContinuationContextFlags(ref vtsCont.Flags, state.CurrentThread!);
 
             sentinelContinuation.Next = vtsCont;
             state.StackState->ValueTaskContinuation = vtsCont;
@@ -559,7 +557,7 @@ namespace System.Runtime.CompilerServices
                 // Head continuation should be the result of async call to AwaitAwaiter or UnsafeAwaitAwaiter.
                 // These never have special continuation context handling.
                 // Except for the scenario with ValueTaskContinuation that wraps ValueTaskSource
-                // which can capture continuation context.
+                // which can capture continuation context flags.
                 const ContinuationFlags continueFlags =
                     ContinuationFlags.ContinueOnCapturedSynchronizationContext |
                     ContinuationFlags.ContinueOnThreadPool |
@@ -611,8 +609,9 @@ namespace System.Runtime.CompilerServices
 
                             // Skip to a nontransparent/user continuation. Such continuation must exist.
                             // Since we see a VTS notifier, something was directly or indirectly
-                            // awaiting an async thunk for a ValueTask-returning method.
-                            // That can only happen in nontransparent/user code.
+                            // awaiting either an async thunk for a ValueTask-returning method or
+                            // the direct AsyncHelpers.Await(ValueTask/ValueTask<T>) path.
+                            // In either case, that can only happen in nontransparent/user code.
                             Continuation contWithContinueFlags = valueTaskSourceCont;
                             while ((contWithContinueFlags.Flags & continueFlags) == 0 && contWithContinueFlags.Next != null)
                             {
@@ -1208,9 +1207,9 @@ namespace System.Runtime.CompilerServices
         }
 
         // Same as above, but only captures flags
-        private static void CaptureContinuationContextFlags(ref ContinuationFlags flags)
+        private static void CaptureContinuationContextFlags(ref ContinuationFlags flags, Thread currentThread)
         {
-            SynchronizationContext? syncCtx = Thread.CurrentThreadAssumedInitialized._synchronizationContext;
+            SynchronizationContext? syncCtx = currentThread._synchronizationContext;
             if (syncCtx != null && syncCtx.GetType() != typeof(SynchronizationContext))
             {
                 flags |= ContinuationFlags.ContinueOnCapturedSynchronizationContext;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -380,7 +380,7 @@ namespace System.Runtime.CompilerServices
 
         // same as above, but with continuation context capture.
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         private static unsafe void AwaitValueTaskSource(object source, short token)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -412,7 +412,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         private static unsafe void TransparentAwaitValueTaskOfT<T>(ValueTask<T> valueTask)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -380,7 +380,7 @@ namespace System.Runtime.CompilerServices
 
         // same as above, but with continuation context capture.
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.Async)]
         private static unsafe void AwaitValueTaskSource(object source, short token)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -398,6 +398,7 @@ namespace System.Runtime.CompilerServices
 
             Debug.Assert(source != null);
             vtsCont.Initialize(source, token);
+            vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
             // capture continuation context. (this is the difference from the transparent helper)
             // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
@@ -411,7 +412,7 @@ namespace System.Runtime.CompilerServices
         }
 
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.Async)]
         private static unsafe void TransparentAwaitValueTaskOfT<T>(ValueTask<T> valueTask)
         {
             ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
@@ -456,6 +457,7 @@ namespace System.Runtime.CompilerServices
 
             Debug.Assert(source != null);
             vtsCont.Initialize<T>(source, token);
+            vtsCont.ExecutionContext = ExecutionContext.CaptureForSuspension(state.CurrentThread!);
 
             // CONSIDER: We capture ContinuationContext for consistency, but we only need flags.
             CaptureContinuationContext(ref vtsCont.ContinuationContext, ref vtsCont.Flags);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
@@ -105,7 +105,6 @@ namespace System.Runtime.CompilerServices
                 {
                     var vtsCont = (ValueTaskContinuation)cont;
                     vtsCont.Next = null;
-                    vtsCont.ContinuationContext = null;
 
                     const ContinuationFlags continueFlags =
                         ContinuationFlags.ContinueOnCapturedSynchronizationContext |

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
@@ -105,6 +105,14 @@ namespace System.Runtime.CompilerServices
                 {
                     var vtsCont = (ValueTaskContinuation)cont;
                     vtsCont.Next = null;
+
+                    const ContinuationFlags continueFlags =
+                        ContinuationFlags.ContinueOnCapturedSynchronizationContext |
+                        ContinuationFlags.ContinueOnThreadPool |
+                        ContinuationFlags.ContinueOnCapturedTaskScheduler;
+
+                    vtsCont.Flags &= ~continueFlags;
+
                     t_runtimeAsyncAwaitState.CachedValueTaskContinuation = vtsCont;
 
                     vtsCont.GetResult(ref result);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.ValueTaskContinuation.cs
@@ -105,13 +105,14 @@ namespace System.Runtime.CompilerServices
                 {
                     var vtsCont = (ValueTaskContinuation)cont;
                     vtsCont.Next = null;
+                    vtsCont.ContinuationContext = null;
 
                     const ContinuationFlags continueFlags =
                         ContinuationFlags.ContinueOnCapturedSynchronizationContext |
                         ContinuationFlags.ContinueOnThreadPool |
                         ContinuationFlags.ContinueOnCapturedTaskScheduler;
 
-                    vtsCont.Flags &= ~continueFlags;
+                    Debug.Assert((vtsCont.Flags & continueFlags) == 0);
 
                     t_runtimeAsyncAwaitState.CachedValueTaskContinuation = vtsCont;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -100,20 +100,25 @@ namespace System.Runtime.CompilerServices
         /// <param name="task">The value task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         [StackTraceHidden]
         public static T Await<T>(ValueTask<T> task)
         {
-            if (task.IsCompleted)
+            if (!task.IsCompleted)
             {
-                return task.Result;
+                if (task._obj is Task<T> t)
+                {
+                    TailAwait();
+                    Await(t);
+                }
+                else
+                {
+                    TailAwait();
+                    AwaitValueTaskSourceOfT<T>(task._obj!, task._token);
+                }
             }
 
-            TailAwait();
-            TransparentAwaitValueTaskOfT(task);
-
-            // unreachable
-            while (true) ;
+            return task.Result;
         }
 
         /// <summary>
@@ -122,18 +127,25 @@ namespace System.Runtime.CompilerServices
         /// <param name="task">The task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
         [StackTraceHidden]
         public static void Await(ValueTask task)
         {
-            if (task.IsCompleted)
+            if (!task.IsCompleted)
             {
-                task.ThrowIfCompletedUnsuccessfully();
-                return;
+                if (task._obj is Task t)
+                {
+                    TailAwait();
+                    Await(t);
+                }
+                else
+                {
+                    TailAwait();
+                    AwaitValueTaskSource(task._obj!, task._token);
+                }
             }
 
-            TailAwait();
-            TransparentAwaitValueTask(task);
+            task.ThrowIfCompletedUnsuccessfully();
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -104,13 +104,16 @@ namespace System.Runtime.CompilerServices
         [StackTraceHidden]
         public static T Await<T>(ValueTask<T> task)
         {
-            ValueTaskAwaiter<T> awaiter = task.GetAwaiter();
-            if (!awaiter.IsCompleted)
+            if (task.IsCompleted)
             {
-                UnsafeAwaitAwaiter(awaiter);
+                return task.Result;
             }
 
-            return awaiter.GetResult();
+            TailAwait();
+            TransparentAwaitValueTaskOfT(task);
+
+            // unreachable
+            while (true) ;
         }
 
         /// <summary>
@@ -123,13 +126,14 @@ namespace System.Runtime.CompilerServices
         [StackTraceHidden]
         public static void Await(ValueTask task)
         {
-            ValueTaskAwaiter awaiter = task.GetAwaiter();
-            if (!awaiter.IsCompleted)
+            if (task.IsCompleted)
             {
-                UnsafeAwaitAwaiter(awaiter);
+                task.ThrowIfCompletedUnsuccessfully();
+                return;
             }
 
-            awaiter.GetResult();
+            TailAwait();
+            TransparentAwaitValueTask(task);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -100,7 +100,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="task">The value task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.Async)]
         [StackTraceHidden]
         public static T Await<T>(ValueTask<T> task)
         {
@@ -127,7 +127,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="task">The task to await.</param>
         [Intrinsic]
         [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.Async)]
+        [MethodImpl(MethodImplOptions.Async)]
         [StackTraceHidden]
         public static void Await(ValueTask task)
         {


### PR DESCRIPTION

Same idea as in #127973, but applied when the actual Await is used (not a thunk).

With the original repro that I was looking at, merging of #127973 helped to reduce Gen0 GCs from ~ 15/sec to ~ 12/sec. 
Alocations went down but not completely, because of code like the following piece in the `DoReceive()` loop and possibly in other places. This pattern still churns continuations:

https://github.com/dotnet/aspnetcore/blob/c0c2230799a3f876aa673a66bc008bf9b803acac/src/Servers/Kestrel/Transport.Sockets/src/Internal/SocketConnection.cs#L173-L182

```cs
                var flushTask = Input.FlushAsync();

                var paused = !flushTask.IsCompleted;

                if (paused)
                {
                    SocketsLog.ConnectionPause(_logger, this);
                }

                var result = await flushTask;
```

Because `flushTask` is not a method, the `await` does not go through a thunk which could reuse the continuation. We call the actual `Await` in this case and it suspends/allocates.

The change in this PR uses the same approach as in the thunk, but applied to the Await, when awaiting a ValueTaskSource.

With this change we get to ~ 2 Gen0/sec in the repro - on par with net10.