### PR TITLE
JIT: Transform floating SELECT(a < b, a, b) to NativeMin(a, b)

### DIFF
--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -637,19 +637,19 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
         }
     }
 
-    // We only produce float SELECTs for optimization into non-SELECTs, otherwise bail
-    if (varTypeIsFloating(select))
-    {
-        return true;
-    }
-
-#ifdef TARGET_RISCV64
     if (select->OperIs(GT_SELECT))
     {
+#ifdef TARGET_RISCV64
         JITDUMP("Skipping if-conversion that could not be optimized to ordinary operations\n");
         return true;
-    }
 #endif
+
+        // We only produce float SELECTs for optimization into non-SELECTs, otherwise bail
+        if (varTypeIsFloating(select))
+        {
+            return true;
+        }
+    }
 
     // Use the SELECT as the source of the Then STORE/RETURN.
     m_thenOperation.node->AddAllEffectsFlags(select);
@@ -976,22 +976,23 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
 GenTree* OptIfConversionDsc::TrySelectToMinMax(GenTreeConditional* select)
 {
 #ifdef TARGET_XARCH
-    GenTree* condInput = select->gtCond;
+    GenTree* condInput  = select->gtCond;
     GenTree* trueInput  = select->gtOp1;
     GenTree* falseInput = select->gtOp2;
-    
-    if (!varTypeIsFloating(select) || !varTypeIsFloating(condInput->gtGetOp1()) || !varTypeIsFloating(condInput->gtGetOp2()))
+
+    if (!varTypeIsFloating(select) || !varTypeIsFloating(condInput->gtGetOp1()) ||
+        !varTypeIsFloating(condInput->gtGetOp2()))
     {
         return nullptr;
     }
-    
+
     GenCondition cond = GenCondition::FromFloatRelop(condInput);
     if (cond.IsUnordered() || !cond.Is(GenCondition::Code::FLT, GenCondition::Code::FGT))
     {
         return nullptr;
     }
 
-    bool isMax = cond.Is(GenCondition::Code::FGT);
+    bool isMax    = cond.Is(GenCondition::Code::FGT);
     bool reversed = !GenTree::Compare(trueInput, condInput->gtGetOp1());
     if (reversed)
     {
@@ -1000,7 +1001,7 @@ GenTree* OptIfConversionDsc::TrySelectToMinMax(GenTreeConditional* select)
         std::swap(trueInput, falseInput);
     }
 
-    if (GenTree::Compare(trueInput, condInput->gtGetOp1()) && 
+    if (GenTree::Compare(trueInput, condInput->gtGetOp1()) &&
         GenTree::Compare(falseInput, condInput->gtGetOp2()->gtEffectiveVal()))
     {
         return m_compiler->gtNewSimdMinMaxNativeNode(select->TypeGet(),

--- a/src/coreclr/jit/ifconversion.cpp
+++ b/src/coreclr/jit/ifconversion.cpp
@@ -56,6 +56,7 @@ private:
     GenTree* TrySelectToCnsOpCond(GenTreeConditional* select);
     GenTree* TrySelectToLclOpCond(GenTreeConditional* select);
     GenTree* TrySelectToCondOpLcl(GenTreeConditional* select);
+    GenTree* TrySelectToMinMax(GenTreeConditional* select);
 
 #ifdef DEBUG
     void IfConvertDump();
@@ -205,7 +206,7 @@ bool OptIfConversionDsc::IfConvertCheckStmts(BasicBlock* block, IfConvertOperati
             }
 
             // Ensure the operation has integer type.
-            if (!varTypeIsIntegralOrI(tree))
+            if (!varTypeIsIntegralOrI(tree) && !varTypeIsFloating(tree))
             {
                 return false;
             }
@@ -636,6 +637,12 @@ bool OptIfConversionDsc::optIfConvert(int* pReachabilityBudget)
         }
     }
 
+    // We only produce float SELECTs for optimization into non-SELECTs, otherwise bail
+    if (varTypeIsFloating(select))
+    {
+        return true;
+    }
+
 #ifdef TARGET_RISCV64
     if (select->OperIs(GT_SELECT))
     {
@@ -734,6 +741,12 @@ GenTree* OptIfConversionDsc::TryOptimizeSelect(GenTreeConditional* select)
     }
 
     opt = TrySelectToCondOpLcl(select);
+    if (opt != nullptr)
+    {
+        return opt;
+    }
+
+    opt = TrySelectToMinMax(select);
     if (opt != nullptr)
     {
         return opt;
@@ -957,6 +970,46 @@ GenTree* OptIfConversionDsc::TrySelectToCondOpLcl(GenTreeConditional* select)
         }
     }
 #endif // TARGET_RISCV64
+    return nullptr;
+}
+
+GenTree* OptIfConversionDsc::TrySelectToMinMax(GenTreeConditional* select)
+{
+#ifdef TARGET_XARCH
+    GenTree* condInput = select->gtCond;
+    GenTree* trueInput  = select->gtOp1;
+    GenTree* falseInput = select->gtOp2;
+    
+    if (!varTypeIsFloating(select) || !varTypeIsFloating(condInput->gtGetOp1()) || !varTypeIsFloating(condInput->gtGetOp2()))
+    {
+        return nullptr;
+    }
+    
+    GenCondition cond = GenCondition::FromFloatRelop(condInput);
+    if (cond.IsUnordered() || !cond.Is(GenCondition::Code::FLT, GenCondition::Code::FGT))
+    {
+        return nullptr;
+    }
+
+    bool isMax = cond.Is(GenCondition::Code::FGT);
+    bool reversed = !GenTree::Compare(trueInput, condInput->gtGetOp1());
+    if (reversed)
+    {
+        // 'return a > b ? b : a;' has a GT but computes the min
+        isMax = !isMax;
+        std::swap(trueInput, falseInput);
+    }
+
+    if (GenTree::Compare(trueInput, condInput->gtGetOp1()) && 
+        GenTree::Compare(falseInput, condInput->gtGetOp2()->gtEffectiveVal()))
+    {
+        return m_compiler->gtNewSimdMinMaxNativeNode(select->TypeGet(),
+                                                     reversed ? condInput->gtGetOp2() : condInput->gtGetOp1(),
+                                                     reversed ? condInput->gtGetOp1() : condInput->gtGetOp2(),
+                                                     select->TypeGet(), 0, isMax);
+    }
+
+#endif
     return nullptr;
 }
 


### PR DESCRIPTION
Example:
```cs
static float Min(float a, float b)
{
    return a < b ? a : b;
}
```
```assembly
;; ------ BASE
G_M000_IG02: 
       vucomiss xmm1, xmm0
       jbe      SHORT G_M000_IG04
 
G_M000_IG03:
       ret      
 
G_M000_IG04:
       vmovaps  xmm0, xmm1
 
G_M000_IG05: 
       ret      

;; ------ DIFF
G_M21498_IG02: 
       vminss   xmm0, xmm0, xmm1

G_M21498_IG03:
       ret      
```

Handles all these cases. I compared the codegen of every single one against it to be sure its correct:
https://godbolt.org/z/389jvnfW4

Fix https://github.com/dotnet/runtime/issues/116802