### PR TITLE
[clr-interp] Fix handling of continuation return when it is not used by the method

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6460,7 +6460,19 @@ void InterpCompiler::UpdateLocalIntervalMaps()
         int32_t varIndex = suspendData->returnValueVarStackOffset;
         if (varIndex != -1)
         {
-            suspendData->returnValueVarStackOffset = m_pVars[varIndex].offset;
+            assert(!m_pVars[varIndex].global);
+            if (m_pVars[varIndex].liveStart == m_pVars[varIndex].liveEnd)
+            {
+                // The return result of the async call is not used by the method so the allocated
+                // offset will be immediately reused by any vars that become live. This means that
+                // the async suspend/resume would operate with wrong values. This async call will
+                // be handled as if it is void return.
+                suspendData->returnValueVarStackOffset = -1;
+            }
+            else
+            {
+                suspendData->returnValueVarStackOffset = m_pVars[varIndex].offset;
+            }
         }
     }
 }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6463,10 +6463,10 @@ void InterpCompiler::UpdateLocalIntervalMaps()
             assert(!m_pVars[varIndex].global);
             if (m_pVars[varIndex].liveStart == m_pVars[varIndex].liveEnd)
             {
-                // The return result of the async call is not used by the method so the allocated
-                // offset will be immediately reused by any vars that become live. This means that
-                // the async suspend/resume would operate with wrong values. This async call will
-                // be handled as if it is void return.
+                // The return result of the async call is not used by the method, so the allocated
+                // stack offset will be immediately reused by any vars that become live. Keep the
+                // continuation layout unchanged, but mark the return value stack offset as invalid
+                // so resume skips copying the stored result back to the interpreter stack.
                 suspendData->returnValueVarStackOffset = -1;
             }
             else

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -4581,7 +4581,7 @@ do                                                                      \
 
                     // Explicitly copy the return value from the continuation's result storage
                     // to the interpreter stack.
-                    if (pAsyncSuspendData->returnValueContinuationDataSize > 0)
+                    if (pAsyncSuspendData->returnValueVarStackOffset != -1)
                     {
                         memcpy(LOCAL_VAR_ADDR(pAsyncSuspendData->returnValueVarStackOffset, uint8_t),
                                continuation->GetResultStorage(),


### PR DESCRIPTION
Consider the scenario where we are emitting an async method call where the return value is not used at all by the method and, by the time we are actually doing the suspend operation, a new live variable is created. This means that the new variable could share the same offset as the return offset. Example interp IR:

```
IR_0074: call           [64 <- 96], .Program:ThrowsAsync[System.__Canon](System.Func`1[System.Threading.Tasks.Task])
// var at offset 56 was present on the interp execution stack and it gets moved to a temporary that shares the same offset with the dead return
// this means that, when we restore the context and write the continuation return to the interp stack, we overwritte this
IR_0078: mov.8          [64 <- 56],
IR_007b: handle.continuation [72 <- nil], AsyncSuspendData[continuationTypeHnd=0x7fff7980c310, flags=3144, liveLocalsIntervals=[{64, 71},], zeroedLocalsIntervals=[], keepAliveOffset=32], 0x7fff797479c0 (CORINFO_HELP_ALLOC_CONTINUATION)(indirect)
IR_007f: capture.context.on.suspend [80 <- 72], AsyncSuspendData[continuationTypeHnd=0x7fff7980c310, flags=3144, liveLocalsIntervals=[{64, 71},], zeroedLocalsIntervals=[], keepAliveOffset=32]
IR_0083: restore.contexts.on.suspend [72 <- 72 0 16], AsyncSuspendData[continuationTypeHnd=0x7fff7980c310, flags=3144, liveLocalsIntervals=[{64, 71},], zeroedLocalsIntervals=[], keepAliveOffset=32]
IR_0089: handle.continuation.suspend [nil <- 72], AsyncSuspendData[continuationTypeHnd=0x7fff7980c310, flags=3144, liveLocalsIntervals=[{64, 71},], zeroedLocalsIntervals=[], keepAliveOffset=32]
IR_008c: handle.continuation.resume [nil <- nil], AsyncSuspendData[continuationTypeHnd=0x7fff7980c310, flags=3144, liveLocalsIntervals=[{64, 71},], zeroedLocalsIntervals=[], keepAliveOffset=32]
IR_008e: ldind.i8       [96 <- 64], 8
```

This bug was exposed by https://github.com/dotnet/runtime/pull/127931, which changed the order of the write to the result var, during resume. 