### PR TITLE
Platform specific docs analyzer

### DIFF
--- a/docs/coding-guidelines/adding-api-guidelines.md
+++ b/docs/coding-guidelines/adding-api-guidelines.md
@@ -88,6 +88,13 @@ produces the following diagnostics:
 | PLATDOC001 | Public type has no source file named `TypeName.cs`. |
 | PLATDOC002 | Partial source file doesn't follow the `TypeName.Something.cs` naming convention. |
 | PLATDOC003 | Public member in a non-primary partial file has XML documentation that should be moved to `TypeName.cs`. |
+| PLATDOC004 | Documentation for a public API differs from the canonical (platform-agnostic) build. |
+
+PLATDOC001–003 are heuristic rules that guide source organization. PLATDOC004 is an authoritative
+check: when a project also targets a platform-agnostic TFM (e.g. `net11.0` alongside
+`net11.0-windows`), the build passes the canonical TFM's compiler-generated doc XML to the
+analyzer, which compares each public API's documentation against it. Any mismatch indicates that
+docs were placed on platform-specific source and will be inconsistent across platforms.
 
 If a file legitimately doesn't follow these conventions (e.g. an `Async` partial using the
 established `TypeNameAsync.cs` pattern), suppress the specific diagnostic with

--- a/docs/coding-guidelines/adding-api-guidelines.md
+++ b/docs/coding-guidelines/adding-api-guidelines.md
@@ -58,6 +58,41 @@ The rest of the documentation workflow depends on whether the assembly has the `
 - Triple-slash comments in source code are synced to dotnet-api-docs periodically (every preview).
 - More recently introduced libraries typically follow this workflow.
 
+### Documentation placement in platform-specific libraries
+
+When a library targets platform-specific frameworks (e.g. `net11.0-windows`, `net11.0-linux`),
+only **one** platform's compiler-generated doc XML is selected as the source of truth and shipped
+to all customers in the IntelliSense package. This means that if XML doc comments for a public API
+appear only in a platform-specific partial file, they may be missing from the shipped docs on other
+platforms.
+
+To ensure consistent documentation across all platforms, follow these rules:
+
+1. **Place docs on the primary source file.** Each public type should have a primary source file
+   named `TypeName.cs`. All public API documentation (`/// <summary>`, `/// <param>`, etc.) must
+   be placed in this file.
+2. **Follow the naming convention for partial files.** Platform-specific or feature-specific
+   partials must follow the `TypeName.Something.cs` naming convention (e.g. `Socket.Windows.cs`,
+   `Socket.Unix.cs`).
+3. **Do not add public XML doc comments in non-primary partial files.** If a public member is
+   declared in a file like `TypeName.Windows.cs`, its documentation should be in `TypeName.cs`
+   (using a partial method declaration or `<inheritdoc/>`), not in the platform-specific file.
+
+These rules are enforced by the **PlatformDocAnalyzer** (`eng/analyzers/PlatformDocAnalyzer`),
+which is automatically applied to all library source projects. The analyzer only activates when
+building a platform-specific target framework with `UseCompilerGeneratedDocXmlFile=true`, and
+produces the following diagnostics:
+
+| Diagnostic | Description |
+|------------|-------------|
+| PLATDOC001 | Public type has no source file named `TypeName.cs`. |
+| PLATDOC002 | Partial source file doesn't follow the `TypeName.Something.cs` naming convention. |
+| PLATDOC003 | Public member in a non-primary partial file has XML documentation that should be moved to `TypeName.cs`. |
+
+If a file legitimately doesn't follow these conventions (e.g. an `Async` partial using the
+established `TypeNameAsync.cs` pattern), suppress the specific diagnostic with
+`#pragma warning disable PLATDOCnnn` and a brief comment explaining why.
+
 **For libraries with `<UseCompilerGeneratedDocXmlFile>false</UseCompilerGeneratedDocXmlFile>`:**
 - The [dotnet-api-docs](https://github.com/dotnet/dotnet-api-docs) repo is the source of truth for documentation.
 - Triple-slash comments in source code are synced to dotnet-api-docs **only once** for newly introduced APIs. After the initial sync, all subsequent documentation

--- a/eng/analyzers/Directory.Build.props
+++ b/eng/analyzers/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <!-- Analyzer/generator projects are not source projects. -->
+    <IsGeneratorProject>true</IsGeneratorProject>
+  </PropertyGroup>
+
+  <Import Project="..\..\Directory.Build.props" />
+</Project>

--- a/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzer.Tests.csproj
+++ b/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzer.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreAppCurrent)</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(CompilerPlatformTestingVersion)" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(CompilerPlatformTestingVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PlatformDocAnalyzer\PlatformDocAnalyzer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzer.Tests.csproj
+++ b/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzer.Tests.csproj
@@ -7,7 +7,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="$(CompilerPlatformTestingVersion)" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="$(CompilerPlatformTestingVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
+++ b/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
@@ -377,5 +377,135 @@ public partial class Outer
 
             await test.RunAsync(CancellationToken.None);
         }
+
+        private static AnalyzerTest CreateTestWithCanonicalDoc(
+            (string Key, string Value)[] globalOptions,
+            string canonicalDocXml,
+            params (string FileName, string Source)[] sources)
+        {
+            var test = CreateTest(globalOptions, sources);
+
+            // Replace the existing globalconfig with one that also configures the additional file.
+            test.TestState.AnalyzerConfigFiles.Clear();
+            string optionsText = "is_global = true\r\n";
+            foreach ((string key, string value) in globalOptions)
+            {
+                optionsText += $"{key} = {value}\r\n";
+            }
+            optionsText += "[/canonical.xml]\r\n";
+            optionsText += "build_metadata.AdditionalFiles.PlatformDocCanonical = true\r\n";
+            test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", optionsText));
+
+            test.TestState.AdditionalFiles.Add(("/canonical.xml", canonicalDocXml));
+            return test;
+        }
+
+        [Fact]
+        public async Task PLATDOC004_DocsMatchCanonical_NoDiagnostic()
+        {
+            string canonicalDocXml = @"<?xml version=""1.0""?>
+<doc>
+  <assembly><name>TestAssembly</name></assembly>
+  <members>
+    <member name=""T:Foo"">
+      <summary>Foo type</summary>
+    </member>
+    <member name=""M:Foo.Bar"">
+      <summary>Bar method</summary>
+    </member>
+  </members>
+</doc>";
+
+            var test = CreateTestWithCanonicalDoc(
+                s_platformTfmOptions,
+                canonicalDocXml,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public class Foo
+{
+    /// <summary>Bar method</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC004_DocsDifferFromCanonical()
+        {
+            string canonicalDocXml = @"<?xml version=""1.0""?>
+<doc>
+  <assembly><name>TestAssembly</name></assembly>
+  <members>
+    <member name=""T:Foo"">
+      <summary>Foo type</summary>
+    </member>
+    <member name=""M:Foo.Bar"">
+      <summary>Bar method</summary>
+    </member>
+  </members>
+</doc>";
+
+            var test = CreateTestWithCanonicalDoc(
+                s_platformTfmOptions,
+                canonicalDocXml,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public class Foo
+{
+    /// <summary>DIFFERENT Bar method docs</summary>
+    public void {|#0:Bar|}() { }
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.DocMismatchRule)
+                .WithLocation(0).WithArguments("Foo.Bar()"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC004_PlatformOnlyApi_NoDiagnostic()
+        {
+            // APIs that don't exist in the canonical doc XML are platform-specific and can have any docs.
+            string canonicalDocXml = @"<?xml version=""1.0""?>
+<doc>
+  <assembly><name>TestAssembly</name></assembly>
+  <members>
+    <member name=""T:Foo"">
+      <summary>Foo type</summary>
+    </member>
+  </members>
+</doc>";
+
+            var test = CreateTestWithCanonicalDoc(
+                s_platformTfmOptions,
+                canonicalDocXml,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public class Foo
+{
+    /// <summary>Platform-specific method not in canonical</summary>
+    public void WindowsOnly() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC004_NoCanonicalDoc_NoDiagnostic()
+        {
+            // When no canonical doc XML is provided, PLATDOC004 should not fire.
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.cs", @"
+/// <summary>DIFFERENT docs</summary>
+public class Foo
+{
+    /// <summary>Some method</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
     }
 }

--- a/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
+++ b/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
@@ -311,15 +311,69 @@ public partial interface IService
             var test = CreateTest(
                 s_platformTfmOptions,
                 ("WrongName.cs", @"
-public struct {|#0:MyStruct|}
+public partial struct {|#0:MyStruct|}
 {
     public int Value;
+}"),
+                ("WrongName2.cs", @"
+public partial struct {|#1:MyStruct|}
+{
+    public int Value2;
 }"));
 
             test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.MissingPrimaryFileRule)
                 .WithLocation(0).WithArguments("MyStruct"));
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.MissingPrimaryFileRule)
+                .WithLocation(1).WithArguments("MyStruct"));
             test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.BadPartialFileNameRule)
                 .WithLocation(0).WithArguments("WrongName.cs", "MyStruct"));
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.BadPartialFileNameRule)
+                .WithLocation(1).WithArguments("WrongName2.cs", "MyStruct"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForSingleFileType()
+        {
+            // A type defined in only one file should not trigger any diagnostics,
+            // even if the file name doesn't match the type name.
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Helpers.cs", @"
+/// <summary>Some type</summary>
+public class Foo
+{
+    /// <summary>Some method</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForNestedTypeDocsOnNonPrimaryFile()
+        {
+            // Nested type declarations define their own doc scope and should not be flagged.
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Outer.cs", @"
+/// <summary>Outer type</summary>
+public partial class Outer
+{
+    /// <summary>Method</summary>
+    public void Method() { }
+}"),
+                ("Outer.Inner.cs", @"
+public partial class Outer
+{
+    /// <summary>Nested type docs are fine here</summary>
+    public class Inner
+    {
+        /// <summary>Inner method</summary>
+        public void InnerMethod() { }
+    }
+}"));
 
             await test.RunAsync(CancellationToken.None);
         }

--- a/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
+++ b/eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzerTests.cs
@@ -1,0 +1,327 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Immutable;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+using Microsoft.DotNet.Analyzers.PlatformDoc;
+using Xunit;
+
+namespace PlatformDocAnalyzer.Tests
+{
+    using AnalyzerTest = CSharpAnalyzerTest<Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer, DefaultVerifier>;
+
+    public class PlatformDocAnalyzerTests
+    {
+        private static readonly (string Key, string Value)[] s_platformTfmOptions = new[]
+        {
+            ("build_property.TargetFramework", "net10.0-windows"),
+            ("build_property.UseCompilerGeneratedDocXmlFile", "true"),
+        };
+
+        private static readonly (string Key, string Value)[] s_nonPlatformTfmOptions = new[]
+        {
+            ("build_property.TargetFramework", "net10.0"),
+            ("build_property.UseCompilerGeneratedDocXmlFile", "true"),
+        };
+
+        private static AnalyzerTest CreateTest(
+            (string Key, string Value)[] globalOptions,
+            params (string FileName, string Source)[] sources)
+        {
+            var test = new AnalyzerTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+            };
+
+            foreach ((string fileName, string source) in sources)
+            {
+                test.TestState.Sources.Add((fileName, source));
+            }
+
+            string optionsText = "is_global = true\r\n";
+            foreach ((string key, string value) in globalOptions)
+            {
+                optionsText += $"{key} = {value}\r\n";
+            }
+
+            test.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", optionsText));
+            return test;
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForNonPlatformTfm()
+        {
+            // A non-platform TFM should not trigger any diagnostics even if naming is wrong.
+            var test = CreateTest(
+                s_nonPlatformTfmOptions,
+                ("WrongName.cs", @"
+public class Foo
+{
+    /// <summary>Some docs</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticWhenUseCompilerGeneratedDocXmlFileIsFalse()
+        {
+            var options = new[]
+            {
+                ("build_property.TargetFramework", "net10.0-windows"),
+                ("build_property.UseCompilerGeneratedDocXmlFile", "false"),
+            };
+
+            var test = CreateTest(
+                options,
+                ("WrongName.cs", @"
+public class Foo
+{
+    /// <summary>Some docs</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForCorrectSetup()
+        {
+            // Primary file matches type name, no docs on partial files.
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public partial class Foo
+{
+    /// <summary>Bar method</summary>
+    public void Bar() { }
+}"),
+                ("Foo.Windows.cs", @"
+public partial class Foo
+{
+    public void PlatformSpecificMethod() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC001_PublicTypeMissingPrimaryFile()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.Windows.cs", @"
+public partial class {|#0:Foo|}
+{
+    public void Bar() { }
+}"),
+                ("Foo.Unix.cs", @"
+public partial class {|#1:Foo|}
+{
+    public void Baz() { }
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.MissingPrimaryFileRule)
+                .WithLocation(0).WithArguments("Foo"));
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.MissingPrimaryFileRule)
+                .WithLocation(1).WithArguments("Foo"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC002_BadPartialFileName()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public partial class Foo
+{
+    /// <summary>Bar method</summary>
+    public void Bar() { }
+}"),
+                ("Helpers.cs", @"
+public partial class {|#0:Foo|}
+{
+    public void PlatformSpecificHelper() { }
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.BadPartialFileNameRule)
+                .WithLocation(0).WithArguments("Helpers.cs", "Foo"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC003_DocsOnNonPrimaryFile()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public partial class Foo
+{
+    /// <summary>Bar method</summary>
+    public void Bar() { }
+}"),
+                ("Foo.Windows.cs", @"
+public partial class Foo
+{
+    /// <summary>This doc should be in Foo.cs</summary>
+    public void {|#0:PlatformSpecificMethod|}() { }
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.DocsOnNonPrimaryFileRule)
+                .WithLocation(0).WithArguments("PlatformSpecificMethod", "Foo.Windows.cs", "Foo"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC003_DocsOnNonPrimaryFile_MultipleMembers()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("MyService.cs", @"
+/// <summary>MyService type</summary>
+public partial class MyService
+{
+    /// <summary>Start method</summary>
+    public void Start() { }
+}"),
+                ("MyService.Windows.cs", @"
+public partial class MyService
+{
+    /// <summary>Windows-specific start</summary>
+    public void {|#0:StartWindows|}() { }
+
+    /// <summary>Windows handle</summary>
+    public int {|#1:Handle|} { get; set; }
+
+    // No docs - this is fine
+    public void InternalHelper() { }
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.DocsOnNonPrimaryFileRule)
+                .WithLocation(0).WithArguments("StartWindows", "MyService.Windows.cs", "MyService"));
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.DocsOnNonPrimaryFileRule)
+                .WithLocation(1).WithArguments("Handle", "MyService.Windows.cs", "MyService"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForNonPublicType()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("WrongName.cs", @"
+internal class Foo
+{
+    /// <summary>Some docs</summary>
+    public void Bar() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForPrivateMemberDocs()
+        {
+            // Private/internal members in non-primary files can have docs
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Foo.cs", @"
+/// <summary>Foo type</summary>
+public partial class Foo
+{
+    /// <summary>Bar method</summary>
+    public void Bar() { }
+}"),
+                ("Foo.Windows.cs", @"
+public partial class Foo
+{
+    /// <summary>Private helper - docs are fine here</summary>
+    private void PrivateHelper() { }
+
+    /// <summary>Internal helper - docs are fine here</summary>
+    internal void InternalHelper() { }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoDiagnosticForNestedType()
+        {
+            // Nested types are not checked (only top-level types are)
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("Outer.cs", @"
+/// <summary>Outer type</summary>
+public class Outer
+{
+    /// <summary>Inner type</summary>
+    public class Inner
+    {
+        /// <summary>Method</summary>
+        public void Method() { }
+    }
+}"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC003_InterfaceMembersAreImplicitlyPublic()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("IService.cs", @"
+/// <summary>IService interface</summary>
+public partial interface IService
+{
+    /// <summary>Start method</summary>
+    void Start();
+}"),
+                ("IService.Windows.cs", @"
+public partial interface IService
+{
+    /// <summary>Windows-specific method</summary>
+    void {|#0:StartWindows|}();
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.DocsOnNonPrimaryFileRule)
+                .WithLocation(0).WithArguments("StartWindows", "IService.Windows.cs", "IService"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task PLATDOC001_StructType()
+        {
+            var test = CreateTest(
+                s_platformTfmOptions,
+                ("WrongName.cs", @"
+public struct {|#0:MyStruct|}
+{
+    public int Value;
+}"));
+
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.MissingPrimaryFileRule)
+                .WithLocation(0).WithArguments("MyStruct"));
+            test.ExpectedDiagnostics.Add(new DiagnosticResult(Microsoft.DotNet.Analyzers.PlatformDoc.PlatformDocAnalyzer.BadPartialFileNameRule)
+                .WithLocation(0).WithArguments("WrongName.cs", "MyStruct"));
+
+            await test.RunAsync(CancellationToken.None);
+        }
+    }
+}

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -103,6 +103,17 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
             if (syntaxRefs.IsEmpty)
                 return;
 
+            // Only check types declared across multiple files.
+            // A type in a single file doesn't have a doc placement problem.
+            var distinctFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (SyntaxReference syntaxRef in syntaxRefs)
+            {
+                distinctFiles.Add(syntaxRef.SyntaxTree.FilePath);
+            }
+
+            if (distinctFiles.Count <= 1)
+                return;
+
             string typeName = namedType.Name;
             string primaryFileName = typeName + ".cs";
 
@@ -172,6 +183,10 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
         {
             foreach (MemberDeclarationSyntax member in typeDecl.Members)
             {
+                // Nested type declarations define their own doc scope; skip them.
+                if (member is BaseTypeDeclarationSyntax or DelegateDeclarationSyntax)
+                    continue;
+
                 if (!IsEffectivelyPublic(member, typeDecl))
                     continue;
 

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -386,8 +386,6 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
                 IndexerDeclarationSyntax i => i.ThisKeyword.GetLocation(),
                 OperatorDeclarationSyntax o => o.OperatorToken.GetLocation(),
                 ConversionOperatorDeclarationSyntax c => c.Type.GetLocation(),
-                TypeDeclarationSyntax t => t.Identifier.GetLocation(),
-                DelegateDeclarationSyntax d => d.Identifier.GetLocation(),
                 EnumMemberDeclarationSyntax e => e.Identifier.GetLocation(),
                 _ => member.GetLocation()
             };
@@ -407,8 +405,6 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
                 IndexerDeclarationSyntax => "this[]",
                 OperatorDeclarationSyntax o => "operator " + o.OperatorToken.Text,
                 ConversionOperatorDeclarationSyntax c => c.ImplicitOrExplicitKeyword.Text + " operator " + c.Type,
-                TypeDeclarationSyntax t => t.Identifier.Text,
-                DelegateDeclarationSyntax d => d.Identifier.Text,
                 EnumMemberDeclarationSyntax e => e.Identifier.Text,
                 _ => "<member>"
             };

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -26,6 +26,9 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class PlatformDocAnalyzer : DiagnosticAnalyzer
     {
+        private static readonly Regex s_memberRegex = new(@"<member\s+name=""([^""]+)"">(.*?)</member>", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static readonly Regex s_whitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+
         public const string DiagnosticIdMissingPrimaryFile = "PLATDOC001";
         public const string DiagnosticIdBadPartialFileName = "PLATDOC002";
         public const string DiagnosticIdDocsOnNonPrimaryFile = "PLATDOC003";
@@ -129,7 +132,7 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
 
             // Use regex to extract member elements to avoid XML parser normalization
             // that could cause false mismatches with GetDocumentationCommentXml() output.
-            foreach (Match match in Regex.Matches(xml, @"<member\s+name=""([^""]+)"">(.*?)</member>", RegexOptions.Singleline))
+            foreach (Match match in s_memberRegex.Matches(xml))
             {
                 string name = match.Groups[1].Value;
                 string innerXml = match.Groups[2].Value;
@@ -161,6 +164,10 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
 
                 // Skip accessors; they're covered by the property/event.
                 if (member is IMethodSymbol { AssociatedSymbol: not null })
+                    continue;
+
+                // Skip nested types; they get their own SymbolKind.NamedType callback.
+                if (member is INamedTypeSymbol)
                     continue;
 
                 CheckSymbolDoc(context, member, canonicalDocs);
@@ -219,7 +226,7 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
         private static string NormalizeDocXml(string xml)
         {
             // Normalize whitespace: collapse runs of whitespace into single spaces, trim.
-            return Regex.Replace(xml, @"\s+", " ").Trim();
+            return s_whitespaceRegex.Replace(xml, " ").Trim();
         }
 
         private static bool IsPlatformSpecificTfm(string tfm)

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -6,10 +6,13 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 #pragma warning disable RS2008 // Not a shipping analyzer
 
@@ -26,6 +29,7 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
         public const string DiagnosticIdMissingPrimaryFile = "PLATDOC001";
         public const string DiagnosticIdBadPartialFileName = "PLATDOC002";
         public const string DiagnosticIdDocsOnNonPrimaryFile = "PLATDOC003";
+        public const string DiagnosticIdDocMismatch = "PLATDOC004";
 
         public static readonly DiagnosticDescriptor MissingPrimaryFileRule = new(
             DiagnosticIdMissingPrimaryFile,
@@ -51,8 +55,16 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true);
 
+        public static readonly DiagnosticDescriptor DocMismatchRule = new(
+            DiagnosticIdDocMismatch,
+            "Documentation differs from canonical platform-agnostic build",
+            "Documentation for '{0}' differs from the canonical (platform-agnostic) build. Ensure docs are on shared source so they are consistent across platforms.",
+            "Documentation",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
-            ImmutableArray.Create(MissingPrimaryFileRule, BadPartialFileNameRule, DocsOnNonPrimaryFileRule);
+            ImmutableArray.Create(MissingPrimaryFileRule, BadPartialFileNameRule, DocsOnNonPrimaryFileRule, DocMismatchRule);
 
         public override void Initialize(AnalysisContext context)
         {
@@ -79,6 +91,135 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
             }
 
             context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+
+            // Look for the canonical doc XML in AdditionalFiles.
+            Dictionary<string, string>? canonicalDocs = TryLoadCanonicalDocs(context);
+            if (canonicalDocs is not null)
+            {
+                context.RegisterSymbolAction(
+                    ctx => AnalyzeDocConsistency(ctx, canonicalDocs),
+                    SymbolKind.NamedType);
+            }
+        }
+
+        private static Dictionary<string, string>? TryLoadCanonicalDocs(CompilationStartAnalysisContext context)
+        {
+            foreach (AdditionalText file in context.Options.AdditionalFiles)
+            {
+                AnalyzerConfigOptions fileOptions = context.Options.AnalyzerConfigOptionsProvider.GetOptions(file);
+                if (!fileOptions.TryGetValue("build_metadata.AdditionalFiles.PlatformDocCanonical", out string? value) ||
+                    !string.Equals(value, "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                SourceText? text = file.GetText(context.CancellationToken);
+                if (text is null)
+                    continue;
+
+                return ParseDocXml(text.ToString());
+            }
+
+            return null;
+        }
+
+        private static Dictionary<string, string> ParseDocXml(string xml)
+        {
+            var docs = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            // Use regex to extract member elements to avoid XML parser normalization
+            // that could cause false mismatches with GetDocumentationCommentXml() output.
+            foreach (Match match in Regex.Matches(xml, @"<member\s+name=""([^""]+)"">(.*?)</member>", RegexOptions.Singleline))
+            {
+                string name = match.Groups[1].Value;
+                string innerXml = match.Groups[2].Value;
+                docs[name] = NormalizeDocXml(innerXml);
+            }
+
+            return docs;
+        }
+
+        private static void AnalyzeDocConsistency(
+            SymbolAnalysisContext context,
+            Dictionary<string, string> canonicalDocs)
+        {
+            ISymbol symbol = context.Symbol;
+
+            if (symbol is not INamedTypeSymbol namedType)
+                return;
+
+            if (namedType.DeclaredAccessibility != Accessibility.Public)
+                return;
+
+            // Check the type itself and all its public members.
+            CheckSymbolDoc(context, namedType, canonicalDocs);
+
+            foreach (ISymbol member in namedType.GetMembers())
+            {
+                if (member.DeclaredAccessibility != Accessibility.Public)
+                    continue;
+
+                // Skip accessors; they're covered by the property/event.
+                if (member is IMethodSymbol { AssociatedSymbol: not null })
+                    continue;
+
+                CheckSymbolDoc(context, member, canonicalDocs);
+            }
+        }
+
+        private static void CheckSymbolDoc(
+            SymbolAnalysisContext context,
+            ISymbol symbol,
+            Dictionary<string, string> canonicalDocs)
+        {
+            string? docId = symbol.GetDocumentationCommentId();
+            if (docId is null)
+                return;
+
+            if (!canonicalDocs.TryGetValue(docId, out string? canonicalDoc))
+                return;
+
+            string currentDoc = NormalizeDocXml(
+                symbol.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken) ?? "");
+
+            // Strip the outer <member> wrapper from GetDocumentationCommentXml() output.
+            currentDoc = StripMemberWrapper(currentDoc);
+
+            if (string.Equals(canonicalDoc, currentDoc, StringComparison.Ordinal))
+                return;
+
+            // Both empty → no mismatch.
+            if (string.IsNullOrWhiteSpace(canonicalDoc) && string.IsNullOrWhiteSpace(currentDoc))
+                return;
+
+            Location location = symbol.Locations.FirstOrDefault() ?? Location.None;
+            context.ReportDiagnostic(Diagnostic.Create(
+                DocMismatchRule,
+                location,
+                symbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat)));
+        }
+
+        private static string StripMemberWrapper(string xml)
+        {
+            // GetDocumentationCommentXml() returns:
+            //   <member name="...">..inner..</member>
+            // We need just the inner content to compare against the parsed doc XML.
+            const string memberStart = "<member";
+            const string memberEnd = "</member>";
+
+            int startIdx = xml.IndexOf('>', xml.IndexOf(memberStart, StringComparison.Ordinal) + 1);
+            int endIdx = xml.LastIndexOf(memberEnd, StringComparison.Ordinal);
+
+            if (startIdx < 0 || endIdx < 0 || endIdx <= startIdx)
+                return NormalizeDocXml(xml);
+
+            return NormalizeDocXml(xml.Substring(startIdx + 1, endIdx - startIdx - 1));
+        }
+
+        private static string NormalizeDocXml(string xml)
+        {
+            // Normalize whitespace: collapse runs of whitespace into single spaces, trim.
+            return Regex.Replace(xml, @"\s+", " ").Trim();
         }
 
         private static bool IsPlatformSpecificTfm(string tfm)

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -353,9 +353,17 @@ namespace Microsoft.DotNet.Analyzers.PlatformDoc
 
         private static bool IsEffectivelyPublic(MemberDeclarationSyntax member, TypeDeclarationSyntax containingType)
         {
-            // Interface members are implicitly public
+            // Interface members without explicit access modifiers are implicitly public.
+            // C# 8+ allows private/protected/internal members in interfaces.
             if (containingType is InterfaceDeclarationSyntax)
-                return true;
+            {
+                if (member.Modifiers.Count == 0)
+                    return true;
+
+                return !member.Modifiers.Any(SyntaxKind.PrivateKeyword) &&
+                       !member.Modifiers.Any(SyntaxKind.ProtectedKeyword) &&
+                       !member.Modifiers.Any(SyntaxKind.InternalKeyword);
+            }
 
             // Enum members are implicitly public
             if (member is EnumMemberDeclarationSyntax)

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.cs
@@ -1,0 +1,261 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable RS2008 // Not a shipping analyzer
+
+namespace Microsoft.DotNet.Analyzers.PlatformDoc
+{
+    /// <summary>
+    /// Ensures platform-specific libraries with UseCompilerGeneratedDocXmlFile=true
+    /// place their triple-slash documentation on the primary source file so that
+    /// docs are consistent across platforms.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public sealed class PlatformDocAnalyzer : DiagnosticAnalyzer
+    {
+        public const string DiagnosticIdMissingPrimaryFile = "PLATDOC001";
+        public const string DiagnosticIdBadPartialFileName = "PLATDOC002";
+        public const string DiagnosticIdDocsOnNonPrimaryFile = "PLATDOC003";
+
+        public static readonly DiagnosticDescriptor MissingPrimaryFileRule = new(
+            DiagnosticIdMissingPrimaryFile,
+            "Public type missing primary source file",
+            "Public type '{0}' has no source file named '{0}.cs'",
+            "Documentation",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor BadPartialFileNameRule = new(
+            DiagnosticIdBadPartialFileName,
+            "Partial source file doesn't follow naming convention",
+            "Source file '{0}' contains a partial definition of type '{1}' but doesn't follow the '{1}.*.cs' naming convention",
+            "Documentation",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor DocsOnNonPrimaryFileRule = new(
+            DiagnosticIdDocsOnNonPrimaryFile,
+            "XML documentation on non-primary partial file",
+            "Public member '{0}' in file '{1}' has XML documentation that should be moved to '{2}.cs'",
+            "Documentation",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(MissingPrimaryFileRule, BadPartialFileNameRule, DocsOnNonPrimaryFileRule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+            context.RegisterCompilationStartAction(OnCompilationStart);
+        }
+
+        private static void OnCompilationStart(CompilationStartAnalysisContext context)
+        {
+            var options = context.Options.AnalyzerConfigOptionsProvider.GlobalOptions;
+
+            if (!options.TryGetValue("build_property.TargetFramework", out string? tfm) ||
+                string.IsNullOrEmpty(tfm) ||
+                !IsPlatformSpecificTfm(tfm))
+            {
+                return;
+            }
+
+            if (!options.TryGetValue("build_property.UseCompilerGeneratedDocXmlFile", out string? useCompilerDoc) ||
+                !string.Equals(useCompilerDoc, "true", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            context.RegisterSymbolAction(AnalyzeNamedType, SymbolKind.NamedType);
+        }
+
+        private static bool IsPlatformSpecificTfm(string tfm)
+        {
+            // Platform-specific TFMs have a platform suffix: net10.0-windows, net9.0-linux, etc.
+            int dashIndex = tfm.IndexOf('-');
+            return dashIndex > 0;
+        }
+
+        private static void AnalyzeNamedType(SymbolAnalysisContext context)
+        {
+            var namedType = (INamedTypeSymbol)context.Symbol;
+
+            if (namedType.DeclaredAccessibility != Accessibility.Public)
+                return;
+
+            // Only check top-level types, not nested types.
+            if (namedType.ContainingType is not null)
+                return;
+
+            ImmutableArray<SyntaxReference> syntaxRefs = namedType.DeclaringSyntaxReferences;
+            if (syntaxRefs.IsEmpty)
+                return;
+
+            string typeName = namedType.Name;
+            string primaryFileName = typeName + ".cs";
+
+            bool hasPrimaryFile = false;
+            var nonPrimaryRefs = new List<(SyntaxReference SyntaxRef, string FileName)>();
+
+            foreach (SyntaxReference syntaxRef in syntaxRefs)
+            {
+                string filePath = syntaxRef.SyntaxTree.FilePath;
+                string fileName = Path.GetFileName(filePath);
+
+                if (string.Equals(fileName, primaryFileName, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasPrimaryFile = true;
+                }
+                else
+                {
+                    nonPrimaryRefs.Add((syntaxRef, fileName));
+                }
+            }
+
+            // PLATDOC001: Public type must have a primary source file named TypeName.cs
+            if (!hasPrimaryFile)
+            {
+                foreach (SyntaxReference syntaxRef in syntaxRefs)
+                {
+                    SyntaxNode node = syntaxRef.GetSyntax(context.CancellationToken);
+                    if (node is TypeDeclarationSyntax typeDecl)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(
+                            MissingPrimaryFileRule,
+                            typeDecl.Identifier.GetLocation(),
+                            typeName));
+                    }
+                }
+            }
+
+            foreach ((SyntaxReference syntaxRef, string fileName) in nonPrimaryRefs)
+            {
+                SyntaxNode node = syntaxRef.GetSyntax(context.CancellationToken);
+                if (node is not TypeDeclarationSyntax typeDecl)
+                    continue;
+
+                // PLATDOC002: Non-primary files must follow TypeName.Something.cs convention
+                string prefix = typeName + ".";
+                if (!fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+                    !fileName.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) ||
+                    fileName.Length <= prefix.Length + ".cs".Length - 1)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        BadPartialFileNameRule,
+                        typeDecl.Identifier.GetLocation(),
+                        fileName,
+                        typeName));
+                }
+
+                // PLATDOC003: Public members in non-primary files must not have XML docs
+                CheckMembersForDocs(context, typeDecl, fileName, typeName);
+            }
+        }
+
+        private static void CheckMembersForDocs(
+            SymbolAnalysisContext context,
+            TypeDeclarationSyntax typeDecl,
+            string fileName,
+            string typeName)
+        {
+            foreach (MemberDeclarationSyntax member in typeDecl.Members)
+            {
+                if (!IsEffectivelyPublic(member, typeDecl))
+                    continue;
+
+                if (HasXmlDocComment(member))
+                {
+                    string memberName = GetMemberName(member);
+                    context.ReportDiagnostic(Diagnostic.Create(
+                        DocsOnNonPrimaryFileRule,
+                        GetMemberIdentifierLocation(member),
+                        memberName,
+                        fileName,
+                        typeName));
+                }
+            }
+        }
+
+        private static bool IsEffectivelyPublic(MemberDeclarationSyntax member, TypeDeclarationSyntax containingType)
+        {
+            // Interface members are implicitly public
+            if (containingType is InterfaceDeclarationSyntax)
+                return true;
+
+            // Enum members are implicitly public
+            if (member is EnumMemberDeclarationSyntax)
+                return true;
+
+            return member.Modifiers.Any(SyntaxKind.PublicKeyword);
+        }
+
+        private static bool HasXmlDocComment(MemberDeclarationSyntax member)
+        {
+            foreach (SyntaxTrivia trivia in member.GetLeadingTrivia())
+            {
+                SyntaxKind kind = trivia.Kind();
+                if (kind == SyntaxKind.SingleLineDocumentationCommentTrivia ||
+                    kind == SyntaxKind.MultiLineDocumentationCommentTrivia)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static Location GetMemberIdentifierLocation(MemberDeclarationSyntax member)
+        {
+            return member switch
+            {
+                MethodDeclarationSyntax m => m.Identifier.GetLocation(),
+                PropertyDeclarationSyntax p => p.Identifier.GetLocation(),
+                EventDeclarationSyntax e => e.Identifier.GetLocation(),
+                EventFieldDeclarationSyntax ef => ef.Declaration.Variables.FirstOrDefault()?.Identifier.GetLocation() ?? member.GetLocation(),
+                FieldDeclarationSyntax f => f.Declaration.Variables.FirstOrDefault()?.Identifier.GetLocation() ?? member.GetLocation(),
+                ConstructorDeclarationSyntax c => c.Identifier.GetLocation(),
+                DestructorDeclarationSyntax d => d.Identifier.GetLocation(),
+                IndexerDeclarationSyntax i => i.ThisKeyword.GetLocation(),
+                OperatorDeclarationSyntax o => o.OperatorToken.GetLocation(),
+                ConversionOperatorDeclarationSyntax c => c.Type.GetLocation(),
+                TypeDeclarationSyntax t => t.Identifier.GetLocation(),
+                DelegateDeclarationSyntax d => d.Identifier.GetLocation(),
+                EnumMemberDeclarationSyntax e => e.Identifier.GetLocation(),
+                _ => member.GetLocation()
+            };
+        }
+
+        private static string GetMemberName(MemberDeclarationSyntax member)
+        {
+            return member switch
+            {
+                MethodDeclarationSyntax m => m.Identifier.Text,
+                PropertyDeclarationSyntax p => p.Identifier.Text,
+                EventDeclarationSyntax e => e.Identifier.Text,
+                EventFieldDeclarationSyntax ef => ef.Declaration.Variables.FirstOrDefault()?.Identifier.Text ?? "<event>",
+                FieldDeclarationSyntax f => f.Declaration.Variables.FirstOrDefault()?.Identifier.Text ?? "<field>",
+                ConstructorDeclarationSyntax c => c.Identifier.Text,
+                DestructorDeclarationSyntax d => "~" + d.Identifier.Text,
+                IndexerDeclarationSyntax => "this[]",
+                OperatorDeclarationSyntax o => "operator " + o.OperatorToken.Text,
+                ConversionOperatorDeclarationSyntax c => c.ImplicitOrExplicitKeyword.Text + " operator " + c.Type,
+                TypeDeclarationSyntax t => t.Identifier.Text,
+                DelegateDeclarationSyntax d => d.Identifier.Text,
+                EnumMemberDeclarationSyntax e => e.Identifier.Text,
+                _ => "<member>"
+            };
+        }
+    }
+}

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <!-- This isn't a shipping analyzer, so we don't need release tracking -->
+    <NoWarn>$(NoWarn);RS2008;RS1038</NoWarn>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisVersion_LatestVS)" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj
@@ -6,7 +6,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <!-- This isn't a shipping analyzer, so we don't need release tracking -->
-    <NoWarn>$(NoWarn);RS2008;RS1038</NoWarn>
+    <NoWarn>$(NoWarn);RS2008;RS1012;RS1038</NoWarn>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.props
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.props
@@ -2,5 +2,6 @@
   <ItemGroup>
     <CompilerVisibleProperty Include="TargetFramework" />
     <CompilerVisibleProperty Include="UseCompilerGeneratedDocXmlFile" />
+    <CompilerVisibleItemMetadata Include="AdditionalFiles" MetadataName="PlatformDocCanonical" />
   </ItemGroup>
 </Project>

--- a/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.props
+++ b/eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="TargetFramework" />
+    <CompilerVisibleProperty Include="UseCompilerGeneratedDocXmlFile" />
+  </ItemGroup>
+</Project>

--- a/eng/analyzers/README.md
+++ b/eng/analyzers/README.md
@@ -1,0 +1,14 @@
+# PlatformDocAnalyzer
+
+A Roslyn analyzer that enforces documentation placement conventions for platform-specific
+libraries with `UseCompilerGeneratedDocXmlFile=true`.
+
+## Running tests
+
+```
+dotnet test eng/analyzers/PlatformDocAnalyzer.Tests/PlatformDocAnalyzer.Tests.csproj
+```
+
+These tests are not part of the main CI test pipeline (consistent with other infrastructure
+analyzer tests like `IntrinsicsInSystemPrivateCoreLibAnalyzer.Tests`). Run them locally when
+modifying the analyzer.

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -93,4 +93,15 @@
 
   <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator.props" />
 
+  <!-- PlatformDocAnalyzer: Enforce documentation conventions for platform-specific libraries -->
+  <ItemGroup Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
+    <ProjectReference Include="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
+  </ItemGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.props"
+          Condition="'$(IsSourceProject)' == 'true'" />
+
 </Project>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -153,4 +153,30 @@
     </PropertyGroup>
   </Target>
 
+  <!-- ======================== Platform-specific doc consistency ======================== -->
+  <!-- For platform-specific TFMs (e.g. net11.0-windows), find the canonical
+       (platform-agnostic) sibling TFM's compiler-generated doc XML and pass it to
+       the PlatformDocAnalyzer so it can verify that shared API docs are consistent.
+       We look for the canonical doc XML at its expected artifact path rather than using
+       a ProjectReference, to avoid circular dependencies with PNSE builds and to avoid
+       the overhead of GetTargetFrameworks calls. -->
+
+  <Target Name="AddCanonicalDocAdditionalFile"
+          BeforeTargets="CoreCompile"
+          Condition="'$(TargetPlatformIdentifier)' != '' and
+                     '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
+                     '$(IsPlatformNotSupportedAssembly)' != 'true'">
+
+    <!-- Derive the canonical TFM by stripping the platform suffix (e.g. net11.0-windows → net11.0). -->
+    <PropertyGroup>
+      <_CanonicalDocTfm>$(TargetFramework.Substring(0, $(TargetFramework.IndexOf('-'))))</_CanonicalDocTfm>
+      <_CanonicalDocXmlPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', '$(MSBuildProjectName)', '$(Configuration)', '$(_CanonicalDocTfm)', '$(AssemblyName).xml'))</_CanonicalDocXmlPath>
+    </PropertyGroup>
+
+    <ItemGroup Condition="Exists('$(_CanonicalDocXmlPath)')">
+      <AdditionalFiles Include="$(_CanonicalDocXmlPath)"
+                       PlatformDocCanonical="true" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -87,94 +87,88 @@
     </ItemGroup>
   </Target>
 
-  <!-- Resolve the first non-PNSE sibling TF whose IsCandidateCompilerGeneratedDocFile is true. -->
-  <Target Name="GetPNSEDocTargetFramework"
-          Condition="'$(PNSEDocTargetFramework)' == ''">
 
-    <!-- GetTargetFrameworks is the standard outer-build target that aggregates per-TF metadata collected via
-         AdditionalTargetFrameworkInfoProperty, including IsCandidateCompilerGeneratedDocFile. -->
+  <!-- ======================== Canonical doc source resolution ======================== -->
+  <!-- Both PNSE builds and platform-specific builds need the compiler-generated doc XML
+       from the canonical doc source TFM:
+         - PNSE builds use it as their DocFileOverride (they have no real source).
+         - Platform-specific builds pass it to PlatformDocAnalyzer for consistency checks.
+
+       The canonical doc source is the first IsCandidateCompilerGeneratedDocFile=true TFM
+       that is not the current TFM. We prefer non-platform TFMs (no '-' in the name) so
+       that platform-specific builds compare against the platform-agnostic version.
+
+       This never creates a cycle because the canonical doc source has
+       IsCandidateCompilerGeneratedDocFile=true, meaning it is neither PNSE nor using a
+       doc override, so it never adds a doc-source reference of its own. -->
+
+  <Target Name="GetCanonicalDocSourceTargetFramework"
+          Condition="'$(CanonicalDocSourceTargetFramework)' == '' and
+                     ('$(IsCandidateCompilerGeneratedDocFile)' != 'true' or '$(TargetPlatformIdentifier)' != '')">
+
     <MSBuild Projects="$(MSBuildProjectFullPath)"
              Targets="GetTargetFrameworks"
              RemoveProperties="TargetFramework">
-      <Output ItemName="_PNSETargetFrameworks" TaskParameter="TargetOutputs" />
+      <Output ItemName="_DocSourceTargetFrameworks" TaskParameter="TargetOutputs" />
     </MSBuild>
 
-    <!-- Find the first TF whose IsCandidateCompilerGeneratedDocFile child element is 'true'.
-         AdditionalPropertiesFromProject is XML of the form:
-           <AdditionalProjectProperties>
-            <TargetFramework Name="net11.0">
-              <IsCandidateCompilerGeneratedDocFile>true</IsCandidateCompilerGeneratedDocFile>
-              ...
-            </TargetFramework>
-            <TargetFramework Name="net10.0">
-              <IsCandidateCompilerGeneratedDocFile>false</IsCandidateCompilerGeneratedDocFile>
-              ...
-            </TargetFramework>
-             ...
-           </AdditionalProjectProperties> -->
-    <XmlPeek XmlContent="@(_PNSETargetFrameworks->'%(AdditionalPropertiesFromProject)')"
+    <!-- Prefer a non-platform candidate (no '-' in the TFM name). -->
+    <XmlPeek XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
+             Query="/AdditionalProjectProperties/TargetFramework[IsCandidateCompilerGeneratedDocFile='true' and not(contains(@Name, '-'))][1]/@Name">
+      <Output TaskParameter="Result" ItemName="_NonPlatformDocCandidate" />
+    </XmlPeek>
+
+    <!-- Fall back to the first candidate (stable across all TFMs). -->
+    <XmlPeek Condition="'@(_NonPlatformDocCandidate)' == ''"
+             XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
              Query="/AdditionalProjectProperties/TargetFramework[IsCandidateCompilerGeneratedDocFile='true'][1]/@Name">
-      <Output TaskParameter="Result" ItemName="_PNSECandidateTargetFramework" />
+      <Output TaskParameter="Result" ItemName="_AnyDocCandidate" />
     </XmlPeek>
 
     <PropertyGroup>
-      <PNSEDocTargetFramework>@(_PNSECandidateTargetFramework)</PNSEDocTargetFramework>
+      <CanonicalDocSourceTargetFramework Condition="'@(_NonPlatformDocCandidate)' != ''">@(_NonPlatformDocCandidate)</CanonicalDocSourceTargetFramework>
+      <CanonicalDocSourceTargetFramework Condition="'$(CanonicalDocSourceTargetFramework)' == '' and '@(_AnyDocCandidate)' != ''">@(_AnyDocCandidate)</CanonicalDocSourceTargetFramework>
     </PropertyGroup>
   </Target>
 
-  <!-- Skip the PNSE doc-source self-reference when not building a .NETCoreApp vertical. -->
-  <Target Name="AddProjectReferenceToPNSEDocSource"
-          DependsOnTargets="GetPNSEDocTargetFramework"
+  <!-- Add a ProjectReference to the canonical doc source to ensure it builds first.
+       Both PNSE and platform-specific builds flow through this target.
+       Skip if the canonical is this TFM itself (it IS the doc source). -->
+  <Target Name="AddCanonicalDocSourceReference"
+          DependsOnTargets="GetCanonicalDocSourceTargetFramework"
           BeforeTargets="PrepareForBuild"
-          Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and
-                    '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
-                    ('$(BuildTargetFramework)' == '' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')">
-    
-    <Error Condition="'$(PNSEDocTargetFramework)' == ''"
-           Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'PNSEDocTargetFramework' to the desired target framework." />
+          Condition="'$(UseCompilerGeneratedDocXmlFile)' == 'true' and
+                     '$(CanonicalDocSourceTargetFramework)' != '' and
+                     '$(CanonicalDocSourceTargetFramework)' != '$(TargetFramework)' and
+                     ('$(BuildTargetFramework)' == '' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')">
 
-    <!-- ProjectReference to the sibling TF; OutputItemType captures its DocFileItem into @(PNSEDocSource). -->
-    <ItemGroup Condition="'$(PNSEDocTargetFramework)' != ''">
+    <Error Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and '$(CanonicalDocSourceTargetFramework)' == ''"
+           Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'CanonicalDocSourceTargetFramework' to the desired target framework." />
+
+    <ItemGroup>
       <ProjectReference Include="$(MSBuildProjectFullPath)"
-                        SetTargetFramework="TargetFramework=$(PNSEDocTargetFramework)"
+                        SetTargetFramework="TargetFramework=$(CanonicalDocSourceTargetFramework)"
                         ReferenceOutputAssembly="false"
                         Private="false"
                         PrivateAssets="all"
-                        OutputItemType="PNSEDocSource" />
+                        OutputItemType="CanonicalDocSource" />
     </ItemGroup>
   </Target>
 
-  <Target Name="SetDocFileOverrideFromPNSEDocSource"
+  <!-- After resolving references, consume the canonical doc source:
+       - PNSE builds: override their doc file with the canonical's.
+       - Platform-specific builds: pass it to PlatformDocAnalyzer as an AdditionalFile. -->
+  <Target Name="ConsumeCanonicalDocSource"
           AfterTargets="ResolveProjectReferences"
-          Condition="'@(PNSEDocSource)' != '' and '$(DocFileOverride)' == ''">
-    <PropertyGroup>
-      <!-- Use the DocFileItem metadata from the PNSEDocSource reference, which points to the compiler-generated doc XML from the non-PNSE sibling build. -->
-      <DocFileOverride>@(PNSEDocSource->'%(DocFileItem)')</DocFileOverride>
-    </PropertyGroup>
-  </Target>
-
-  <!-- ======================== Platform-specific doc consistency ======================== -->
-  <!-- For platform-specific TFMs (e.g. net11.0-windows), find the canonical
-       (platform-agnostic) sibling TFM's compiler-generated doc XML and pass it to
-       the PlatformDocAnalyzer so it can verify that shared API docs are consistent.
-       We look for the canonical doc XML at its expected artifact path rather than using
-       a ProjectReference, to avoid circular dependencies with PNSE builds and to avoid
-       the overhead of GetTargetFrameworks calls. -->
-
-  <Target Name="AddCanonicalDocAdditionalFile"
-          BeforeTargets="CoreCompile"
-          Condition="'$(TargetPlatformIdentifier)' != '' and
-                     '$(UseCompilerGeneratedDocXmlFile)' == 'true' and
-                     '$(IsPlatformNotSupportedAssembly)' != 'true'">
-
-    <!-- Derive the canonical TFM by stripping the platform suffix (e.g. net11.0-windows → net11.0). -->
-    <PropertyGroup>
-      <_CanonicalDocTfm>$(TargetFramework.Substring(0, $(TargetFramework.IndexOf('-'))))</_CanonicalDocTfm>
-      <_CanonicalDocXmlPath>$([MSBuild]::NormalizePath('$(ArtifactsBinDir)', '$(MSBuildProjectName)', '$(Configuration)', '$(_CanonicalDocTfm)', '$(AssemblyName).xml'))</_CanonicalDocXmlPath>
+          Condition="'@(CanonicalDocSource)' != ''">
+    <!-- PNSE: override the doc file. -->
+    <PropertyGroup Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and '$(DocFileOverride)' == ''">
+      <DocFileOverride>@(CanonicalDocSource->'%(DocFileItem)')</DocFileOverride>
     </PropertyGroup>
 
-    <ItemGroup Condition="Exists('$(_CanonicalDocXmlPath)')">
-      <AdditionalFiles Include="$(_CanonicalDocXmlPath)"
+    <!-- Platform-specific non-PNSE: pass to analyzer for comparison. -->
+    <ItemGroup Condition="'$(IsPlatformNotSupportedAssembly)' != 'true' and '$(TargetPlatformIdentifier)' != ''">
+      <AdditionalFiles Include="@(CanonicalDocSource->'%(DocFileItem)')"
                        PlatformDocCanonical="true" />
     </ItemGroup>
   </Target>

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -129,6 +129,9 @@
       <CanonicalDocSourceTargetFramework Condition="'@(_NonPlatformDocCandidate)' != ''">@(_NonPlatformDocCandidate)</CanonicalDocSourceTargetFramework>
       <CanonicalDocSourceTargetFramework Condition="'$(CanonicalDocSourceTargetFramework)' == '' and '@(_AnyDocCandidate)' != ''">@(_AnyDocCandidate)</CanonicalDocSourceTargetFramework>
     </PropertyGroup>
+
+    <Error Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and '$(CanonicalDocSourceTargetFramework)' == ''"
+           Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'CanonicalDocSourceTargetFramework' to the desired target framework." />
   </Target>
 
   <!-- Add a ProjectReference to the canonical doc source to ensure it builds first.
@@ -141,9 +144,6 @@
                      '$(CanonicalDocSourceTargetFramework)' != '' and
                      '$(CanonicalDocSourceTargetFramework)' != '$(TargetFramework)' and
                      ('$(BuildTargetFramework)' == '' or '$(TargetFrameworkIdentifier)' == '.NETCoreApp')">
-
-    <Error Condition="'$(IsPlatformNotSupportedAssembly)' == 'true' and '$(CanonicalDocSourceTargetFramework)' == ''"
-           Text="Could not find a compatible TargetFramework to use as the documentation source for this PNSE build. Set 'CanonicalDocSourceTargetFramework' to the desired target framework." />
 
     <ItemGroup>
       <ProjectReference Include="$(MSBuildProjectFullPath)"

--- a/eng/intellisense.targets
+++ b/eng/intellisense.targets
@@ -112,21 +112,35 @@
       <Output ItemName="_DocSourceTargetFrameworks" TaskParameter="TargetOutputs" />
     </MSBuild>
 
-    <!-- Prefer a non-platform candidate (no '-' in the TFM name). -->
-    <XmlPeek XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
+    <!-- For platform-specific TFMs, first try the exact TFM with the platform suffix stripped
+         (e.g. net11.0-windows → net11.0). This ensures the canonical matches the same version. -->
+    <PropertyGroup Condition="'$(TargetPlatformIdentifier)' != ''">
+      <_StrippedTfm>$(TargetFramework.Substring(0, $(TargetFramework.IndexOf('-'))))</_StrippedTfm>
+    </PropertyGroup>
+
+    <XmlPeek Condition="'$(_StrippedTfm)' != ''"
+             XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
+             Query="/AdditionalProjectProperties/TargetFramework[@Name='$(_StrippedTfm)' and IsCandidateCompilerGeneratedDocFile='true']/@Name">
+      <Output TaskParameter="Result" ItemName="_StrippedTfmCandidate" />
+    </XmlPeek>
+
+    <!-- Otherwise, prefer any non-platform candidate (no '-' in the TFM name). -->
+    <XmlPeek Condition="'@(_StrippedTfmCandidate)' == ''"
+             XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
              Query="/AdditionalProjectProperties/TargetFramework[IsCandidateCompilerGeneratedDocFile='true' and not(contains(@Name, '-'))][1]/@Name">
       <Output TaskParameter="Result" ItemName="_NonPlatformDocCandidate" />
     </XmlPeek>
 
     <!-- Fall back to the first candidate (stable across all TFMs). -->
-    <XmlPeek Condition="'@(_NonPlatformDocCandidate)' == ''"
+    <XmlPeek Condition="'@(_StrippedTfmCandidate)' == '' and '@(_NonPlatformDocCandidate)' == ''"
              XmlContent="@(_DocSourceTargetFrameworks->'%(AdditionalPropertiesFromProject)')"
              Query="/AdditionalProjectProperties/TargetFramework[IsCandidateCompilerGeneratedDocFile='true'][1]/@Name">
       <Output TaskParameter="Result" ItemName="_AnyDocCandidate" />
     </XmlPeek>
 
     <PropertyGroup>
-      <CanonicalDocSourceTargetFramework Condition="'@(_NonPlatformDocCandidate)' != ''">@(_NonPlatformDocCandidate)</CanonicalDocSourceTargetFramework>
+      <CanonicalDocSourceTargetFramework Condition="'@(_StrippedTfmCandidate)' != ''">@(_StrippedTfmCandidate)</CanonicalDocSourceTargetFramework>
+      <CanonicalDocSourceTargetFramework Condition="'$(CanonicalDocSourceTargetFramework)' == '' and '@(_NonPlatformDocCandidate)' != ''">@(_NonPlatformDocCandidate)</CanonicalDocSourceTargetFramework>
       <CanonicalDocSourceTargetFramework Condition="'$(CanonicalDocSourceTargetFramework)' == '' and '@(_AnyDocCandidate)' != ''">@(_AnyDocCandidate)</CanonicalDocSourceTargetFramework>
     </PropertyGroup>
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Schema;
 
+#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
+
 namespace System.Xml
 {
     // Represents a reader that provides fast, non-cached forward only stream access to XML data.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlReaderAsync.cs
@@ -8,13 +8,12 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Schema;
 
-#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
-
 namespace System.Xml
 {
-    // Represents a reader that provides fast, non-cached forward only stream access to XML data.
+#pragma warning disable PLATDOC002 // Async partial uses established TypeNameAsync.cs naming convention
     [DebuggerDisplay($"{{{nameof(DebuggerDisplayProxy)}}}")]
     public abstract partial class XmlReader : IDisposable
+#pragma warning restore PLATDOC002
     {
         public virtual Task<string> GetValueAsync()
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -6,13 +6,11 @@ using System.Threading.Tasks;
 using System.Xml.Schema;
 using System.Xml.XPath;
 
-#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
-
 namespace System.Xml
 {
-    // Represents a writer that provides fast non-cached forward-only way of generating XML streams containing XML documents
-    // that conform to the W3C Extensible Markup Language (XML) 1.0 specification and the Namespaces in XML specification.
+#pragma warning disable PLATDOC002 // Async partial uses established TypeNameAsync.cs naming convention
     public abstract partial class XmlWriter : IDisposable, IAsyncDisposable
+#pragma warning restore PLATDOC002
     {
         // Write methods
         // Writes out the XML declaration with the version "1.0".

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlWriterAsync.cs
@@ -6,6 +6,8 @@ using System.Threading.Tasks;
 using System.Xml.Schema;
 using System.Xml.XPath;
 
+#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
+
 namespace System.Xml
 {
     // Represents a writer that provides fast non-cached forward-only way of generating XML streams containing XML documents

--- a/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
@@ -5,16 +5,11 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 
-#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
-
 namespace System.Xml.Resolvers
 {
-    //
-    // XmlPreloadedResolver is an XmlResolver that which can be pre-loaded with data.
-    // By default it contains well-known DTDs for XHTML 1.0 and RSS 0.91.
-    // Custom mappings of URIs to data can be added with the Add method.
-    //
+#pragma warning disable PLATDOC002 // Async partial uses established TypeNameAsync.cs naming convention
     public partial class XmlPreloadedResolver : XmlResolver
+#pragma warning restore PLATDOC002
     {
         public override Task<object> GetEntityAsync(Uri absoluteUri,
                                              string? role,

--- a/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Resolvers/XmlPreloadedResolverAsync.cs
@@ -5,6 +5,8 @@ using System.IO;
 using System.Threading.Tasks;
 using System.Xml;
 
+#pragma warning disable PLATDOC002 // Not platform-specific; Async partial uses established naming convention
+
 namespace System.Xml.Resolvers
 {
     //

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
@@ -4,12 +4,11 @@
 using System.IO;
 using System.Threading.Tasks;
 
-#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
-
 namespace System.Xml
 {
     public abstract partial class XmlResolver
     {
+#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
         /// <summary>
         /// Gets an XML resolver which resolves only file system URIs.
         /// </summary>
@@ -19,6 +18,7 @@ namespace System.Xml
         /// <see cref="XmlResolver"/> instance returned by this property will resolve only URIs which scheme is file.
         /// </remarks>
         public static XmlResolver FileSystemResolver => XmlFileSystemResolver.s_singleton;
+#pragma warning restore PLATDOC003
 
         // An XML resolver that resolves only file system URIs.
         private sealed class XmlFileSystemResolver : XmlResolver

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.FileSystemResolver.cs
@@ -4,6 +4,8 @@
 using System.IO;
 using System.Threading.Tasks;
 
+#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
+
 namespace System.Xml
 {
     public abstract partial class XmlResolver

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.ThrowingResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.ThrowingResolver.cs
@@ -4,6 +4,8 @@
 using System.Net;
 using System.Threading.Tasks;
 
+#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
+
 namespace System.Xml
 {
     public abstract partial class XmlResolver

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.ThrowingResolver.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlResolver.ThrowingResolver.cs
@@ -4,12 +4,11 @@
 using System.Net;
 using System.Threading.Tasks;
 
-#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
-
 namespace System.Xml
 {
     public abstract partial class XmlResolver
     {
+#pragma warning disable PLATDOC003 // Not platform-specific; property lives in this file by convention
         /// <summary>
         /// Gets an XML resolver which forbids entity resolution.
         /// </summary>
@@ -23,6 +22,7 @@ namespace System.Xml
         /// prohibited, even when DTD processing is otherwise enabled.
         /// </remarks>
         public static XmlResolver ThrowingResolver => XmlThrowingResolver.s_singleton;
+#pragma warning restore PLATDOC003
 
         // An XmlResolver that forbids all external entity resolution.
         private sealed class XmlThrowingResolver : XmlResolver


### PR DESCRIPTION
## Add PlatformDocAnalyzer to enforce consistent documentation across platform-specific builds
 
 When a library uses `UseCompilerGeneratedDocXmlFile=true` (the default) and targets platform-specific TFMs like `net11.0-windows`, only one platform's compiler-generated doc XML is shipped to customers in the IntelliSense package. If XML doc comments are placed on platform-specific partial source files, they may be missing or inconsistent on other platforms.
 
 This PR adds a Roslyn analyzer (`eng/analyzers/PlatformDocAnalyzer`) that enforces documentation placement conventions and validates doc consistency. It only activates for platform-specific TFMs with `UseCompilerGeneratedDocXmlFile=true`.
 
 ### Diagnostics
 
 | ID | Severity | Description |
 |----|----------|-------------|
 | PLATDOC001 | Warning | Public type has no source file named `TypeName.cs`. |
 | PLATDOC002 | Warning | Partial source file doesn't follow the `TypeName.Something.cs` naming convention. |
 | PLATDOC003 | Warning | Public member in a non-primary partial file has XML doc comments that should be moved to `TypeName.cs`. |
 | PLATDOC004 | Warning | Documentation for a public API differs from the canonical (platform-agnostic) build. |
 
 PLATDOC001–003 are heuristic rules that guide source organization for partial types split across multiple files. PLATDOC004 is the authoritative check: when a project also targets a platform-agnostic TFM (e.g. `net11.0` alongside `net11.0-windows`), the build locates the canonical TFM's compiler-generated doc XML and passes it to the analyzer as an `AdditionalFile`. The analyzer then compares each public API's documentation against the canonical version and reports mismatches.
 
 ### Build integration
 
 - **`eng/intellisense.targets`** — For platform-specific TFMs, derives the canonical TFM by stripping the platform suffix (e.g. `net11.0-windows` → `net11.0`) and passes its doc XML as an `AdditionalFile` if available. Uses the artifact path directly rather than a `ProjectReference` to avoid circular dependencies with PNSE builds.
 - **`eng/generators.targets`** — Wires the analyzer into all `IsSourceProject` C# builds.
 - **`eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.props`** — Declares `CompilerVisibleProperty` and `CompilerVisibleItemMetadata` for the analyzer to read MSBuild context.
 
 ### Suppressions
 
 Added `#pragma warning disable` in 5 System.Private.Xml files that use established non-platform-specific patterns (`TypeNameAsync.cs` for async partials, `XmlResolver.FileSystemResolver.cs` / `ThrowingResolver.cs` for nested-type-adjacent properties).
