### PR TITLE
Fix PGO instrumentation for libcoreclr.so static libraries

### DIFF
--- a/src/coreclr/pgosupport.cmake
+++ b/src/coreclr/pgosupport.cmake
@@ -78,18 +78,20 @@ endfunction(add_pgo)
 # On Windows, PGO is handled entirely via link-time flags (/LTCG) so this isn't needed.
 if(NOT WIN32)
     if(CLR_CMAKE_PGO_INSTRUMENT)
-        if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
-            add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fprofile-instr-generate>)
-            # All shared libraries need to link the profiling runtime to resolve
-            # instrumentation symbols from their static library dependencies.
-            add_link_options(-fprofile-instr-generate)
+        if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
+                add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fprofile-instr-generate>)
+                # All shared libraries need to link the profiling runtime to resolve
+                # instrumentation symbols from their static library dependencies.
+                add_link_options(-fprofile-instr-generate)
+            endif()
         endif()
     elseif(CLR_CMAKE_PGO_OPTIMIZE AND NOT CLR_CMAKE_ENABLE_SANITIZERS)
         file(TO_NATIVE_PATH "${CLR_CMAKE_OPTDATA_PATH}/data/coreclr.profdata" _PgoGlobalProfilePath)
-        if(EXISTS ${_PgoGlobalProfilePath})
+        if(EXISTS "${_PgoGlobalProfilePath}")
             if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
                 if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
-                    check_have_lto_and_pgodata_supported(${_PgoGlobalProfilePath})
+                    check_have_lto_and_pgodata_supported("${_PgoGlobalProfilePath}")
                     if(HAVE_LTO_AND_PGO_DATA_SUPPORTED)
                         message(STATUS "Enabling profile guided optimizations globally for coreclr static libraries")
                         add_compile_options(

--- a/src/coreclr/pgosupport.cmake
+++ b/src/coreclr/pgosupport.cmake
@@ -67,3 +67,39 @@ function(add_pgo TargetName)
         endif(NOT EXISTS ${ProfilePath})
     endif(CLR_CMAKE_PGO_INSTRUMENT)
 endfunction(add_pgo)
+
+# On non-Windows platforms, PGO compile flags (-fprofile-instr-generate for instrumentation,
+# -fprofile-instr-use for optimization) must be applied at directory scope so they also affect
+# the static and object libraries (cee_wks, utilcode, coreclrpal, etc.) that are linked into
+# the final shared libraries. The per-target add_pgo function above only applies compile flags
+# to the shared library target itself, which only covers its directly compiled sources
+# (e.g. mscoree.cpp and exports.cpp for coreclr). add_pgo still sets the per-target LTO
+# link flags needed by the final shared library.
+# On Windows, PGO is handled entirely via link-time flags (/LTCG) so this isn't needed.
+if(NOT WIN32)
+    if(CLR_CMAKE_PGO_INSTRUMENT)
+        if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
+            add_compile_options($<$<COMPILE_LANGUAGE:C,CXX>:-fprofile-instr-generate>)
+            # All shared libraries need to link the profiling runtime to resolve
+            # instrumentation symbols from their static library dependencies.
+            add_link_options(-fprofile-instr-generate)
+        endif()
+    elseif(CLR_CMAKE_PGO_OPTIMIZE AND NOT CLR_CMAKE_ENABLE_SANITIZERS)
+        file(TO_NATIVE_PATH "${CLR_CMAKE_OPTDATA_PATH}/data/coreclr.profdata" _PgoGlobalProfilePath)
+        if(EXISTS ${_PgoGlobalProfilePath})
+            if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+                if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE OR UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELWITHDEBINFO)
+                    check_have_lto_and_pgodata_supported(${_PgoGlobalProfilePath})
+                    if(HAVE_LTO_AND_PGO_DATA_SUPPORTED)
+                        message(STATUS "Enabling profile guided optimizations globally for coreclr static libraries")
+                        add_compile_options(
+                            $<$<COMPILE_LANGUAGE:C,CXX>:-fprofile-instr-use=${_PgoGlobalProfilePath}>
+                            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-profile-instr-out-of-date>
+                            $<$<COMPILE_LANGUAGE:C,CXX>:-Wno-profile-instr-unprofiled>
+                        )
+                    endif()
+                endif()
+            endif()
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
> [!NOTE]
> This PR was created with the assistance of GitHub Copilot.

Fixes #124141

On non-Windows, `add_pgo(coreclr)` used `target_compile_options(PRIVATE)` which only applied `-fprofile-instr-generate`/`-fprofile-instr-use` to the 2 source files directly compiled by the `coreclr` target (`mscoree.cpp`, `exports.cpp`). The runtime's real code lives in static libraries (`cee_wks`, `utilcode`, `coreclrpal`, etc.) that were linked in without instrumentation. This doesn't affect `clrjit` (all JIT sources compile directly into the shared library) or Windows (PGO uses link-time `/LTCG` flags).

Fix: add directory-scoped PGO compile flags in `pgosupport.cmake` so all C/C++ sources in the coreclr tree get the flags. The existing `add_pgo()` is unchanged — it still sets per-target LTO link flags. Assembly files are excluded via `$<$<COMPILE_LANGUAGE:C,CXX>:...>`.

### Before (instrumented `libcoreclr.so`)

| Section | Size |
|---|---|
| `__llvm_prf_names` | — |
| `__llvm_prf_cnts` | — |
| `__llvm_prf_data` | — |
| **Estimated profiled functions** | **~30** |

### After (instrumented `libcoreclr.so`)

| Section | Size |
|---|---|
| `__llvm_prf_names` | 283 KB |
| `__llvm_prf_cnts` | 801 KB |
| `__llvm_prf_data` | 1,094 KB |
| **Estimated profiled functions** | **~20,000** |

No changes needed in `dotnet-optimization` — the training pipeline already collects all `*.profraw` files and merges them into `coreclr.profdata`.