### PR TITLE
Add ProjectReference for crossgen2 in tests project

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/ILCompiler.ReadyToRun.Tests.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <ProjectReference Include="../ILCompiler.Reflection.ReadyToRun/ILCompiler.Reflection.ReadyToRun.csproj" />
+    <ProjectReference Include="../crossgen2/crossgen2_inbuild.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <!-- Test case source files are embedded as resources so we can compile them with Roslyn at test time.


### PR DESCRIPTION
To make sure the latest changes for crossgen2 are picked up when building and running the test project locally.