### PR TITLE
Update SafeProcessHandle.Unix.cs

### DIFF
--- a/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
+++ b/src/libraries/System.Diagnostics.Process/src/Microsoft/Win32/SafeHandles/SafeProcessHandle.Unix.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Win32.SafeHandles
             }
 
             // use default program to open file/url
-            filename = Process.GetPathToOpenFile();
+            filename = Process.GetPathToOpenFile() ?? throw new Win32Exception(Interop.Errors.ERROR_NO_ASSOCIATION);
             string[] openFileArgv = ProcessUtils.ParseArgv(startInfo, filename, ignoreArguments: true);
 
             SafeProcessHandle result = ForkAndExecProcess(


### PR DESCRIPTION
# fix: Throw appropriate exception when no shell-open utility is found

fixes : https://github.com/dotnet/runtime/issues/96565

## Problem

`Process.GetPathToOpenFile()` can return `null` when no shell-open utility (e.g. `xdg-open`, `open`) is found on the system. The return value was previously used without a null check, which could lead to a null reference further down the call path.

## Changes

Added a null check on the return value of `GetPathToOpenFile()` that throws a `Win32Exception` with `ERROR_NO_ASSOCIATION` when no utility is found.

```csharp
filename = Process.GetPathToOpenFile()
    ?? throw new Win32Exception(Interop.Errors.ERROR_NO_ASSOCIATION);