### PR TITLE
fix: 1 mili sec delay for read and write

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Unix.cs
@@ -787,11 +787,13 @@ namespace System.IO.Ports
                 {
                     Interop.ErrorInfo lastError = Interop.Sys.GetLastErrorInfo();
 
-                    // ignore EWOULDBLOCK since we handle timeout elsewhere
-                    if (lastError.Error != Interop.Error.EWOULDBLOCK)
+                    if (lastError.Error == Interop.Error.EWOULDBLOCK)
                     {
-                        readRequest.Complete(Interop.GetIOException(lastError));
+                        // no data available right now, signal caller to stop draining
+                        return -1;
                     }
+
+                    readRequest.Complete(Interop.GetIOException(lastError));
                 }
                 else if (numBytes > 0)
                 {
@@ -820,9 +822,13 @@ namespace System.IO.Ports
                 {
                     Interop.ErrorInfo lastError = Interop.Sys.GetLastErrorInfo();
 
-                    // ignore EWOULDBLOCK since we handle timeout elsewhere
-                    // numBytes == 0 means that there might be an error
-                    if (lastError.Error != Interop.Error.SUCCESS && lastError.Error != Interop.Error.EWOULDBLOCK)
+                    if (lastError.Error == Interop.Error.EWOULDBLOCK)
+                    {
+                        // write buffer full right now, signal caller to stop draining
+                        return -1;
+                    }
+
+                    if (lastError.Error != Interop.Error.SUCCESS)
                     {
                         r.Complete(Interop.GetIOException(lastError));
                     }
@@ -850,7 +856,12 @@ namespace System.IO.Ports
             while (TryPeekNextRequest(out SerialStreamIORequest r))
             {
                 int ret = op(r);
-                Debug.Assert(ret >= 0);
+
+                if (ret < 0)
+                {
+                    // EWOULDBLOCK — no data available right now, propagate to caller
+                    return -1;
+                }
 
                 if (r.IsCompleted)
                 {
@@ -947,9 +958,9 @@ namespace System.IO.Ports
                 else
                 {
                     Interop.PollEvents events = PollEvents(1,
-                                                               pollReadEvents: hasPendingReads,
-                                                               pollWriteEvents: hasPendingWrites,
-                                                               out Interop.ErrorInfo? error);
+                                                            pollReadEvents: hasPendingReads,
+                                                            pollWriteEvents: hasPendingWrites,
+                                                            out Interop.ErrorInfo? error);
 
                     if (error.HasValue)
                     {
@@ -967,13 +978,23 @@ namespace System.IO.Ports
 
                     if (events.HasFlag(Interop.PollEvents.POLLIN))
                     {
-                        int bytesRead = DoIORequest(_readQueue, _readQueueLock, _processReadDelegate);
-                        _totalBytesRead += bytesRead;
+                        // drain all requests that have data ready right now
+                        // without paying another 1ms poll cost per request
+                        while (!IsReadQueueEmpty())
+                        {
+                            int bytesRead = DoIORequest(_readQueue, _readQueueLock, _processReadDelegate);
+                            if (bytesRead <= 0) break; // 0 = queue empty, -1 = EWOULDBLOCK
+                            _totalBytesRead += bytesRead;
+                        }
                     }
 
                     if (events.HasFlag(Interop.PollEvents.POLLOUT))
                     {
-                        DoIORequest(_writeQueue, _writeQueueLock, _processWriteDelegate);
+                        // flush as many pending write requests as possible
+                        while (!IsWriteQueueEmpty())
+                        {
+                            if (DoIORequest(_writeQueue, _writeQueueLock, _processWriteDelegate) <= 0) break;
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/45635

### Problem

When calling `ReadByte()` multiple times while data is already available in the
driver buffer, each call incurs a minimum 1ms delay. For example:

```csharp
// 4 bytes already sitting in driver buffer — costs 4ms instead of ~0ms
port.ReadByte(); // 1ms
port.ReadByte(); // 1ms
port.ReadByte(); // 1ms
port.ReadByte(); // 1ms
```

The same issue affects writes. When writing chunks of data in sequence,
each `Write()` call enqueues a request and waits for the next poll cycle
to flush it, paying the same 1ms cost per write even when the driver's
send buffer has room and could accept the data immediately:

```csharp
// driver send buffer has room — but still costs 1ms per write
port.Write(buf1, 0, buf1.Length); // 1ms
port.Write(buf2, 0, buf2.Length); // 1ms
port.Write(buf3, 0, buf3.Length); // 1ms
```

This affects any scenario where `port.BytesToRead > 1` and the caller reads
in a loop using `ReadByte()` or any read smaller than the available data.
Reported on Linux and WSL2. Windows is not affected as it uses a different
code path.

### Root cause

Two bugs working together in `SerialStream.Unix.cs`:

**Bug 1 — `IOLoop` only processes one request per poll cycle.**
After a successful `PollEvents` call confirms data is ready, `DoIORequest` is
called once, completes one request, and returns. The loop then goes back to the
top and calls `PollEvents(timeout: 1ms)` again for the next request — even
though data is still sitting in the buffer ready to go. Each byte pays the full
1ms poll cost independently. This applies to both reads and writes.

**Bug 2 — `ProcessRead` and `ProcessWrite` return `0` for both "queue empty"
and "EWOULDBLOCK".**
Even if we tried to drain multiple requests in one shot, there was no way for
`DoIORequest` to know whether `0` meant "nothing left to read/write right now"
vs "the queue is empty". This made it impossible to implement a correct drain
loop without risking spinning forever.

### Fix

Four coupled changes, all required together:

**`ProcessRead`** — on `EWOULDBLOCK`, explicitly return `-1` instead of falling
through to `return 0` at the bottom. This gives the caller a distinct signal
that no data is available right now, separate from the queue-empty case.

**`ProcessWrite`** — same change on the write side. Return `-1` on `EWOULDBLOCK`
instead of falling through.

**`DoIORequest`** — remove `Debug.Assert(ret >= 0)` since `-1` is now a valid
and meaningful return value. Propagate `-1` immediately to the caller when
received from the processor delegate.

**`IOLoop`** — replace the single `DoIORequest` call with a drain loop for both
reads and writes. After a single successful `PollEvents`, keep processing
requests until either the queue is empty (`0`) or the driver signals no more
data right now (`-1`). `_totalBytesRead` is updated inside the loop so it only
accumulates real positive reads.

```csharp
// before — one request per poll cycle
if (events.HasFlag(Interop.PollEvents.POLLIN))
{
    int bytesRead = DoIORequest(_readQueue, _readQueueLock, _processReadDelegate);
    _totalBytesRead += bytesRead;
}

if (events.HasFlag(Interop.PollEvents.POLLOUT))
{
    DoIORequest(_writeQueue, _writeQueueLock, _processWriteDelegate);
}

// after — drain all ready requests in one shot for both reads and writes
if (events.HasFlag(Interop.PollEvents.POLLIN))
{
    while (!IsReadQueueEmpty())
    {
        int bytesRead = DoIORequest(_readQueue, _readQueueLock, _processReadDelegate);
        if (bytesRead <= 0) break; // 0 = queue empty, -1 = EWOULDBLOCK
        _totalBytesRead += bytesRead;
    }
}

if (events.HasFlag(Interop.PollEvents.POLLOUT))
{
    while (!IsWriteQueueEmpty())
    {
        if (DoIORequest(_writeQueue, _writeQueueLock, _processWriteDelegate) <= 0) break;
    }
}
```
