### PR TITLE
Fix for index out of bounds in sve scatter test

### DIFF
--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
@@ -163,8 +163,7 @@ namespace {Namespace}._Sve
             {
                 if(!dict.Add(input[i]))
                 {
-                    // value already exist
-                    input[i] += sizeof({Op1BaseType});
+                    input[i] = (input[i] + 1) % ({Op2BaseType})OutElementCount;
                     continue;
                 }
                 i++;

--- a/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
+++ b/src/tests/JIT/HardwareIntrinsics/Arm/Shared/SveScatterVectorBases.template
@@ -163,6 +163,7 @@ namespace {Namespace}._Sve
             {
                 if(!dict.Add(input[i]))
                 {
+                    // value already exists
                     input[i] = (input[i] + 1) % ({Op2BaseType})OutElementCount;
                     continue;
                 }


### PR DESCRIPTION
Test `Sve_Scatter8BitNarrowing_long_ulong` gets "Index 1031 exceeds array length 1024" on osx arm64.  This assert comes out of test setup

I could not reproduce this locally - a couple of these ScatterNBitNarrowing tests failed sporadically across different pipelines, but locally I couldn't get the RNG to line up.

The error itself is printed when the test input array contains out of bounds data.  Likely a problem with test setup - `SveScatterVector.template` (see MakeDistinct) already clamps its index values to array length, so the same fix is needed in `SveScatterVectorBases.template`

fixes #128311 