### PR TITLE
Add DataFlowInPrimaryConstructor test case

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/ConstructorDataFlow.cs
@@ -18,6 +18,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         public static void Main()
         {
             DataFlowInConstructor.Test();
+            DataFlowInPrimaryConstructor.Test();
             DataFlowInStaticConstructor.Test();
         }
 
@@ -92,6 +93,18 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             {
                 var instance = new DataFlowInConstructor();
                 var _ = instance.PropertyWithReturnStatementInGetter;
+            }
+        }
+
+        class DataFlowInPrimaryConstructor(Type type)
+        {
+            [ExpectedWarning("IL2069", nameof(annotatedField), nameof(type))]
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)]
+            Type annotatedField = type;
+
+            public static void Test()
+            {
+                new DataFlowInPrimaryConstructor(null);
             }
         }
 


### PR DESCRIPTION
This should be the scenario that was running into asserts in the Roslyn analyzer according to my AI. Let's see what the CI says now that asserts are enabled.