### PR TITLE
Pass null to setBoundaries if the il to native map is empty

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1270,6 +1270,12 @@ void InterpCompiler::EmitCode()
 
         m_compHnd->setVars(m_methodInfo->ftn, m_numILVars, eeVars);
     }
+
+    if (m_ILToNativeMapSize == 0 && m_pILToNativeMap != NULL)
+    {
+        m_compHnd->freeArray(m_pILToNativeMap);
+        m_pILToNativeMap = NULL;
+    }
     m_compHnd->setBoundaries(m_methodInfo->ftn, m_ILToNativeMapSize, m_pILToNativeMap);
     m_pILToNativeMap = NULL; // Ownership transferred to the VM
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,7 +319,7 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    if (m_isFirstInstForEmptyILStack)
+    if (m_isFirstInstForEmptyILStack && !InterpOpIsEmitNop(opcode))
     {
         // This is the first instruction we are emitting for this IL offset and the stack is empty, which
         // implies the IL stack is empty too.
@@ -1130,6 +1130,9 @@ int32_t *InterpCompiler::EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Re
             ins->nativeOffset = (int32_t)(ip - m_pMethodCode);
             if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
             {
+                // FIXME We should avoid removing these instructions in the first place. I believe
+                // this only needs to be handled by emitting INTOP_DEBUG_SEQ_POINT for CEE_POP.
+                //
                 // Emit a debug sequence point so that eliminated IL instructions
                 // still occupy a bytecode slot. This ensures return addresses after
                 // calls land within the call's native offset range rather than on


### PR DESCRIPTION
We preallocate this array, with IL code size capacity, but we don't always add maps to it. The runtime has an assert that the array should be null if the size is 0.

The map can be empty with simple methods like:
```
IL_0000 newobj    , sp 0,
IL_0005 ret       , sp 1, O System.Text.Json.Utf8JsonWriter
```

Regressed after https://github.com/dotnet/runtime/pull/127469 where we reduce the amount of map entries to locations with empty stack.

Fixes assertions like `FAILED: (iOffsetMapping == 0) == (pOffsetMapping == 0)`

Fixes https://github.com/dotnet/runtime/issues/127663