### PR TITLE
 Change PerfMap CRST to use UNSAFE_ANYMODE

### DIFF
--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -47,7 +47,15 @@ void PerfMap::Initialize()
 {
     LIMITED_METHOD_CONTRACT;
 
-    s_csPerfMap.Init(CrstPerfMap);
+    // Use CRST_UNSAFE_ANYMODE to avoid a GC-mode toggle deadlock: callers such as
+    // CodeFragmentHeap::RealAllocAlignedMem hold CRST_UNSAFE_ANYMODE locks in cooperative
+    // mode. A default Crst here would toggle cooperative->preemptive->acquire->cooperative,
+    // and the post-acquire DisablePreemptiveGC can block on a pending GC suspension,
+    // forming a deadlock cycle with threads waiting on the outer UNSAFE_ANYMODE lock.
+    // All data accessed under this lock is native (FILE*, fd, SString) so holding it
+    // in cooperative mode does not introduce new GC-safety issues -- the I/O was already
+    // performed in cooperative mode with the previous default Crst.
+    s_csPerfMap.Init(CrstPerfMap, CrstFlags(CRST_UNSAFE_ANYMODE));
 
     PerfMapType perfMapType = (PerfMapType)CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled);
     PerfMap::Enable(perfMapType, false);
@@ -299,7 +307,7 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
     CONTRACTL{
         THROWS;
         GC_NOTRIGGER;
-        MODE_PREEMPTIVE;
+        MODE_ANY;
         PRECONDITION(pMethod != nullptr);
         PRECONDITION(pCode != nullptr);
         PRECONDITION(codeSize > 0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/128401

A .NET process on Linux can permanently deadlock when PerfMap is enabled (`DOTNET_PerfMapEnabled` or via Diagnostics Server IPC). The deadlock is a three-way cycle between GC suspension, `CodeFragmentHeap::m_Lock` (CRST_UNSAFE_ANYMODE), and `PerfMap::s_csPerfMap` (CRST_DEFAULT).

Acuiring s_csPerfMap on a coop thread toggles a to preemptive before acquiring the mutex, then back to cooperative after. The post-acquire DisablePreemptiveGC can block indefinitely via `RareDisablePreemptiveGC` when a GC suspension is in progress if another thread started GC suspension and a that hasn't been suspended tries to hold CodeFragmentHeap lock. That thread cannot reach a GC safe point, so we end up blocking suspension indefinitely.

The fix changes s_csPerfMap to `CRST_UNSAFE_ANYMODE`, eliminating the GC-mode toggle. All data accessed under this lock is native (FILE*, fd, SString), so holding it in cooperative mode introduces no new GC-safety issues — the I/O was already performed in cooperative mode with the previous default Crst (the toggle only affected the mutex-wait phase, not the work phase). The IO operations could be slow and cause gc pause times, but those are already done in coop mode right now so it's not regressing that case.