### PR TITLE
[release/10.0] Change PerfMap CRST to use UNSAFE_ANYMODE

### DIFF
--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -46,7 +46,15 @@ void PerfMap::Initialize()
 {
     LIMITED_METHOD_CONTRACT;
 
-    s_csPerfMap.Init(CrstPerfMap);
+    // Use CRST_UNSAFE_ANYMODE to avoid a GC-mode toggle deadlock: callers such as
+    // CodeFragmentHeap::RealAllocAlignedMem hold CRST_UNSAFE_ANYMODE locks in cooperative
+    // mode. A default Crst here would toggle cooperative->preemptive->acquire->cooperative,
+    // and the post-acquire DisablePreemptiveGC can block on a pending GC suspension,
+    // forming a deadlock cycle with threads waiting on the outer UNSAFE_ANYMODE lock.
+    // All data accessed under this lock is native (FILE*, fd, SString) so holding it
+    // in cooperative mode does not introduce new GC-safety issues -- the I/O was already
+    // performed in cooperative mode with the previous default Crst.
+    s_csPerfMap.Init(CrstPerfMap, CrstFlags(CRST_UNSAFE_ANYMODE));
 
     PerfMapType perfMapType = (PerfMapType)CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PerfMapEnabled);
     PerfMap::Enable(perfMapType, false);
@@ -313,7 +321,7 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
     CONTRACTL{
         THROWS;
         GC_NOTRIGGER;
-        MODE_PREEMPTIVE;
+        MODE_ANY;
         PRECONDITION(pMethod != nullptr);
         PRECONDITION(pCode != nullptr);
         PRECONDITION(codeSize > 0);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/128401

main PR https://github.com/dotnet/runtime/pull/128429

# Description

 A .NET process on Linux can permanently deadlock when PerfMap is enabled (`DOTNET_PerfMapEnabled` or via Diagnostics Server IPC). The deadlock is a three-way cycle between GC suspension, `CodeFragmentHeap::m_Lock` (CRST_UNSAFE_ANYMODE), and `PerfMap::s_csPerfMap` (CRST_DEFAULT).

Acuiring s_csPerfMap on a coop thread toggles a to preemptive before acquiring the mutex, then back to cooperative after. The post-acquire DisablePreemptiveGC can block indefinitely via `RareDisablePreemptiveGC` when a GC suspension is in progress if another thread started GC suspension and a that hasn't been suspended tries to hold CodeFragmentHeap lock. That thread cannot reach a GC safe point, so we end up blocking suspension indefinitely.

The fix changes s_csPerfMap to `CRST_UNSAFE_ANYMODE`, eliminating the GC-mode toggle. All data accessed under this lock is native (FILE*, fd, SString), so holding it in cooperative mode introduces no new GC-safety issues — the I/O was already performed in cooperative mode with the previous default Crst (the toggle only affected the mutex-wait phase, not the work phase). The IO operations could be slow and cause gc pause times, but those are already done in coop mode right now so it's not regressing that case.

# Customer Impact

Any .NET application running with PerfMap enabled on Linux (directly or via diagnostic tools like dotnet-trace, dotnet-monitor, or third-party APM agents) can hang permanently under concurrent virtual-call-stub creation and GC pressure. The process becomes unresponsive with no way to recover short of killing it. The only workaround is disabling both DOTNET_PerfMapEnabled=0 and DOTNET_EnableDiagnostics_IPC=0, which disables all perf profiling and diagnostics capabilities.

# Regression

Yes, from 8 to 10. Likely around perfmap granularity changes when stub creation got rewritten.

# Testing

- Audited all s_csPerfMap holders (Enable, Disable, LogJITCompiledMethod, LogPreCompiledMethod, LogStubs) - all access only native data (FILE*, fd, SString, PCODE) with no managed references. Audited the 4 problematic call sites as well.
- Stress-tested with a repro app with 2000 emitted types across 20 interfaces with concurrent polymorphic dispatch and aggressive GC pressure (DOTNET_GCConserveMemory=9). Usually 5 - 10 runs repro'd the issue against .NET 10, but with this 50 iterations ran to completion.

# Risk

Low. The change is a single flag addition to a lock initialization call. CRST_UNSAFE_ANYMODE is well-established and widely used throughout the VM for locks that protect native-only data (e.g., CodeFragmentHeap::m_Lock, m_JumpStubCrst, m_CodeHeapLock). The behavioral change is strictly a removal of an unnecessary GC-mode toggle - the I/O under the lock was already executing in cooperative mode after the post-acquire toggle, so no new GC-latency regression is introduced.