### PR TITLE
JIT: Disallow CSE of multireg nodes

### DIFF
--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1803,7 +1803,9 @@ bool CSE_HeuristicCommon::CanConsiderTree(GenTree* tree, bool isReturn)
         // IR that lower is not yet prepared to handle.
         //
         if (isReturn)
+        {
             return false;
+        }
 
         // The locals we introduce cannot be be enregistered in multiple
         // registers since we do not promote them, so they would always be
@@ -1811,7 +1813,9 @@ bool CSE_HeuristicCommon::CanConsiderTree(GenTree* tree, bool isReturn)
         // destinations when replacing the CSEs uses and we do not currently do
         // that.
         if (tree->IsMultiRegNode())
+        {
             return false;
+        }
     }
 
     // No good if the expression contains side effects or if it was marked as DONT CSE

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1796,13 +1796,22 @@ bool CSE_HeuristicCommon::CanConsiderTree(GenTree* tree, bool isReturn)
         }
     }
 
-    // Don't allow non-SIMD struct CSEs under a return; we don't fully
-    // re-morph these if we introduce a CSE store, and so may create
-    // IR that lower is not yet prepared to handle.
-    //
-    if (isReturn && varTypeIsStruct(tree->gtType) && !varTypeIsSIMD(tree->gtType))
+    if (varTypeIsStruct(tree->gtType) && !varTypeIsSIMD(tree->gtType))
     {
-        return false;
+        // Don't allow non-SIMD struct CSEs under a return; we don't fully
+        // re-morph these if we introduce a CSE store, and so may create
+        // IR that lower is not yet prepared to handle.
+        //
+        if (isReturn)
+            return false;
+
+        // The locals we introduce cannot be be enregistered in multiple
+        // registers since we do not promote them, so they would always be
+        // spilled. Also, for correctness we would need to DNER existing store
+        // destinations when replacing the CSEs uses and we do not currently do
+        // that.
+        if (tree->IsMultiRegNode())
+            return false;
     }
 
     // No good if the expression contains side effects or if it was marked as DONT CSE

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -1807,11 +1807,12 @@ bool CSE_HeuristicCommon::CanConsiderTree(GenTree* tree, bool isReturn)
             return false;
         }
 
-        // The locals we introduce cannot be be enregistered in multiple
-        // registers since we do not promote them, so they would always be
-        // spilled. Also, for correctness we would need to DNER existing store
-        // destinations when replacing the CSEs uses and we do not currently do
-        // that.
+        // Skip all multireg nodes. The locals we introduce cannot be
+        // enregistered in multiple registers since we do not promote them, so
+        // they would always be spilled. Also, for correctness we would need to
+        // DNER existing store destinations when replacing the CSE uses and we
+        // do not currently do that.
+        //
         if (tree->IsMultiRegNode())
         {
             return false;


### PR DESCRIPTION
These will always be spilled since we do not promote the new locals, but also for correctness we would need to DNER destinations of existing stores from these locals.

Fix #127142
Fix #128452