### PR TITLE
Fix NativeAOT string GC config handling

### DIFF
--- a/src/coreclr/nativeaot/Runtime/RhConfig.cpp
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.cpp
@@ -106,24 +106,38 @@ bool RhConfig::Environment::TryGetStringValue(const char* name, char** value)
     if (actualLen == 0)
         return false;
 
+    char* strValue = nullptr;
+
     if (actualLen < bufferLen)
     {
-        *value = PalCopyTCharAsChar(buffer);
+        strValue = PalCopyTCharAsChar(buffer);
+        if (strValue == nullptr)
+            return false;
+
+        *value = strValue;
         return true;
     }
 
     // Expand the buffer to get the value
     bufferLen = actualLen + 1;
     NewArrayHolder<TCHAR> newBuffer {new (nothrow) TCHAR[bufferLen]};
+
+    if (newBuffer.IsNull())
+        return false;
+
     actualLen = PalGetEnvironmentVariable(variableName, newBuffer, bufferLen);
     if (actualLen >= bufferLen)
         return false;
 
 #ifdef TARGET_WINDOWS
-    *value = PalCopyTCharAsChar(newBuffer);
+    strValue = PalCopyTCharAsChar(newBuffer);
+    if (strValue == nullptr)
+        return false;
 #else
-    *value = newBuffer.Extract();
+    strValue = newBuffer.Extract();
 #endif
+
+    *value = strValue;
     return true;
 }
 

--- a/src/coreclr/nativeaot/Runtime/RhConfig.cpp
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.cpp
@@ -130,6 +130,36 @@ bool RhConfig::Environment::TryGetStringValue(const char* name, char** value)
 extern "C" RhConfig::Config g_compilerEmbeddedSettingsBlob;
 extern "C" RhConfig::Config g_compilerEmbeddedKnobsBlob;
 
+bool RhConfig::ReadStringConfigValue(_In_z_ const char* name, const char** pValue)
+{
+    char *envValue = nullptr;
+    if (Environment::TryGetStringValue(name, &envValue))
+    {
+        *pValue = envValue;
+        return true;
+    }
+
+    const char *embeddedValue = nullptr;
+    if (GetEmbeddedVariable(&g_compilerEmbeddedSettingsBlob, name, true, &embeddedValue))
+    {
+        char* strCopy = new (nothrow) char[strlen(embeddedValue) + 1];
+        if (strCopy != nullptr)
+        {
+            strcpy(strCopy, embeddedValue);
+            *pValue = strCopy;
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void RhConfig::FreeStringConfigValue(const char* value)
+{
+    delete[] value;
+}
+
 bool RhConfig::ReadConfigValue(_In_z_ const char *name, uint64_t* pValue, bool decimal)
 {
     if (Environment::TryGetIntegerValue(name, pValue, decimal))
@@ -141,6 +171,24 @@ bool RhConfig::ReadConfigValue(_In_z_ const char *name, uint64_t* pValue, bool d
     {
         *pValue = strtoull(embeddedValue, NULL, decimal ? 10 : 16);
         return true;
+    }
+
+    return false;
+}
+
+bool RhConfig::ReadKnobStringValue(_In_z_ const char *name, const char** pValue)
+{
+    const char *embeddedValue = nullptr;
+    if (GetEmbeddedVariable(&g_compilerEmbeddedKnobsBlob, name, false, &embeddedValue))
+    {
+        char* strCopy = new (nothrow) char[strlen(embeddedValue) + 1];
+        if (strCopy != nullptr)
+        {
+            strcpy(strCopy, embeddedValue);
+            *pValue = strCopy;
+
+            return true;
+        }
     }
 
     return false;

--- a/src/coreclr/nativeaot/Runtime/RhConfig.h
+++ b/src/coreclr/nativeaot/Runtime/RhConfig.h
@@ -45,8 +45,11 @@ public:
     };
 
     bool ReadConfigValue(_In_z_ const char* wszName, uint64_t* pValue, bool decimal = false);
+    bool ReadStringConfigValue(_In_z_ const char* wszName, const char** pValue);
     bool ReadKnobUInt64Value(_In_z_ const char* wszName, uint64_t* pValue);
+    bool ReadKnobStringValue(_In_z_ const char* wszName, const char** pValue);
     bool ReadKnobBooleanValue(_In_z_ const char* wszName, bool* pValue);
+    void FreeStringConfigValue(const char* value);
 
     char** GetKnobNames();
     char** GetKnobValues();

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -801,12 +801,22 @@ bool GCToEEInterface::GetStringConfigValue(const char* privateKey, const char* p
     UNREFERENCED_PARAMETER(publicKey);
     UNREFERENCED_PARAMETER(value);
 
+    if (g_pRhConfig->ReadStringConfigValue(privateKey, value))
+    {
+        return true;
+    }
+
+    if (publicKey)
+    {
+        return g_pRhConfig->ReadKnobStringValue(publicKey, value);
+    }
+
     return false;
 }
 
 void GCToEEInterface::FreeStringConfigValue(const char* value)
 {
-    delete[] value;
+    g_pRhConfig->FreeStringConfigValue(value);
 }
 
 void GCToEEInterface::TriggerClientBridgeProcessing(MarkCrossReferencesArgs* args)

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -797,9 +797,6 @@ uint64_t GCToEEInterface::GetThreadOSThreadId(Thread* thread)
 
 bool GCToEEInterface::GetStringConfigValue(const char* privateKey, const char* publicKey, const char** value)
 {
-    UNREFERENCED_PARAMETER(privateKey);
-    UNREFERENCED_PARAMETER(publicKey);
-    UNREFERENCED_PARAMETER(value);
     if (g_pRhConfig->ReadStringConfigValue(privateKey, value))
     {
         return true;

--- a/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
+++ b/src/coreclr/nativeaot/Runtime/gcenv.ee.cpp
@@ -800,7 +800,6 @@ bool GCToEEInterface::GetStringConfigValue(const char* privateKey, const char* p
     UNREFERENCED_PARAMETER(privateKey);
     UNREFERENCED_PARAMETER(publicKey);
     UNREFERENCED_PARAMETER(value);
-
     if (g_pRhConfig->ReadStringConfigValue(privateKey, value))
     {
         return true;

--- a/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/PalUnix.cpp
@@ -868,6 +868,11 @@ void PalPrintFatalError(const char* message)
 char* PalCopyTCharAsChar(const TCHAR* toCopy)
 {
     NewArrayHolder<char> copy {new (nothrow) char[strlen(toCopy) + 1]};
+    if (copy.IsNull())
+    {
+        return nullptr;
+    }
+
     strcpy(copy, toCopy);
     return copy.Extract();
 }

--- a/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
@@ -954,8 +954,12 @@ char* PalCopyTCharAsChar(const TCHAR* toCopy)
         return nullptr;
 
     char* converted = new (nothrow) char[len];
-    int written = ::WideCharToMultiByte(CP_UTF8, 0, toCopy, -1, converted, len, nullptr, nullptr);
-    assert(len == written);
+
+    if (converted != nullptr)
+    {
+        int written = ::WideCharToMultiByte(CP_UTF8, 0, toCopy, -1, converted, len, nullptr, nullptr);
+        assert(len == written);
+    }
     return converted;
 }
 

--- a/src/tests/GC/API/GC/GetConfigurationVariables.cs
+++ b/src/tests/GC/API/GC/GetConfigurationVariables.cs
@@ -26,7 +26,11 @@ namespace ConfigurationVariables
                     foundGCHeapAffinitizeRanges = true;
                 }
             }
-            Assert.True(foundGCHeapAffinitizeRanges, "The GCHeapAffinitizeRanges was not found");
+
+            if (!TestLibrary.Utilities.IsMonoRuntime)
+            {
+                Assert.True(foundGCHeapAffinitizeRanges, "The GCHeapAffinitizeRanges was not found");
+            }
         }
     }
 }

--- a/src/tests/GC/API/GC/GetConfigurationVariables.cs
+++ b/src/tests/GC/API/GC/GetConfigurationVariables.cs
@@ -14,11 +14,19 @@ namespace ConfigurationVariables
             var configurations = GC.GetConfigurationVariables();
             Assert.True(configurations != null);
             Assert.True(configurations.Count >= 0);
+            bool foundGCHeapAffinitizeRanges = false;
             foreach(var kvp in configurations)
             {
+                Console.WriteLine($"{kvp.Key} set to {kvp.Value}");
                 Assert.True(kvp.Key != null, "The name of the configuration is null.");
                 Assert.True(kvp.Value != null, $"The value of configuration: {kvp.Key} is null.");
+                if (kvp.Key == "GCHeapAffinitizeRanges")
+                {
+                    Assert.True(kvp.Value.ToString() == "1", "The expected value of GCHeapAffinitizeRanges is 1");
+                    foundGCHeapAffinitizeRanges = true;
+                }
             }
+            Assert.True(foundGCHeapAffinitizeRanges, "The GCHeapAffinitizeRanges was not found");
         }
     }
 }

--- a/src/tests/GC/API/GC/GetConfigurationVariables.csproj
+++ b/src/tests/GC/API/GC/GetConfigurationVariables.csproj
@@ -2,10 +2,12 @@
   <PropertyGroup>
     <CLRTestPriority>0</CLRTestPriority>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
-    <CLRTestEnvironmentVariable Include="DOTNET_GCHeapAffinitizeRanges" Value="1" />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GetConfigurationVariables.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_GCHeapAffinitizeRanges" Value="1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(TestLibraryProjectPath)" />

--- a/src/tests/GC/API/GC/GetConfigurationVariables.csproj
+++ b/src/tests/GC/API/GC/GetConfigurationVariables.csproj
@@ -2,12 +2,12 @@
   <PropertyGroup>
     <CLRTestPriority>0</CLRTestPriority>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <CLRTestEnvironmentVariable Include="DOTNET_GCHeapAffinitizeRanges" Value="1" />
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GetConfigurationVariables.cs" />
   </ItemGroup>
   <ItemGroup>
-    <CLRTestEnvironmentVariable Include="DOTNET_GCHeapAffinitizeRanges" Value="1" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
-
 </Project>

--- a/src/tests/GC/API/GC/GetConfigurationVariables.csproj
+++ b/src/tests/GC/API/GC/GetConfigurationVariables.csproj
@@ -1,8 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <CLRTestPriority>0</CLRTestPriority>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="GetConfigurationVariables.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <CLRTestEnvironmentVariable Include="DOTNET_GCHeapAffinitizeRanges" Value="1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The NativeAOT doesn't have real implementation of
GCToEEInterface::GetStringConfigValue, the method
just return false. That prevents extraction of
settings that are strings, like GCHeapAffinitizeRanges.

This change fixes it by adding proper implementation.

Close #128396