### PR TITLE
Add DependencyKind.DisablePrivateReflectionRequirement to methodreasons and typereasons to fix tests.

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -166,6 +166,7 @@ namespace Mono.Linker.Steps
             DependencyKind.ReturnTypeMarshalSpec,
             DependencyKind.DynamicInterfaceCastableImplementation,
             DependencyKind.XmlDescriptor,
+            DependencyKind.DisablePrivateReflectionRequirement,
         };
 
         static readonly DependencyKind[] _methodReasons = new DependencyKind[] {
@@ -215,6 +216,7 @@ namespace Mono.Linker.Steps
             DependencyKind.ReturnTypeMarshalSpec,
             DependencyKind.XmlDescriptor,
             DependencyKind.UnsafeAccessorTarget,
+            DependencyKind.DisablePrivateReflectionRequirement,
         };
 #endif
 

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresUnsafeAnalyzerTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/RequiresUnsafeAnalyzerTests.cs
@@ -218,7 +218,9 @@ namespace System.Diagnostics.CodeAnalysis
 
             await VerifyRequiresUnsafeAnalyzer(source,
                 // /0/Test0.cs(6,12): warning IL3061: 'RequiresUnsafeAttribute' cannot be placed directly on static constructor 'C.C()'.
-                VerifyCS.Diagnostic(DiagnosticId.RequiresUnsafeOnStaticConstructor).WithSpan(6, 12, 6, 13).WithArguments("C..cctor()")
+                VerifyCS.Diagnostic(DiagnosticId.RequiresUnsafeOnStaticConstructor).WithSpan(6, 12, 6, 13).WithArguments("C..cctor()"),
+                // Why is this an compiler error?
+                DiagnosticResult.CompilerError("CS9367").WithSpan(5, 6, 5, 20)
             );
         }
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/128349 started running tests with a Debug illink, which is tripping an assert. I missed the fact that the illink unit tests didn't run and now those tests are failing: https://github.com/dotnet/runtime/pull/128349#issuecomment-4504368923

To fix, add this reason as an expected reason for marking a method or a type.