### PR TITLE
Remove redundant `#if NET` in `CollectionHelpers.ValidateCopyToArguments`

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/CollectionHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/ObjectModel/CollectionHelpers.cs
@@ -9,11 +9,7 @@ namespace System.Collections.ObjectModel
     {
         internal static void ValidateCopyToArguments(int sourceCount, Array array, int index)
         {
-#if NET
             ArgumentNullException.ThrowIfNull(array);
-#else
-            ArgumentNullException.ThrowIfNull(array);
-#endif
 
             if (array.Rank != 1)
             {


### PR DESCRIPTION
Both branches of the first `#if NET` / `#else` in `CollectionHelpers.ValidateCopyToArguments` called `ArgumentNullException.ThrowIfNull(array);` identically. Removed the preprocessor split.