### PR TITLE
JIT: Propagate class handle when split tree

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18683,7 +18683,6 @@ bool Compiler::gtSplitTree(BasicBlock* block,
                 GenTree* store = m_compiler->gtNewTempStore(lclNum, value);
 
                 LclVarDsc* const lclDsc = m_compiler->lvaGetDesc(lclNum);
-                assert(lclDsc->lvSingleDef == 0);
                 lclDsc->lvSingleDef = 1;
                 JITDUMP("Marked V%02u as a single def temp\n", lclNum);
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18679,10 +18679,28 @@ bool Compiler::gtSplitTree(BasicBlock* block,
                     m_compiler->lvaGetDesc(lclNum)->lvIsMultiRegRet = true;
                 }
 
-                GenTree* store = m_compiler->gtNewTempStore(lclNum, *use);
-                stmt           = m_compiler->fgNewStmtFromTree(store, m_splitStmt->GetDebugInfo());
-                *use           = m_compiler->gtNewLclvNode(lclNum, genActualType(*use));
-                MadeChanges    = true;
+                GenTree* value = *use;
+                GenTree* store = m_compiler->gtNewTempStore(lclNum, value);
+
+                LclVarDsc* const lclDsc = m_compiler->lvaGetDesc(lclNum);
+                assert(lclDsc->lvSingleDef == 0);
+                lclDsc->lvSingleDef = 1;
+                JITDUMP("Marked V%02u as a single def temp\n", lclNum);
+
+                if (value->TypeIs(TYP_REF))
+                {
+                    bool                 isExact   = false;
+                    bool                 isNonNull = false;
+                    CORINFO_CLASS_HANDLE clsHnd    = m_compiler->gtGetClassHandle(value, &isExact, &isNonNull);
+                    if (clsHnd != NO_CLASS_HANDLE)
+                    {
+                        m_compiler->lvaSetClass(lclNum, clsHnd, isExact);
+                    }
+                }
+
+                stmt        = m_compiler->fgNewStmtFromTree(store, m_splitStmt->GetDebugInfo());
+                *use        = m_compiler->gtNewLclvNode(lclNum, genActualType(value));
+                MadeChanges = true;
             }
 
             if (stmt != nullptr)

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -18683,7 +18683,7 @@ bool Compiler::gtSplitTree(BasicBlock* block,
                 GenTree* store = m_compiler->gtNewTempStore(lclNum, value);
 
                 LclVarDsc* const lclDsc = m_compiler->lvaGetDesc(lclNum);
-                lclDsc->lvSingleDef = 1;
+                lclDsc->lvSingleDef     = 1;
                 JITDUMP("Marked V%02u as a single def temp\n", lclNum);
 
                 if (value->TypeIs(TYP_REF))


### PR DESCRIPTION
Propagate the class handle when we spill a tree into a local so that later devirtualization can see the more exact class.

Codegen for the snippet in the linked issue:

Before:

```nasm
G_M000_IG01:                ;; offset=0x0000
       sub      rsp, 40
 
G_M000_IG02:                ;; offset=0x0004
       mov      rcx, 0x7FFB9190F410
       call     CORINFO_HELP_NEWSFAST
       mov      rcx, rax
       mov      byte  ptr [rcx+0x08], 0
       mov      r11, 0x7FFB91640078
       call     [r11]Program+IBar:Bar():this
       nop      
 
G_M000_IG03:                ;; offset=0x0028
       add      rsp, 40
       ret      
 
; Total bytes of code 45
```

After:

```nasm
G_M24006_IG01:  ;; offset=0x0000
       sub      rsp, 40
                                                ;; size=4 bbWeight=1 PerfScore 0.25
G_M24006_IG02:  ;; offset=0x0004
       mov      ecx, 42
       call     [System.Console:WriteLine(int)]
       nop
                                                ;; size=12 bbWeight=1 PerfScore 3.50
G_M24006_IG03:  ;; offset=0x0010
       add      rsp, 40
       ret
                                                ;; size=5 bbWeight=1 PerfScore 1.25

; Total bytes of code 21
```

Resolves #128483 