### PR TITLE
Fix async stack walk crash for continuations with null DiagnosticIP

### DIFF
--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -918,7 +918,7 @@ HRESULT CordbAsyncStackWalk::PopulateFrame()
         // Skip continuations with null DiagnosticIP. These are infrastructure
         // continuations (e.g. ValueTaskContinuation) that have no user code
         // associated with them and cannot be represented as a debug frame.
-        if (diagnosticIP == NULL)
+        if (diagnosticIP == 0)
         {
             m_continuationAddress = nextContinuation;
             continue;

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -915,6 +915,15 @@ HRESULT CordbAsyncStackWalk::PopulateFrame()
             &nextContinuation,
             &state));
 
+        // Skip continuations with null DiagnosticIP. These are infrastructure
+        // continuations (e.g. ValueTaskContinuation) that have no user code
+        // associated with them and cannot be represented as a debug frame.
+        if (diagnosticIP == NULL)
+        {
+            m_continuationAddress = nextContinuation;
+            continue;
+        }
+
         NativeCodeFunctionData codeData;
         VMPTR_Module pModule;
         mdMethodDef methodDef;


### PR DESCRIPTION
CordbAsyncStackWalk::PopulateFrame() crashes when encountering a continuation whose ResumeInfo.DiagnosticIP is NULL (e.g. the new ValueTaskContinuation introduced in #127973). GetNativeCodeInfoForAddr is called with a null address which fails.

Fix: In PopulateFrame(), skip continuations with diagnosticIP == NULL the same way DiagnosticHidden frames are skipped (advance to Next).