### PR TITLE
JIT: fold isinst using reaching VNs and compareTypesForCast

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2386,24 +2386,94 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
     return NO_ASSERTION_INDEX;
 }
 
-/**********************************************************************************
- *
- * Given a "tree" that is usually arg1 of a isinst/cast kind of GT_CALL (a class
- * handle), and "methodTableArg" which is a const int (a class handle), then search
- * if there is an assertion in "assertions", that asserts the equality of the two
- * class handles and then returns the index of the assertion. If one such assertion
- * could not be found, then it returns NO_ASSERTION_INDEX.
- *
- */
-AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions)
+//------------------------------------------------------------------------
+// optAssertionIsSubtype: see if a tree is known to be castable to a class.
+//
+// Determines whether the object value behind "tree" is known to be a
+// subtype of the class indicated by "methodTableArg", using the live
+// assertion set, VN-level type info (e.g. VNF_JitNew exact-type), and
+// assertions that reach via PHI definitions.
+//
+// Arguments:
+//   tree           - the object being cast (usually the second arg of an
+//                    isinst/castclass helper)
+//   methodTableArg - the helper's first arg, expected to be a class handle
+//                    (constant int) identifying the target type
+//   assertions     - set of live assertions at the call site
+//
+// Return Value:
+//   True if the cast can be proven to succeed.
+//
+bool Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions)
 {
+    ValueNum objVN = optConservativeNormalVN(tree);
+    if (objVN == ValueNumStore::NoVN)
+    {
+        return false;
+    }
+
+    // Resolve the compile-time class handle from the method-table arg.
+    //
+    CORINFO_CLASS_HANDLE castTo = gtGetHelperArgClassHandle(methodTableArg);
+    if (castTo == NO_CLASS_HANDLE)
+    {
+        // Fall back to VN-based resolution (covers cases where the helper-arg
+        // recognizer can't find the handle but the VN encodes a type handle).
+        ValueNum castToVN = optConservativeNormalVN(methodTableArg);
+        if (vnStore->IsVNTypeHandle(castToVN))
+        {
+            ssize_t handle = 0;
+            if (vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castToVN), &handle) && (handle != 0))
+            {
+                castTo = reinterpret_cast<CORINFO_CLASS_HANDLE>(handle);
+            }
+        }
+    }
+
+    if (castTo == NO_CLASS_HANDLE)
+    {
+        return false;
+    }
+
+    return optAssertionVNIsSubtype(objVN, castTo, assertions);
+}
+
+//------------------------------------------------------------------------
+// optAssertionVNIsSubtype: see if a VN is known to be a subtype of castTo
+//    using the given assertion set, VN-level type info, and assertions that
+//    reach via PHI definitions.
+//
+// Arguments:
+//   vn         - VN to check
+//   castTo     - class handle to test the cast against
+//   assertions - set of live assertions
+//   budget     - limits the depth of recursion when chasing assertions across
+//                phi-def reaching VNs.
+//
+// Return Value:
+//   True if the VN is known to be a subtype of castTo.
+//
+bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
+                                       CORINFO_CLASS_HANDLE castTo,
+                                       ASSERT_VALARG_TP     assertions,
+                                       int                  budget)
+{
+    if ((vn == ValueNumStore::NoVN) || (castTo == NO_CLASS_HANDLE))
+    {
+        return false;
+    }
+
+    // 1. Check assertions for a Subtype/ExactType assertion on this VN.
+    //
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        bvIndex = 0;
     while (iter.NextElem(&bvIndex))
     {
         AssertionIndex const index        = GetAssertionIndex(bvIndex);
         const AssertionDsc&  curAssertion = optGetAssertion(index);
-        if (!curAssertion.KindIs(OAK_EQUAL) || !curAssertion.GetOp1().KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE))
+
+        if (!curAssertion.KindIs(OAK_EQUAL) || !curAssertion.GetOp1().KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE) ||
+            !curAssertion.GetOp2().KindIs(O2K_CONST_INT))
         {
             // TODO-CQ: We might benefit from OAK_NOT_EQUAL assertion as well, e.g.:
             // if (obj is not MyClass) // obj is known to be never of MyClass class
@@ -2414,27 +2484,61 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
             continue;
         }
 
-        if ((curAssertion.GetOp1().GetVN() != vnStore->VNConservativeNormalValue(tree->gtVNPair) ||
-             !curAssertion.GetOp2().KindIs(O2K_CONST_INT)))
+        if (curAssertion.GetOp1().GetVN() != vn)
         {
             continue;
         }
 
-        ssize_t      methodTableVal = 0;
-        GenTreeFlags iconFlags      = GTF_EMPTY;
-        if (!optIsTreeKnownIntValue(!optLocalAssertionProp, methodTableArg, &methodTableVal, &iconFlags))
+        // Resolve the source class handle from the type-handle VN stored in the
+        // assertion. We must go through the embedded-handle map so AOT/R2R works.
+        //
+        ValueNum castFromVN     = curAssertion.GetOp2().GetVN();
+        ssize_t  castFromHandle = 0;
+        if (!vnStore->IsVNTypeHandle(castFromVN) ||
+            !vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castFromVN), &castFromHandle) ||
+            (castFromHandle == 0))
         {
             continue;
         }
 
-        if (curAssertion.GetOp2().GetIntConstant() == methodTableVal)
+        CORINFO_CLASS_HANDLE castFrom = (CORINFO_CLASS_HANDLE)castFromHandle;
+
+        // For O1K_EXACT_TYPE the object is exactly castFrom; for O1K_SUBTYPE it
+        // is some subtype of castFrom. In both cases, if castFrom is castable
+        // to castTo (Must), every actual runtime type of obj is too.
+        //
+        if (info.compCompHnd->compareTypesForCast(castFrom, castTo) == TypeCompareState::Must)
         {
-            // TODO-CQ: if they don't match, we might still be able to prove that the result is foldable via
-            // compareTypesForCast.
-            return index;
+            return true;
         }
     }
-    return NO_ASSERTION_INDEX;
+
+    // 2. Try to recover a class from the VN itself (e.g. VNF_JitNew(classHandle)).
+    //
+    bool                 isExact;
+    bool                 isNonNull;
+    CORINFO_CLASS_HANDLE castFromVN = vnStore->GetObjectType(vn, &isExact, &isNonNull);
+    if ((castFromVN != NO_CLASS_HANDLE) &&
+        (info.compCompHnd->compareTypesForCast(castFromVN, castTo) == TypeCompareState::Must))
+    {
+        return true;
+    }
+
+    if (budget <= 0)
+    {
+        return false;
+    }
+
+    // 3. For PHI-defs, walk reaching assertions/VNs and recursively check.
+    //    optVisitReachingAssertions yields per-edge assertion sets so each
+    //    reaching VN is evaluated against the assertions that hold on its edge.
+    //
+    auto visitor = [this, castTo, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+        return optAssertionVNIsSubtype(reachingVN, castTo, reachingAssertions, budget - 1) ? AssertVisit::Continue
+                                                                                           : AssertVisit::Abort;
+    };
+
+    return optVisitReachingAssertions(vn, visitor) == AssertVisit::Continue;
 }
 
 //------------------------------------------------------------------------------
@@ -5362,10 +5466,9 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             GenTree* castToArg     = castToCallArg->GetNode();
             GenTree* objArg        = objCallArg->GetNode();
 
-            const unsigned index = optAssertionIsSubtype(objArg, castToArg, assertions);
-            if (index != NO_ASSERTION_INDEX)
+            if (optAssertionIsSubtype(objArg, castToArg, assertions))
             {
-                JITDUMP("\nDid VN based subtype prop for index #%02u in " FMT_BB ":\n", index, compCurBB->bbNum);
+                JITDUMP("\nDid VN based subtype prop in " FMT_BB ":\n", compCurBB->bbNum);
                 DISPTREE(call);
 
                 // if castObjArg is not simple, we replace the arg with a temp assignment and

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2387,58 +2387,6 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
 }
 
 //------------------------------------------------------------------------
-// optAssertionIsSubtype: see if a tree is known to be castable to a class.
-//
-// Determines whether the object value behind "tree" is known to be a
-// subtype of the class indicated by "methodTableArg", using the live
-// assertion set, VN-level type info (e.g. VNF_JitNew exact-type), and
-// assertions that reach via PHI definitions.
-//
-// Arguments:
-//   tree           - the object being cast (usually the second arg of an
-//                    isinst/castclass helper)
-//   methodTableArg - the helper's first arg, expected to be a class handle
-//                    (constant int) identifying the target type
-//   assertions     - set of live assertions at the call site
-//
-// Return Value:
-//   True if the cast can be proven to succeed.
-//
-bool Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions)
-{
-    ValueNum objVN = optConservativeNormalVN(tree);
-    if (objVN == ValueNumStore::NoVN)
-    {
-        return false;
-    }
-
-    // Resolve the compile-time class handle from the method-table arg.
-    //
-    CORINFO_CLASS_HANDLE castTo = gtGetHelperArgClassHandle(methodTableArg);
-    if (castTo == NO_CLASS_HANDLE)
-    {
-        // Fall back to VN-based resolution (covers cases where the helper-arg
-        // recognizer can't find the handle but the VN encodes a type handle).
-        ValueNum castToVN = optConservativeNormalVN(methodTableArg);
-        if (vnStore->IsVNTypeHandle(castToVN))
-        {
-            ssize_t handle = 0;
-            if (vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castToVN), &handle) && (handle != 0))
-            {
-                castTo = reinterpret_cast<CORINFO_CLASS_HANDLE>(handle);
-            }
-        }
-    }
-
-    if (castTo == NO_CLASS_HANDLE)
-    {
-        return false;
-    }
-
-    return optAssertionVNIsSubtype(objVN, castTo, assertions);
-}
-
-//------------------------------------------------------------------------
 // optAssertionVNIsSubtype: see if a VN is known to be a subtype of castTo
 //    using the given assertion set, VN-level type info, and assertions that
 //    reach via PHI definitions.
@@ -2533,12 +2481,10 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
     //    optVisitReachingAssertions yields per-edge assertion sets so each
     //    reaching VN is evaluated against the assertions that hold on its edge.
     //
-    auto visitor = [this, castTo, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+    return optVisitReachingAssertions(vn, [this, castTo, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
         return optAssertionVNIsSubtype(reachingVN, castTo, reachingAssertions, budget - 1) ? AssertVisit::Continue
                                                                                            : AssertVisit::Abort;
-    };
-
-    return optVisitReachingAssertions(vn, visitor) == AssertVisit::Continue;
+    }) == AssertVisit::Continue;
 }
 
 //------------------------------------------------------------------------------
@@ -5465,8 +5411,13 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             CallArg* objCallArg    = call->gtArgs.GetArgByIndex(1);
             GenTree* castToArg     = castToCallArg->GetNode();
             GenTree* objArg        = objCallArg->GetNode();
+            ValueNum objVN         = optConservativeNormalVN(objArg);
+            ValueNum castToVN      = optConservativeNormalVN(castToArg);
 
-            if (optAssertionIsSubtype(objArg, castToArg, assertions))
+            ssize_t handle = 0;
+            if (vnStore->IsVNTypeHandle(castToVN) &&
+                vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castToVN), &handle) &&
+                optAssertionVNIsSubtype(objVN, reinterpret_cast<CORINFO_CLASS_HANDLE>(handle), assertions))
             {
                 JITDUMP("\nDid VN based subtype prop in " FMT_BB ":\n", compCurBB->bbNum);
                 DISPTREE(call);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2406,13 +2406,25 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
                                        ASSERT_VALARG_TP     assertions,
                                        int                  budget)
 {
-    if ((vn == ValueNumStore::NoVN) || (castTo == NO_CLASS_HANDLE))
+    if ((budget <= 0) || (vn == ValueNumStore::NoVN) || (castTo == NO_CLASS_HANDLE))
     {
         return false;
     }
 
-    // 1. Check assertions for a Subtype/ExactType assertion on this VN.
-    //
+    bool isExact;
+    bool isNonNull;
+
+    // First, try the VN's version of gtGetClassHandle over the vn itself, e.g. vn being
+    // Jit_NewObj(MyClass) while we're trying to prove "Jit_NewObj(MyClass) is MyClass".
+    CORINFO_CLASS_HANDLE castFromVN = vnStore->GetObjectType(vn, &isExact, &isNonNull);
+    if ((castFromVN != NO_CLASS_HANDLE) &&
+        (info.compCompHnd->compareTypesForCast(castFromVN, castTo) == TypeCompareState::Must))
+    {
+        return true;
+    }
+
+    // Now look through assertions directly on the VN.
+    // We're looking for "vn is (exactly/subtype) cls" assertions that can help us prove the cast.
     BitVecOps::Iter iter(apTraits, assertions);
     unsigned        bvIndex = 0;
     while (iter.NextElem(&bvIndex))
@@ -2421,7 +2433,7 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
         const AssertionDsc&  curAssertion = optGetAssertion(index);
 
         if (!curAssertion.KindIs(OAK_EQUAL) || !curAssertion.GetOp1().KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE) ||
-            !curAssertion.GetOp2().KindIs(O2K_CONST_INT))
+            (curAssertion.GetOp1().GetVN() != vn))
         {
             // TODO-CQ: We might benefit from OAK_NOT_EQUAL assertion as well, e.g.:
             // if (obj is not MyClass) // obj is known to be never of MyClass class
@@ -2432,55 +2444,23 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
             continue;
         }
 
-        if (curAssertion.GetOp1().GetVN() != vn)
+        // Extract CORINFO_CLASS_HANDLE from curAssertion.GetOp2()
+        CORINFO_CLASS_HANDLE cls;
+        if (!vnStore->IsVNTypeHandle(curAssertion.GetOp2().GetVN(), &cls))
         {
             continue;
         }
 
-        // Resolve the source class handle from the type-handle VN stored in the
-        // assertion. We must go through the embedded-handle map so AOT/R2R works.
-        //
-        ValueNum castFromVN     = curAssertion.GetOp2().GetVN();
-        ssize_t  castFromHandle = 0;
-        if (!vnStore->IsVNTypeHandle(castFromVN) ||
-            !vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castFromVN), &castFromHandle) ||
-            (castFromHandle == 0))
+        // Now we have "thisVN is (exactly/subtype) cls" assertion.
+        // We want to see if this implies "thisVN is (exactly/subtype) cls".
+        if (info.compCompHnd->compareTypesForCast(cls, castTo) == TypeCompareState::Must)
         {
-            continue;
-        }
-
-        CORINFO_CLASS_HANDLE castFrom = (CORINFO_CLASS_HANDLE)castFromHandle;
-
-        // For O1K_EXACT_TYPE the object is exactly castFrom; for O1K_SUBTYPE it
-        // is some subtype of castFrom. In both cases, if castFrom is castable
-        // to castTo (Must), every actual runtime type of obj is too.
-        //
-        if (info.compCompHnd->compareTypesForCast(castFrom, castTo) == TypeCompareState::Must)
-        {
+            // The assertion implies the cast is always successful.
             return true;
         }
     }
 
-    // 2. Try to recover a class from the VN itself (e.g. VNF_JitNew(classHandle)).
-    //
-    bool                 isExact;
-    bool                 isNonNull;
-    CORINFO_CLASS_HANDLE castFromVN = vnStore->GetObjectType(vn, &isExact, &isNonNull);
-    if ((castFromVN != NO_CLASS_HANDLE) &&
-        (info.compCompHnd->compareTypesForCast(castFromVN, castTo) == TypeCompareState::Must))
-    {
-        return true;
-    }
-
-    if (budget <= 0)
-    {
-        return false;
-    }
-
-    // 3. For PHI-defs, walk reaching assertions/VNs and recursively check.
-    //    optVisitReachingAssertions yields per-edge assertion sets so each
-    //    reaching VN is evaluated against the assertions that hold on its edge.
-    //
+    // For PHI-defs, walk reaching assertions/VNs and recursively check.
     return optVisitReachingAssertions(vn, [this, castTo, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
         return optAssertionVNIsSubtype(reachingVN, castTo, reachingAssertions, budget - 1) ? AssertVisit::Continue
                                                                                            : AssertVisit::Abort;
@@ -5411,13 +5391,10 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             CallArg* objCallArg    = call->gtArgs.GetArgByIndex(1);
             GenTree* castToArg     = castToCallArg->GetNode();
             GenTree* objArg        = objCallArg->GetNode();
-            ValueNum objVN         = optConservativeNormalVN(objArg);
-            ValueNum castToVN      = optConservativeNormalVN(castToArg);
 
-            ssize_t handle = 0;
-            if (vnStore->IsVNTypeHandle(castToVN) &&
-                vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(castToVN), &handle) &&
-                optAssertionVNIsSubtype(objVN, reinterpret_cast<CORINFO_CLASS_HANDLE>(handle), assertions))
+            CORINFO_CLASS_HANDLE castTo;
+            if (vnStore->IsVNTypeHandle(optConservativeNormalVN(castToArg), &castTo) &&
+                optAssertionVNIsSubtype(optConservativeNormalVN(objArg), castTo, assertions))
             {
                 JITDUMP("\nDid VN based subtype prop in " FMT_BB ":\n", compCurBB->bbNum);
                 DISPTREE(call);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2392,8 +2392,8 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
 //    reach via PHI definitions.
 //
 // Arguments:
-//   vn         - VN to check
-//   castTo     - class handle to test the cast against
+//   objVN      - VN to check
+//   castToVN   - VN representing the type handle being cast to.
 //   assertions - set of live assertions
 //   budget     - limits the depth of recursion when chasing assertions across
 //                phi-def reaching VNs.
@@ -2401,12 +2401,9 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
 // Return Value:
 //   True if the VN is known to be a subtype of castTo.
 //
-bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
-                                       CORINFO_CLASS_HANDLE castTo,
-                                       ASSERT_VALARG_TP     assertions,
-                                       int                  budget)
+bool Compiler::optAssertionVNIsSubtype(ValueNum objVN, ValueNum castToVN, ASSERT_VALARG_TP assertions, int budget)
 {
-    if ((budget <= 0) || (vn == ValueNumStore::NoVN) || (castTo == NO_CLASS_HANDLE))
+    if ((budget <= 0) || (objVN == ValueNumStore::NoVN))
     {
         return false;
     }
@@ -2414,9 +2411,16 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
     bool isExact;
     bool isNonNull;
 
+    CORINFO_CLASS_HANDLE castTo;
+    if (!vnStore->IsVNTypeHandle(castToVN, &castTo))
+    {
+        return false;
+    }
+    assert(castTo != NO_CLASS_HANDLE);
+
     // First, try the VN's version of gtGetClassHandle over the vn itself, e.g. vn being
     // Jit_NewObj(MyClass) while we're trying to prove "Jit_NewObj(MyClass) is MyClass".
-    CORINFO_CLASS_HANDLE castFromVN = vnStore->GetObjectType(vn, &isExact, &isNonNull);
+    CORINFO_CLASS_HANDLE castFromVN = vnStore->GetObjectType(objVN, &isExact, &isNonNull);
     if ((castFromVN != NO_CLASS_HANDLE) &&
         (info.compCompHnd->compareTypesForCast(castFromVN, castTo) == TypeCompareState::Must))
     {
@@ -2433,7 +2437,7 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
         const AssertionDsc&  curAssertion = optGetAssertion(index);
 
         if (!curAssertion.KindIs(OAK_EQUAL) || !curAssertion.GetOp1().KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE) ||
-            (curAssertion.GetOp1().GetVN() != vn))
+            (curAssertion.GetOp1().GetVN() != objVN))
         {
             // TODO-CQ: We might benefit from OAK_NOT_EQUAL assertion as well, e.g.:
             // if (obj is not MyClass) // obj is known to be never of MyClass class
@@ -2451,8 +2455,8 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
             continue;
         }
 
-        // Now we have "thisVN is (exactly/subtype) cls" assertion.
-        // We want to see if this implies "thisVN is (exactly/subtype) cls".
+        // Now we have "objVN is (exactly/subtype) cls" assertion.
+        // We want to see if this implies "objVN is (exactly/subtype) castTo".
         if (info.compCompHnd->compareTypesForCast(cls, castTo) == TypeCompareState::Must)
         {
             // The assertion implies the cast is always successful.
@@ -2461,9 +2465,10 @@ bool Compiler::optAssertionVNIsSubtype(ValueNum             vn,
     }
 
     // For PHI-defs, walk reaching assertions/VNs and recursively check.
-    return optVisitReachingAssertions(vn, [this, castTo, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
-        return optAssertionVNIsSubtype(reachingVN, castTo, reachingAssertions, budget - 1) ? AssertVisit::Continue
-                                                                                           : AssertVisit::Abort;
+    return optVisitReachingAssertions(objVN,
+                                      [this, castToVN, budget](ValueNum reachingVN, ASSERT_TP reachingAssertions) {
+        return optAssertionVNIsSubtype(reachingVN, castToVN, reachingAssertions, budget - 1) ? AssertVisit::Continue
+                                                                                             : AssertVisit::Abort;
     }) == AssertVisit::Continue;
 }
 
@@ -5391,10 +5396,10 @@ GenTree* Compiler::optAssertionProp_Call(ASSERT_VALARG_TP assertions, GenTreeCal
             CallArg* objCallArg    = call->gtArgs.GetArgByIndex(1);
             GenTree* castToArg     = castToCallArg->GetNode();
             GenTree* objArg        = objCallArg->GetNode();
+            ValueNum objVN         = optConservativeNormalVN(objArg);
+            ValueNum castToVN      = optConservativeNormalVN(castToArg);
 
-            CORINFO_CLASS_HANDLE castTo;
-            if (vnStore->IsVNTypeHandle(optConservativeNormalVN(castToArg), &castTo) &&
-                optAssertionVNIsSubtype(optConservativeNormalVN(objArg), castTo, assertions))
+            if (optAssertionVNIsSubtype(objVN, castToVN, assertions))
             {
                 JITDUMP("\nDid VN based subtype prop in " FMT_BB ":\n", compCurBB->bbNum);
                 DISPTREE(call);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9075,7 +9075,11 @@ public:
 
     // Used for respective assertion propagations.
     AssertionIndex optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
-    AssertionIndex optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
+    bool           optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
+    bool           optAssertionVNIsSubtype(ValueNum             vn,
+                                           CORINFO_CLASS_HANDLE castTo,
+                                           ASSERT_VALARG_TP     assertions,
+                                           int                  budget = 10);
     bool           optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
     bool           optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9075,12 +9075,9 @@ public:
 
     // Used for respective assertion propagations.
     AssertionIndex optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
-    bool           optAssertionVNIsSubtype(ValueNum             vn,
-                                           CORINFO_CLASS_HANDLE castTo,
-                                           ASSERT_VALARG_TP     assertions,
-                                           int                  budget = 10);
-    bool           optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
-    bool           optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
+    bool optAssertionVNIsSubtype(ValueNum objVN, ValueNum castToVN, ASSERT_VALARG_TP assertions, int budget = 10);
+    bool optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions, int budget = 10);
+    bool optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
 
     AssertionIndex optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP assertions, GenTree* op1, GenTree* op2);
     AssertionIndex optLocalAssertionIsEqualOrNotEqual(

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9075,7 +9075,6 @@ public:
 
     // Used for respective assertion propagations.
     AssertionIndex optAssertionIsSubrange(GenTree* tree, IntegralRange range, ASSERT_VALARG_TP assertions);
-    bool           optAssertionIsSubtype(GenTree* tree, GenTree* methodTableArg, ASSERT_VALARG_TP assertions);
     bool           optAssertionVNIsSubtype(ValueNum             vn,
                                            CORINFO_CLASS_HANDLE castTo,
                                            ASSERT_VALARG_TP     assertions,

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -2101,7 +2101,8 @@ void GenTree::BashToConst(T value, var_types type /* = TYP_UNDEF */)
             }
 
             AsIntCon()->SetIconValue(static_cast<ssize_t>(value));
-            AsIntCon()->gtFieldSeq = nullptr;
+            AsIntCon()->gtFieldSeq          = nullptr;
+            AsIntCon()->gtCompileTimeHandle = 0;
             break;
 
 #if !defined(TARGET_64BIT)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7174,6 +7174,18 @@ bool ValueNumStore::IsVNTypeHandle(ValueNum vn)
     return IsVNHandle(vn, GTF_ICON_CLASS_HDL);
 }
 
+bool ValueNumStore::IsVNTypeHandle(ValueNum vn, CORINFO_CLASS_HANDLE* pCls)
+{
+    ssize_t handle = 0;
+    if (IsVNTypeHandle(vn) && EmbeddedHandleMapLookup(ConstantValue<ssize_t>(vn), &handle) && (handle != 0))
+    {
+        *pCls = reinterpret_cast<CORINFO_CLASS_HANDLE>(handle);
+        return true;
+    }
+    *pCls = NO_CLASS_HANDLE;
+    return false;
+}
+
 //------------------------------------------------------------------------
 // SwapRelop: return VNFunc for swapped relop
 //
@@ -15849,17 +15861,15 @@ CORINFO_CLASS_HANDLE ValueNumStore::GetObjectType(ValueNum vn, bool* pIsExact, b
     const VNFunc func = funcApp.m_func;
     if ((func == VNF_CastClass) || (func == VNF_IsInstanceOf) || (func == VNF_JitNew))
     {
-        ssize_t  clsHandle = 0;
-        ValueNum clsVN     = funcApp.m_args[0];
+        ValueNum clsVN = funcApp.m_args[0];
 
-        // NOTE: EmbeddedHandleMapLookup may return 0 for non-0 embedded handle
-        if (IsVNTypeHandle(clsVN) && EmbeddedHandleMapLookup(ConstantValue<ssize_t>(clsVN), &clsHandle) &&
-            (clsHandle != 0))
+        CORINFO_CLASS_HANDLE clsHandle;
+        if (IsVNTypeHandle(clsVN, &clsHandle))
         {
             // JitNew returns an exact and non-null obj, castclass and isinst do not have this guarantee.
             *pIsNonNull = func == VNF_JitNew;
             *pIsExact   = func == VNF_JitNew;
-            return (CORINFO_CLASS_HANDLE)clsHandle;
+            return clsHandle;
         }
     }
 

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7180,19 +7180,11 @@ bool ValueNumStore::IsVNTypeHandle(ValueNum vn)
 //
 // Arguments:
 //    vn   - the VN to inspect
-//    pCls - [out] set to the resolved compile-time class handle on success,
-//           or NO_CLASS_HANDLE on failure
+//    pCls - [out] compile-time class handle
 //
 // Return Value:
 //    True if vn is a constant class-handle VN and its compile-time class
 //    handle was found in the embedded-handle map; false otherwise.
-//
-// Notes:
-//    Always go through this helper (rather than reinterpret-casting the
-//    raw VN constant) when recovering a class handle from a type-handle VN.
-//    In AOT/R2R builds the constant in the VN is an embedded handle that
-//    must be mapped back to the compile-time handle before being passed
-//    to the EE.
 //
 bool ValueNumStore::IsVNTypeHandle(ValueNum vn, CORINFO_CLASS_HANDLE* pCls)
 {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -12287,8 +12287,12 @@ void Compiler::fgValueNumberTreeConst(GenTree* tree)
                 const GenTreeIntCon* cns         = tree->AsIntCon();
                 const GenTreeFlags   handleFlags = tree->GetIconHandleFlag();
                 tree->gtVNPair.SetBoth(vnStore->VNForHandle(cns->IconValue(), handleFlags));
-                if (handleFlags == GTF_ICON_CLASS_HDL)
+                if ((handleFlags == GTF_ICON_CLASS_HDL) && (cns->gtCompileTimeHandle != 0))
                 {
+                    // Skip registration when gtCompileTimeHandle is unknown (e.g., the node was created by
+                    // BashToConst+gtFlags|=GTF_ICON_CLASS_HDL in optConstantAssertionProp). Overwriting an
+                    // existing valid mapping with 0 would poison the map for any constant assertion-based
+                    // re-flagging that happens to share the same iconValue as a real embedded handle node.
                     vnStore->AddToEmbeddedHandleMap(cns->IconValue(), cns->gtCompileTimeHandle);
                 }
             }
@@ -14430,9 +14434,11 @@ bool Compiler::fgValueNumberSpecialIntrinsic(GenTreeCall* call)
             ValueNum clsVN     = typeHandleFuncApp.m_args[0];
             ssize_t  clsHandle = 0;
 
-            // NOTE: EmbeddedHandleMapLookup may return 0 for non-0 embedded handle
-            if (!vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(clsVN), &clsHandle) &&
-                (clsHandle != 0))
+            // EmbeddedHandleMapLookup may return false (no entry) or true with a 0 handle when the
+            // backing iconNode was produced by BashToConst (i.e., it has no compile-time handle).
+            // Either way, we cannot resolve the runtime type, so bail.
+            if (!vnStore->EmbeddedHandleMapLookup(vnStore->ConstantValue<ssize_t>(clsVN), &clsHandle) ||
+                (clsHandle == 0))
             {
                 break;
             }

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7174,6 +7174,26 @@ bool ValueNumStore::IsVNTypeHandle(ValueNum vn)
     return IsVNHandle(vn, GTF_ICON_CLASS_HDL);
 }
 
+//------------------------------------------------------------------------
+// IsVNTypeHandle: check whether a VN represents a class type handle and,
+//    if so, recover the underlying compile-time class handle.
+//
+// Arguments:
+//    vn   - the VN to inspect
+//    pCls - [out] set to the resolved compile-time class handle on success,
+//           or NO_CLASS_HANDLE on failure
+//
+// Return Value:
+//    True if vn is a constant class-handle VN and its compile-time class
+//    handle was found in the embedded-handle map; false otherwise.
+//
+// Notes:
+//    Always go through this helper (rather than reinterpret-casting the
+//    raw VN constant) when recovering a class handle from a type-handle VN.
+//    In AOT/R2R builds the constant in the VN is an embedded handle that
+//    must be mapped back to the compile-time handle before being passed
+//    to the EE.
+//
 bool ValueNumStore::IsVNTypeHandle(ValueNum vn, CORINFO_CLASS_HANDLE* pCls)
 {
     ssize_t handle = 0;

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1133,6 +1133,9 @@ public:
     // Returns true iff the VN represents a Type handle constant.
     bool IsVNTypeHandle(ValueNum vn);
 
+    // Returns true iff the VN represents a Type handle constant.
+    bool IsVNTypeHandle(ValueNum vn, CORINFO_CLASS_HANDLE* pCls);
+
     // Returns true iff the VN represents a relop
     bool IsVNRelop(ValueNum vn, VNFuncApp* pFuncApp = nullptr);
 

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1133,7 +1133,10 @@ public:
     // Returns true iff the VN represents a Type handle constant.
     bool IsVNTypeHandle(ValueNum vn);
 
-    // Returns true iff the VN represents a Type handle constant.
+    // Returns true iff the VN represents a Type handle constant. If so,
+    // *pCls is set to the resolved compile-time class handle (looked up
+    // through the embedded-handle map so AOT/R2R-encoded handles are
+    // mapped back). On failure *pCls is set to NO_CLASS_HANDLE.
     bool IsVNTypeHandle(ValueNum vn, CORINFO_CLASS_HANDLE* pCls);
 
     // Returns true iff the VN represents a relop

--- a/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.cs
@@ -1,0 +1,92 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT License.
+
+// Regression test for assertion-prop / VN folding of `isinst` across reaching
+// definitions (PHIs of typed allocations).
+//
+// These tests exercise the path in optAssertionVNIsSubtype where the cast
+// target type is proven from reaching VNs (VNF_JitNew / VNF_JitNewArr) for
+// PHI inputs. The JIT must:
+//   * Fold `isinst BaseClass` to true when every reaching VN is a subtype.
+//   * NOT fold to true when any reaching VN can be null or an unrelated type.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class IsInstReachingVN
+{
+    public class BaseClass { }
+    public class DerivedClass1 : BaseClass { }
+    public class DerivedClass2 : BaseClass { }
+    public class Unrelated { }
+
+    public static object s_sink;
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool PhiOfDerived(int len)
+    {
+        object bc;
+        if (len > 100)
+            bc = new DerivedClass1();
+        else
+            bc = new DerivedClass2();
+
+        // Keep `bc` live so DCE cannot remove the allocations / cast.
+        s_sink = bc;
+        return bc is BaseClass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool PhiWithNull(int len)
+    {
+        object bc;
+        if (len > 100)
+            bc = new DerivedClass1();
+        else
+            bc = null;
+
+        s_sink = bc;
+        // Must NOT be folded to true: null reaches here.
+        return bc is BaseClass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool DirectAlloc()
+    {
+        object bc = new DerivedClass1();
+        s_sink = bc;
+        return bc is BaseClass;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public static bool PhiWithUnrelated(int len)
+    {
+        object bc;
+        if (len > 100)
+            bc = new DerivedClass1();
+        else
+            bc = new Unrelated();
+
+        s_sink = bc;
+        // Must NOT be folded to true: Unrelated is not a BaseClass.
+        return bc is BaseClass;
+    }
+
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        if (!PhiOfDerived(200)) return 101;
+        if (!PhiOfDerived(50))  return 102;
+
+        if (PhiWithNull(50))    return 103;
+        if (!PhiWithNull(200))  return 104;
+
+        if (!DirectAlloc())     return 105;
+
+        if (!PhiWithUnrelated(200)) return 106;
+        if (PhiWithUnrelated(50))   return 107;
+
+        return 100;
+    }
+}

--- a/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.cs
+++ b/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.cs
@@ -23,7 +23,7 @@ public class IsInstReachingVN
 
     public static object s_sink;
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool PhiOfDerived(int len)
     {
         object bc;
@@ -37,7 +37,7 @@ public class IsInstReachingVN
         return bc is BaseClass;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool PhiWithNull(int len)
     {
         object bc;
@@ -51,7 +51,7 @@ public class IsInstReachingVN
         return bc is BaseClass;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool DirectAlloc()
     {
         object bc = new DerivedClass1();
@@ -59,7 +59,7 @@ public class IsInstReachingVN
         return bc is BaseClass;
     }
 
-    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool PhiWithUnrelated(int len)
     {
         object bc;

--- a/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.csproj
@@ -1,8 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <CLRTestPriority>1</CLRTestPriority>
-  </PropertyGroup>
-  <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>

--- a/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.csproj
+++ b/src/tests/JIT/opt/AssertionPropagation/IsInstReachingVN.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="IsInstReachingVN.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This PR extends `optAssertionIsSubtype` to support PHI nodes via optVisitReachingAssertions. Also it makes logic slightly less conservative than direct == for class handles when we iterate assertions.

Example: the following always-true cast is currently not folded by the JIT:

```cs
static void Test(int len)
{
    object bc;
    if (len > 100)
        bc = new DerivedClass1();
    else
        bc = new DerivedClass2();

    if (bc is BaseClass) // <--- always true, but we don't fold it.
        Console.WriteLine("bc is a BaseClass");
    else
        Console.WriteLine("bc is not a BaseClass");
}

class BaseClass {}
class DerivedClass1 : BaseClass {}
class DerivedClass2 : BaseClass {}
```

Codegen:

```diff
 ; Assembly listing for method Program:Test(int) (FullOpts)
 G_M29168_IG01:
        sub      rsp, 40
-G_M29168_IG02:
-       cmp      ecx, 100
-       jg       SHORT G_M29168_IG04
-G_M29168_IG03:
-       mov      rcx, 0x7FFEA76B8E60      ; DerivedClass2
-       call     CORINFO_HELP_NEWSFAST
-       jmp      SHORT G_M29168_IG05
-G_M29168_IG04:
-       mov      rcx, 0x7FFEA76BC140      ; DerivedClass1
-       call     CORINFO_HELP_NEWSFAST
-G_M29168_IG05:
-       mov      rdx, rax
-       mov      rcx, 0x7FFEA76B8CD8      ; BaseClass
-       call     CORINFO_HELP_ISINSTANCEOFCLASS
-       test     rax, rax
-       jne      SHORT G_M29168_IG07
-G_M29168_IG06:
-       mov      rcx, 0x26775762D58      ; 'bc is not a BaseClass'
-       call     [System.Console:WriteLine(System.String)]
-       jmp      SHORT G_M29168_IG08
-G_M29168_IG07:
+G_M29168_IG02:
        mov      rcx, 0x26775762D98      ; 'bc is a BaseClass'
        call     [System.Console:WriteLine(System.String)]
-G_M29168_IG08:
        nop
-G_M29168_IG09:
+G_M29168_IG03:
        add      rsp, 40
        ret
-; Total bytes of code 104
+; Total bytes of code 26
```