### PR TITLE
CI pipeline monitor label fixes

### DIFF
--- a/.github/skills/ci-pipeline-monitor/.gitignore
+++ b/.github/skills/ci-pipeline-monitor/.gitignore
@@ -13,3 +13,4 @@ temp/
 # Intermediate JSON output files (piped between scripts)
 failing_builds.json
 failed_tests.json
+cached_labels.json

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -85,19 +85,16 @@ class IssueGenerator:
         else:
             print("GitHub Issue: NEW — creating new issue")
             gh_issue_command.append("create")
-            gh_issue_command.append("--label")
-            gh_issue_command.append("blocking-clean-ci-optional")
             creating_new_issue = True
 
-        if fail["labels"]:
-            if creating_new_issue:
-                for label in fail["labels"].split(','):
-                    stripped_label = label.strip()
-                    if stripped_label and (stripped_label != "blocking-clean-ci-optional"):
-                        gh_issue_command.append('--label')
-                        gh_issue_command.append(stripped_label)
-
         # Title / Labels / Milestone for issue filing
+        if fail["labels"] and creating_new_issue:
+            label_set = set([l.strip().lower() for l in fail["labels"].split(',')])
+            label_set.add("blocking-clean-ci-optional")
+            for label in sorted(label_set):
+                gh_issue_command.append('--label')
+                gh_issue_command.append(label)
+
         test_name = fail["test_name"]
         if creating_new_issue:
             gh_issue_command.append('--title')

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -129,7 +129,7 @@ class IssueGenerator:
         #  perform this check, the database often wants us to generate multiple issues for a given build ID.
         # TODO: Investigate why we can't use stamp filtering on new issues more deeply, it seems like it should work.
         if not creating_new_issue and (len(unstamped_affected) == 0):
-            affected_build_list = ", ".join([ap["build_id"] for ap in affected])
+            affected_build_list = ", ".join([str(ap["build_id"]) for ap in affected])
             print(f"All affected builds ({affected_build_list}) have stamps; skipping.")
             return
 

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -93,7 +93,7 @@ class IssueGenerator:
             if creating_new_issue:
                 for label in fail["labels"].split(','):
                     stripped_label = label.strip()
-                    if stripped_label:
+                    if stripped_label and (stripped_label != "blocking-clean-ci-optional"):
                         gh_issue_command.append('--label')
                         gh_issue_command.append(stripped_label)
 

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -85,6 +85,8 @@ class IssueGenerator:
         else:
             print("GitHub Issue: NEW — creating new issue")
             gh_issue_command.append("create")
+            gh_issue_command.append("--label")
+            gh_issue_command.append("blocking-clean-ci-optional")
             creating_new_issue = True
 
         if fail["labels"]:

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -88,10 +88,17 @@ class IssueGenerator:
             creating_new_issue = True
 
         # Title / Labels / Milestone for issue filing
-        if fail["labels"] and creating_new_issue:
-            label_set = set([l.strip().lower() for l in fail["labels"].split(',')])
+        if creating_new_issue:
+            if fail["labels"]:
+                # TODO: Find a way to make a case-insensitive set so we can avoid normalizing the labels to lowercase
+                label_set = set([l.strip().lower() for l in fail["labels"].split(',')])
+            else:
+                label_set = set()
             label_set.add("blocking-clean-ci-optional")
+
             for label in sorted(label_set):
+                if len(label) == 0:
+                    continue
                 gh_issue_command.append('--label')
                 gh_issue_command.append(label)
 

--- a/.github/skills/ci-pipeline-monitor/scripts/update_github.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/update_github.py
@@ -122,10 +122,15 @@ class IssueGenerator:
         ))
 
         # Filter affected list to build IDs that don't have stamp files
-        affected = [ap for ap in affected if not os.path.exists(self.get_stamp_path(ap))]
+        unstamped_affected = [ap for ap in affected if not os.path.exists(self.get_stamp_path(ap))]
 
-        if len(affected) == 0:
-            print("All affected builds have stamps; skipping.")
+        # If the database tells us to add a comment instead of creating a new issue, ensure we don't generate redundant
+        #  comments for builds that we've already generated a comment for before. When creating new issues we can't
+        #  perform this check, the database often wants us to generate multiple issues for a given build ID.
+        # TODO: Investigate why we can't use stamp filtering on new issues more deeply, it seems like it should work.
+        if not creating_new_issue and (len(unstamped_affected) == 0):
+            affected_build_list = ", ".join([ap["build_id"] for ap in affected])
+            print(f"All affected builds ({affected_build_list}) have stamps; skipping.")
             return
 
         out.append(f"**Failed in ({len(affected)}):**")

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -599,7 +599,7 @@ def main():
                 for name in page_label_names:
                     all_label_names.add(name.lower())
 
-        with open(LABELS_CACHE_FILE) as f:
+        with open(LABELS_CACHE_FILE, "w") as f:
             f.write(json.dumps(sorted(all_label_names)))
     except urllib.error.HTTPError:
         print("  [WARN] Failed to fetch labels list from GitHub due to an HTTP error. Loading cached labels list.")

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -19,6 +19,7 @@ import urllib.parse
 import urllib.request
 
 LABELS_API_ENDPOINT = "https://api.github.com/repos/dotnet/runtime/labels"
+LABELS_CACHE_FILE = os.path.join(__file__, "..", "cached_labels.json")
 
 def check(name, passed, detail="", warn_only=False):
     if not passed and warn_only:
@@ -580,22 +581,32 @@ def main():
 
     total += 1
     all_label_names = set()
-    # TODO: If dotnet/runtime ever has more than 999 labels, increase this page limit. At time of script authoring
-    #  we have around 300 so this is more than enough.
-    for page_index in range(1, 10):
-        req = urllib.request.Request(f"{LABELS_API_ENDPOINT}?per_page=100&page={page_index}", headers={
-            "Accept": "application/vnd.github+json",
-            "User-Agent": "ci-pipeline-monitor-validator",
-        })
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            data = json.loads(resp.read())
-            page_label_names = set([item["name"] for item in data])
-            # Don't bother querying additional empty pages after this one.
-            if len(page_label_names) <= 0:
-                break
+    try:
+        # TODO: If dotnet/runtime ever has more than 999 labels, increase this page limit. At time of script authoring
+        #  we have around 300 so this is more than enough.
+        for page_index in range(1, 10):
+            req = urllib.request.Request(f"{LABELS_API_ENDPOINT}?per_page=100&page={page_index}", headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "ci-pipeline-monitor-validator",
+            })
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                data = json.loads(resp.read())
+                page_label_names = set([item["name"] for item in data])
+                # Don't bother querying additional empty pages after this one.
+                if len(page_label_names) <= 0:
+                    break
 
-            for name in page_label_names:
-                all_label_names.add(name.lower())
+                for name in page_label_names:
+                    all_label_names.add(name.lower())
+
+        with open(LABELS_CACHE_FILE) as f:
+            f.write(json.dumps(sorted(all_label_names)))
+    except urllib.error.HTTPError:
+        print("  [WARN] Failed to fetch labels list from GitHub due to an HTTP error. Loading cached labels list.")
+        with open(LABELS_CACHE_FILE) as f:
+            labels_json = f.read()
+            labels_list = json.loads(labels_json)
+            all_label_names = set(labels_list)
 
     all_failure_rows = conn.execute("""
         SELECT id, labels FROM failures

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -594,7 +594,7 @@ def main():
                 break
 
             for name in page_label_names:
-                all_label_names.add(name)
+                all_label_names.add(name.lower())
 
     all_failure_rows = conn.execute("""
         SELECT id, labels FROM failures
@@ -603,7 +603,7 @@ def main():
     for failure_row in all_failure_rows:
         failure_labels = failure_row["labels"].split(',')
         for failure_label in failure_labels:
-            failure_label = failure_label.strip()
+            failure_label = failure_label.strip().lower()
             if not (failure_label in all_label_names):
                 print(f"  [FAIL] Invalid label '{failure_label}' for failure {failure_row['id']}")
                 bad_labels.append(failure_row)

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -18,6 +18,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 
+LABELS_API_ENDPOINT = "https://api.github.com/repos/dotnet/runtime/labels"
 
 def check(name, passed, detail="", warn_only=False):
     if not passed and warn_only:
@@ -573,6 +574,45 @@ def main():
                 f"{len(bad_console_url)} URL(s) were invalid (see above)" if len(bad_console_url) else "")
         if not ok:
             failures += 1
+
+    # 16h. Every failure's suggested labels are valid labels on the dotnet/runtime repo
+    # Otherwise, update_github will fail to file the issue
+
+    all_label_names = set()
+    # TODO: If dotnet/runtime ever has more than 999 labels, increase this page limit. At time of script authoring
+    #  we have around 300 so this is more than enough.
+    for page_index in range(10):
+        req = urllib.request.Request(f"{LABELS_API_ENDPOINT}?per_page=100&page={page_index}", headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "ci-pipeline-monitor-validator",
+        })
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = json.loads(resp.read())
+            page_label_names = set([item["name"] for item in data])
+            # Don't bother querying additional empty pages after this one.
+            if len(page_label_names) <= 0:
+                break
+
+            for name in page_label_names:
+                all_label_names.add(name)
+
+    all_failure_rows = conn.execute("""
+        SELECT id, labels FROM failures
+    """).fetchall()
+    bad_labels = []
+    for failure_row in all_failure_rows:
+        failure_labels = failure_row["labels"].split(',')
+        for failure_label in failure_labels:
+            failure_label = failure_label.strip()
+            if not (failure_label in all_label_names):
+                print(f"  [FAIL] Invalid label '{failure_label}' for failure {failure_row['id']}")
+                bad_labels.append(failure_row)
+
+    ok = check("All failure labels are valid labels from dotnet/runtime repo",
+            len(bad_labels) == 0,
+            f"{len(bad_labels)} label(s) were invalid (see above)" if len(bad_labels) else "")
+    if not ok:
+        failures += 1
 
     # Report checks (only if --report provided)
     if args.report:

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -793,10 +793,10 @@ def main():
     warn_str = f", {warnings} warnings" if warnings else ""
     print(f"Results: {passed}/{total} passed, {failures} failed{warn_str}")
     if failures:
-        print("❌ VALIDATION FAILED — fix issues before publishing report")
+        print("/!\\ VALIDATION FAILED — fix issues before publishing report /!\\")
         sys.exit(1)
     else:
-        print("✅ ALL CHECKS PASSED")
+        print("ALL CHECKS PASSED")
         sys.exit(0)
 
 

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -584,7 +584,7 @@ def main():
     try:
         # TODO: If dotnet/runtime ever has more than 999 labels, increase this page limit. At time of script authoring
         #  we have around 300 so this is more than enough.
-        for page_index in range(1, 10):
+        for page_index in range(1, 11):
             req = urllib.request.Request(f"{LABELS_API_ENDPOINT}?per_page=100&page={page_index}", headers={
                 "Accept": "application/vnd.github+json",
                 "User-Agent": "ci-pipeline-monitor-validator",

--- a/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
+++ b/.github/skills/ci-pipeline-monitor/scripts/validate_results.py
@@ -578,10 +578,11 @@ def main():
     # 16h. Every failure's suggested labels are valid labels on the dotnet/runtime repo
     # Otherwise, update_github will fail to file the issue
 
+    total += 1
     all_label_names = set()
     # TODO: If dotnet/runtime ever has more than 999 labels, increase this page limit. At time of script authoring
     #  we have around 300 so this is more than enough.
-    for page_index in range(10):
+    for page_index in range(1, 10):
         req = urllib.request.Request(f"{LABELS_API_ENDPOINT}?per_page=100&page={page_index}", headers={
             "Accept": "application/vnd.github+json",
             "User-Agent": "ci-pipeline-monitor-validator",
@@ -601,9 +602,12 @@ def main():
     """).fetchall()
     bad_labels = []
     for failure_row in all_failure_rows:
-        failure_labels = failure_row["labels"].split(',')
+        raw_labels = failure_row["labels"]
+        failure_labels = raw_labels.split(',') if raw_labels else []
         for failure_label in failure_labels:
             failure_label = failure_label.strip().lower()
+            if not failure_label:
+                continue
             if not (failure_label in all_label_names):
                 print(f"  [FAIL] Invalid label '{failure_label}' for failure {failure_row['id']}")
                 bad_labels.append(failure_row)
@@ -612,6 +616,8 @@ def main():
             len(bad_labels) == 0,
             f"{len(bad_labels)} label(s) were invalid (see above)" if len(bad_labels) else "")
     if not ok:
+        print("Full set of valid labels follows:")
+        print(", ".join(sorted(all_label_names)))
         failures += 1
 
     # Report checks (only if --report provided)


### PR DESCRIPTION
* Ensure that when the CI pipeline monitor updater script generates a new issue, it applies blocking-clean-ci-optional
* Ensure that during validation we check to make sure all assigned labels are real labels. In a previous run I had generating an issue fail because one of the labels was wrong.

cc @JulieLeeMSFT 