### PR TITLE
Fix host-dependent assertion prop non-null proof

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4991,7 +4991,15 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
     if (!optLocalAssertionProp)
     {
         ValueNum vn = vnStore->VNConservativeNormalValue(op->gtVNPair);
-        return optAssertionVNIsNonNull(vn, assertions);
+        // Substitute an empty bitset for uninit so the iter inside
+        // optAssertionVNIsNonNull is safe. Semantically "no known assertions" and
+        // "uninit" produce the same answer; this also avoids a host-dependent
+        // codegen divergence where short-rep treats empty == uninit while long-rep
+        // does not. See https://github.com/dotnet/runtime/issues/128602.
+        ASSERT_TP safeAssertions = BitVecOps::MayBeUninit(assertions)
+            ? BitVecOps::MakeEmpty(apTraits)
+            : assertions;
+        return optAssertionVNIsNonNull(vn, safeAssertions);
     }
     else
     {
@@ -5904,6 +5912,12 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
 ASSERT_VALRET_TP Compiler::optGetEdgeAssertions(const BasicBlock* block, const BasicBlock* blockPred) const
 {
     assert(block != nullptr);
+    // Blocks added after optInitAssertionDataflowFlags have no valid
+    // bbAssertionOut / bbJtrueAssertionOut slot. Treat them as carrying no assertions.
+    if (blockPred->bbNum > optDataflowBBNumMax)
+    {
+        return BitVecOps::MakeEmpty(apTraits);
+    }
     if (blockPred->KindIs(BBJ_COND))
     {
         if (blockPred->TrueTargetIs(block))
@@ -6207,6 +6221,9 @@ ASSERT_TP* Compiler::optComputeAssertionGen()
 ASSERT_TP* Compiler::optInitAssertionDataflowFlags()
 {
     ASSERT_TP* jumpDestOut = fgAllocateTypeForEachBlk<ASSERT_TP>();
+    // Capture the bbNum bound so optGetEdgeAssertions can detect blocks added
+    // after init (whose bbAssertionOut / bbJtrueAssertionOut slots are uninitialized).
+    optDataflowBBNumMax = fgBBNumMax;
 
     // The local assertion gen phase may have created unreachable blocks.
     // They will never be visited in the dataflow propagation phase, so they need to

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4976,7 +4976,7 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
         return true;
     }
 
-    if (!optCanPropNonNull || BitVecOps::MayBeUninit(assertions))
+    if (!optCanPropNonNull || (optLocalAssertionProp && BitVecOps::MayBeUninit(assertions)))
     {
         return false;
     }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9037,6 +9037,11 @@ public:
     }
     ASSERT_TP* bbJtrueAssertionOut;
 
+    // fgBBNumMax captured when bbJtrueAssertionOut / bbAssertionOut storage was allocated.
+    // Blocks with bbNum greater than this were added after dataflow init and have no valid
+    // entry — optGetEdgeAssertions must treat them as having no incoming assertions.
+    unsigned   optDataflowBBNumMax = 0;
+
     // Assertion prop helpers.
     ASSERT_TP&          GetAssertionDep(unsigned lclNum, bool mustExist = false);
     const AssertionDsc& optGetAssertion(AssertionIndex assertIndex) const;


### PR DESCRIPTION
Crossgen2 was emitting different code for the same methods with null-coalescing statements when targeting ARM depending on which host it was on. On ARM (and I believe x86), it is able to prove the local is non-null, but on x64 it is not. My understanding (based on Copilot's investigation), is that the `MayBeUninit()` check causes an early return on 64-bit systems, but not on 32-bit when the assertions bitmap is between 32 and 64 bits long. But when `optLocalAssertionProp == false` we may still return true from `optAssertionVNIsNonNull(vn, assertions)`. So we want to make sure `optLocalAssertionProp` is also `true` before we return early.

> [!NOTE]
> This PR description was generated by GitHub Copilot.

## Summary

Restrict the `BitVecOps::MayBeUninit(assertions)` bailout in `optAssertionIsNonNull` to local assertion propagation. Global assertion propagation can still prove a value non-null by walking VN/PHI predecessor edge assertions, even when the current block's assertion set is empty.

This fixes a host-dependent JIT behavior exposed by crossgen2 comparison runs: on x64, an empty short `BitSetShortLongRep` is `nullptr` and aliases `UninitVal()`, while on 32-bit ARM the same assertion table is long/heap-backed and empty is non-null. The old global-AP bailout therefore prevented x64-hosted ARM cross-JIT from proving a PHI non-null, but allowed native ARM-hosted JIT to do so.

## Validation

- `./build.sh clr.jit+clr.aot -c Debug`
- Reran the x64-hosted single-method crossgen2 repro for `Microsoft.Extensions.Logging.Console.ConsoleLogger:LogRecords` targeting `linux-arm`; output hash was `80198ba3b1ae56900de7bc8de9d221e0a6be42b9c61ed2b951a35b3401e746dd`, matching the native ARM-hosted behavior, and the disassembly no longer has the extra explicit null-check before `StringWriter.GetStringBuilder`.
