### PR TITLE
Make O1K_LCLVAR local assertprop only

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1538,6 +1538,11 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
         case O1K_VN:
             assert(!optLocalAssertionProp);
             break;
+
+        case O1K_LCLVAR:
+            assert(optLocalAssertionProp);
+            break;
+
         default:
             break;
     }
@@ -2490,8 +2495,9 @@ GenTree* Compiler::optVNBasedFoldExpr_Call_Memcmp(GenTreeCall* call)
     CallArg* arg2   = call->gtArgs.GetUserArgByIndex(1);
     CallArg* lenArg = call->gtArgs.GetUserArgByIndex(2);
 
-    ValueNum lenVN = vnStore->VNConservativeNormalValue(lenArg->GetNode()->gtVNPair);
-    if (!vnStore->IsVNConstant(lenVN))
+    ValueNum lenVN = optConservativeNormalVN(lenArg->GetNode());
+    size_t   len;
+    if (!vnStore->IsVNIntegralConstant(lenVN, &len))
     {
         // See if arguments are the same - in that case we can optimize to constant true
         ValueNum arg1VN = optConservativeNormalVN(arg1->GetNode());
@@ -2505,8 +2511,6 @@ GenTree* Compiler::optVNBasedFoldExpr_Call_Memcmp(GenTreeCall* call)
         JITDUMP("...length is not a constant - bail out.\n");
         return nullptr;
     }
-
-    const size_t len = vnStore->CoercedConstantValue<size_t>(lenVN);
 
     // SequenceEqual(..., len == 0) => true, and does not dereference pointers
     if (len == 0)
@@ -3687,9 +3691,12 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         {
             break;
         }
-        // See if the variable is equal to a constant or another variable.
+
         const AssertionDsc& curAssertion = optGetAssertion(assertionIndex);
-        if (!curAssertion.CanPropLclVar())
+
+        // We need an equality assertion for either a copy prop or a constant prop.
+        if (!curAssertion.CanPropLclVar() ||
+            !(curAssertion.GetOp2().IsConstant() || curAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY)))
         {
             continue;
         }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8257,7 +8257,7 @@ public:
             ValueNum GetVN() const
             {
                 assert(!m_compiler->optLocalAssertionProp);
-                // TODO-Cleanup: O1K_LCLVAR should be Local-AP only.
+                assert(KindIs(O1K_VN, O1K_EXACT_TYPE, O1K_SUBTYPE));
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -8432,6 +8432,11 @@ public:
                 assert(KindIs(O2K_CONST_INT));
                 return m_icon.m_fieldSeq;
             }
+
+            bool IsConstant() const
+            {
+                return KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CONST_VEC);
+            }
         };
 
     private:
@@ -8486,7 +8491,8 @@ public:
 
         bool CanPropLclVar() const
         {
-            return KindIs(OAK_EQUAL) && GetOp1().KindIs(O1K_LCLVAR);
+            // O1K_LCLVAR is local-AP only, for global-AP we use O1K_VN
+            return KindIs(OAK_EQUAL) && GetOp1().KindIs(O1K_LCLVAR, O1K_VN);
         }
 
         bool CanPropEqualOrNotEqual() const
@@ -8660,15 +8666,15 @@ public:
             {
                 return false;
             }
-            else if (GetOp1().KindIs(O1K_VN))
+            else if (GetOp1().KindIs(O1K_VN, O1K_EXACT_TYPE, O1K_SUBTYPE))
             {
                 assert(vnBased);
                 return (GetOp1().GetVN() == that.GetOp1().GetVN());
             }
             else
             {
-                return ((vnBased && (GetOp1().GetVN() == that.GetOp1().GetVN())) ||
-                        (!vnBased && (GetOp1().GetLclNum() == that.GetOp1().GetLclNum())));
+                assert(!vnBased);
+                return (GetOp1().GetLclNum() == that.GetOp1().GetLclNum());
             }
         }
 
@@ -8747,12 +8753,12 @@ public:
         {
             AssertionDsc dsc    = CreateEmptyAssertion(comp);
             dsc.m_assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
-            dsc.m_op1.m_kind    = O1K_LCLVAR;
 
             if (comp->optLocalAssertionProp)
             {
                 assert(lclNum != BAD_VAR_NUM);
 
+                dsc.m_op1.m_kind   = O1K_LCLVAR;
                 dsc.m_op1.m_lclNum = lclNum;
 
                 // We use ValueNumStore::VNForNull() as a hint of nullness. This allows us to avoid looking up the
@@ -8771,8 +8777,9 @@ public:
             {
                 assert(vn != ValueNumStore::NoVN);
                 assert(cnsVN != ValueNumStore::NoVN);
-                dsc.m_op1.m_vn = vn;
-                dsc.m_op2.m_vn = cnsVN;
+                dsc.m_op1.m_kind = O1K_VN;
+                dsc.m_op1.m_vn   = vn;
+                dsc.m_op2.m_vn   = cnsVN;
             }
 
             if constexpr (std::is_same_v<T, int> || std::is_same_v<T, ssize_t>)


### PR DESCRIPTION
This PR makes `O1K_LCLVAR` local assertion prop only, it's fully replaced with `O1K_VN` in global assertion prop now.

Interestingly, it catches a few constant-props that are useful to unroll more SequenceEqual, e.g:

```cs
static readonly string Temp = Environment.GetEnvironmentVariable("TEMP");

static bool Test(string str) => str == Temp;
```

**Codegen before this PR:**
```asm
; Assembly listing for method Prog:Test(System.String):bool (Tier1)
       sub      rsp, 40
       mov      rdx, 0x1BF978001C0      ; const ptr
       mov      rdx, gword ptr [rdx]
       cmp      rcx, rdx
       je       SHORT G_M47511_IG05
       test     rcx, rcx
       je       SHORT G_M47511_IG06
       mov      r8d, dword ptr [rcx+0x08]
       cmp      r8d, 33
       jne      SHORT G_M47511_IG06
       add      rcx, 12
       add      rdx, 12
       add      r8d, r8d
       call     [System.SpanHelpers:SequenceEqual(byref,byref,nuint):bool]
G_M47511_IG03:
       nop      
       add      rsp, 40
       ret      
G_M47511_IG05:
       mov      eax, 1
       jmp      SHORT G_M47511_IG03
G_M47511_IG06:
       xor      eax, eax
       jmp      SHORT G_M47511_IG03
; Total bytes of code 71, prolog size 4, PerfScore 13.50
```

**With this PR:**
```asm
; Assembly listing for method Prog:Test(System.String):bool (Tier1)
       mov      rax, 0x2A43C8001C0      ; const ptr
       mov      rax, gword ptr [rax]
       cmp      rcx, rax
       je       SHORT G_M47511_IG04
       test     rcx, rcx
       je       SHORT G_M47511_IG05
       mov      edx, dword ptr [rcx+0x08]
       cmp      edx, 33
       jne      SHORT G_M47511_IG05
       add      rcx, 12
       add      rax, 12
       vmovups  zmm0, zmmword ptr [rcx]
       vmovups  zmm1, zmmword ptr [rcx+0x02]
       vpxord   zmm1, zmm1, zmmword ptr [rax+0x02]
       vpternlogq zmm0, zmm1, zmmword ptr [rax], -34
       vptestmq k1, zmm0, zmm0
       kortestb k1, k1
       sete     al
       movzx    rax, al
G_M47511_IG03:
       vzeroupper 
       ret      
G_M47511_IG04:
       mov      eax, 1
       jmp      SHORT G_M47511_IG03
G_M47511_IG05:
       xor      eax, eax
       jmp      SHORT G_M47511_IG03
; Total bytes of code 103, prolog size 0, PerfScore 33.25
```

^ unfortunately, PerfScore (and size) treat it as a pure regression, which is not true. We probably should improve our PerfScore for calls (e.g. actual PerfScore of the call's impl?)