### PR TITLE
[cDAC] Remove irrelevant method table test and update relevant one

### DIFF
--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -464,66 +464,6 @@ public class MethodTableTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
-    public void IsContinuationWithoutMetadata_ReturnsFalseWhenSingletonEEClassGlobalIsNull(MockTarget.Architecture arch)
-    {
-        TargetPointer continuationInstanceMethodTablePtr = default;
-        TestPlaceholderTarget target = CreateTarget(
-            arch,
-            rtsBuilder =>
-            {
-                TargetTestHelpers targetTestHelpers = rtsBuilder.Builder.TargetTestHelpers;
-                MockMethodTable continuationBaseMethodTable = rtsBuilder.ContinuationMethodTable;
-                rtsBuilder.SetContinuationSingletonEEClass(0);
-
-                MockMethodTable continuationInstanceMethodTable = rtsBuilder.AddMethodTable("ContinuationInstance");
-                continuationInstanceMethodTable.BaseSize = targetTestHelpers.ObjectBaseSize;
-                continuationInstanceMethodTable.ParentMethodTable = continuationBaseMethodTable.Address;
-                continuationInstanceMethodTable.NumVirtuals = 3;
-                continuationInstanceMethodTablePtr = continuationInstanceMethodTable.Address;
-                continuationInstanceMethodTable.EEClassOrCanonMT = rtsBuilder.ContinuationEEClass.Address;
-            });
-
-        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
-        TypeHandle continuationTypeHandle = contract.GetTypeHandle(continuationInstanceMethodTablePtr);
-        Assert.False(contract.IsContinuationWithoutMetadata(continuationTypeHandle));
-    }
-
-    [Theory]
-    [ClassData(typeof(MockTarget.StdArch))]
-    public void ValidateContinuationMethodTablePointer(MockTarget.Architecture arch)
-    {
-        TargetPointer continuationInstanceMethodTablePtr = default;
-        TestPlaceholderTarget target = CreateTarget(
-            arch,
-            rtsBuilder =>
-            {
-                TargetTestHelpers targetTestHelpers = rtsBuilder.Builder.TargetTestHelpers;
-                MockMethodTable continuationBaseMethodTable = rtsBuilder.ContinuationMethodTable;
-
-                MockEEClass sharedEEClass = rtsBuilder.AddEEClass("SubContinuation");
-                MockMethodTable sharedCanonMT = rtsBuilder.AddMethodTable("SubContinuationCanon");
-                sharedCanonMT.BaseSize = targetTestHelpers.ObjectBaseSize;
-                sharedCanonMT.ParentMethodTable = continuationBaseMethodTable.Address;
-                sharedCanonMT.NumVirtuals = 3;
-                sharedEEClass.MethodTable = sharedCanonMT.Address;
-                sharedCanonMT.EEClassOrCanonMT = sharedEEClass.Address;
-
-                MockMethodTable continuationInstanceMethodTable = rtsBuilder.AddMethodTable("ContinuationInstance");
-                continuationInstanceMethodTable.BaseSize = targetTestHelpers.ObjectBaseSize;
-                continuationInstanceMethodTable.ParentMethodTable = continuationBaseMethodTable.Address;
-                continuationInstanceMethodTable.NumVirtuals = 3;
-                continuationInstanceMethodTablePtr = continuationInstanceMethodTable.Address;
-                continuationInstanceMethodTable.EEClassOrCanonMT = sharedCanonMT.Address | 1;
-            });
-
-        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
-        Contracts.TypeHandle continuationTypeHandle = contract.GetTypeHandle(continuationInstanceMethodTablePtr);
-        Assert.Equal(continuationInstanceMethodTablePtr.Value, continuationTypeHandle.Address.Value);
-        Assert.False(contract.IsContinuationWithoutMetadata(continuationTypeHandle));
-    }
-
-    [Theory]
-    [ClassData(typeof(MockTarget.StdArch))]
     public void IsContinuationWithoutMetadata_ReturnsTrueForSingletonEEClass(MockTarget.Architecture arch)
     {
         TargetPointer continuationInstanceMethodTablePtr = default;

--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -476,7 +476,6 @@ public class MethodTableTests
 
                 MockEEClass sharedEEClass = rtsBuilder.AddEEClass("SubContinuation");
                 MockMethodTable sharedCanonMT = rtsBuilder.AddMethodTable("SubContinuationCanon");
-
                 sharedCanonMT.BaseSize = targetTestHelpers.ObjectBaseSize;
                 sharedCanonMT.ParentMethodTable = continuationBaseMethodTable.Address;
                 sharedCanonMT.NumVirtuals = 3;
@@ -495,7 +494,7 @@ public class MethodTableTests
         IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
         Contracts.TypeHandle continuationTypeHandle = contract.GetTypeHandle(continuationInstanceMethodTablePtr);
         Assert.Equal(continuationInstanceMethodTablePtr.Value, continuationTypeHandle.Address.Value);
-        Assert.False(contract.IsContinuationWithoutMetadata(continuationTypeHandle));
+        Assert.True(contract.IsContinuationWithoutMetadata(continuationTypeHandle));
     }
 
     [Theory]

--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -464,6 +464,42 @@ public class MethodTableTests
 
     [Theory]
     [ClassData(typeof(MockTarget.StdArch))]
+    public void ValidateContinuationMethodTablePointer(MockTarget.Architecture arch)
+    {
+        TargetPointer continuationInstanceMethodTablePtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                TargetTestHelpers targetTestHelpers = rtsBuilder.Builder.TargetTestHelpers;
+                MockMethodTable continuationBaseMethodTable = rtsBuilder.ContinuationMethodTable;
+
+                MockEEClass sharedEEClass = rtsBuilder.AddEEClass("SubContinuation");
+                MockMethodTable sharedCanonMT = rtsBuilder.AddMethodTable("SubContinuationCanon");
+
+                sharedCanonMT.BaseSize = targetTestHelpers.ObjectBaseSize;
+                sharedCanonMT.ParentMethodTable = continuationBaseMethodTable.Address;
+                sharedCanonMT.NumVirtuals = 3;
+                sharedEEClass.MethodTable = sharedCanonMT.Address;
+                sharedCanonMT.EEClassOrCanonMT = sharedEEClass.Address;
+                rtsBuilder.SetContinuationSingletonEEClass(sharedEEClass.Address);
+
+                MockMethodTable continuationInstanceMethodTable = rtsBuilder.AddMethodTable("ContinuationInstance");
+                continuationInstanceMethodTable.BaseSize = targetTestHelpers.ObjectBaseSize;
+                continuationInstanceMethodTable.ParentMethodTable = continuationBaseMethodTable.Address;
+                continuationInstanceMethodTable.NumVirtuals = 3;
+                continuationInstanceMethodTablePtr = continuationInstanceMethodTable.Address;
+                continuationInstanceMethodTable.EEClassOrCanonMT = sharedCanonMT.Address | 1;
+            });
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+        Contracts.TypeHandle continuationTypeHandle = contract.GetTypeHandle(continuationInstanceMethodTablePtr);
+        Assert.Equal(continuationInstanceMethodTablePtr.Value, continuationTypeHandle.Address.Value);
+        Assert.False(contract.IsContinuationWithoutMetadata(continuationTypeHandle));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
     public void IsContinuationWithoutMetadata_ReturnsTrueForSingletonEEClass(MockTarget.Architecture arch)
     {
         TargetPointer continuationInstanceMethodTablePtr = default;


### PR DESCRIPTION
These tests constructed scenarios where we attempted to verify a non-metadata Continuation MethodTable despite the global singleton Continuation EEClass being zero or null. This is an inconsistent/invalid method table, so the test appropriately failed. Removing one of these as it is out of scope for a test of IsContinuationWithoutMetadata. Adding a singleton EEClass to the other.