### PR TITLE
JIT: generalize cloning conditions slightly

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1991,10 +1991,13 @@ struct NaturalLoopIterInfo
     // length of an invariant array.
     bool HasArrayLengthLimit : 1;
 
-    // Whether the consumer must emit its own runtime zero-trip guard for this
-    // loop (i.e. the analysis could not prove statically that the loop body
-    // executes at least once, and no preheader BBJ_COND guards entry).
-    // Only set when AnalyzeIteration is called with allowMissingBaseCase=true.
+    // Whether the consumer must emit its own runtime entry guard for this loop.
+    // Set when AnalyzeIteration could not prove statically that the loop
+    // condition [IterVar TestOper Limit] holds on entry (so the analysis
+    // invariants only hold conditionally). The consumer must insert a runtime
+    // test equivalent to that condition on the path that reaches the analyzed
+    // loop body. Only set when AnalyzeIteration is called with
+    // allowMissingBaseCase=true.
     bool NeedsZeroTripGuard : 1;
 
     NaturalLoopIterInfo()

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -1991,6 +1991,12 @@ struct NaturalLoopIterInfo
     // length of an invariant array.
     bool HasArrayLengthLimit : 1;
 
+    // Whether the consumer must emit its own runtime zero-trip guard for this
+    // loop (i.e. the analysis could not prove statically that the loop body
+    // executes at least once, and no preheader BBJ_COND guards entry).
+    // Only set when AnalyzeIteration is called with allowMissingBaseCase=true.
+    bool NeedsZeroTripGuard : 1;
+
     NaturalLoopIterInfo()
         : ExitedOnTrue(false)
         , HasConstInit(false)
@@ -1998,6 +2004,7 @@ struct NaturalLoopIterInfo
         , HasSimdLimit(false)
         , HasInvariantLocalLimit(false)
         , HasArrayLengthLimit(false)
+        , NeedsZeroTripGuard(false)
     {
     }
 
@@ -2191,7 +2198,7 @@ public:
     BasicBlock* GetLexicallyTopMostBlock();
     BasicBlock* GetLexicallyBottomMostBlock();
 
-    bool AnalyzeIteration(NaturalLoopIterInfo* info);
+    bool AnalyzeIteration(NaturalLoopIterInfo* info, bool allowMissingBaseCase = false);
 
     bool HasDef(unsigned lclNum);
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5566,19 +5566,30 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 // the loop.
 //
 // Parameters:
-//   info - [out] Loop information
+//   info                 - [out] Loop information
+//   allowMissingBaseCase - If true, succeed even when we cannot prove that the
+//                          loop invariant holds on entry, provided the limit
+//                          form is one we know how to materialize at runtime.
+//                          The caller is then responsible for emitting a
+//                          runtime zero-trip guard when
+//                          info->NeedsZeroTripGuard is set on return.
+//                          Defaults to false; existing callers retain the
+//                          stronger guarantees described below.
 //
 // Returns:
 //   True if the structure was analyzed and we can make guarantees about it;
 //   otherwise false.
 //
 // Remarks:
-//   On a true return, the function guarantees that the loop invariant is true
-//   and maintained at all points within the loop, except possibly right after
-//   the update of the iterator variable (NaturalLoopIterInfo::IterTree). The
-//   function guarantees that the test (NaturalLoopIterInfo::TestTree) occurs
-//   immediately after the update, so no IR in the loop is executed without the
-//   loop invariant being true, except for the test.
+//   On a true return with allowMissingBaseCase == false (or with the flag set
+//   but info->NeedsZeroTripGuard == false), the function guarantees that the
+//   loop invariant is true and maintained at all points within the loop,
+//   except possibly right after the update of the iterator variable
+//   (NaturalLoopIterInfo::IterTree). optExtractTestIncr permits the IV update
+//   to be separated from the loop test by other statements, but it rejects
+//   any candidate where an intervening statement references the iterator
+//   variable, so no IR in the loop is executed observing the post-update
+//   value of the iterator except the test itself.
 //
 //   The loop invariant is defined as the expression obtained by
 //   [info->IterVar] [info->TestOper()] [info->Limit()]. Note that
@@ -5598,6 +5609,15 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 //
 //   In some cases we also know the initial value on entry to the loop; see
 //   ::HasConstInit and ::ConstInitValue.
+//
+//   When allowMissingBaseCase is true and the function would otherwise fail
+//   because the loop is not provably entered (no suitable preheader BBJ_COND
+//   guard and no constant init/limit pair that proves base case), the function
+//   may instead succeed with info->NeedsZeroTripGuard set. In that mode the
+//   above invariant only holds conditionally: it is the caller's obligation
+//   to insert a runtime test equivalent to [IterVar TestOper() Limit] on the
+//   path that reaches the analyzed loop body. Loop cloning uses this to emit
+//   the guard as an extra cloning condition on the fast-path version.
 //
 bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allowMissingBaseCase)
 {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5568,10 +5568,11 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 // Parameters:
 //   info                 - [out] Loop information
 //   allowMissingBaseCase - If true, succeed even when we cannot prove that the
-//                          loop invariant holds on entry, provided the limit
-//                          form is one we know how to materialize at runtime.
-//                          The caller is then responsible for emitting a
-//                          runtime zero-trip guard when
+//                          loop condition [IterVar TestOper Limit] holds on
+//                          entry, provided the limit form is one we know how
+//                          to materialize at runtime. The caller is then
+//                          responsible for emitting a runtime entry guard
+//                          equivalent to that condition when
 //                          info->NeedsZeroTripGuard is set on return.
 //                          Defaults to false; existing callers retain the
 //                          stronger guarantees described below.
@@ -5611,13 +5612,16 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 //   ::HasConstInit and ::ConstInitValue.
 //
 //   When allowMissingBaseCase is true and the function would otherwise fail
-//   because the loop is not provably entered (no suitable preheader BBJ_COND
-//   guard and no constant init/limit pair that proves base case), the function
-//   may instead succeed with info->NeedsZeroTripGuard set. In that mode the
-//   above invariant only holds conditionally: it is the caller's obligation
-//   to insert a runtime test equivalent to [IterVar TestOper() Limit] on the
+//   because the loop condition [IterVar TestOper Limit] cannot be proven to
+//   hold on entry (no suitable preheader BBJ_COND guard and no constant
+//   init/limit pair that proves the base case), the function may instead
+//   succeed with info->NeedsZeroTripGuard set. In that mode the above
+//   invariant only holds conditionally: it is the caller's obligation to
+//   insert a runtime test equivalent to [IterVar TestOper() Limit] on the
 //   path that reaches the analyzed loop body. Loop cloning uses this to emit
-//   the guard as an extra cloning condition on the fast-path version.
+//   the guard as an extra cloning condition on the fast-path version. Note
+//   that this includes do/while-style loops that are guaranteed to execute
+//   at least once but whose loop condition may be false on entry.
 //
 bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allowMissingBaseCase)
 {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5633,7 +5633,8 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allo
 
     GenTree* test = nullptr;
 
-    info->IterVar = BAD_VAR_NUM;
+    info->IterVar            = BAD_VAR_NUM;
+    info->NeedsZeroTripGuard = false;
 
     for (FlowEdge* exitEdge : ExitEdges())
     {

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5599,7 +5599,7 @@ GenTreeLclVarCommon* FlowGraphNaturalLoop::FindDef(unsigned lclNum)
 //   In some cases we also know the initial value on entry to the loop; see
 //   ::HasConstInit and ::ConstInitValue.
 //
-bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info)
+bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allowMissingBaseCase)
 {
     JITDUMP("Analyzing iteration for " FMT_LP " with header " FMT_BB "\n", m_index, m_header->bbNum);
 
@@ -5700,8 +5700,22 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info)
 
     if (!CheckLoopConditionBaseCase(preheader, info))
     {
-        JITDUMP("  Loop condition may not be true on the first iteration\n");
-        return false;
+        // If the caller can emit its own runtime guard for the case where the
+        // loop body might not execute on the first iteration, allow the loop
+        // through provided we have enough symbolic info about init and limit
+        // to express the guard.
+        if (allowMissingBaseCase && info->HasConstInit &&
+            (info->HasConstLimit || info->HasInvariantLocalLimit || info->HasArrayLengthLimit))
+        {
+            JITDUMP("  Loop condition may not be true on the first iteration; deferring to caller "
+                    "(NeedsZeroTripGuard)\n");
+            info->NeedsZeroTripGuard = true;
+        }
+        else
+        {
+            JITDUMP("  Loop condition may not be true on the first iteration\n");
+            return false;
+        }
     }
 
 #ifdef DEBUG

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -5704,8 +5704,7 @@ bool FlowGraphNaturalLoop::AnalyzeIteration(NaturalLoopIterInfo* info, bool allo
         // loop body might not execute on the first iteration, allow the loop
         // through provided we have enough symbolic info about init and limit
         // to express the guard.
-        if (allowMissingBaseCase && info->HasConstInit &&
-            (info->HasConstLimit || info->HasInvariantLocalLimit || info->HasArrayLengthLimit))
+        if (allowMissingBaseCase && (info->HasConstLimit || info->HasInvariantLocalLimit || info->HasArrayLengthLimit))
         {
             JITDUMP("  Loop condition may not be true on the first iteration; deferring to caller "
                     "(NeedsZeroTripGuard)\n");

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1232,20 +1232,31 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
     // The fast path is then only entered when "init TestOper limit" holds.
     if (iterInfo->NeedsZeroTripGuard)
     {
-        // For the first cut we only handle const init (the only init form
-        // AnalyzeIteration currently extracts).
-        if (!iterInfo->HasConstInit)
+        LC_Ident initIdent;
+        if (iterInfo->HasConstInit)
         {
-            JITDUMP("> NeedsZeroTripGuard but init is not constant\n");
-            return false;
+            if (iterInfo->ConstInitValue < 0)
+            {
+                JITDUMP("> NeedsZeroTripGuard: init %d is invalid\n", iterInfo->ConstInitValue);
+                return false;
+            }
+            initIdent = LC_Ident::CreateConst(static_cast<unsigned>(iterInfo->ConstInitValue));
         }
-        if (iterInfo->ConstInitValue < 0)
+        else
         {
-            JITDUMP("> NeedsZeroTripGuard: init %d is invalid\n", iterInfo->ConstInitValue);
-            return false;
+            // Init is unknown statically; use the IV local as it stands at the
+            // preheader (the analysis already verified the local is not
+            // address-exposed and has no extraneous defs inside the loop, so
+            // reading it in the preheader gives the entry value).
+            const unsigned initLcl = iterInfo->IterVar;
+            if (!genActualTypeIsInt(lvaGetDesc(initLcl)))
+            {
+                JITDUMP("> NeedsZeroTripGuard: iter var V%02u not compatible with TYP_INT\n", initLcl);
+                return false;
+            }
+            initIdent = LC_Ident::CreateVar(initLcl);
         }
 
-        LC_Ident initIdent = LC_Ident::CreateConst(static_cast<unsigned>(iterInfo->ConstInitValue));
         LC_Ident limitIdent;
         if (iterInfo->HasConstLimit)
         {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1227,6 +1227,74 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         return false;
     }
 
+    // If AnalyzeIteration could not prove the loop body executes at least once,
+    // emit an explicit runtime zero-trip guard as one of the cloning conditions.
+    // The fast path is then only entered when "init TestOper limit" holds.
+    if (iterInfo->NeedsZeroTripGuard)
+    {
+        // For the first cut we only handle const init (the only init form
+        // AnalyzeIteration currently extracts).
+        if (!iterInfo->HasConstInit)
+        {
+            JITDUMP("> NeedsZeroTripGuard but init is not constant\n");
+            return false;
+        }
+        if (iterInfo->ConstInitValue < 0)
+        {
+            JITDUMP("> NeedsZeroTripGuard: init %d is invalid\n", iterInfo->ConstInitValue);
+            return false;
+        }
+
+        LC_Ident initIdent = LC_Ident::CreateConst(static_cast<unsigned>(iterInfo->ConstInitValue));
+        LC_Ident limitIdent;
+        if (iterInfo->HasConstLimit)
+        {
+            int limit = iterInfo->ConstLimit();
+            if (limit < 0)
+            {
+                JITDUMP("> NeedsZeroTripGuard: limit %d is invalid\n", limit);
+                return false;
+            }
+            limitIdent = LC_Ident::CreateConst(static_cast<unsigned>(limit));
+        }
+        else if (iterInfo->HasInvariantLocalLimit)
+        {
+            const unsigned limitLcl = iterInfo->VarLimit();
+            if (!genActualTypeIsInt(lvaGetDesc(limitLcl)))
+            {
+                JITDUMP("> NeedsZeroTripGuard: limit var V%02u not compatible with TYP_INT\n", limitLcl);
+                return false;
+            }
+            limitIdent = LC_Ident::CreateVar(limitLcl);
+        }
+        else if (iterInfo->HasArrayLengthLimit)
+        {
+            ArrIndex* index = new (getAllocator(CMK_LoopClone)) ArrIndex(getAllocator(CMK_LoopClone));
+            if (!iterInfo->ArrLenLimit(this, index))
+            {
+                JITDUMP("> NeedsZeroTripGuard: ArrLen not matching\n");
+                return false;
+            }
+            limitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, index, LC_Array::ArrLen));
+
+            // The array must be dereferenceable before evaluating the guard.
+            LC_Array array(LC_Array::Jagged, index, LC_Array::None);
+            context->EnsureArrayDerefs(loop->GetIndex())->Push(array);
+        }
+        else
+        {
+            JITDUMP("> NeedsZeroTripGuard: undetected limit\n");
+            return false;
+        }
+
+        // TestOper() returns the stays-in-loop relop in IV-on-lhs form, already
+        // adjusted for IsReversed and ExitedOnTrue.
+        LC_Condition zeroTrip(iterInfo->TestOper(), LC_Expr(initIdent), LC_Expr(limitIdent),
+                              iterInfo->TestTree->IsUnsigned());
+        context->EnsureConditions(loop->GetIndex())->Push(zeroTrip);
+        JITDUMP("Added zero-trip guard cloning condition\n");
+    }
+
     LC_Ident ident;
     // Init conditions
     if (iterInfo->HasConstInit)
@@ -2993,7 +3061,7 @@ bool Compiler::optObtainLoopCloningOpts(LoopCloneContext* context)
     {
         JITDUMP("Considering loop " FMT_LP " to clone for optimizations.\n", loop->GetIndex());
         NaturalLoopIterInfo iterInfo;
-        if (loop->AnalyzeIteration(&iterInfo))
+        if (loop->AnalyzeIteration(&iterInfo, /* allowMissingBaseCase */ true))
         {
             context->SetLoopIterInfo(loop->GetIndex(), new (this, CMK_LoopClone) NaturalLoopIterInfo(iterInfo));
         }

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1246,8 +1246,8 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         context->EnsureArrayDerefs(loop->GetIndex())->Push(array);
     }
 
-    // If AnalyzeIteration could not prove the loop body executes at least once,
-    // emit an explicit runtime zero-trip guard as one of the cloning conditions.
+    // If AnalyzeIteration could not prove the loop condition holds on entry,
+    // emit an explicit runtime entry guard as one of the cloning conditions.
     // The fast path is then only entered when "init TestOper limit" holds.
     if (iterInfo->NeedsZeroTripGuard)
     {

--- a/src/coreclr/jit/loopcloning.cpp
+++ b/src/coreclr/jit/loopcloning.cpp
@@ -1227,6 +1227,25 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         return false;
     }
 
+    // If the loop limit is an array length, compute the underlying ArrIndex
+    // and queue the deref check once up front. Both the optional zero-trip
+    // guard below and the regular limit conditions further down reuse this
+    // single ArrIndex to avoid duplicating the deref entry and allocation.
+    //
+    ArrIndex* limitArrIndex = nullptr;
+    if (iterInfo->HasArrayLengthLimit)
+    {
+        limitArrIndex = new (getAllocator(CMK_LoopClone)) ArrIndex(getAllocator(CMK_LoopClone));
+        if (!iterInfo->ArrLenLimit(this, limitArrIndex))
+        {
+            JITDUMP("> ArrLen not matching\n");
+            return false;
+        }
+
+        LC_Array array(LC_Array::Jagged, limitArrIndex, LC_Array::None);
+        context->EnsureArrayDerefs(loop->GetIndex())->Push(array);
+    }
+
     // If AnalyzeIteration could not prove the loop body executes at least once,
     // emit an explicit runtime zero-trip guard as one of the cloning conditions.
     // The fast path is then only entered when "init TestOper limit" holds.
@@ -1280,17 +1299,8 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
         }
         else if (iterInfo->HasArrayLengthLimit)
         {
-            ArrIndex* index = new (getAllocator(CMK_LoopClone)) ArrIndex(getAllocator(CMK_LoopClone));
-            if (!iterInfo->ArrLenLimit(this, index))
-            {
-                JITDUMP("> NeedsZeroTripGuard: ArrLen not matching\n");
-                return false;
-            }
-            limitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, index, LC_Array::ArrLen));
-
-            // The array must be dereferenceable before evaluating the guard.
-            LC_Array array(LC_Array::Jagged, index, LC_Array::None);
-            context->EnsureArrayDerefs(loop->GetIndex())->Push(array);
+            assert(limitArrIndex != nullptr);
+            limitIdent = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
         }
         else
         {
@@ -1390,17 +1400,8 @@ bool Compiler::optDeriveLoopCloningConditions(FlowGraphNaturalLoop* loop, LoopCl
     }
     else if (iterInfo->HasArrayLengthLimit)
     {
-        ArrIndex* index = new (getAllocator(CMK_LoopClone)) ArrIndex(getAllocator(CMK_LoopClone));
-        if (!iterInfo->ArrLenLimit(this, index))
-        {
-            JITDUMP("> ArrLen not matching\n");
-            return false;
-        }
-        ident = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, index, LC_Array::ArrLen));
-
-        // Ensure that this array must be dereference-able, before executing the actual condition.
-        LC_Array array(LC_Array::Jagged, index, LC_Array::None);
-        context->EnsureArrayDerefs(loop->GetIndex())->Push(array);
+        assert(limitArrIndex != nullptr);
+        ident = LC_Ident::CreateArrAccess(LC_Array(LC_Array::Jagged, limitArrIndex, LC_Array::ArrLen));
     }
     else
     {

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -381,17 +381,30 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     //     violating the AnalyzeIteration invariant that no loop body IR observes
     //     the post-increment value except the test. Stores are not checked here:
     //     AnalyzeIteration's VisitDefs already rejects any def of iterVar in the
-    //     loop other than the picked increment.
+    //     loop other than the picked increment. If the test block is in a try
+    //     region, treat any intervening statement that may throw as if it were
+    //     an intervening read, since an EH handler could observe the
+    //     post-increment value.
     // On any rejection, continue scanning backward; only fail when no candidate
-    // in the block satisfies all checks.
+    // in the block satisfies all checks. A budget bounds the combined work of
+    // the outer scan and the inner intervening-read scan to avoid pathological
+    // O(N^2) behavior in blocks with many IV-shaped statements.
     //
-    Statement* incrStmt  = nullptr;
-    unsigned   iterVar   = BAD_VAR_NUM;
-    Statement* firstStmt = cond->firstStmt();
+    Statement*   incrStmt  = nullptr;
+    unsigned     iterVar   = BAD_VAR_NUM;
+    Statement*   firstStmt = cond->firstStmt();
+    const bool   condInTry = cond->hasTryIndex();
+    unsigned int budget    = 100;
     if (testStmt != firstStmt)
     {
         for (Statement* s = testStmt->GetPrevStmt();; s = s->GetPrevStmt())
         {
+            if (budget-- == 0)
+            {
+                JITDUMP("optExtractTestIncr: budget exhausted in " FMT_BB "\n", cond->bbNum);
+                return false;
+            }
+
             unsigned candVar = optIsLoopIncrTree(s->GetRootNode());
             if (candVar != BAD_VAR_NUM)
             {
@@ -401,7 +414,13 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
                     for (Statement* t = s->GetNextStmt(); t != testStmt; t = t->GetNextStmt())
                     {
                         assert(t != nullptr);
-                        if (gtTreeHasLocalRead(t->GetRootNode(), candVar))
+                        if (budget-- == 0)
+                        {
+                            JITDUMP("optExtractTestIncr: budget exhausted in " FMT_BB "\n", cond->bbNum);
+                            return false;
+                        }
+                        GenTree* root = t->GetRootNode();
+                        if (gtTreeHasLocalRead(root, candVar) || (condInTry && ((root->gtFlags & GTF_EXCEPT) != 0)))
                         {
                             intermediateUse = true;
                             break;

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -370,8 +370,20 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     }
 
     // Walk backward from the test statement looking for a candidate IV increment
-    // of the form 'v = v op c'. Skip any intervening statements that are not IV
-    // updates.
+    // of the form 'v = v op c'. For each such candidate, verify it is suitable:
+    //   - the iterator local is not address-exposed (our intervening-read check
+    //     would not see indirect accesses, and AnalyzeIteration rejects
+    //     address-exposed IVs anyway);
+    //   - the test actually reads the iterator (otherwise this is an unrelated
+    //     update that happens to be IV-shaped);
+    //   - no statement strictly between the candidate and the test reads the
+    //     iterator. Such statements would execute with the post-increment value,
+    //     violating the AnalyzeIteration invariant that no loop body IR observes
+    //     the post-increment value except the test. Stores are not checked here:
+    //     AnalyzeIteration's VisitDefs already rejects any def of iterVar in the
+    //     loop other than the picked increment.
+    // On any rejection, continue scanning backward; only fail when no candidate
+    // in the block satisfies all checks.
     //
     Statement* incrStmt  = nullptr;
     unsigned   iterVar   = BAD_VAR_NUM;
@@ -380,12 +392,31 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     {
         for (Statement* s = testStmt->GetPrevStmt();; s = s->GetPrevStmt())
         {
-            iterVar = optIsLoopIncrTree(s->GetRootNode());
-            if (iterVar != BAD_VAR_NUM)
+            unsigned candVar = optIsLoopIncrTree(s->GetRootNode());
+            if (candVar != BAD_VAR_NUM)
             {
-                incrStmt = s;
-                break;
+                if (!lvaGetDesc(candVar)->IsAddressExposed() && gtTreeHasLocalRead(testStmt->GetRootNode(), candVar))
+                {
+                    bool intermediateUse = false;
+                    for (Statement* t = s->GetNextStmt(); t != testStmt; t = t->GetNextStmt())
+                    {
+                        assert(t != nullptr);
+                        if (gtTreeHasLocalRead(t->GetRootNode(), candVar))
+                        {
+                            intermediateUse = true;
+                            break;
+                        }
+                    }
+
+                    if (!intermediateUse)
+                    {
+                        incrStmt = s;
+                        iterVar  = candVar;
+                        break;
+                    }
+                }
             }
+
             if (s == firstStmt)
             {
                 break;
@@ -399,33 +430,7 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     }
 
     assert(testStmt != incrStmt);
-
-    // The intervening-statement read check below operates on the iterator
-    // local directly, so it would not be meaningful for an address-exposed
-    // iterator (indirect references would be invisible). AnalyzeIteration
-    // ultimately rejects address-exposed IVs anyway, so bail here and let it
-    // try the next candidate.
-    //
-    if (lvaGetDesc(iterVar)->IsAddressExposed())
-    {
-        return false;
-    }
-
-    // Statements strictly between the increment and the test execute with the
-    // iterator already advanced, before the exit test runs. To preserve the
-    // AnalyzeIteration invariant that no loop-body IR observes the post-increment
-    // value, reject the candidate if any such statement reads iterVar. (We do
-    // not need to check for stores: AnalyzeIteration's VisitDefs already
-    // rejects any def of iterVar in the loop other than the picked increment.)
-    //
-    for (Statement* s = incrStmt->GetNextStmt(); s != testStmt; s = s->GetNextStmt())
-    {
-        assert(s != nullptr);
-        if (gtTreeHasLocalRead(s->GetRootNode(), iterVar))
-        {
-            return false;
-        }
-    }
+    assert(iterVar != BAD_VAR_NUM);
 
     *ppTest = testStmt->GetRootNode();
     *ppIncr = incrStmt->GetRootNode();

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -403,27 +403,13 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     // Statements strictly between the increment and the test execute with the
     // iterator already advanced, before the exit test runs. To preserve the
     // AnalyzeIteration invariant that no loop-body IR observes the post-increment
-    // value, reject the candidate if any such statement references iterVar.
-    //
-    // Note: depending on the phase that calls us, locals may not be threaded
-    // (NodeThreading::AllLocals is not guaranteed). Walk each statement's tree
-    // explicitly to find local references rather than using LocalsTreeList().
+    // value, reject the candidate if any such statement reads or writes iterVar.
     //
     for (Statement* s = incrStmt->GetNextStmt(); s != testStmt; s = s->GetNextStmt())
     {
         assert(s != nullptr);
-        GenTree* root    = s->GetRootNode();
-        unsigned target  = iterVar;
-        auto     visitor = [](GenTree** use, fgWalkData* data) -> fgWalkResult {
-            GenTree* node = *use;
-            if (node->OperIsAnyLocal() &&
-                (node->AsLclVarCommon()->GetLclNum() == *static_cast<unsigned*>(data->pCallbackData)))
-            {
-                return WALK_ABORT;
-            }
-            return WALK_CONTINUE;
-        };
-        if (fgWalkTreePre(&root, visitor, &target, /* lclVarsOnly */ false) == WALK_ABORT)
+        GenTree* root = s->GetRootNode();
+        if (gtTreeHasLocalRead(root, iterVar) || gtTreeHasLocalStore(root, iterVar))
         {
             return false;
         }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -356,8 +356,9 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     assert(ppTest != nullptr);
     assert(ppIncr != nullptr);
 
-    // Check if last two statements in the loop body are the increment of the iterator
-    // and the loop termination test.
+    // The loop termination test is expected to be the last statement of the exiting
+    // block. The increment of the iterator is expected somewhere earlier in the
+    // same block; we scan backward from the test to find an IV-shaped update.
     noway_assert(cond->firstStmt() != nullptr);
     Statement* testStmt = cond->lastStmt();
     noway_assert(testStmt != nullptr && testStmt->GetNextStmt() == nullptr);
@@ -368,19 +369,33 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
         testStmt = newTestStmt;
     }
 
-    // Check if we have the incr stmt before the test stmt, if we don't,
-    // check if incr is part of the loop "header".
-    Statement* incrStmt = testStmt->GetPrevStmt();
-
-    // If we've added profile instrumentation, we may need to skip past a BB counter update.
+    // Walk backward from the test statement looking for a candidate IV increment
+    // of the form 'v = v op c'. Skip any intervening statements that are not IV
+    // updates. The AnalyzeIteration caller enforces (via VisitDefs) that the
+    // picked IV has no extraneous defs in the loop, and MatchLimit rejects the
+    // candidate if the test does not actually use the picked iterVar -- so it
+    // is safe to pick the first IV-shaped update we find, even if there are
+    // intervening unrelated stores.
     //
-    if (opts.jitFlags->IsSet(JitFlags::JIT_FLAG_BBINSTR) && (incrStmt != nullptr) &&
-        incrStmt->GetRootNode()->IsBlockProfileUpdate())
+    Statement* incrStmt  = nullptr;
+    Statement* firstStmt = cond->firstStmt();
+    if (testStmt != firstStmt)
     {
-        incrStmt = incrStmt->GetPrevStmt();
+        for (Statement* s = testStmt->GetPrevStmt();; s = s->GetPrevStmt())
+        {
+            if (optIsLoopIncrTree(s->GetRootNode()) != BAD_VAR_NUM)
+            {
+                incrStmt = s;
+                break;
+            }
+            if (s == firstStmt)
+            {
+                break;
+            }
+        }
     }
 
-    if (incrStmt == nullptr || (optIsLoopIncrTree(incrStmt->GetRootNode()) == BAD_VAR_NUM))
+    if (incrStmt == nullptr)
     {
         return false;
     }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -400,6 +400,17 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
 
     assert(testStmt != incrStmt);
 
+    // The intervening-statement read check below operates on the iterator
+    // local directly, so it would not be meaningful for an address-exposed
+    // iterator (indirect references would be invisible). AnalyzeIteration
+    // ultimately rejects address-exposed IVs anyway, so bail here and let it
+    // try the next candidate.
+    //
+    if (lvaGetDesc(iterVar)->IsAddressExposed())
+    {
+        return false;
+    }
+
     // Statements strictly between the increment and the test execute with the
     // iterator already advanced, before the exit test runs. To preserve the
     // AnalyzeIteration invariant that no loop-body IR observes the post-increment

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -403,13 +403,14 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     // Statements strictly between the increment and the test execute with the
     // iterator already advanced, before the exit test runs. To preserve the
     // AnalyzeIteration invariant that no loop-body IR observes the post-increment
-    // value, reject the candidate if any such statement reads or writes iterVar.
+    // value, reject the candidate if any such statement reads iterVar. (We do
+    // not need to check for stores: AnalyzeIteration's VisitDefs already
+    // rejects any def of iterVar in the loop other than the picked increment.)
     //
     for (Statement* s = incrStmt->GetNextStmt(); s != testStmt; s = s->GetNextStmt())
     {
         assert(s != nullptr);
-        GenTree* root = s->GetRootNode();
-        if (gtTreeHasLocalRead(root, iterVar) || gtTreeHasLocalStore(root, iterVar))
+        if (gtTreeHasLocalRead(s->GetRootNode(), iterVar))
         {
             return false;
         }

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -405,15 +405,27 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     // AnalyzeIteration invariant that no loop-body IR observes the post-increment
     // value, reject the candidate if any such statement references iterVar.
     //
+    // Note: depending on the phase that calls us, locals may not be threaded
+    // (NodeThreading::AllLocals is not guaranteed). Walk each statement's tree
+    // explicitly to find local references rather than using LocalsTreeList().
+    //
     for (Statement* s = incrStmt->GetNextStmt(); s != testStmt; s = s->GetNextStmt())
     {
         assert(s != nullptr);
-        for (GenTreeLclVarCommon* lcl : s->LocalsTreeList())
-        {
-            if (lcl->GetLclNum() == iterVar)
+        GenTree* root    = s->GetRootNode();
+        unsigned target  = iterVar;
+        auto     visitor = [](GenTree** use, fgWalkData* data) -> fgWalkResult {
+            GenTree* node = *use;
+            if (node->OperIsAnyLocal() &&
+                (node->AsLclVarCommon()->GetLclNum() == *static_cast<unsigned*>(data->pCallbackData)))
             {
-                return false;
+                return WALK_ABORT;
             }
+            return WALK_CONTINUE;
+        };
+        if (fgWalkTreePre(&root, visitor, &target, /* lclVarsOnly */ false) == WALK_ABORT)
+        {
+            return false;
         }
     }
 

--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -371,19 +371,17 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
 
     // Walk backward from the test statement looking for a candidate IV increment
     // of the form 'v = v op c'. Skip any intervening statements that are not IV
-    // updates. The AnalyzeIteration caller enforces (via VisitDefs) that the
-    // picked IV has no extraneous defs in the loop, and MatchLimit rejects the
-    // candidate if the test does not actually use the picked iterVar -- so it
-    // is safe to pick the first IV-shaped update we find, even if there are
-    // intervening unrelated stores.
+    // updates.
     //
     Statement* incrStmt  = nullptr;
+    unsigned   iterVar   = BAD_VAR_NUM;
     Statement* firstStmt = cond->firstStmt();
     if (testStmt != firstStmt)
     {
         for (Statement* s = testStmt->GetPrevStmt();; s = s->GetPrevStmt())
         {
-            if (optIsLoopIncrTree(s->GetRootNode()) != BAD_VAR_NUM)
+            iterVar = optIsLoopIncrTree(s->GetRootNode());
+            if (iterVar != BAD_VAR_NUM)
             {
                 incrStmt = s;
                 break;
@@ -401,6 +399,23 @@ bool Compiler::optExtractTestIncr(BasicBlock* cond, GenTree** ppTest, GenTree** 
     }
 
     assert(testStmt != incrStmt);
+
+    // Statements strictly between the increment and the test execute with the
+    // iterator already advanced, before the exit test runs. To preserve the
+    // AnalyzeIteration invariant that no loop-body IR observes the post-increment
+    // value, reject the candidate if any such statement references iterVar.
+    //
+    for (Statement* s = incrStmt->GetNextStmt(); s != testStmt; s = s->GetNextStmt())
+    {
+        assert(s != nullptr);
+        for (GenTreeLclVarCommon* lcl : s->LocalsTreeList())
+        {
+            if (lcl->GetLclNum() == iterVar)
+            {
+                return false;
+            }
+        }
+    }
 
     *ppTest = testStmt->GetRootNode();
     *ppIncr = incrStmt->GetRootNode();


### PR DESCRIPTION
Generalize loop cloning a bit:
* allow more statements between increment and test
* allow cloning conditions to establish a zero trip test if one is missing.