### PR TITLE
Fix invalid IL test

### DIFF
--- a/src/tests/JIT/Methodical/refany/lcs.il
+++ b/src/tests/JIT/Methodical/refany/lcs.il
@@ -212,7 +212,6 @@
 		ldarg.1
 		refanytype
 		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
-
 		ceq		
 
 		ldarg.2

--- a/src/tests/JIT/Methodical/refany/lcs.il
+++ b/src/tests/JIT/Methodical/refany/lcs.il
@@ -205,16 +205,25 @@
                int32[] V_6,
                int32 V_7)
 
-		ldarg.0 refanytype
+		ldarg.0
+		refanytype
 		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
-		ldarg.1 refanytype
+
+		ldarg.1
+		refanytype
 		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
-		ldarg.2 refanytype
-		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
-		ldarg.3 refanytype
-		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
+
 		ceq		
+
+		ldarg.2
+		refanytype
+		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
+
+		ldarg.3
+		refanytype
+		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
 		ceq
+
 		ceq
 		pop
 

--- a/src/tests/JIT/Methodical/refany/lcs.il
+++ b/src/tests/JIT/Methodical/refany/lcs.il
@@ -212,7 +212,7 @@
 		ldarg.1
 		refanytype
 		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
-		ceq		
+		ceq
 
 		ldarg.2
 		refanytype


### PR DESCRIPTION
This test ended up comparing
```
GetTypeFromHandle(x) == (GetTypeFromHandle(y) == (GetTypeFromHandle(z) == GetTypeFromHandle(w)))
```
That's illegal IL, comparing an integer to an object, and it produced internally invalid JIT IR.

Fix the test to do
```
(GetTypeFromHandle(x) == GetTypeFromHandle(y)) == (GetTypeFromHandle(z) == GetTypeFromHandle(w)))
```
which I expect was the original intention (main test here seems to be about `refanytype` for arguments).