### PR TITLE
[clrinterp] Remove wrong assertion

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -6444,8 +6444,7 @@ void InterpCompiler::UpdateLocalIntervalMaps()
         int32_t varIndex = suspendData->returnValueVarStackOffset;
         if (varIndex != -1)
         {
-            assert(!m_pVars[varIndex].global);
-            if (m_pVars[varIndex].liveStart == m_pVars[varIndex].liveEnd)
+            if (!m_pVars[varIndex].global && m_pVars[varIndex].liveStart == m_pVars[varIndex].liveEnd)
             {
                 // The return result of the async call is not used by the method, so the allocated
                 // stack offset will be immediately reused by any vars that become live. Keep the


### PR DESCRIPTION
The return value of a call is normally a local var, but it can later be promoted to a global var if it is left on the IL stack and then later used in a different basic block. We don't need any special handling if the return value of an async call is a global var.

Assertion incorrectly added in https://github.com/dotnet/runtime/pull/128403