### PR TITLE
JIT: Tail merge async suspensions

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1017,7 +1017,8 @@ void AsyncTransformation::Transform(BasicBlock*               block,
 
     CallDefinitionInfo callDefInfo = CanonicalizeCallDefinition(block, call, &analyses);
 
-    const AsyncState* reusedState = FindReusableSuspension(block, call, callDefInfo, layoutBuilder, resumeReachable, mutatedSinceResumption);
+    const AsyncState* reusedState =
+        FindReusableSuspension(block, call, callDefInfo, layoutBuilder, resumeReachable, mutatedSinceResumption);
 
     if (reusedState != nullptr)
     {
@@ -1757,7 +1758,12 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
 // Returns:
 //   Reusable existing state, or nullptr if no such state.
 //
-const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption)
+const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock*                block,
+                                                              GenTreeCall*               call,
+                                                              const CallDefinitionInfo&  defInfo,
+                                                              ContinuationLayoutBuilder* layoutBuilder,
+                                                              bool                       resumeReachable,
+                                                              VARSET_VALARG_TP           mutatedSinceResumption)
 {
     if (m_compiler->opts.OptimizationDisabled())
     {
@@ -1803,11 +1809,12 @@ const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock* block,
             }
 
             assert(state.ResumptionBB->KindIs(BBJ_ALWAYS));
-            BasicBlock* resumptionJoin = state.ResumptionBB->GetUniqueSucc(); 
+            BasicBlock* resumptionJoin = state.ResumptionBB->GetUniqueSucc();
 
             // This existing async state resumes at a sibling join block. We
             // can reuse that resumption if it has the same state as us.
-            if ((resumptionJoin == pred) && IsReusableSuspension(&state, block, call, defInfo, layoutBuilder, resumeReachable, mutatedSinceResumption))
+            if ((resumptionJoin == pred) && IsReusableSuspension(&state, block, call, defInfo, layoutBuilder,
+                                                                 resumeReachable, mutatedSinceResumption))
             {
                 return &state;
             }
@@ -1833,11 +1840,19 @@ const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock* block,
 // Returns:
 //   True if the suspension is reusable.
 //
-bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption)
+bool AsyncTransformation::IsReusableSuspension(const AsyncState*          state,
+                                               BasicBlock*                block,
+                                               GenTreeCall*               call,
+                                               const CallDefinitionInfo&  defInfo,
+                                               ContinuationLayoutBuilder* layoutBuilder,
+                                               bool                       resumeReachable,
+                                               VARSET_VALARG_TP           mutatedSinceResumption)
 {
     GenTreeCall* predAsyncCall = state->Call;
 
-    JITDUMP("  Sibling to the join is resumption for async call [%06u]; checking for possible tail merging of suspension points\n", Compiler::dspTreeID(predAsyncCall));
+    JITDUMP(
+        "  Sibling to the join is resumption for async call [%06u]; checking for possible tail merging of suspension points\n",
+        Compiler::dspTreeID(predAsyncCall));
 
     if (!BasicBlock::sameEHRegion(block, state->CallBlock))
     {
@@ -1852,41 +1867,48 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlo
         return false;
     }
 
-    if ((defInfo.DefinitionNode != nullptr) && !GenTreeLclVarCommon::EqualsLocal(defInfo.DefinitionNode, state->CallDefInfo.DefinitionNode))
+    if ((defInfo.DefinitionNode != nullptr) &&
+        !GenTreeLclVarCommon::EqualsLocal(defInfo.DefinitionNode, state->CallDefInfo.DefinitionNode))
     {
-        JITDUMP("    No; disagreement on return value destination ([%06u] does not equal [%06u])\n", Compiler::dspTreeID(defInfo.DefinitionNode), Compiler::dspTreeID(state->CallDefInfo.DefinitionNode));
+        JITDUMP("    No; disagreement on return value destination ([%06u] does not equal [%06u])\n",
+                Compiler::dspTreeID(defInfo.DefinitionNode), Compiler::dspTreeID(state->CallDefInfo.DefinitionNode));
         return false;
     }
 
     if (call->gtReturnType != predAsyncCall->AsCall()->gtReturnType)
     {
-        JITDUMP("    No; disagreement on return type (%s vs %s)\n", varTypeName(call->gtReturnType), varTypeName(predAsyncCall->AsCall()->gtReturnType));
+        JITDUMP("    No; disagreement on return type (%s vs %s)\n", varTypeName(call->gtReturnType),
+                varTypeName(predAsyncCall->AsCall()->gtReturnType));
         return false;
     }
 
     if (call->gtReturnType == TYP_STRUCT)
     {
-        ClassLayout* thisLayout = m_compiler->typGetObjLayout(call->gtRetClsHnd);
+        ClassLayout* thisLayout  = m_compiler->typGetObjLayout(call->gtRetClsHnd);
         ClassLayout* otherLayout = m_compiler->typGetObjLayout(predAsyncCall->AsCall()->gtRetClsHnd);
         if (!ClassLayout::AreCompatible(thisLayout, otherLayout))
         {
-            JITDUMP("    No; disagreement on return type (%s vs %s)\n", thisLayout->GetClassName(), otherLayout->GetClassName());
+            JITDUMP("    No; disagreement on return type (%s vs %s)\n", thisLayout->GetClassName(),
+                    otherLayout->GetClassName());
             return false;
         }
     }
 
-    const AsyncCallInfo& asyncInfoThis = call->GetAsyncInfo();
+    const AsyncCallInfo& asyncInfoThis  = call->GetAsyncInfo();
     const AsyncCallInfo& asyncInfoOther = predAsyncCall->AsCall()->GetAsyncInfo();
 
     if (asyncInfoThis.ContinuationContextHandling != asyncInfoOther.ContinuationContextHandling)
     {
-        JITDUMP("    No; disagreement on continuation context handling (%u vs %u)\n", asyncInfoThis.ContinuationContextHandling, asyncInfoOther.ContinuationContextHandling);
+        JITDUMP("    No; disagreement on continuation context handling (%u vs %u)\n",
+                asyncInfoThis.ContinuationContextHandling, asyncInfoOther.ContinuationContextHandling);
         return false;
     }
 
     if (asyncInfoThis.NeedsToSaveAndRestoreExecutionContext() != asyncInfoOther.NeedsToSaveAndRestoreExecutionContext())
     {
-        JITDUMP("    No; disagreement on whether execution context needs to be saved and restored (%s vs %s)\n", asyncInfoThis.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no", asyncInfoOther.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no");
+        JITDUMP("    No; disagreement on whether execution context needs to be saved and restored (%s vs %s)\n",
+                asyncInfoThis.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no",
+                asyncInfoOther.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no");
         return false;
     }
 
@@ -1895,7 +1917,8 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlo
         // Not being resume reachable means we can skip checking for a
         // reusable continuation. We do not want to give up that
         // optimization.
-        JITDUMP("    No; disagreement on resume reachability (%s vs %s)\n", state->ResumeReachable ? "yes" : "no", resumeReachable ? "yes" : "no");
+        JITDUMP("    No; disagreement on resume reachability (%s vs %s)\n", state->ResumeReachable ? "yes" : "no",
+                resumeReachable ? "yes" : "no");
         return false;
     }
 
@@ -1909,18 +1932,22 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlo
         for (unsigned lclNum : layoutBuilder->Locals())
         {
             LclVarDsc* dsc = m_compiler->lvaGetDesc(lclNum);
-            if (GetLocalSaveSet(dsc, mutatedSinceResumption) != GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption))
+            if (GetLocalSaveSet(dsc, mutatedSinceResumption) !=
+                GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption))
             {
-                JITDUMP("    No; disagreement on save set for V%02u (%d vs %d)\n", lclNum, (unsigned)GetLocalSaveSet(dsc, mutatedSinceResumption), (unsigned)GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption));
+                JITDUMP("    No; disagreement on save set for V%02u (%d vs %d)\n", lclNum,
+                        (unsigned)GetLocalSaveSet(dsc, mutatedSinceResumption),
+                        (unsigned)GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption));
                 return false;
             }
         }
     }
 
-    static const WellKnownArg validateArgs[] = { WellKnownArg::AsyncExecutionContext, WellKnownArg::AsyncSynchronizationContext };
+    static const WellKnownArg validateArgs[] = {WellKnownArg::AsyncExecutionContext,
+                                                WellKnownArg::AsyncSynchronizationContext};
     for (WellKnownArg arg : validateArgs)
     {
-        CallArg* thisArg = call->gtArgs.FindWellKnownArg(arg);
+        CallArg* thisArg  = call->gtArgs.FindWellKnownArg(arg);
         CallArg* otherArg = predAsyncCall->gtArgs.FindWellKnownArg(arg);
 
         if ((thisArg == nullptr) != (otherArg == nullptr))
@@ -1939,12 +1966,16 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlo
 
             if (!GenTree::Compare(thisArg->GetNode(), otherArg->GetNode()))
             {
-                JITDUMP("    No; disagreement on value of %s argument ([%06u] vs [%06u])\n", getWellKnownArgName(arg), Compiler::dspTreeID(thisArg->GetNode()), Compiler::dspTreeID(otherArg->GetNode()));
+                JITDUMP("    No; disagreement on value of %s argument ([%06u] vs [%06u])\n", getWellKnownArgName(arg),
+                        Compiler::dspTreeID(thisArg->GetNode()), Compiler::dspTreeID(otherArg->GetNode()));
                 return false;
             }
         }
     }
 
+    // At this point we expect both suspensions to agree on the live locals
+    // since they both join at the same point. So we only need to assert that
+    // the layouts match.
     assert(ContinuationLayoutBuilder::Equals(*layoutBuilder, *state->Layout));
     return true;
 }
@@ -1959,7 +1990,8 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlo
 //
 void AsyncTransformation::HandleReusedSuspension(BasicBlock* callBlock, GenTreeCall* call)
 {
-    static const WellKnownArg argsToRemove[] = { WellKnownArg::AsyncExecutionContext, WellKnownArg::AsyncSynchronizationContext };
+    static const WellKnownArg argsToRemove[] = {WellKnownArg::AsyncExecutionContext,
+                                                WellKnownArg::AsyncSynchronizationContext};
     for (WellKnownArg wka : argsToRemove)
     {
         CallArg* arg = call->gtArgs.FindWellKnownArg(wka);

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -514,6 +514,79 @@ bool ContinuationLayoutBuilder::ContainsLocal(unsigned lclNum) const
 }
 
 //------------------------------------------------------------------------
+// ContinuationLayoutBuilder::Equals:
+//   Check if two builders produce the same layout.
+//
+// Parameters:
+//   a - The first builder to compare.
+//   b - The second builder to compare.
+//
+// Returns:
+//   True if the builders produce the same layout.
+//
+bool ContinuationLayoutBuilder::Equals(const ContinuationLayoutBuilder& a, const ContinuationLayoutBuilder& b)
+{
+    if (a.m_needsOSRAddress != b.m_needsOSRAddress)
+    {
+        return false;
+    }
+
+    if (a.m_needsException != b.m_needsException)
+    {
+        return false;
+    }
+
+    if (a.m_needsContinuationContext != b.m_needsContinuationContext)
+    {
+        return false;
+    }
+
+    if (a.m_needsKeepAlive != b.m_needsKeepAlive)
+    {
+        return false;
+    }
+
+    if (a.m_needsExecutionContext != b.m_needsExecutionContext)
+    {
+        return false;
+    }
+
+    if (a.m_returns.size() != b.m_returns.size())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.m_returns.size(); i++)
+    {
+        if (a.m_returns[i].ReturnType != b.m_returns[i].ReturnType)
+        {
+            return false;
+        }
+
+        if ((a.m_returns[i].ReturnType == TYP_STRUCT) &&
+            !ClassLayout::AreCompatible(a.m_returns[i].ReturnLayout, b.m_returns[i].ReturnLayout))
+        {
+            return false;
+        }
+    }
+
+    if (a.m_locals.size() != b.m_locals.size())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < a.m_locals.size(); i++)
+    {
+        if (a.m_locals[i] != b.m_locals[i])
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------
 // TransformAsync: Run async transformation.
 //
 // Returns:
@@ -944,17 +1017,29 @@ void AsyncTransformation::Transform(BasicBlock*               block,
 
     CallDefinitionInfo callDefInfo = CanonicalizeCallDefinition(block, call, &analyses);
 
-    unsigned stateNum = (unsigned)m_states.size();
-    JITDUMP("  Assigned state %u\n", stateNum);
+    const AsyncState* reusedState = FindReusableSuspension(block, call, callDefInfo, layoutBuilder, resumeReachable, mutatedSinceResumption);
 
-    BasicBlock* suspendBB = CreateSuspensionBlock(block, stateNum);
+    if (reusedState != nullptr)
+    {
+        JITDUMP("  Reused state %u\n", reusedState->Number);
+        CreateCheckAndSuspendAfterCall(block, call, callDefInfo, reusedState->SuspensionBB, remainder);
 
-    CreateCheckAndSuspendAfterCall(block, call, callDefInfo, suspendBB, remainder);
+        HandleReusedSuspension(block, call);
+    }
+    else
+    {
+        unsigned stateNum = (unsigned)m_states.size();
+        JITDUMP("  Assigned state %u\n", stateNum);
 
-    BasicBlock* resumeBB = CreateResumptionBlock(*remainder, stateNum);
+        BasicBlock* suspendBB = CreateSuspensionBlock(block, stateNum);
 
-    m_states.push_back(AsyncState(stateNum, layoutBuilder, block, call, callDefInfo, suspendBB, resumeBB,
-                                  resumeReachable, mutatedSinceResumption));
+        CreateCheckAndSuspendAfterCall(block, call, callDefInfo, suspendBB, remainder);
+
+        BasicBlock* resumeBB = CreateResumptionBlock(*remainder, stateNum);
+
+        m_states.push_back(AsyncState(stateNum, layoutBuilder, block, call, callDefInfo, suspendBB, resumeBB,
+                                      resumeReachable, mutatedSinceResumption));
+    }
 
     JITDUMP("\n");
 }
@@ -1657,6 +1742,236 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
 }
 
 //------------------------------------------------------------------------
+// AsyncTransformation::FindReusableSuspension:
+//   Try to find a suspension/resumption state that we can merge with.
+//
+// Parameters:
+//   block          - The block containing the async call.
+//   call           - The async call
+//   defInfo        - Async call def info
+//   layoutBuilder  - Layout for this async call
+//   resumeReachable - Whether 'call' is reachable after a previous resumption
+//   mutatedSinceResumption - Set of variables mutated since the last resumption
+//
+// Returns:
+//   Reusable existing state, or nullptr if no such state.
+//
+const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption)
+{
+    if (m_compiler->opts.OptimizationDisabled())
+    {
+        // Tail merging breaks debugging.
+        return nullptr;
+    }
+
+    // Call must be at the tail of its block.
+    GenTree* thisLastNode = block->lastNode();
+    if ((thisLastNode != call) && (thisLastNode != defInfo.DefinitionNode))
+    {
+        return nullptr;
+    }
+
+    // We can only merge if we logically could move the suspension point into a
+    // successor of two blocks.
+    BasicBlock* target = block->GetUniqueSucc();
+    if (target == nullptr)
+    {
+        return nullptr;
+    }
+
+    for (BasicBlock* pred : target->PredBlocks())
+    {
+        if (pred == block)
+        {
+            continue;
+        }
+
+        if (!pred->KindIs(BBJ_ALWAYS) || !pred->isEmpty())
+        {
+            // We are looking for the "remainder" block that was created for a previous async transformation.
+            // If they are in a usable tail position they will always be empty BBJ_ALWAYS blocks.
+            continue;
+        }
+
+        int limit = 128;
+        for (const AsyncState& state : m_states)
+        {
+            if (limit-- == 0)
+            {
+                break;
+            }
+
+            assert(state.ResumptionBB->KindIs(BBJ_ALWAYS));
+            BasicBlock* resumptionJoin = state.ResumptionBB->GetUniqueSucc(); 
+
+            // This existing async state resumes at a sibling join block. We
+            // can reuse that resumption if it has the same state as us.
+            if ((resumptionJoin == pred) && IsReusableSuspension(&state, block, call, defInfo, layoutBuilder, resumeReachable, mutatedSinceResumption))
+            {
+                return &state;
+            }
+        }
+    }
+
+    return nullptr;
+}
+
+//------------------------------------------------------------------------
+// AsyncTransformation::IsReusableSuspension:
+//   Check if the suspension for a specified state is reusable for an async call.
+//
+// Parameters:
+//   state          - State for existing suspension.
+//   block          - The block containing the async call.
+//   call           - The async call
+//   defInfo        - Async call def info
+//   layoutBuilder  - Layout for this async call
+//   resumeReachable - Whether 'call' is reachable after a previous resumption
+//   mutatedSinceResumption - Set of variables mutated since the last resumption
+//
+// Returns:
+//   True if the suspension is reusable.
+//
+bool AsyncTransformation::IsReusableSuspension(const AsyncState* state, BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption)
+{
+    GenTreeCall* predAsyncCall = state->Call;
+
+    JITDUMP("  Sibling to the join is resumption for async call [%06u]; checking for possible tail merging of suspension points\n", Compiler::dspTreeID(predAsyncCall));
+
+    if (!BasicBlock::sameEHRegion(block, state->CallBlock))
+    {
+        JITDUMP("    Not same EH region\n");
+        return false;
+    }
+
+    // We have a sibling of the join that ends with an async call. Check if it is compatible.
+    if ((defInfo.DefinitionNode == nullptr) != (state->CallDefInfo.DefinitionNode == nullptr))
+    {
+        JITDUMP("    No; disagreement on presence of return value\n");
+        return false;
+    }
+
+    if ((defInfo.DefinitionNode != nullptr) && !GenTreeLclVarCommon::EqualsLocal(defInfo.DefinitionNode, state->CallDefInfo.DefinitionNode))
+    {
+        JITDUMP("    No; disagreement on return value destination ([%06u] does not equal [%06u])\n", Compiler::dspTreeID(defInfo.DefinitionNode), Compiler::dspTreeID(state->CallDefInfo.DefinitionNode));
+        return false;
+    }
+
+    if (call->gtReturnType != predAsyncCall->AsCall()->gtReturnType)
+    {
+        JITDUMP("    No; disagreement on return type (%s vs %s)\n", varTypeName(call->gtReturnType), varTypeName(predAsyncCall->AsCall()->gtReturnType));
+        return false;
+    }
+
+    if (call->gtReturnType == TYP_STRUCT)
+    {
+        ClassLayout* thisLayout = m_compiler->typGetObjLayout(call->gtRetClsHnd);
+        ClassLayout* otherLayout = m_compiler->typGetObjLayout(predAsyncCall->AsCall()->gtRetClsHnd);
+        if (!ClassLayout::AreCompatible(thisLayout, otherLayout))
+        {
+            JITDUMP("    No; disagreement on return type (%s vs %s)\n", thisLayout->GetClassName(), otherLayout->GetClassName());
+            return false;
+        }
+    }
+
+    const AsyncCallInfo& asyncInfoThis = call->GetAsyncInfo();
+    const AsyncCallInfo& asyncInfoOther = predAsyncCall->AsCall()->GetAsyncInfo();
+
+    if (asyncInfoThis.ContinuationContextHandling != asyncInfoOther.ContinuationContextHandling)
+    {
+        JITDUMP("    No; disagreement on continuation context handling (%u vs %u)\n", asyncInfoThis.ContinuationContextHandling, asyncInfoOther.ContinuationContextHandling);
+        return false;
+    }
+
+    if (asyncInfoThis.NeedsToSaveAndRestoreExecutionContext() != asyncInfoOther.NeedsToSaveAndRestoreExecutionContext())
+    {
+        JITDUMP("    No; disagreement on whether execution context needs to be saved and restored (%s vs %s)\n", asyncInfoThis.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no", asyncInfoOther.NeedsToSaveAndRestoreExecutionContext() ? "yes" : "no");
+        return false;
+    }
+
+    if (state->ResumeReachable != resumeReachable)
+    {
+        // Not being resume reachable means we can skip checking for a
+        // reusable continuation. We do not want to give up that
+        // optimization.
+        JITDUMP("    No; disagreement on resume reachability (%s vs %s)\n", state->ResumeReachable ? "yes" : "no", resumeReachable ? "yes" : "no");
+        return false;
+    }
+
+    if (resumeReachable)
+    {
+        // If both are reachable after resuming then we need to take care that
+        // we update the right set of locals in the continuation on suspension.
+        // In one path we may have mutated a local that we didn't in another
+        // path, and that results in a difference when we reuse a continuation
+        // and need to decide if that local needs to be saved again or not.
+        for (unsigned lclNum : layoutBuilder->Locals())
+        {
+            LclVarDsc* dsc = m_compiler->lvaGetDesc(lclNum);
+            if (GetLocalSaveSet(dsc, mutatedSinceResumption) != GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption))
+            {
+                JITDUMP("    No; disagreement on save set for V%02u (%d vs %d)\n", lclNum, (unsigned)GetLocalSaveSet(dsc, mutatedSinceResumption), (unsigned)GetLocalSaveSet(dsc, state->MutatedSincePreviousResumption));
+                return false;
+            }
+        }
+    }
+
+    static const WellKnownArg validateArgs[] = { WellKnownArg::AsyncExecutionContext, WellKnownArg::AsyncSynchronizationContext };
+    for (WellKnownArg arg : validateArgs)
+    {
+        CallArg* thisArg = call->gtArgs.FindWellKnownArg(arg);
+        CallArg* otherArg = predAsyncCall->gtArgs.FindWellKnownArg(arg);
+
+        if ((thisArg == nullptr) != (otherArg == nullptr))
+        {
+            JITDUMP("    No; disagreement on presence of %s argument\n", getWellKnownArgName(arg));
+            return false;
+        }
+
+        if (thisArg != nullptr)
+        {
+            if (!thisArg->GetNode()->OperIsLocal())
+            {
+                JITDUMP("    No; %s argument is too complex\n", getWellKnownArgName(arg));
+                return false;
+            }
+
+            if (!GenTree::Compare(thisArg->GetNode(), otherArg->GetNode()))
+            {
+                JITDUMP("    No; disagreement on value of %s argument ([%06u] vs [%06u])\n", getWellKnownArgName(arg), Compiler::dspTreeID(thisArg->GetNode()), Compiler::dspTreeID(otherArg->GetNode()));
+                return false;
+            }
+        }
+    }
+
+    assert(ContinuationLayoutBuilder::Equals(*layoutBuilder, *state->Layout));
+    return true;
+}
+
+//------------------------------------------------------------------------
+// AsyncTransformation::HandleReusedSuspension:
+//   Handle the case where we were able to reuse a previously created suspension state.
+//
+// Parameters:
+//   callBlock - Block containing async call
+//   call      - The async call
+//
+void AsyncTransformation::HandleReusedSuspension(BasicBlock* callBlock, GenTreeCall* call)
+{
+    static const WellKnownArg argsToRemove[] = { WellKnownArg::AsyncExecutionContext, WellKnownArg::AsyncSynchronizationContext };
+    for (WellKnownArg wka : argsToRemove)
+    {
+        CallArg* arg = call->gtArgs.FindWellKnownArg(wka);
+        if (arg != nullptr)
+        {
+            assert(arg->GetNode()->OperIsLocal());
+            LIR::AsRange(callBlock).Remove(arg->GetNode());
+            call->gtArgs.RemoveUnsafe(arg);
+        }
+    }
+}
+
+//------------------------------------------------------------------------
 // AsyncTransformation::CreateSuspensionBlock:
 //   Create an empty basic block that will hold the suspension IR for the
 //   specified async call.
@@ -1790,7 +2105,7 @@ void AsyncTransformation::CreateSuspension(BasicBlock*                      call
 
         // In the path where we allocated a new continuation we save only locals that we know to be unmutated since the
         // last resumption.
-        FillInDataOnSuspension(call, layout, subLayout, allocNewBB, mutatedSinceResumption, SaveSet::UnmutatedLocals);
+        FillInDataOnSuspension(layout, subLayout, allocNewBB, mutatedSinceResumption, SaveSet::UnmutatedLocals);
 
         // We can skip saving unmutated locals in the shared path -- we only need to save locals that may have been
         // mutated since the last resumption.
@@ -1868,7 +2183,7 @@ void AsyncTransformation::CreateSuspension(BasicBlock*                      call
     GenTree* storeFlags  = StoreAtOffset(newContinuation, flagsOffset, flagsNode, TYP_INT);
     LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, storeFlags));
 
-    FillInDataOnSuspension(call, layout, subLayout, suspendBB, mutatedSinceResumption, tailSaveSet);
+    FillInDataOnSuspension(layout, subLayout, suspendBB, mutatedSinceResumption, tailSaveSet);
 
     FinishContextHandlingAndSuspension(callBlock, call, suspendBB, layout, subLayout);
 }
@@ -1918,13 +2233,13 @@ GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool              
 //   context.
 //
 // Parameters:
-//   call      - The async call.
 //   layout    - Information about the continuation layout.
 //   subLayout - Per-call layout builder indicating which fields are needed.
 //   suspendBB - Basic block to add IR to.
+//   mutatedSinceResumption - Set of locals mutated since the last resumption.
+//   saveSet   - Set of locals to save
 //
-void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*                     call,
-                                                 const ContinuationLayout&        layout,
+void AsyncTransformation::FillInDataOnSuspension(const ContinuationLayout&        layout,
                                                  const ContinuationLayoutBuilder& subLayout,
                                                  BasicBlock*                      suspendBB,
                                                  VARSET_VALARG_TP                 mutatedSinceResumption,

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1025,6 +1025,7 @@ void AsyncTransformation::Transform(BasicBlock*               block,
         CreateCheckAndSuspendAfterCall(block, call, callDefInfo, reusedState->SuspensionBB, remainder);
 
         HandleReusedSuspension(block, call);
+        m_compiler->Metrics.SuspensionPointsMerged++;
     }
     else
     {

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1801,12 +1801,14 @@ const AsyncState* AsyncTransformation::FindReusableSuspension(BasicBlock*       
         }
 
         int limit = 128;
-        for (const AsyncState& state : m_states)
+        for (size_t i = m_states.size(); i != 0; i--)
         {
             if (limit-- == 0)
             {
                 break;
             }
+
+            const AsyncState& state = m_states[i - 1];
 
             assert(state.ResumptionBB->KindIs(BBJ_ALWAYS));
             BasicBlock* resumptionJoin = state.ResumptionBB->GetUniqueSucc();

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -119,6 +119,8 @@ public:
         return m_locals;
     }
 
+    static bool Equals(const ContinuationLayoutBuilder& a, const ContinuationLayoutBuilder& b);
+
     struct ContinuationLayout* Create();
 
     static ContinuationLayoutBuilder* CreateSharedLayout(Compiler*                                comp,
@@ -404,6 +406,10 @@ class AsyncTransformation
 
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncAnalysis* analyses);
 
+    const AsyncState* FindReusableSuspension(BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption);
+    bool IsReusableSuspension(const AsyncState* state, BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption);
+    void HandleReusedSuspension(BasicBlock* callBlock, GenTreeCall* call);
+
     BasicBlock* CreateSuspensionBlock(BasicBlock* block, unsigned stateNum);
     void        CreateSuspension(BasicBlock*                      callBlock,
                                  GenTreeCall*                     call,
@@ -418,8 +424,7 @@ class AsyncTransformation
                                              GenTree*                  prevContinuation,
                                              const ContinuationLayout& layout);
 
-    void                    FillInDataOnSuspension(GenTreeCall*                     call,
-                                                   const ContinuationLayout&        layout,
+    void                    FillInDataOnSuspension(const ContinuationLayout&        layout,
                                                    const ContinuationLayoutBuilder& subLayout,
                                                    BasicBlock*                      suspendBB,
                                                    VARSET_VALARG_TP                 mutatedSinceResumption,
@@ -443,6 +448,7 @@ class AsyncTransformation
                                                            const CallDefinitionInfo& callDefInfo,
                                                            BasicBlock*               suspendBB,
                                                            BasicBlock**              remainder);
+
     BasicBlock*             CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
     void                    CreateResumption(BasicBlock*                      callBlock,
                                              GenTreeCall*                     call,

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -406,9 +406,20 @@ class AsyncTransformation
 
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncAnalysis* analyses);
 
-    const AsyncState* FindReusableSuspension(BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption);
-    bool IsReusableSuspension(const AsyncState* state, BasicBlock* block, GenTreeCall* call, const CallDefinitionInfo& defInfo, ContinuationLayoutBuilder* layoutBuilder, bool resumeReachable, VARSET_VALARG_TP mutatedSinceResumption);
-    void HandleReusedSuspension(BasicBlock* callBlock, GenTreeCall* call);
+    const AsyncState* FindReusableSuspension(BasicBlock*                block,
+                                             GenTreeCall*               call,
+                                             const CallDefinitionInfo&  defInfo,
+                                             ContinuationLayoutBuilder* layoutBuilder,
+                                             bool                       resumeReachable,
+                                             VARSET_VALARG_TP           mutatedSinceResumption);
+    bool              IsReusableSuspension(const AsyncState*          state,
+                                           BasicBlock*                block,
+                                           GenTreeCall*               call,
+                                           const CallDefinitionInfo&  defInfo,
+                                           ContinuationLayoutBuilder* layoutBuilder,
+                                           bool                       resumeReachable,
+                                           VARSET_VALARG_TP           mutatedSinceResumption);
+    void              HandleReusedSuspension(BasicBlock* callBlock, GenTreeCall* call);
 
     BasicBlock* CreateSuspensionBlock(BasicBlock* block, unsigned stateNum);
     void        CreateSuspension(BasicBlock*                      callBlock,
@@ -449,13 +460,13 @@ class AsyncTransformation
                                                            BasicBlock*               suspendBB,
                                                            BasicBlock**              remainder);
 
-    BasicBlock*             CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
-    void                    CreateResumption(BasicBlock*                      callBlock,
-                                             GenTreeCall*                     call,
-                                             BasicBlock*                      resumeBB,
-                                             const CallDefinitionInfo&        callDefInfo,
-                                             const ContinuationLayout&        layout,
-                                             const ContinuationLayoutBuilder& subLayout);
+    BasicBlock* CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
+    void        CreateResumption(BasicBlock*                      callBlock,
+                                 GenTreeCall*                     call,
+                                 BasicBlock*                      resumeBB,
+                                 const CallDefinitionInfo&        callDefInfo,
+                                 const ContinuationLayout&        layout,
+                                 const ContinuationLayoutBuilder& subLayout);
 
     void        RestoreFromDataOnResumption(const ContinuationLayout&        layout,
                                             const ContinuationLayoutBuilder& subLayout,

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -33109,6 +33109,47 @@ ClassLayout* GenTreeLclVarCommon::GetLayout(Compiler* compiler) const
 }
 
 //------------------------------------------------------------------------
+// EqualsLocal:
+//   Check if the locals information of two locals is equal.
+//
+// Arguments:
+//   lcl1 - The first local
+//   lcl2 - The second local
+//
+// Returns:
+//   True if equal.
+//
+// Remarks:
+//   For LCL_VAR, LCL_FLD and LCL_ADDR this is equivalent to GenTree::Compare.
+//   For STORE_LCL_VAR and STORE_LCL_FLD this only checks the local
+//   information; it does not check the data node for equality.
+//
+bool GenTreeLclVarCommon::EqualsLocal(GenTreeLclVarCommon* lcl1, GenTreeLclVarCommon* lcl2)
+{
+    if (lcl1->OperGet() != lcl2->OperGet())
+    {
+        return false;
+    }
+
+    if (lcl1->GetLclNum() != lcl2->GetLclNum())
+    {
+        return false;
+    }
+
+    if (lcl1->GetLclOffs() != lcl2->GetLclOffs())
+    {
+        return false;
+    }
+
+    if (lcl1->OperIs(GT_LCL_FLD, GT_STORE_LCL_FLD) && lcl1->AsLclFld()->GetLayout() != lcl2->AsLclFld()->GetLayout())
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------
 // GenTreeLclVar::IsNeverNegative: Gets true if the lcl var is never negative; otherwise false.
 //
 // Arguments:

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -3851,6 +3851,8 @@ public:
     {
     }
 #endif
+
+    static bool EqualsLocal(GenTreeLclVarCommon* lcl1, GenTreeLclVarCommon* lcl2);
 };
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/jitmetadatalist.h
+++ b/src/coreclr/jit/jitmetadatalist.h
@@ -94,6 +94,7 @@ JITMETADATAMETRIC(MorphTrackedLocals,                    int,              0)
 JITMETADATAMETRIC(MorphLocals,                           int,              0)
 JITMETADATAMETRIC(EnumeratorGDVProvisionalNoEscape,      int,              0)
 JITMETADATAMETRIC(EnumeratorGDVCanCloneToEnsureNoEscape, int,              0)
+JITMETADATAMETRIC(SuspensionPointsMerged,                int,              0)
 
 #undef JITMETADATA
 #undef JITMETADATAINFO


### PR DESCRIPTION
This adds an optimization that tail merges suspension points when predecessors of joins end with async calls.

Fixes #128258

Example:
```csharp
        [MethodImpl(MethodImplOptions.NoInlining)]
        public static async Task<int> Foo(bool b)
        {
            if (b)
            {
                return await Bar();
            }
            else
            {
                return await Baz();
            }
        }
```
```diff
@@ -23,7 +23,7 @@ G_M000_IG01:                ;; offset=0x0000
  
 G_M000_IG02:                ;; offset=0x001D
        test     rcx, rcx
-       jne      G_M000_IG22
+       jne      G_M000_IG20
        mov      rax, qword ptr GS:[0x0058]
        mov      rax, qword ptr [rax+0x28]
        cmp      dword ptr [rax+0x250], 3
@@ -50,7 +50,7 @@ G_M000_IG05:                ;; offset=0x0070
        call     [TestNamespace.Program:Baz():int]
        mov      ebx, eax
        test     rcx, rcx
-       jne      G_M000_IG19
+       jne      G_M000_IG18
        jmp      SHORT G_M000_IG07
  
 G_M000_IG06:                ;; offset=0x0085
@@ -123,44 +123,29 @@ G_M000_IG17:                ;; offset=0x010B
        jmp      G_M000_IG03
  
 G_M000_IG18:                ;; offset=0x011A
-       mov      rdx, 0x7FFF23280718
+       mov      rdx, 0x7FFF529D0718
        call     [CORINFO_HELP_ALLOC_CONTINUATION]
-       mov      rdi, rax
+       mov      rbx, rax
        lea      rcx, [reloc @RWD00]
-       mov      qword ptr [rdi+0x10], rcx
-       mov      qword ptr [rdi+0x18], 0xC48
-       lea      rcx, bword ptr [rdi+0x38]
+       mov      qword ptr [rbx+0x10], rcx
+       mov      qword ptr [rbx+0x18], 0xC48
+       lea      rcx, bword ptr [rbx+0x38]
        mov      rdx, rsi
        call     CORINFO_HELP_ASSIGN_REF
-       jmp      SHORT G_M000_IG20
- 
-G_M000_IG19:                ;; offset=0x014E
-       mov      rdx, 0x7FFF23280718
-       call     [CORINFO_HELP_ALLOC_CONTINUATION]
-       mov      rdi, rax
-       lea      rcx, [reloc @RWD16]
-       mov      qword ptr [rdi+0x10], rcx
-       mov      rcx, 0x100000C48
-       mov      qword ptr [rdi+0x18], rcx
-       lea      rcx, bword ptr [rdi+0x38]
-       mov      rdx, rsi
-       call     CORINFO_HELP_ASSIGN_REF
- 
-G_M000_IG20:                ;; offset=0x0186
        mov      r8, gword ptr [rbp-0x28]
        mov      gword ptr [rsp+0x20], r8
        mov      r9, gword ptr [rbp-0x30]
        mov      gword ptr [rsp+0x28], r9
-       lea      rcx, bword ptr [rdi+0x28]
-       lea      rdx, bword ptr [rdi+0x18]
-       lea      r8, bword ptr [rdi+0x20]
+       lea      rcx, bword ptr [rbx+0x28]
+       lea      rdx, bword ptr [rbx+0x18]
+       lea      r8, bword ptr [rbx+0x20]
        cmp      gword ptr [rbp+0x10], 0
        setne    r9b
        movzx    r9, r9b
        call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionWithContinuationContext(byref,byref,byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
-       mov      rcx, rdi
+       mov      rcx, rbx
  
-G_M000_IG21:                ;; offset=0x01BA
+G_M000_IG19:                ;; offset=0x0180
        add      rsp, 72
        pop      rbx
        pop      rsi
@@ -168,23 +153,16 @@ G_M000_IG21:                ;; offset=0x01BA
        pop      rbp
        ret      
  
-G_M000_IG22:                ;; offset=0x01C3
+G_M000_IG20:                ;; offset=0x0189
        mov      rcx, gword ptr [rbp+0x10]
-       cmp      dword ptr [rcx+0x1C], 0
-       jne      SHORT G_M000_IG23
        mov      rsi, gword ptr [rcx+0x38]
        mov      ebx, dword ptr [rcx+0x30]
        jmp      G_M000_IG07
  
-G_M000_IG23:                ;; offset=0x01D9
-       mov      rsi, gword ptr [rcx+0x38]
-       mov      ebx, dword ptr [rcx+0x30]
-       jmp      G_M000_IG07
- 
-G_M000_IG24:                ;; offset=0x01E5
+G_M000_IG21:                ;; offset=0x0199
        sub      rsp, 56
  
-G_M000_IG25:                ;; offset=0x01E9
+G_M000_IG22:                ;; offset=0x019D
        cmp      gword ptr [rbp+0x10], 0
        setne    cl
        movzx    rcx, cl
@@ -194,14 +172,12 @@ G_M000_IG25:                ;; offset=0x01E9
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreContexts(bool,System.Threading.Thread,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        nop      
  
-G_M000_IG26:                ;; offset=0x0207
+G_M000_IG23:                ;; offset=0x01BB
        add      rsp, 56
        ret      
  
 RWD00  	dq	(dynamicClass):IL_STUB_AsyncResume(System.Object,byref):System.Object
 	dq	G_M000_IG18
-RWD16  	dq	(dynamicClass):IL_STUB_AsyncResume(System.Object,byref):System.Object
-	dq	G_M000_IG19
 
-; Total bytes of code 524
+; Total bytes of code 448
 

```

<details>

<summary> NativeAOT test sizes </summary>

| BaseSize | DiffSize | Delta | Percent | Improved | Name |
| ---: | ---: | ---: | ---: | :---: | --- |
| 123,078,144 | 122,450,432 | -627,712 | -0.510% | ✅ | System.Text.Json.SourceGeneration.Roslyn4.4.Tests.exe |
| 16,737,280 | 16,721,408 | -15,872 | -0.095% | ✅ | System.Xml.Linq.Misc.Tests.exe |
| 14,865,920 | 14,852,096 | -13,824 | -0.093% | ✅ | System.Xml.Linq.Streaming.Tests.exe |
| 16,484,864 | 16,471,040 | -13,824 | -0.084% | ✅ | System.Xml.Linq.Events.Tests.exe |
| 16,632,832 | 16,619,008 | -13,824 | -0.083% | ✅ | System.Xml.Linq.Properties.Tests.exe |
| 16,969,216 | 16,955,392 | -13,824 | -0.081% | ✅ | System.Xml.Linq.xNodeReader.Tests.exe |
| 17,081,344 | 17,067,520 | -13,824 | -0.081% | ✅ | System.Xml.Linq.TreeManipulation.Tests.exe |
| 17,024,512 | 17,011,200 | -13,312 | -0.078% | ✅ | System.Xml.Linq.xNodeBuilder.Tests.exe |
| 33,084,416 | 33,070,592 | -13,824 | -0.042% | ✅ | System.Private.Xml.Tests.exe |
| 17,033,216 | 17,026,560 | -6,656 | -0.039% | ✅ | System.Linq.AsyncEnumerable.Tests.exe |
| 19,948,544 | 19,940,864 | -7,680 | -0.038% | ✅ | System.Net.WebSockets.Client.Tests.exe |
| 9,317,888 | 9,314,304 | -3,584 | -0.038% | ✅ | Microsoft.Extensions.Diagnostics.Abstractions.Tests.exe |
| 26,335,232 | 26,326,016 | -9,216 | -0.035% | ✅ | System.Text.Json.SourceGeneration.Roslyn3.11.Tests.exe |
| 10,252,288 | 10,248,704 | -3,584 | -0.035% | ✅ | System.Threading.Channels.Tests.exe |
| 12,387,328 | 12,383,232 | -4,096 | -0.033% | ✅ | System.Xml.Linq.SDMSample.Tests.exe |
| 13,832,704 | 13,828,096 | -4,608 | -0.033% | ✅ | Microsoft.Extensions.Configuration.Functional.Tests.exe |
| 31,187,968 | 31,177,728 | -10,240 | -0.033% | ✅ | System.Net.Http.Functional.Tests.exe |
| 13,205,504 | 13,201,408 | -4,096 | -0.031% | ✅ | System.IO.Packaging.Tests.exe |
| 10,030,080 | 10,027,008 | -3,072 | -0.031% | ✅ | System.IO.Compression.ZipFile.Tests.exe |
| 15,065,088 | 15,060,480 | -4,608 | -0.031% | ✅ | System.Drawing.Primitives.Tests.exe |
| 22,828,544 | 22,821,376 | -7,168 | -0.031% | ✅ | System.Net.Sockets.Tests.exe |
| 10,083,840 | 10,080,768 | -3,072 | -0.030% | ✅ | Microsoft.Extensions.Caching.Memory.Tests.exe |
| 13,906,944 | 13,902,848 | -4,096 | -0.029% | ✅ | Microsoft.Extensions.Configuration.Xml.Tests.exe |
| 16,066,048 | 16,061,440 | -4,608 | -0.029% | ✅ | System.Data.Odbc.Tests.exe |
| 14,093,824 | 14,089,728 | -4,096 | -0.029% | ✅ | System.DirectoryServices.Protocols.Tests.exe |
| 18,396,160 | 18,391,040 | -5,120 | -0.028% | ✅ | Microsoft.Extensions.Configuration.FileExtensions.Tests.exe |
| 12,817,920 | 12,814,336 | -3,584 | -0.028% | ✅ | System.Xml.Schema.Extensions.Tests.exe |
| 14,528,512 | 14,524,416 | -4,096 | -0.028% | ✅ | System.Net.WebClient.Tests.exe |
| 9,231,360 | 9,228,800 | -2,560 | -0.028% | ✅ | Microsoft.Bcl.AsyncInterfaces.Tests.exe |
| 15,000,576 | 14,996,480 | -4,096 | -0.027% | ✅ | System.Data.DataSetExtensions.Tests.exe |
| 9,424,896 | 9,422,336 | -2,560 | -0.027% | ✅ | Microsoft.Extensions.Logging.Testing.Tests.exe |
| 15,054,848 | 15,050,752 | -4,096 | -0.027% | ✅ | System.Security.Cryptography.Cng.Tests.exe |
| 9,641,984 | 9,639,424 | -2,560 | -0.027% | ✅ | Microsoft.Extensions.Hosting.Functional.Tests.exe |
| 17,615,360 | 17,610,752 | -4,608 | -0.026% | ✅ | System.IO.FileSystem.Watcher.Tests.exe |
| 17,983,488 | 17,978,880 | -4,608 | -0.026% | ✅ | Microsoft.Extensions.Diagnostics.Tests.exe |
| 11,745,280 | 11,742,208 | -3,072 | -0.026% | ✅ | System.Net.Http.Json.Unit.Tests.exe |
| 10,067,968 | 10,065,408 | -2,560 | -0.025% | ✅ | System.Net.ServerSentEvents.Tests.exe |
| 18,432,000 | 18,427,392 | -4,608 | -0.025% | ✅ | Microsoft.Extensions.Configuration.Tests.exe |
| 18,724,864 | 18,720,256 | -4,608 | -0.025% | ✅ | Microsoft.Extensions.FileProviders.Physical.Tests.exe |
| 18,299,904 | 18,295,296 | -4,608 | -0.025% | ✅ | Microsoft.Extensions.FileProviders.Composite.Tests.exe |
| 17,316,864 | 17,312,768 | -4,096 | -0.024% | ✅ | System.Diagnostics.StackTrace.Tests.exe |
| 17,238,528 | 17,234,432 | -4,096 | -0.024% | ✅ | System.Threading.Overlapped.Tests.exe |
| 17,192,448 | 17,188,352 | -4,096 | -0.024% | ✅ | System.Runtime.InvariantTimezone.Tests.exe |
| 17,283,584 | 17,279,488 | -4,096 | -0.024% | ✅ | System.Threading.Timer.Tests.exe |
| 19,504,128 | 19,499,520 | -4,608 | -0.024% | ✅ | System.Diagnostics.Process.Tests.exe |
| 17,171,968 | 17,167,872 | -4,096 | -0.024% | ✅ | System.Net.ServicePoint.Tests.exe |
| 17,268,224 | 17,264,128 | -4,096 | -0.024% | ✅ | System.Security.Principal.Windows.Tests.exe |
| 10,486,784 | 10,484,224 | -2,560 | -0.024% | ✅ | Microsoft.Extensions.Options.Tests.exe |
| 19,907,584 | 19,902,976 | -4,608 | -0.023% | ✅ | Microsoft.Extensions.Logging.Tests.exe |
| 19,812,352 | 19,807,744 | -4,608 | -0.023% | ✅ | System.Text.Encoding.Tests.exe |
| 24,194,560 | 24,188,928 | -5,632 | -0.023% | ✅ | Microsoft.Extensions.Http.Tests.exe |
| 17,619,968 | 17,615,872 | -4,096 | -0.023% | ✅ | System.Buffers.Tests.exe |
| 15,726,592 | 15,723,008 | -3,584 | -0.023% | ✅ | System.Windows.Extensions.Tests.exe |
| 19,975,168 | 19,970,560 | -4,608 | -0.023% | ✅ | Microsoft.Extensions.Configuration.UserSecrets.Tests.exe |
| 19,699,200 | 19,694,592 | -4,608 | -0.023% | ✅ | System.Resources.ResourceManager.Tests.exe |
| 17,929,728 | 17,925,632 | -4,096 | -0.023% | ✅ | System.Threading.ThreadPool.Tests.exe |
| 17,573,888 | 17,569,792 | -4,096 | -0.023% | ✅ | System.Threading.Thread.Tests.exe |
| 17,523,712 | 17,519,616 | -4,096 | -0.023% | ✅ | MetricOuterLoop.Tests.exe |
| 17,527,296 | 17,523,200 | -4,096 | -0.023% | ✅ | MetricOuterLoop1.Tests.exe |
| 21,191,168 | 21,186,560 | -4,608 | -0.022% | ✅ | System.Net.Requests.Tests.exe |
| 18,547,200 | 18,543,104 | -4,096 | -0.022% | ✅ | ComInterfaceGenerator.Tests.exe |
| 20,877,824 | 20,873,216 | -4,608 | -0.022% | ✅ | System.Net.Quic.Functional.Tests.exe |
| 18,465,792 | 18,461,696 | -4,096 | -0.022% | ✅ | System.IO.MemoryMappedFiles.Tests.exe |
| 18,323,968 | 18,319,872 | -4,096 | -0.022% | ✅ | Microsoft.Extensions.Primitives.Tests.exe |
| 18,328,064 | 18,323,968 | -4,096 | -0.022% | ✅ | System.Threading.Tests.exe |
| 18,873,856 | 18,869,760 | -4,096 | -0.022% | ✅ | System.Runtime.Caching.Tests.exe |
| 19,030,528 | 19,026,432 | -4,096 | -0.022% | ✅ | Microsoft.Extensions.Hosting.WindowsServices.Tests.exe |
| 17,253,376 | 17,249,792 | -3,584 | -0.021% | ✅ | System.Security.Claims.Tests.exe |
| 19,233,792 | 19,229,696 | -4,096 | -0.021% | ✅ | System.IO.Pipes.Tests.exe |
| 17,387,520 | 17,383,936 | -3,584 | -0.021% | ✅ | System.Net.Ping.Functional.Tests.exe |
| 21,649,920 | 21,645,312 | -4,608 | -0.021% | ✅ | System.IO.FileSystem.Tests.exe |
| 17,187,328 | 17,183,744 | -3,584 | -0.021% | ✅ | System.ComponentModel.EventBasedAsync.Tests.exe |
| 17,385,984 | 17,382,400 | -3,584 | -0.021% | ✅ | System.Diagnostics.TraceSource.Tests.exe |
| 17,245,184 | 17,241,600 | -3,584 | -0.021% | ✅ | System.Runtime.InteropServices.RuntimeInformation.Tests.exe |
| 17,116,672 | 17,113,088 | -3,584 | -0.021% | ✅ | System.Runtime.Serialization.Formatters.Disabled.Tests.exe |
| 19,529,216 | 19,525,120 | -4,096 | -0.021% | ✅ | System.IO.Compression.Tests.exe |
| 17,311,744 | 17,308,160 | -3,584 | -0.021% | ✅ | Microsoft.Win32.SystemEvents.Tests.exe |
| 17,111,040 | 17,107,456 | -3,584 | -0.021% | ✅ | IcuAppLocal.Tests.exe |
| 20,855,808 | 20,851,712 | -4,096 | -0.020% | ✅ | System.Security.Cryptography.Csp.Tests.exe |
| 19,987,456 | 19,983,360 | -4,096 | -0.020% | ✅ | System.Formats.Tar.Tests.exe |
| 20,185,600 | 20,181,504 | -4,096 | -0.020% | ✅ | System.Runtime.InteropServices.Tests.exe |
| 17,670,144 | 17,666,560 | -3,584 | -0.020% | ✅ | System.Threading.Tasks.Extensions.Tests.exe |
| 17,753,600 | 17,750,016 | -3,584 | -0.020% | ✅ | System.Formats.Tar.Manual.Tests.exe |
| 20,197,376 | 20,193,280 | -4,096 | -0.020% | ✅ | System.Threading.Tasks.Dataflow.Tests.exe |
| 20,035,072 | 20,030,976 | -4,096 | -0.020% | ✅ | Microsoft.Extensions.Configuration.Json.Tests.exe |
| 17,929,728 | 17,926,144 | -3,584 | -0.020% | ✅ | System.Threading.ThreadPool.WindowsThreadPool.Tests.exe |
| 18,080,768 | 18,077,184 | -3,584 | -0.020% | ✅ | System.Diagnostics.TextWriterTraceListener.Tests.exe |
| 18,131,968 | 18,128,384 | -3,584 | -0.020% | ✅ | System.Text.Encoding.CodePages.Tests.exe |
| 20,665,344 | 20,661,248 | -4,096 | -0.020% | ✅ | System.Collections.Concurrent.Tests.exe |
| 18,627,584 | 18,624,000 | -3,584 | -0.019% | ✅ | Microsoft.Extensions.Logging.Console.Tests.exe |
| 18,439,680 | 18,436,096 | -3,584 | -0.019% | ✅ | Microsoft.Extensions.Hosting.Systemd.Tests.exe |
| 19,004,928 | 19,001,344 | -3,584 | -0.019% | ✅ | System.Net.HttpListener.Tests.exe |
| 19,351,552 | 19,347,968 | -3,584 | -0.019% | ✅ | System.Net.Primitives.Functional.Tests.exe |
| 18,399,744 | 18,396,160 | -3,584 | -0.019% | ✅ | System.Threading.Tasks.Parallel.Tests.exe |
| 26,350,080 | 26,344,960 | -5,120 | -0.019% | ✅ | System.ComponentModel.TypeConverter.Tests.exe |
| 29,393,408 | 29,387,776 | -5,632 | -0.019% | ✅ | System.Net.Http.WinHttpHandler.Functional.Tests.exe |
| 19,623,936 | 19,620,352 | -3,584 | -0.018% | ✅ | System.Net.Http.Unit.Tests.exe |
| 27,957,760 | 27,952,640 | -5,120 | -0.018% | ✅ | System.Net.Security.Tests.exe |
| 20,402,176 | 20,398,592 | -3,584 | -0.018% | ✅ | System.Reflection.Tests.exe |
| 20,869,632 | 20,866,048 | -3,584 | -0.017% | ✅ | System.Runtime.Extensions.Tests.exe |
| 21,559,808 | 21,556,224 | -3,584 | -0.017% | ✅ | System.Data.OleDb.Tests.exe |
| 27,211,264 | 27,206,656 | -4,608 | -0.017% | ✅ | Microsoft.Extensions.Hosting.Unit.Tests.exe |
| 20,524,032 | 20,520,448 | -3,584 | -0.017% | ✅ | System.Diagnostics.DiagnosticSource.Tests.exe |
| 18,016,256 | 18,013,184 | -3,072 | -0.017% | ✅ | System.Console.Tests.exe |
| 23,069,696 | 23,066,112 | -3,584 | -0.016% | ✅ | System.Threading.Tasks.Tests.exe |
| 45,468,160 | 45,460,992 | -7,168 | -0.016% | ✅ | System.Security.Cryptography.Tests.exe |
| 29,943,808 | 29,939,200 | -4,608 | -0.015% | ✅ | Microsoft.Extensions.DependencyModel.Tests.exe |
| 23,320,576 | 23,316,992 | -3,584 | -0.015% | ✅ | System.Memory.Tests.exe |
| 25,956,864 | 25,953,280 | -3,584 | -0.014% | ✅ | System.Globalization.Nls.Tests.exe |
| 26,045,952 | 26,042,368 | -3,584 | -0.014% | ✅ | System.Globalization.Tests.exe |
| 26,552,832 | 26,549,248 | -3,584 | -0.013% | ✅ | Microsoft.Extensions.Logging.EventSource.Tests.exe |
| 32,654,336 | 32,650,240 | -4,096 | -0.013% | ✅ | System.Linq.Expressions.Tests.exe |
| 33,341,440 | 33,337,344 | -4,096 | -0.012% | ✅ | Microsoft.Bcl.Cryptography.Tests.exe |
| 9,345,024 | 9,344,000 | -1,024 | -0.011% | ✅ | System.Net.Mail.Unit.Tests.exe |
| 44,716,032 | 44,711,424 | -4,608 | -0.010% | ✅ | System.Runtime.Tests.exe |
| 11,302,400 | 11,301,888 | -512 | -0.005% | ✅ | System.Net.WebSockets.Tests.exe |
| 7,457,280 | 7,457,280 | 0 | 0.000% |  | XUnitLogChecker.exe |
| 8,836,608 | 8,836,608 | 0 | 0.000% |  | System.Reflection.Extensions.Tests.exe |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 9,332,736 | 9,332,736 | 0 | 0.000% |  | System.Reflection.Context.Tests.exe |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 8,692,736 | 8,692,736 | 0 | 0.000% |  | System.Private.Uri.Unit.Tests.exe |
| 1,377,280 | 1,377,280 | 0 | 0.000% |  | System.IO.Compression.Native.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 84,480 | 84,480 | 0 | 0.000% |  | System.Globalization.Native.dll |
| 108,032 | 108,032 | 0 | 0.000% |  | CMakeCXXCompilerId.exe |
| 12,246,016 | 12,246,016 | 0 | 0.000% |  | System.Reflection.Metadata.Tests.exe |
| 108,032 | 108,032 | 0 | 0.000% |  | CMakeCCompilerId.exe |
| 9,616,384 | 9,616,384 | 0 | 0.000% |  | System.Private.Uri.Functional.Tests.exe |
| 18,767,360 | 18,767,360 | 0 | 0.000% |  | System.Numerics.Vectors.Tests.exe |
| 9,769,984 | 9,769,984 | 0 | 0.000% |  | System.Net.WebProxy.Tests.exe |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 8,613,888 | 8,613,888 | 0 | 0.000% |  | System.Net.WebHeaderCollection.Tests.exe |
| 8,676,864 | 8,676,864 | 0 | 0.000% |  | System.Security.SecureString.Tests.exe |
| 8,996,352 | 8,996,352 | 0 | 0.000% |  | System.Reflection.TypeExtensions.Tests.exe |
| 9,332,736 | 9,332,736 | 0 | 0.000% |  | System.Security.Permissions.Tests.exe |
| 8,530,944 | 8,530,944 | 0 | 0.000% |  | System.Text.Encoding.Extensions.Tests.exe |
| 11,164,160 | 11,164,160 | 0 | 0.000% |  | System.Text.Encodings.Web.Tests.exe |
| 8,673,280 | 8,673,280 | 0 | 0.000% |  | System.Security.Cryptography.ProtectedData.Tests.exe |
| 22,298,624 | 22,298,624 | 0 | 0.000% |  | System.Security.Cryptography.Pkcs.Tests.exe |
| 9,674,240 | 9,674,240 | 0 | 0.000% |  | System.Text.RegularExpressions.Unit.Tests.exe |
| 11,768,832 | 11,768,832 | 0 | 0.000% |  | System.Security.Cryptography.Cose.Tests.exe |
| 8,929,792 | 8,929,792 | 0 | 0.000% |  | System.Threading.AccessControl.Tests.exe |
| 9,716,736 | 9,716,736 | 0 | 0.000% |  | System.Threading.RateLimiting.Tests.exe |
| 9,116,672 | 9,116,672 | 0 | 0.000% |  | System.Security.AccessControl.Tests.exe |
| 8,974,848 | 8,974,848 | 0 | 0.000% |  | System.Runtime.Serialization.Primitives.Tests.exe |
| 11,018,752 | 11,018,752 | 0 | 0.000% |  | System.Runtime.Numerics.Tests.exe |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 10,911,232 | 10,911,232 | 0 | 0.000% |  | System.Runtime.Intrinsics.Tests.exe |
| 8,789,504 | 8,789,504 | 0 | 0.000% |  | System.Web.HttpUtility.Tests.exe |
| 8,594,944 | 8,594,944 | 0 | 0.000% |  | System.Xml.Linq.Axes.Tests.exe |
| 8,659,456 | 8,659,456 | 0 | 0.000% |  | System.Runtime.InteropServices.ComDisabled.Tests.exe |
| 8,642,048 | 8,642,048 | 0 | 0.000% |  | System.Runtime.Handles.Tests.exe |
| 8,519,680 | 8,519,680 | 0 | 0.000% |  | System.Runtime.CompilerServices.VisualC.Tests.exe |
| 8,653,824 | 8,653,824 | 0 | 0.000% |  | System.Runtime.CompilerServices.Unsafe.Tests.exe |
| 9,186,816 | 9,186,816 | 0 | 0.000% |  | System.ServiceProcess.ServiceController.Tests.exe |
| 8,579,072 | 8,579,072 | 0 | 0.000% |  | System.Resources.Writer.Tests.exe |
| 8,784,384 | 8,784,384 | 0 | 0.000% |  | System.Resources.Reader.Tests.exe |
| 11,577,856 | 11,577,856 | 0 | 0.000% |  | System.Resources.Extensions.Tests.exe |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 9,094,656 | 9,094,656 | 0 | 0.000% |  | System.ValueTuple.Tests.exe |
| 536,096 | 536,096 | 0 | 0.000% |  | msquic.dll |
| 8,517,120 | 8,517,120 | 0 | 0.000% |  | System.IO.FileSystem.Primitives.Tests.exe |
| 9,285,120 | 9,285,120 | 0 | 0.000% |  | System.Net.Primitives.UnitTests.Tests.exe |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 307,200 | 307,200 | 0 | 0.000% |  | clretwrc.dll |
| 678,400 | 678,400 | 0 | 0.000% |  | clrgc.dll |
| 723,968 | 723,968 | 0 | 0.000% |  | clrgcexp.dll |
| 4,901,888 | 4,901,888 | 0 | 0.000% |  | coreclr.dll |
| 210,944 | 210,944 | 0 | 0.000% |  | corerun.exe |
| 62,464 | 62,464 | 0 | 0.000% |  | createdump.exe |
| 350,208 | 350,208 | 0 | 0.000% |  | hostfxr.dll |
| 361,984 | 361,984 | 0 | 0.000% |  | hostpolicy.dll |
| 1,463,296 | 1,463,296 | 0 | 0.000% |  | mscordaccore_amd64_amd64_42.42.42.42424.dll |
| 1,463,296 | 1,463,296 | 0 | 0.000% |  | mscordaccore.dll |
| 1,286,656 | 1,286,656 | 0 | 0.000% |  | mscordbi.dll |
| 536,096 | 536,096 | 0 | 0.000% |  | msquic.dll |
| 1,377,280 | 1,377,280 | 0 | 0.000% |  | System.IO.Compression.Native.dll |
| 17,022,976 | 17,022,976 | 0 | 0.000% |  | System.Private.CoreLib.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 84,480 | 84,480 | 0 | 0.000% |  | System.Globalization.Native.dll |
| 1,377,280 | 1,377,280 | 0 | 0.000% |  | System.IO.Compression.Native.dll |
| 10,562,560 | 10,562,560 | 0 | 0.000% |  | Common.Tests.exe |
| 696,320 | 696,320 | 0 | 0.000% |  | FileCheck.exe |
| 9,956,864 | 9,956,864 | 0 | 0.000% |  | llvm-mca.exe |
| 13,585,920 | 13,585,920 | 0 | 0.000% |  | crossgen2.exe |
| 7,809,536 | 7,809,536 | 0 | 0.000% |  | ilasm.exe |
| 16,050,688 | 16,050,688 | 0 | 0.000% |  | ilc.exe |
| 8,731,648 | 8,731,648 | 0 | 0.000% |  | Invariant.Tests.exe |
| 9,929,216 | 9,929,216 | 0 | 0.000% |  | LibraryImportGenerator.Tests.exe |
| 8,923,648 | 8,923,648 | 0 | 0.000% |  | Microsoft.Bcl.Memory.Tests.exe |
| 8,564,736 | 8,564,736 | 0 | 0.000% |  | Microsoft.Bcl.Numerics.Tests.exe |
| 8,749,056 | 8,749,056 | 0 | 0.000% |  | Microsoft.Bcl.TimeProvider.Tests.exe |
| 9,025,024 | 9,025,024 | 0 | 0.000% |  | Microsoft.Extensions.Configuration.CommandLine.Tests.exe |
| 9,183,232 | 9,183,232 | 0 | 0.000% |  | Microsoft.Extensions.Configuration.EnvironmentVariables.Tests.exe |
| 9,454,592 | 9,454,592 | 0 | 0.000% |  | Microsoft.Extensions.Configuration.Ini.Tests.exe |
| 9,007,616 | 9,007,616 | 0 | 0.000% |  | Microsoft.Extensions.FileSystemGlobbing.Tests.exe |
| 8,573,952 | 8,573,952 | 0 | 0.000% |  | Microsoft.Extensions.Hosting.Abstractions.Tests.exe |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.arm64.dll |
| 15,370,752 | 15,370,752 | 0 | 0.000% |  | System.Globalization.Extensions.Tests.exe |
| 11,248,128 | 11,248,128 | 0 | 0.000% |  | System.IO.Compression.Brotli.Tests.exe |
| 9,079,296 | 9,079,296 | 0 | 0.000% |  | System.IO.FileSystem.AccessControl.Tests.exe |
| 8,740,864 | 8,740,864 | 0 | 0.000% |  | System.IO.FileSystem.DriveInfo.Tests.exe |
| 8,672,768 | 8,672,768 | 0 | 0.000% |  | System.IO.FileSystem.Manual.Tests.exe |
| 696,320 | 696,320 | 0 | 0.000% |  | FileCheck.exe |
| 9,508,864 | 9,508,864 | 0 | 0.000% |  | System.IO.Hashing.Tests.exe |
| 9,318,912 | 9,318,912 | 0 | 0.000% |  | System.IO.IsolatedStorage.Tests.exe |
| 10,644,992 | 10,644,992 | 0 | 0.000% |  | System.IO.Pipelines.Tests.exe |
| 8,900,608 | 8,900,608 | 0 | 0.000% |  | System.IO.Pipes.AccessControl.Tests.exe |
| 11,449,856 | 11,449,856 | 0 | 0.000% |  | System.IO.Ports.Tests.exe |
| 11,959,296 | 11,959,296 | 0 | 0.000% |  | System.IO.Tests.exe |
| 9,641,472 | 9,641,472 | 0 | 0.000% |  | System.IO.UnmanagedMemoryStream.Tests.exe |
| 15,542,272 | 15,542,272 | 0 | 0.000% |  | System.Linq.Tests.exe |
| 9,590,272 | 9,590,272 | 0 | 0.000% |  | System.Memory.Data.Tests.exe |
| 10,476,544 | 10,476,544 | 0 | 0.000% |  | System.Net.Http.WinHttpHandler.Unit.Tests.exe |
| 9,012,224 | 9,012,224 | 0 | 0.000% |  | System.Net.NameResolution.Pal.Tests.exe |
| 12,248,064 | 12,248,064 | 0 | 0.000% |  | System.Net.NetworkInformation.Functional.Tests.exe |
| 8,960,512 | 8,960,512 | 0 | 0.000% |  | System.Net.Primitives.Pal.Tests.exe |
| 15,370,752 | 15,370,752 | 0 | 0.000% |  | System.Globalization.Extensions.Nls.Tests.exe |
| 8,625,152 | 8,625,152 | 0 | 0.000% |  | System.Globalization.CalendarsWithConfigSwitch.Tests.exe |
| 9,136,640 | 9,136,640 | 0 | 0.000% |  | System.Globalization.Calendars.Tests.exe |
| 9,820,160 | 9,820,160 | 0 | 0.000% |  | System.Formats.Nrbf.Tests.exe |
| 2,309,152 | 2,309,152 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.amd64.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% |  | Microsoft.DiaSymReader.Native.x86.dll |
| 8,636,416 | 8,636,416 | 0 | 0.000% |  | Microsoft.Win32.Primitives.Tests.exe |
| 8,620,032 | 8,620,032 | 0 | 0.000% |  | Microsoft.Win32.Registry.AccessControl.Tests.exe |
| 8,962,560 | 8,962,560 | 0 | 0.000% |  | Microsoft.Win32.Registry.Tests.exe |
| 9,914,368 | 9,914,368 | 0 | 0.000% |  | System.Collections.NonGeneric.Tests.exe |
| 9,714,176 | 9,714,176 | 0 | 0.000% |  | System.Collections.Specialized.Tests.exe |
| 17,754,624 | 17,754,624 | 0 | 0.000% |  | System.Collections.Tests.exe |
| 9,133,056 | 9,133,056 | 0 | 0.000% |  | System.ComponentModel.Primitives.Tests.exe |
| 11,342,848 | 11,342,848 | 0 | 0.000% |  | System.Net.Security.Unit.Tests.exe |
| 8,520,704 | 8,520,704 | 0 | 0.000% |  | System.ComponentModel.Tests.exe |
| 9,589,760 | 9,589,760 | 0 | 0.000% |  | System.Composition.Convention.Tests.exe |
| 8,596,480 | 8,596,480 | 0 | 0.000% |  | System.Composition.Runtime.Tests.exe |
| 8,809,472 | 8,809,472 | 0 | 0.000% |  | System.Console.Manual.Tests.exe |
| 8,535,552 | 8,535,552 | 0 | 0.000% |  | System.Diagnostics.Contracts.Tests.exe |
| 10,027,520 | 10,027,520 | 0 | 0.000% |  | System.Diagnostics.Debug.Tests.exe |
| 9,590,784 | 9,590,784 | 0 | 0.000% |  | System.Diagnostics.EventLog.Tests.exe |
| 8,689,664 | 8,689,664 | 0 | 0.000% |  | System.Diagnostics.FileVersionInfo.Tests.exe |
| 8,521,728 | 8,521,728 | 0 | 0.000% |  | System.Diagnostics.Tools.Tests.exe |
| 9,735,168 | 9,735,168 | 0 | 0.000% |  | System.Formats.Asn1.Tests.exe |
| 8,531,968 | 8,531,968 | 0 | 0.000% |  | System.Composition.AttributeModel.Tests.exe |
| 9,956,864 | 9,956,864 | 0 | 0.000% |  | llvm-mca.exe |

</details>