### PR TITLE
Add jit.instructions.md for JIT folder

### DIFF
--- a/.github/instructions/jit.instructions.md
+++ b/.github/instructions/jit.instructions.md
@@ -6,4 +6,4 @@ applyTo: "src/coreclr/jit/**"
 
 ## Code Review Guidelines
 
-- **Do not request tests for JIT codebase improvements.** - JIT changes alter global codegen and are fully validated by existing end-to-end suites and differential testing. Individual PR regression tests are redundant and unnecessary unless it's a bug-fix PR that with a clear repro that is not covered by existing tests.
+- **Do not routinely request new targeted tests for pure refactors, mechanical cleanups, or other non-behavioral JIT codebase improvements.** JIT changes alter global codegen and are often validated by existing end-to-end suites and differential testing, so additional per-PR regression tests may not be needed for changes that do not affect observable behavior. However, targeted tests are appropriate and should be encouraged for bug fixes, changes with a clear repro, observable behavior changes, and previously untested edge cases that are not already covered by existing tests.

--- a/.github/instructions/jit.instructions.md
+++ b/.github/instructions/jit.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "src/coreclr/jit/**"
+---
+
+# RyuJIT (JIT compiler) — Folder-Specific Guidance
+
+## Code Review Guidelines
+
+- **Do not request tests for JIT codebase improvements.** - JIT changes alter global codegen and are fully validated by existing end-to-end suites and differential testing. Individual PR regression tests are redundant and unnecessary unless it's a bug-fix PR that with a clear repro that is not covered by existing tests.


### PR DESCRIPTION
CCR is usually very verbose in JIT PRs and is constantly asking for adding tests which is very annoying and adds 0 value.

I am not 100% sure CCR will auto-load these custom instructions, but based on the docs, it should.