### PR TITLE
[browser][coreCLR] Export `__stack_pointer` global

### DIFF
--- a/eng/native.wasm.targets
+++ b/eng/native.wasm.targets
@@ -81,6 +81,7 @@
       <EmccExportedFunction Include="stackAlloc" />
       <EmccExportedFunction Include="stackRestore" />
       <EmccExportedFunction Include="stackSave" />
+      <EmccExportedFunction Include="___stack_pointer" />
     </ItemGroup>
     <PropertyGroup>
       <_EmccExportedRuntimeMethods>@(EmccExportedRuntimeMethod -> '%(Identity)',',')</_EmccExportedRuntimeMethods>

--- a/eng/native/configureoptimization.cmake
+++ b/eng/native/configureoptimization.cmake
@@ -9,6 +9,9 @@ elseif(CLR_CMAKE_HOST_UNIX)
     if(CLR_CMAKE_TARGET_ANDROID)
         # -O2 optimization generates faster/smaller code on Android
         add_compile_options($<$<CONFIG:Release>:-O2>)
+    elseif (CLR_CMAKE_TARGET_BROWSER)
+        # -O2 disables metadce optimization and protects __stack_pointer
+        add_compile_options($<$<CONFIG:Release>:-O2>)
     else()
         add_compile_options($<$<CONFIG:Release>:-O3>)
     endif()

--- a/eng/native/configureoptimization.cmake
+++ b/eng/native/configureoptimization.cmake
@@ -11,9 +11,7 @@ elseif(CLR_CMAKE_HOST_UNIX)
         add_compile_options($<$<CONFIG:Release>:-O2>)
     elseif (CLR_CMAKE_TARGET_BROWSER)
         # -O2 prevents emscripten metadce from stripping user-requested global exports
-        # Must override CMAKE_*_FLAGS_RELEASE because those propagate to the link line
-        set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
-        set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+        add_link_options($<$<CONFIG:Release>:-O2>)
     else()
         add_compile_options($<$<CONFIG:Release>:-O3>)
     endif()

--- a/eng/native/configureoptimization.cmake
+++ b/eng/native/configureoptimization.cmake
@@ -10,8 +10,10 @@ elseif(CLR_CMAKE_HOST_UNIX)
         # -O2 optimization generates faster/smaller code on Android
         add_compile_options($<$<CONFIG:Release>:-O2>)
     elseif (CLR_CMAKE_TARGET_BROWSER)
-        # -O2 disables metadce optimization and protects __stack_pointer
-        add_compile_options($<$<CONFIG:Release>:-O2>)
+        # -O2 prevents emscripten metadce from stripping user-requested global exports
+        # Must override CMAKE_*_FLAGS_RELEASE because those propagate to the link line
+        set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
+        set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
     else()
         add_compile_options($<$<CONFIG:Release>:-O3>)
     endif()

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -89,9 +89,11 @@ else()
                 -sEXPORT_ES6=1
                 -sEXIT_RUNTIME=1
                 -sEXPORTED_RUNTIME_METHODS=CORERUN,ENV,${CMAKE_EMCC_EXPORTED_RUNTIME_METHODS}
-                -sEXPORTED_FUNCTIONS=_main,___stack_pointer,${CMAKE_EMCC_EXPORTED_FUNCTIONS}
+                -sEXPORTED_FUNCTIONS=_main,${CMAKE_EMCC_EXPORTED_FUNCTIONS}
                 -sEXPORT_NAME=createDotnetRuntime
                 -sENVIRONMENT=node,shell,web
+                -lexports.js
+                -Wl,--export=__stack_pointer
                 -Wl,--error-limit=0)
 
             if (CORERUN_IN_BROWSER)

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -597,8 +597,9 @@
       <!-- Extra user flags -->
       <_EmccLinkStepArgs Include="$(EmccExtraLDFlags)" />
 
-      <!-- protect __stack_pointer -->
+      <!-- -lexports.js to set MINIFY_WASM_EXPORT_NAMES=0 -->
       <_EmccLinkStepArgs Include="-lexports.js" />
+      <!-- Ensure the __stack_pointer global is exported -->
       <_EmccLinkStepArgs Include="-Wl,--export=__stack_pointer" />
 
       <!-- Linker error limit -->

--- a/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
+++ b/src/mono/browser/build/BrowserWasmApp.CoreCLR.targets
@@ -555,7 +555,6 @@
 
       <!-- ES6 module output -->
       <_EmccLinkStepArgs Include="-s EXPORT_ES6=1" />
-      <_EmccLinkStepArgs Include="-lexports.js" />
 
       <!-- Memory configuration -->
       <_EmccLinkStepArgs Include="-s INITIAL_MEMORY=$(WasmInitialHeapSize)" />
@@ -597,6 +596,10 @@
 
       <!-- Extra user flags -->
       <_EmccLinkStepArgs Include="$(EmccExtraLDFlags)" />
+
+      <!-- protect __stack_pointer -->
+      <_EmccLinkStepArgs Include="-lexports.js" />
+      <_EmccLinkStepArgs Include="-Wl,--export=__stack_pointer" />
 
       <!-- Linker error limit -->
       <_EmccLinkStepArgs Include="-Wl,--error-limit=0" />

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -122,6 +122,8 @@ target_link_options(browserhost PRIVATE
     -sEXPORT_NAME=createDotnetRuntime
     -sENVIRONMENT=web,webview,worker,node,shell
     --emit-symbol-map
+    -lexports.js
+    -Wl,--export=__stack_pointer
     -Wl,--error-limit=0)
 
 target_link_libraries(browserhost PRIVATE


### PR DESCRIPTION
## Problem

The `__stack_pointer` WebAssembly global export was being removed from the final `.wasm` binary despite being explicitly requested via `-sEXPORTED_FUNCTIONS=___stack_pointer` and `-Wl,--export=__stack_pointer`.

This global is needed by `libCorerun.js` to share the stack pointer with dynamically loaded Webcil sub-modules (`wasmExports.__stack_pointer` is passed as an import to child wasm instances).

## Root Cause

Emscripten's `wasm-metadce` pass (dead code elimination) unconditionally excludes **all wasm global exports** from its reachability graph:

```python
# building.py line 766
exports = sorted(set(settings.WASM_EXPORTS) - set(settings.WASM_GLOBAL_EXPORTS))
```

Since `__stack_pointer` is a wasm global (not a function), it's never included in the DCE graph regardless of `EXPORTED_FUNCTIONS`. The `wasm-metadce` tool then considers it unreachable and removes it.

Metadce runs when `OPT_LEVEL >= 3` or `SHRINK_LEVEL >= 1` (i.e., `-O3`, `-Os`, or `-Oz`).

## Fix

1. **Set `-O2` for Browser Release builds** in `configureoptimization.cmake` — this prevents metadce from running while still enabling wasm-opt optimizations.
2. **Add `-Wl,--export=__stack_pointer`** to all Browser link targets (corerun, browserhost, BrowserWasmApp) to ensure wasm-ld emits the export.
3. **Add `___stack_pointer` to `EmccExportedFunction`** in `eng/native.wasm.targets`

## Follow-up

We should re-visit this after we upgrade emscripten, we could have more efficient way how to do it