### PR TITLE
[cDAC] Fix ARM32 thumb-bit bug in GetFuncletStartAddress

### DIFF
--- a/docs/design/datacontracts/ExecutionManager.md
+++ b/docs/design/datacontracts/ExecutionManager.md
@@ -206,7 +206,7 @@ Data descriptors used:
 | `ReadyToRunHeader` | `MinorVersion` | ReadyToRun minor version |
 | `ImageDataDirectory` | `VirtualAddress` | Virtual address of the image data directory |
 | `ImageDataDirectory` | `Size` | Size of the data |
-| `RuntimeFunction` | `BeginAddress` | Begin address of the function |
+| `RuntimeFunction` | `BeginAddress` | Begin address of the function. On ARM32, bit 0 (the Thumb bit) is set. |
 | `RuntimeFunction` | `EndAddress` | End address of the function. Only exists on some platforms |
 | `RuntimeFunction` | `UnwindData` | Pointer to the unwind info for the function |
 | `HashMap` | `Buckets` | Pointer to the buckets of a `HashMap` |

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
@@ -260,7 +260,8 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
         // TODO(cdac): EXCEPTION_DATA_SUPPORTS_FUNCTION_FRAGMENTS, implement iterating over fragments until finding
         // non-fragment RuntimeFunction
 
-        return range.Data.RangeBegin + runtimeFunction.BeginAddress;
+        return CodePointerUtils.AddressFromCodePointer(
+            new TargetCodePointer(range.Data.RangeBegin + runtimeFunction.BeginAddress), _target);
     }
 
     void IExecutionManager.GetMethodRegionInfo(CodeBlockHandle codeInfoHandle, out uint hotSize, out TargetPointer coldStart, out uint coldSize)


### PR DESCRIPTION
## Problem

`runtime-diagnostics` build [1423045](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1423045) and many runs since have failed `StackReferenceDumpTests.WalkStackReferences_*` on **linux_arm** R2R dumps with:

```
Microsoft.Diagnostics.DataContractReader.VirtualReadException : Failed to read System.UInt32 at 0xeff9b908.
   at Microsoft.Diagnostics.DataContractReader.Data.ExceptionLookupTableEntry..ctor
   at ...ReadyToRunJitManager.GetExceptionClauses
   at ...StackWalk_1.IsFilterFunclet
```

5 of 8 recent builds (1416195 - 1423045) failed across 6 CdacXPlatDumpTest legs.

## Root cause

Since #128154, `IExecutionManager.GetStartAddress` returns a `TargetPointer` with the ARM32 thumb bit stripped (matching native `TADDR` semantics, returned by `RUNTIME_FUNCTION__BeginAddress` in `clrnt.h`). `GetMethodInfo` was updated to honor that, but `GetFuncletStartAddress` was missed:

```csharp
// ExecutionManagerCore.cs (before fix)
return range.Data.RangeBegin + runtimeFunction.BeginAddress;   // thumb bit preserved on ARM32
```

### Consequence on ARM32

- `GetStartAddress` returns `0x........0` (clean)
- `GetFuncletStartAddress` returns `0x........1` (thumb bit set)
- `IsFunclet` (`return startAddress != GetFuncletStartAddress(...)`) returns **true** for every R2R method
- `IsFilterFunclet` then calls `GetExceptionClauses` for every non-funclet, which tries to binary-search the R2R `ExceptionInfo` lookup table whose data is not paged into the minidump -> `VirtualReadException` at `0xeff9b908`

arm64/x64 do not have a thumb bit, so the comparison still matched there.

## Fix

Strip the thumb bit at the call site by running the `RangeBegin + BeginAddress` sum through `CodePointerUtils.AddressFromCodePointer` -- the cdac analog of native `ThumbCodeToDataPointer` used by `RUNTIME_FUNCTION__BeginAddress`.

Fixes #128292.

## Validation

- Built cdac Contracts: clean.
- `dotnet test` filtered to `ExecutionManager`: 285/285 pass.
- runtime-diagnostics CI will validate end-to-end behavior on ARM32 dumps.

> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.
