### PR TITLE
[release/9.0-staging] [TestOnly] Fix NumberFormatInfoGroupSize test

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -10,21 +10,24 @@ namespace System.Globalization.Tests
     {
         public static IEnumerable<object[]> NumberGroupSizes_TestData()
         {
-            yield return new object[] { NumberFormatInfo.InvariantInfo, new int[] { 3 } };
-            yield return new object[] { CultureInfo.GetCultureInfo("en-US").NumberFormat, new int[] { 3 } };
+            yield return new object[] { "Invariant", NumberFormatInfo.InvariantInfo, new int[] { 3 }, null };
+            yield return new object[] { "en-US", CultureInfo.GetCultureInfo("en-US").NumberFormat, new int[] { 3 }, null };
 
             // Culture does not exist on Windows 7 and in Browser's ICU
             if (!PlatformDetection.IsWindows7 && PlatformDetection.IsNotBrowser)
             {
-                yield return new object[] { CultureInfo.GetCultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes() };
+                yield return new object[] { "ur-IN", CultureInfo.GetCultureInfo("ur-IN").NumberFormat, NumberFormatInfoData.UrINNumberGroupSizes(), new int[] { 3, 2 } };
             }
         }
 
         [Theory]
         [MemberData(nameof(NumberGroupSizes_TestData))]
-        public void NumberGroupSizes_Get_ReturnsExpected(NumberFormatInfo format, int[] expected)
+        public void NumberGroupSizes_Get_ReturnsExpected(string cultureName, NumberFormatInfo format, int[] expected1, int[] expected2)
         {
-            Assert.Equal(expected, format.NumberGroupSizes);
+            int[] actual = format.NumberGroupSizes;
+            Assert.True(expected1.SequenceEqual(actual) || (expected2 is not null && expected2.SequenceEqual(actual)),
+                $"Expected: [{string.Join(", ", expected1)}] or [{(expected2 is null ? "<null>" : string.Join(", ", expected2))}], Actual: [{string.Join(", ", actual)}]"
+                + $"{Environment.NewLine}Culture: {cultureName}");
         }
 
         [Theory]

--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -25,7 +25,7 @@ namespace System.Globalization.Tests
         public void NumberGroupSizes_Get_ReturnsExpected(string cultureName, NumberFormatInfo format, int[] expected1, int[] expected2)
         {
             int[] actual = format.NumberGroupSizes;
-            Assert.True(expected1.SequenceEqual(actual) || (expected2 is not null && expected2.SequenceEqual(actual)),
+            Assert.True(expected1.AsSpan().SequenceEqual(actual) || (expected2 is not null && expected2.AsSpan().SequenceEqual(actual)),
                 $"Expected: [{string.Join(", ", expected1)}] or [{(expected2 is null ? "<null>" : string.Join(", ", expected2))}], Actual: [{string.Join(", ", actual)}]"
                 + $"{Environment.NewLine}Culture: {cultureName}");
         }


### PR DESCRIPTION
Backport of #120546 to release/9.0-staging

/cc @jeffhandley @tarekgh

## Customer Impact

- [ ] Customer reported
- [x] Found internally

This test failed in CI on 9.0: https://dev.azure.com/dnceng-public/public/_build/results?buildId=1431345&view=ms.vss-test-web.build-test-results-tab&runId=39820274&paneView=debug&resultId=132492

## Regression

- [ ] Yes
- [x] No

## Testing

Verified in main, and the failing test is occurring in release/9.0-staging as well.

## Risk

Low. Test only, handling new data.