### PR TITLE
Fix ConnectAsync_WithBuffer_Succeeds blocking mode assertion on non-Apple Unix

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -220,11 +220,11 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(SocketError.Success, saea.SocketError);
             Assert.True(client.Blocking);
 
-            // On Apple and Android platforms, TFO (connectx/sendto) may complete the connect+send
-            // in a single syscall, so the socket can end up blocking even on the async path.
-            // On Linux, async connect always leaves the socket non-blocking when
-            // buffer > 0 because SendToAsync is pending.
-            if (!completedAsync || PlatformDetection.IsApplePlatform || PlatformDetection.IsAndroid)
+            // On Apple platforms, connectx may complete connect+send atomically,
+            // allowing the socket to be restored to blocking even on the async path.
+            // On other Unix platforms (Linux, Android), completedAsync means either
+            // connect or the follow-up send pended, leaving the socket non-blocking.
+            if (!completedAsync || PlatformDetection.IsApplePlatform)
             {
                 Assert.False(IsSocketNonBlocking(client));
             }


### PR DESCRIPTION
The test `ConnectAsync_WithBuffer_Succeeds` assumes that on Android, `ConnectAsync` with a data buffer always completes the connect+send atomically (like Apple's `connectx`), leaving the socket in blocking mode. This is incorrect.

## Root cause

Android uses the Linux kernel, which does **not** have `connectx()`. The native PAL code in [`pal_networking.c`](https://github.com/dotnet/runtime/blob/main/src/native/libs/System.Native/pal_networking.c#L1832-L1868) confirms this:

- **Apple** (`#if HAVE_CONNECTX`): Uses `connectx()` syscall which atomically connects + sends data
- **Linux/Android** (`#else`): Falls back to plain `connect()` — the data buffer is **ignored** (`sent = 0`), and data is sent separately via `SendToAsync`

`HAVE_CONNECTX` is [detected at build time](https://github.com/dotnet/runtime/blob/main/src/native/libs/configure.cmake#L526-L529) via CMake `check_symbol_exists(connectx "sys/socket.h")`. Since `connectx` is an Apple-specific API (not part of POSIX or the Linux kernel), it's never available on Android.

On Linux/Android, TFO is implemented differently: `setsockopt(TCP_FASTOPEN_CONNECT)` + regular `connect()`, which defers the SYN until the first write. Connect and send are always separate operations.

## The bug

When the follow-up `SendToAsync` goes async (`IOPending`), `SetBlocking()` is [skipped](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs#L1588-L1591) and the socket stays non-blocking. The test then hits `Assert.False(IsSocketNonBlocking(client))` and fails.

## The fix

Remove `PlatformDetection.IsAndroid` from the blocking-mode assertion. Android should follow the same code path as Linux: when `completedAsync == true`, the socket is expected to be non-blocking.

## Impact

Failures across 15+ builds per week, growing over months:
- `azurelinux.3.amd64`: 157 failures (14d)
- `ubuntu.2204.amd64.android.29`: 122 failures
- `windows.11.amd64.android`: 78 failures
- `azurelinux.3.arm64`: 30 failures
- `windows.11.amd64.android-armel`: 20 failures

Fixes #125825