### PR TITLE
[release/10.0] Fix Linux madvise() advice values

### DIFF
--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -741,31 +741,20 @@ bool GCToOSInterface::VirtualReset(void * address, size_t size, bool unlock)
 {
     int st = EINVAL;
 
-#if defined(MADV_DONTDUMP) || defined(HAVE_MADV_FREE)
-
-    int madviseFlags = 0;
-
 #ifdef MADV_DONTDUMP
     // Do not include reset memory in coredump.
-    madviseFlags |= MADV_DONTDUMP;
+    st = madvise(address, size, MADV_DONTDUMP);
 #endif
 
-#ifdef HAVE_MADV_FREE
+#ifdef MADV_FREE
     // Tell the kernel that the application doesn't need the pages in the range.
     // Freeing the pages can be delayed until a memory pressure occurs.
-    madviseFlags |= MADV_FREE;
-#endif
-
-    st = madvise(address, size, madviseFlags);
-
-#endif //defined(MADV_DONTDUMP) || defined(HAVE_MADV_FREE)
-
-#if defined(HAVE_POSIX_MADVISE) && !defined(MADV_DONTDUMP)
+    st = madvise(address, size, MADV_FREE);
+#elif defined(HAVE_POSIX_MADVISE)
     // DONTNEED is the nearest posix equivalent of FREE.
     // Prefer FREE as, since glibc2.6 DONTNEED is a nop.
     st = posix_madvise(address, size, POSIX_MADV_DONTNEED);
-
-#endif //defined(HAVE_POSIX_MADVISE) && !defined(MADV_DONTDUMP)
+#endif // MADV_FREE
 
     return (st == 0);
 }


### PR DESCRIPTION
Backport of #126966 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

`VirtualReset` in GC was combining `MADV_FREE` (8) and `MADV_DONTDUMP` (16) via bitwise OR and passing the result (24) to a single `madvise` call. `madvise` takes a single advice constant — not a bitmask — so this was either rejected as `EINVAL` (kernels < 5.18) or silently matched `MADV_DONTNEED_LOCKED` (kernels ≥ 5.18), a completely different operation.

## Regression
- [x] Yes - introduced in .NET 9 by #95643 (an optimization to reduce syscall count).
- [ ] No

## Testing
CI tests, local testing using targeted repro app from the customer, GC tests

## Risk
Low. It is a simple targeted fix that just makes two calls to `madvise` with correct arguments where we were making one call with a combination of those values that had no effect or was outright wrong.