### PR TITLE
JIT: remove some useless code in escape analysis

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -1893,7 +1893,6 @@ void ObjectAllocator::AnalyzeParentStack(ArrayStack<GenTree*>* parentStack, unsi
 
     bool       keepChecking                  = true;
     bool       canLclVarEscapeViaParentStack = true;
-    bool       isCopy                        = true;
     bool const isEnumeratorLocal             = lclDsc->lvIsEnumerator;
     bool       isAddress                     = parentStack->Top()->OperIs(GT_LCL_ADDR);
 
@@ -1905,11 +1904,9 @@ void ObjectAllocator::AnalyzeParentStack(ArrayStack<GenTree*>* parentStack, unsi
             break;
         }
 
-        GenTree* tree    = parentStack->Top(parentIndex - 1);
-        GenTree* parent  = parentStack->Top(parentIndex);
-        bool     wasCopy = isCopy;
+        GenTree* tree   = parentStack->Top(parentIndex - 1);
+        GenTree* parent = parentStack->Top(parentIndex);
 
-        isCopy                        = false;
         canLclVarEscapeViaParentStack = true;
         keepChecking                  = false;
 
@@ -1942,14 +1939,6 @@ void ObjectAllocator::AnalyzeParentStack(ArrayStack<GenTree*>* parentStack, unsi
                 //
                 AddConnGraphEdgeIndex(dstIndex, lclIndex);
                 canLclVarEscapeViaParentStack = false;
-
-                // If the source of this store is an enumerator local,
-                // then the dest also becomes an enumerator local.
-                //
-                if (isCopy)
-                {
-                    CheckForEnumeratorUse(lclNum, dstLclNum);
-                }
 
                 // Note that we modelled this store in the connection graph
                 //
@@ -2001,7 +1990,6 @@ void ObjectAllocator::AnalyzeParentStack(ArrayStack<GenTree*>* parentStack, unsi
                 break;
 
             case GT_BOX:
-                isCopy = wasCopy;
                 ++parentIndex;
                 keepChecking = true;
                 break;


### PR DESCRIPTION
Remove some obsolete copy detection code. We now track copies via `CheckForGuardedAllocationOrCopy` and the old code is non-functional.