### PR TITLE
Use a distinct Wasm machine type for R2R images

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using ILCompiler.ReadyToRun.Tests.TestCasesRunner;
 using ILCompiler.Reflection.ReadyToRun;
@@ -54,6 +55,41 @@ public class R2RTestSuites
             Assert.True(R2RAssert.HasCrossModuleInlinedMethod(reader, "TestGetValue", "GetValue", out diag), diag);
             Assert.True(R2RAssert.HasCrossModuleInlinedMethod(reader, "TestGetString", "GetString", out diag), diag);
             Assert.True(R2RAssert.HasCrossModuleInliningInfo(reader, out diag), diag);
+        }
+    }
+
+    [Fact]
+    public void WasmWebcilModule()
+    {
+        var wasmWebcilModule = new CompiledAssembly
+        {
+            AssemblyName = nameof(WasmWebcilModule),
+            SourceResourceNames = ["Webcil/WasmWebcilModule.cs"],
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(WasmWebcilModule),
+            [
+                new(nameof(WasmWebcilModule), [new CrossgenAssembly(wasmWebcilModule)])
+                {
+                    OutputFileExtension = ".wasm",
+                    AdditionalArgs =
+                    {
+                        "--targetarch",
+                        "wasm",
+                        "--targetos",
+                        "browser",
+                    },
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            var webcilReader = Assert.IsType<WebcilImageReader>(reader.CompositeReader);
+            Assert.True(webcilReader.IsWasmWrapped);
+            Assert.True(R2RAssert.GetAllMethods(reader).Exists(method =>
+                method.SignatureString.Contains("AddIntegers", StringComparison.Ordinal)));
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -78,7 +78,6 @@ public class R2RTestSuites
                         "wasm",
                         "--targetos",
                         "browser",
-                        "--compile-no-methods",
                     },
                     Validate = Validate,
                 },

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Generic;
 using ILCompiler.ReadyToRun.Tests.TestCasesRunner;
 using ILCompiler.Reflection.ReadyToRun;
@@ -79,6 +78,7 @@ public class R2RTestSuites
                         "wasm",
                         "--targetos",
                         "browser",
+                        "--compile-no-methods",
                     },
                     Validate = Validate,
                 },
@@ -86,10 +86,14 @@ public class R2RTestSuites
 
         static void Validate(ReadyToRunReader reader)
         {
+            Assert.Equal(WasmMachine.Wasm32, reader.Machine);
             var webcilReader = Assert.IsType<WebcilImageReader>(reader.CompositeReader);
+            Assert.Equal(WasmMachine.Wasm32, webcilReader.Machine);
             Assert.True(webcilReader.IsWasmWrapped);
-            Assert.True(R2RAssert.GetAllMethods(reader).Exists(method =>
-                method.SignatureString.Contains("AddIntegers", StringComparison.Ordinal)));
+
+            var metadataReader = reader.GetGlobalMetadata().MetadataReader;
+            Assert.Contains(metadataReader.MethodDefinitions, methodHandle =>
+                metadataReader.GetString(metadataReader.GetMethodDefinition(methodHandle).Name) == "AddIntegers");
         }
     }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/Webcil/WasmWebcilModule.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Webcil;
+
+public static class WasmWebcilModule
+{
+    public static int AddIntegers(int left, int right)
+    {
+        return left + right;
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RDriver.cs
@@ -30,11 +30,8 @@ internal enum Crossgen2Option
 {
     Composite,
     InputBubble,
-    ObjectFormat,
     HotColdSplitting,
     Optimize,
-    TargetArch,
-    TargetOS,
 }
 
 internal static class Crossgen2OptionsExtensions
@@ -58,11 +55,8 @@ internal static class Crossgen2OptionsExtensions
     {
         Crossgen2Option.Composite => $"--composite",
         Crossgen2Option.InputBubble => $"--input-bubble",
-        Crossgen2Option.ObjectFormat => $"--object-format",
         Crossgen2Option.HotColdSplitting => $"--hot-cold-splitting",
         Crossgen2Option.Optimize => $"--optimize",
-        Crossgen2Option.TargetArch => $"--target-arch",
-        Crossgen2Option.TargetOS => $"--target-os",
         _ => throw new ArgumentOutOfRangeException(nameof(kind)),
     };
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCasesRunner/R2RTestRunner.cs
@@ -105,8 +105,13 @@ internal sealed class CrossgenCompilation(string name, List<CrossgenAssembly> as
     /// to avoid colliding with component stubs that crossgen2 creates alongside the composite image.
     /// </summary>
     public string FilePath => _outputDir != null
-        ? Path.Combine(_outputDir, "CG2", Name + (IsComposite ? "-composite" : "") + ".dll")
+        ? Path.Combine(_outputDir, "CG2", Name + (IsComposite ? "-composite" : "") + OutputFileExtension)
         : throw new InvalidOperationException("Output directory not set");
+
+    /// <summary>
+    /// File extension for the crossgen2 output image.
+    /// </summary>
+    public string OutputFileExtension { get; init; } = ".dll";
 
     public void SetOutputDir(string outputDir)
     {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -74,6 +74,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     case Machine.RiscV64:
                         return ((RiscV64.Registers)registerNumber).ToString();
 
+                    case WasmMachine.Wasm32:
+                        throw new NotImplementedException("No implementation for machine type Wasm32.");
                     default:
                         throw new NotImplementedException(machine.ToString());
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
@@ -75,6 +75,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         regType = typeof(RiscV64.Registers);
                         break;
 
+                    case WasmMachine.Wasm32:
+                        throw new NotImplementedException($"No implementation for machine type Wasm32.");
+
                     default:
                         throw new NotImplementedException();
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -86,6 +86,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                     return ((LoongArch64.Registers)regnum).ToString();
                 case Machine.RiscV64:
                     return ((RiscV64.Registers)regnum).ToString();
+                case WasmMachine.Wasm32:
+                    throw new NotImplementedException($"No implementation for machine type {machine}.");
                 default:
                     throw new NotImplementedException($"No implementation for machine type {machine}.");
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -149,6 +149,34 @@ namespace ILCompiler.Reflection.ReadyToRun
                     STACK_BASE_REGISTER_ENCBASE = 2;
                     NUM_REGISTERS_ENCBASE = 3;
                     break;
+                case WasmMachine.Wasm32:
+                    PSP_SYM_STACK_SLOT_ENCBASE = 6;
+                    GENERICS_INST_CONTEXT_STACK_SLOT_ENCBASE = 6;
+                    SECURITY_OBJECT_STACK_SLOT_ENCBASE = 6;
+                    GS_COOKIE_STACK_SLOT_ENCBASE = 6;
+                    CODE_LENGTH_ENCBASE = 6;
+                    STACK_BASE_REGISTER_ENCBASE = 3;
+                    SIZE_OF_STACK_AREA_ENCBASE = 6;
+                    SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA_ENCBASE = 3;
+                    REVERSE_PINVOKE_FRAME_ENCBASE = 6;
+                    NUM_REGISTERS_ENCBASE = 3;
+                    NUM_STACK_SLOTS_ENCBASE = 5;
+                    NUM_UNTRACKED_SLOTS_ENCBASE = 5;
+                    NORM_PROLOG_SIZE_ENCBASE = 4;
+                    NORM_EPILOG_SIZE_ENCBASE = 3;
+                    INTERRUPTIBLE_RANGE_DELTA1_ENCBASE = 5;
+                    INTERRUPTIBLE_RANGE_DELTA2_ENCBASE = 5;
+                    REGISTER_ENCBASE = 3;
+                    REGISTER_DELTA_ENCBASE = REGISTER_ENCBASE;
+                    STACK_SLOT_ENCBASE = 6;
+                    STACK_SLOT_DELTA_ENCBASE = 4;
+                    NUM_SAFE_POINTS_ENCBASE = 4;
+                    NUM_INTERRUPTIBLE_RANGES_ENCBASE = 1;
+                    POINTER_SIZE_ENCBASE = 3;
+                    LIVESTATE_RLE_RUN_ENCBASE = 2;
+                    LIVESTATE_RLE_SKIP_ENCBASE = 4;
+                    break;
+
                 case Machine.I386:
                     CODE_LENGTH_ENCBASE = 6;
                     NORM_PROLOG_SIZE_ENCBASE = 4;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -33,6 +33,11 @@ namespace ILCompiler.Reflection.ReadyToRun
         Unknown = -1
     }
 
+    public static class WasmMachine
+    {
+        public const Machine Wasm32 = (Machine)0xFFFE;
+    }
+
     public struct InstanceMethod
     {
         public byte Bucket;
@@ -683,6 +688,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case Machine.Arm:
                 case Machine.Thumb:
                 case Machine.ArmThumb2:
+                case WasmMachine.Wasm32:
                     _pointerSize = 4;
                     break;
 
@@ -1532,6 +1538,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     {
                         case Machine.I386:
                         case Machine.ArmThumb2:
+                        case WasmMachine.Wasm32:
                             entrySize = 4;
                             break;
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -37,6 +37,9 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case Machine.RiscV64:
                     return RiscV64TransitionBlock.Instance;
 
+                case WasmMachine.Wasm32:
+                    return Wasm32TransitionBlock.Instance;
+
                 default:
                     throw new NotImplementedException();
             }
@@ -97,6 +100,23 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     return OffsetOfArgs + (pos - NumArgumentRegisters) * PointerSize;
                 }
+            }
+        }
+
+        private sealed class Wasm32TransitionBlock : TransitionBlock
+        {
+            public static readonly TransitionBlock Instance = new Wasm32TransitionBlock();
+
+            public override int PointerSize => 4;
+            public override int NumArgumentRegisters => 0;
+            public override int NumCalleeSavedRegisters => 0;
+            // Argument registers, callee-save registers, return address
+            public override int SizeOfTransitionBlock => 8;
+            public override int OffsetOfArgumentRegisters => 0;
+
+            public override int OffsetFromGCRefMapPos(int pos)
+            {
+                return SizeOfTransitionBlock + pos * PointerSize;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/WebcilImageReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/WebcilImageReader.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         private readonly CorFlags _corFlags;
         private readonly DirectoryEntry _managedNativeHeaderDirectory;
 
-        public Machine Machine => Machine.I386; // Webcil doesn't encode machine type; wasm targets use a placeholder
+        public Machine Machine => WasmMachine.Wasm32; // Webcil doesn't encode machine type; wasm targets use a placeholder
         public OperatingSystem OperatingSystem => OperatingSystem.Unknown;
         public ulong ImageBase => 0;
 

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -78,6 +78,8 @@ namespace R2RDump
                 case Machine.RiscV64:
                     target = TargetArch.Target_RiscV64;
                     break;
+                case WasmMachine.Wasm32:
+                    return IntPtr.Zero;
                 default:
                     Program.WriteWarning($"{machine} not supported on CoreDisTools");
                     return IntPtr.Zero;
@@ -187,6 +189,7 @@ namespace R2RDump
                     // to 7 * 3 characters; see https://github.com/dotnet/llilc/blob/master/lib/CoreDisTools/coredistools.cpp.
                     Machine.I386 => 7 * 3,
                     Machine.Amd64 => 7 * 3,
+                    WasmMachine.Wasm32 => 7 * 3,
 
                     // Instructions are either 2 or 4 bytes long
                     Machine.ArmThumb2 => 4 * 3,

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -212,6 +212,7 @@ namespace R2RDump
                     Machine.Arm64 => TargetArchitecture.ARM64,
                     Machine.LoongArch64 => TargetArchitecture.LoongArch64,
                     Machine.RiscV64 => TargetArchitecture.RiscV64,
+                    WasmMachine.Wasm32 => TargetArchitecture.Wasm32,
                     _ => throw new NotImplementedException(r2r.Machine.ToString()),
                 };
                 TargetOS os = r2r.OperatingSystem switch
@@ -466,7 +467,7 @@ namespace R2RDump
                     // parse the ReadyToRun image
                     ReadyToRunReader r2r = new(model, filename);
                     r2r.ValidateDebugInfo = Get(_command.ValidateDebugInfo);
-                    if (disasm && !(r2r.CompositeReader is WebcilImageReader))
+                    if (disasm)
                     {
                         disassembler = new Disassembler(r2r, model);
                     }


### PR DESCRIPTION
Splits the Wasm machine-type plumbing out of #128423 so it can be reviewed and merged on its own.

Previously the R2R reflection/dump code pretended Webcil images were i386. This switches them to a dedicated \`WasmMachine.Wasm32\` so:

- \`WebcilImageReader.Machine\` reports \`Wasm32\` instead of \`I386\`
- \`ReadyToRunReader\`, \`TransitionBlock\`, AMD64 GC info readers, and \`r2rdump\` handle the wasm case explicitly
- The disassembler warning is skipped for wasm (no CoreDisTools support)

Stacked on #128609 — the test commit there is included in this diff until that PR merges; after it merges this PR will rebase down to just the wasm machine-type changes. The Webcil smoke test in #128609 is also updated here to assert \`reader.Machine == WasmMachine.Wasm32\` and to compile methods normally (no \`--compile-no-methods\`).

> [!NOTE]
> This PR description and the code changes were drafted with GitHub Copilot.