### PR TITLE
Reduce contention in UnwindInfoTable seen during high volume LCG method creation

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -380,12 +380,8 @@ Crst SingleUseLock
     AcquiredBefore LoaderHeap UniqueStack DebuggerJitInfo
 End
 
-Crst UnwindInfoTableInitLock
-    AcquiredBefore UnwindInfoTablePublishLock
-End
-
 Crst UnwindInfoTablePublishLock
-    AcquiredAfter SingleUseLock UnwindInfoTableInitLock
+    AcquiredAfter SingleUseLock
     AcquiredBefore UnwindInfoTablePendingLock
 End
 

--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -380,8 +380,12 @@ Crst SingleUseLock
     AcquiredBefore LoaderHeap UniqueStack DebuggerJitInfo
 End
 
+Crst UnwindInfoTableInitLock
+    AcquiredBefore UnwindInfoTablePublishLock
+End
+
 Crst UnwindInfoTablePublishLock
-    AcquiredAfter SingleUseLock
+    AcquiredAfter SingleUseLock UnwindInfoTableInitLock
     AcquiredBefore UnwindInfoTablePendingLock
 End
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -96,8 +96,6 @@ static RtlGrowFunctionTableFnPtr pRtlGrowFunctionTable;
 static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
 
 static bool s_publishingActive;              // Publishing to ETW is turned on
-static Crst* s_pUnwindInfoTablePublishLock;  // Protects main table, OS registration, and lazy init
-static Crst* s_pUnwindInfoTablePendingLock;  // Protects pending buffer only
 
 /****************************************************************************/
 // initialize the entry points for new win8 unwind info publishing functions.
@@ -135,9 +133,10 @@ bool InitUnwindFtns()
 
 /****************************************************************************/
 UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
+    : m_publishLock(CrstUnwindInfoTablePublishLock)
+    , m_pendingLock(CrstUnwindInfoTablePendingLock)
 {
     STANDARD_VM_CONTRACT;
-    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
     _ASSERTE((rangeEnd - rangeStart) <= 0x7FFFFFFF);
 
     // We can choose the average method size estimate dynamically based on past experience
@@ -176,7 +175,8 @@ UnwindInfoTable::~UnwindInfoTable()
 /*****************************************************************************/
 void UnwindInfoTable::Register()
 {
-    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
+    // Caller either holds m_publishLock, or has just constructed this object
+    // and has not yet exposed it to other threads.
 
     NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
     if (ret != STATUS_SUCCESS)
@@ -205,7 +205,7 @@ void UnwindInfoTable::UnRegister()
 
 /*****************************************************************************/
 // Add 'data' entries to the pending buffer for later publication to the OS.
-// When the buffer is full, entries are flushed under s_pUnwindInfoTablePublishLock.
+// When the buffer is full, entries are flushed under m_publishLock.
 //
 void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
 {
@@ -221,7 +221,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
     for (int i = 0; i < count; )
     {
         {
-            CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+            CrstHolder pendingLock(&m_pendingLock);
             while (i < count && cPendingCount < cPendingMaxCount)
             {
                 _ASSERTE(data[i].BeginAddress <= RUNTIME_FUNCTION__EndAddress(&data[i], iRangeStart));
@@ -254,13 +254,13 @@ void UnwindInfoTable::FlushPendingEntries()
     // Free the old table outside the lock
     NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable;
 
-    CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+    CrstHolder publishLock(&m_publishLock);
 
     if (hHandle == NULL)
     {
         // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
         // RtlGrowFunctionTable with a null handle.
-        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+        CrstHolder pendingLock(&m_pendingLock);
         cPendingCount = 0;
         return;
     }
@@ -270,7 +270,7 @@ void UnwindInfoTable::FlushPendingEntries()
     T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
     ULONG localPendingCount;
     {
-        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+        CrstHolder pendingLock(&m_pendingLock);
         localPendingCount = cPendingCount;
         memcpy(localPending, pendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cPendingCount = 0;
@@ -406,7 +406,7 @@ void UnwindInfoTable::FlushPendingEntries()
     // We don't need to check the pending buffer because the method should have already been published
     // before it can be removed.
     {
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+        CrstHolder publishLock(&unwindInfo->m_publishLock);
         for (ULONG i = 0; i < unwindInfo->cTableCurCount; i++)
         {
             if (unwindInfo->pTable[i].BeginAddress <= relativeEntryPoint &&
@@ -442,16 +442,24 @@ void UnwindInfoTable::FlushPendingEntries()
     UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
     if (unwindInfo == NULL)
     {
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-        if (pRS->_pUnwindInfoTable == NULL)
+        // Create a candidate table for this RangeSection and try to install it via CAS.
+        // Any losing thread (if any) deletes its candidate table. This avoids
+        // a process-wide lock on the cold path.
+        NewHolder<UnwindInfoTable> candidate(
+            new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen()));
+        candidate->Register();
+
+        UnwindInfoTable* installed = InterlockedCompareExchangeT(
+            &pRS->_pUnwindInfoTable, candidate.GetValue(), (UnwindInfoTable*)NULL);
+        if (installed == NULL)
         {
-            unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
-            unwindInfo->Register();
-            VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
+            unwindInfo = candidate.Extract();
         }
         else
         {
-            unwindInfo = pRS->_pUnwindInfoTable;
+            // Our candidate will be destroyed by the NewHolder,
+            // which also tears down the OS registration via ~UnwindInfoTable.
+            unwindInfo = installed;
         }
     }
 
@@ -506,9 +514,6 @@ void UnwindInfoTable::FlushPendingEntries()
     if (!InitUnwindFtns())
         return;
 
-    // Create the locks
-    s_pUnwindInfoTablePublishLock = new Crst(CrstUnwindInfoTablePublishLock);
-    s_pUnwindInfoTablePendingLock = new Crst(CrstUnwindInfoTablePendingLock);
     s_publishingActive = true;
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -110,9 +110,23 @@ namespace
     class FlushGateHolder
     {
         volatile LONG* m_pFlag;
+        SRWLOCK* m_pLock;
     public:
-        explicit FlushGateHolder(volatile LONG* pFlag) : m_pFlag(pFlag) {}
-        ~FlushGateHolder() { InterlockedExchange(m_pFlag, 0); }
+        FlushGateHolder(volatile LONG* pFlag, SRWLOCK* pLock) : m_pFlag(pFlag), m_pLock(pLock) {}
+        ~FlushGateHolder()
+        {
+            // We clear the gate under m_flushLock such that threads that called
+            // SleepConditionVariableSRW do not lose the wakeup signal and deadlock.
+            // Both paths execute under the same lock, so if a thread observes
+            // VolatileLoad(&m_flushInProgress) != 0 (has taken the lock), the flushing thread cannot
+            // release the gate and call WakeAllConditionVariable until the first thread actually sleeps
+            // and releases the lock. Otherwise, if the flushing thread releases the gate first,
+            // other threads would observe m_flushInProgress is 0 and continue without sleeping.
+            // Either way, no thread would sleep without a corresponding wakeup, preventing deadlocks.
+            AcquireSRWLockExclusive(m_pLock);
+            InterlockedExchange(m_pFlag, 0);
+            ReleaseSRWLockExclusive(m_pLock);
+        }
 
         FlushGateHolder(const FlushGateHolder&) = delete;
         FlushGateHolder& operator=(const FlushGateHolder&) = delete;
@@ -260,9 +274,7 @@ UnwindInfoTable::~UnwindInfoTable()
 /*****************************************************************************/
 void UnwindInfoTable::Register()
 {
-    // Caller either holds m_publishLock, or has just constructed this object
-    // and has not yet exposed it to other threads.
-
+    // Caller holds m_publishLock.
     NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
     if (ret != STATUS_SUCCESS)
     {
@@ -485,13 +497,17 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
         {
             // Another thread is flushing. Wait until either our entries are
             // published or the gate becomes free.
-            AcquireSRWLockExclusive(&m_flushLock);
+            bool isSequenceReached;
+
+            AcquireSRWLockShared(&m_flushLock);
             while (!SequenceReached(m_publishedSeq, waitForSeq) && VolatileLoad(&m_flushInProgress) != 0)
             {
-                SleepConditionVariableSRW(&m_flushCV, &m_flushLock, INFINITE, 0);
+                SleepConditionVariableSRW(&m_flushCV, &m_flushLock, INFINITE, CONDITION_VARIABLE_LOCKMODE_SHARED);
             }
-            ReleaseSRWLockExclusive(&m_flushLock);
-            if (SequenceReached(m_publishedSeq, waitForSeq))
+            isSequenceReached = SequenceReached(m_publishedSeq, waitForSeq);
+            ReleaseSRWLockShared(&m_flushLock);
+
+            if (isSequenceReached)
                 return;
             // Retry taking the gate.
             continue;
@@ -500,7 +516,7 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
         LONG drainedSeq;
         // Scope the gate holder so m_flushInProgress is reset when the scope exits.
         {
-            FlushGateHolder gateHolder(&m_flushInProgress);
+            FlushGateHolder gateHolder(&m_flushInProgress, &m_flushLock);
             drainedSeq = FlushPendingEntriesUnderGate();
 
             // Update published sequence while still holding the gate.
@@ -512,11 +528,12 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
                 ReleaseSRWLockExclusive(&m_flushLock);
             }
         }
-        // Gate released BEFORE WakeAll. Critical for correctness: if a waiter
-        // wakes while the gate is still held and its seq isn't satisfied, it
-        // could sleep again (see waiter loop above), and we'd never wake it
-        // again. By releasing the gate first, the waiter observes
-        // m_flushInProgress == 0 and can take over the flush itself.
+        // The gate was cleared under m_flushLock by ~FlushGateHolder above, which
+        // prevents waiters from missing this wakeup. Calling WakeAll outside the
+        // lock is intentional: if a waiter wakes while the gate is still held and
+        // its seq isn't satisfied, it could sleep again (see waiter loop above),
+        // and we'd never wake it again. By releasing the gate first, the waiter
+        // observes m_flushInProgress == 0 and can take over the flush itself.
         WakeAllConditionVariable(&m_flushCV);
 
         // drainedSeq could be -1 if registration is still in progress.
@@ -617,10 +634,15 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
             // Other threads that observe the table before Register()
             // completes will accumulate entries in the pending buffer.
             // The first successful flush publishes them.
-            newTable->Register();
-            if (newTable->hHandle == NULL)
+            // We take m_publishLock since FlushPendingEntriesUnderGate
+            // checks hHandle under this same lock.
             {
-                newTable->m_registrationFailed = true;
+                CrstHolder publishLock(&newTable->m_publishLock);
+                newTable->Register();
+                if (newTable->hHandle == NULL)
+                {
+                    newTable->m_registrationFailed = true;
+                }
             }
         }
         // else another thread won. NewHolder frees our unregistered table (no OS call).

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -516,8 +516,17 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     }
 
     LONG drainedSeq;
+    // Ensure waiters are always woken even if FlushPendingEntriesUnderGate throws.
+    struct WakeAllOnExit
+    {
+        CONDITION_VARIABLE* m_pCV;
+        explicit WakeAllOnExit(CONDITION_VARIABLE* pCV) : m_pCV(pCV) {}
+        ~WakeAllOnExit() { WakeAllConditionVariable(m_pCV); }
+    };
+
     // Scope the gate holder so m_flushInProgress is reset when the scope exits.
     {
+        WakeAllOnExit wakeAll(&m_flushCV);
         FlushGateHolder gateHolder(&m_flushInProgress, &m_flushLock);
         drainedSeq = FlushPendingEntriesUnderGate();
 
@@ -526,14 +535,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
         m_publishedSeq = drainedSeq;
         ReleaseSRWLockExclusive(&m_flushLock);
     }
-
-    // The gate was cleared under m_flushLock by ~FlushGateHolder above, which
-    // prevents waiters from missing this wakeup. Calling WakeAll outside the
-    // lock is intentional: if a waiter wakes while the gate is still held and
-    // its seq isn't satisfied, it could sleep again (see waiter loop above),
-    // and we'd never wake it again. By releasing the gate first, the waiter
-    // observes m_flushInProgress == 0 and can take over the flush itself.
-    WakeAllConditionVariable(&m_flushCV);
 
     // Our entries are guaranteed published (drainedSeq >= waitForSeq) since
     // FlushPendingEntriesUnderGate drains all pending entries atomically.

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -375,6 +375,7 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     // Grab the pending entries under the pending lock, then release it so
     // other threads can keep accumulating new entries while we publish.
+    T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
     ULONG localPendingCount;
     LONG drainedSeq;
     {
@@ -385,19 +386,19 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
         if (localPendingCount == 0)
             return drainedSeq;
 
-        memcpy(flushBuffer, pendingTable, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        memcpy(localPending, pendingTable, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cPendingCount = 0;
         INDEBUG( memset(pendingTable, 0xcc, sizeof(pendingTable)); )
     }
 
-    SortPendingByBeginAddress(flushBuffer, localPendingCount);
+    SortPendingByBeginAddress(localPending, localPendingCount);
 
     // Fast path: if all pending entries can be appended in order with room to spare,
     // we can just append and call RtlGrowFunctionTable.
     if (cTableCurCount + localPendingCount <= cTableMaxCount
-        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < flushBuffer[0].BeginAddress))
+        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
     {
-        memcpy(&pTable[cTableCurCount], flushBuffer, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cTableCurCount += localPendingCount;
         pRtlGrowFunctionTable(hHandle, cTableCurCount);
 
@@ -431,9 +432,9 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
             continue;
         }
 
-        if (flushBuffer[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+        if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
         {
-            newPTable[toIdx++] = flushBuffer[pendIdx++];
+            newPTable[toIdx++] = localPending[pendIdx++];
         }
         else
         {
@@ -450,7 +451,7 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     while (pendIdx < localPendingCount)
     {
-        newPTable[toIdx++] = flushBuffer[pendIdx++];
+        newPTable[toIdx++] = localPending[pendIdx++];
     }
 
     _ASSERTE(toIdx == newCount);

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -280,6 +280,7 @@ void UnwindInfoTable::Register()
     {
         _ASSERTE(!"Failed to publish UnwindInfo (ignorable)");
         hHandle = NULL;
+        m_registrationFailed = true;
         STRESS_LOG3(LF_JIT, LL_ERROR, "UnwindInfoTable::Register ERROR %x creating table [%p, %p]\n", ret, iRangeStart, iRangeEnd);
     }
     else
@@ -359,24 +360,12 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     CrstHolder publishLock(&m_publishLock);
 
-    if (hHandle == NULL)
+    if (m_registrationFailed)
     {
-        if (!m_registrationFailed)
-        {
-            Register();
-            if (hHandle == NULL)
-            {
-                m_registrationFailed = true;
-            }
-        }
-
-        if (m_registrationFailed)
-        {
-            // Registration failed permanently. Discard pending entries.
-            CrstHolder pendingLock(&m_pendingLock);
-            cPendingCount = 0;
-            return m_pendingSeq;
-        }
+        // Registration failed permanently. Discard pending entries.
+        CrstHolder pendingLock(&m_pendingLock);
+        cPendingCount = 0;
+        return m_pendingSeq;
     }
 
     // Grab the pending entries under the pending lock, then release it so
@@ -406,7 +395,16 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
     {
         memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cTableCurCount += localPendingCount;
-        pRtlGrowFunctionTable(hHandle, cTableCurCount);
+
+        if (hHandle != NULL)
+        {
+            pRtlGrowFunctionTable(hHandle, cTableCurCount);
+        }
+        else
+        {
+            // Register with entries already populated.
+            Register();
+        }
 
         STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
             hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -97,6 +97,23 @@ static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
 
 static bool s_publishingActive;              // Publishing to ETW is turned on
 
+namespace
+{
+    // RAII helper used by UnwindInfoTable::FlushPendingEntries
+    class FlushGateHolder
+    {
+        UnwindInfoTable* m_pTable;
+    public:
+        explicit FlushGateHolder(UnwindInfoTable* pTable) : m_pTable(pTable) {}
+        ~FlushGateHolder() { m_pTable->ReleaseFlushGate(); }
+
+        FlushGateHolder(const FlushGateHolder&) = delete;
+        FlushGateHolder& operator=(const FlushGateHolder&) = delete;
+        FlushGateHolder(FlushGateHolder&&) = delete;
+        FlushGateHolder& operator=(FlushGateHolder&&) = delete;
+    };
+}
+
 /****************************************************************************/
 // initialize the entry points for new win8 unwind info publishing functions.
 // return true if the initialize is successful (the functions exist)
@@ -155,6 +172,7 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
     hHandle = NULL;
     pTable = new T_RUNTIME_FUNCTION[cTableMaxCount];
     cPendingCount = 0;
+    m_flushInProgress = 0;
 }
 
 /****************************************************************************/
@@ -241,13 +259,13 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
     }
 }
 
-/*****************************************************************************/
-void UnwindInfoTable::FlushPendingEntries()
+void UnwindInfoTable::FlushPendingEntriesUnderGate()
 {
     CONTRACTL
     {
         THROWS;
         GC_TRIGGERS;
+        PRECONDITION(m_flushInProgress != 0);
     }
     CONTRACTL_END;
 
@@ -378,6 +396,46 @@ void UnwindInfoTable::FlushPendingEntries()
     cDeletedEntries = 0;
 
     Register();
+}
+
+/*****************************************************************************/
+void UnwindInfoTable::FlushPendingEntries()
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+    }
+    CONTRACTL_END;
+
+    // This thread attempts to become the sole flusher for this table by taking
+    // the flush gate. If it wins, publish the pending entries, then release the gate,
+    // re-check if more entries arrived and loop if so.
+    while (true)
+    {
+        // Gate: only one thread flushes at a time.
+        if (InterlockedCompareExchange(&m_flushInProgress, 1, 0) != 0)
+        {
+            return;
+        }
+
+        // Scope the gate holder so m_flushInProgress is reset when the scope exits.
+        {
+            FlushGateHolder gateHolder(this);
+            FlushPendingEntriesUnderGate();
+        }
+
+        // Re-check pending table under m_pendingLock.
+        // We only stop the retry loop if we see no more pending entries.
+        // If producer threads enqueued after we determined we should break the loop,
+        // at least one will surely be able to set m_flushInProgress to 1 and publish its entry.
+        bool needRetry;
+        {
+            CrstHolder pendingLock(&m_pendingLock);
+            needRetry = (cPendingCount != 0);
+        }
+        if (!needRetry) return;
+    }
 }
 
 /*****************************************************************************/

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -315,7 +315,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
 
     _ASSERTE(s_publishingActive);
 
-    if (m_registrationFailed)
+    if (VolatileLoad(&m_registrationFailed))
         return;
 
     for (int i = 0; i < count; )

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -190,6 +190,7 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
     pTable = new T_RUNTIME_FUNCTION[cTableMaxCount];
     cPendingCount = 0;
     m_flushInProgress = 0;
+    m_registrationFailed = false;
 }
 
 /****************************************************************************/
@@ -252,6 +253,9 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
     CONTRACTL_END;
 
     _ASSERTE(s_publishingActive);
+
+    if (m_registrationFailed)
+        return;
 
     for (int i = 0; i < count; )
     {
@@ -466,8 +470,8 @@ void UnwindInfoTable::FlushPendingEntries()
         entryPoint, baseAddress, relativeEntryPoint);
 
     // Check the main (published) table under the publish lock.
-    // We don't need to check the pending buffer because the method should have already been published
-    // before it can be removed.
+    // If it wasn't found there, check the pending buffer.
+    // Most removes hit in the published table so this avoids taking the pending lock unnecessarily.
     {
         CrstHolder publishLock(&unwindInfo->m_publishLock);
 
@@ -495,6 +499,22 @@ void UnwindInfoTable::FlushPendingEntries()
                 unwindInfo->pTable[i].UnwindData = 0;        // Mark the entry for deletion
                 STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed entry 0x%x\n", i);
                 return;
+            }
+        }
+
+        // Check the pending buffer while still holding publishLock so the
+        // flusher cannot drain entries out from under us between the two searches.
+        {
+            CrstHolder pendingLock(&unwindInfo->m_pendingLock);
+            for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
+            {
+                if (unwindInfo->pendingTable[i].BeginAddress <= relativeEntryPoint &&
+                    relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pendingTable[i], unwindInfo->iRangeStart))
+                {
+                    unwindInfo->pendingTable[i] = unwindInfo->pendingTable[--unwindInfo->cPendingCount];
+                    STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
+                    return;
+                }
             }
         }
     }
@@ -526,6 +546,10 @@ void UnwindInfoTable::FlushPendingEntries()
         NewHolder<UnwindInfoTable> candidate(
             new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen()));
         candidate->Register();
+        if (candidate->hHandle == NULL)
+        {
+            candidate->m_registrationFailed = true;
+        }
 
         UnwindInfoTable* installed = InterlockedCompareExchangeT(
             &pRS->_pUnwindInfoTable, candidate.GetValue(), (UnwindInfoTable*)NULL);

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -315,7 +315,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
 
     _ASSERTE(s_publishingActive);
 
-    if (VolatileLoad(&m_registrationFailed))
+    if (m_registrationFailed)
         return;
 
     for (int i = 0; i < count; )

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -190,6 +190,9 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
     pTable = new T_RUNTIME_FUNCTION[cTableMaxCount];
     cPendingCount = 0;
     m_flushInProgress = 0;
+    m_pendingSeq = 0;
+    m_publishedSeq = 0;
+    m_flushCompleteEvent.CreateManualEvent(FALSE);
     m_registrationFailed = false;
 }
 
@@ -206,6 +209,7 @@ UnwindInfoTable::~UnwindInfoTable()
     // It would be cleaner if we could take the lock (we did not have to be GC_NOTRIGGER)
     UnRegister();
     delete[] pTable;
+    m_flushCompleteEvent.CloseEvent();
 }
 
 /*****************************************************************************/
@@ -259,6 +263,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
 
     for (int i = 0; i < count; )
     {
+        LONG currentSeq;
         {
             CrstHolder pendingLock(&m_pendingLock);
             while (i < count && cPendingCount < cPendingMaxCount)
@@ -273,14 +278,15 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                     data[i].BeginAddress, cPendingCount);
                 i++;
             }
+            currentSeq = ++m_pendingSeq;
         }
         // Flush any pending entries if we run out of space, or when we are at the end
         // of the batch so the OS can unwind this method immediately.
-        FlushPendingEntries();
+        FlushPendingEntries(currentSeq);
     }
 }
 
-void UnwindInfoTable::FlushPendingEntriesUnderGate()
+LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 {
     CONTRACTL
     {
@@ -301,23 +307,25 @@ void UnwindInfoTable::FlushPendingEntriesUnderGate()
         // RtlGrowFunctionTable with a null handle.
         CrstHolder pendingLock(&m_pendingLock);
         cPendingCount = 0;
-        return;
+        return m_pendingSeq;
     }
 
     // Grab the pending entries under the pending lock, then release it so
     // other threads can keep accumulating new entries while we publish.
     T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
     ULONG localPendingCount;
+    LONG drainedSeq;
     {
         CrstHolder pendingLock(&m_pendingLock);
         localPendingCount = cPendingCount;
         memcpy(localPending, pendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cPendingCount = 0;
+        drainedSeq = m_pendingSeq;
         INDEBUG( memset(pendingTable, 0xcc, sizeof(pendingTable)); )
     }
 
     if (localPendingCount == 0)
-        return;
+        return drainedSeq;
 
     // Sort the pending entries by BeginAddress.
     qsort(localPending, localPendingCount, sizeof(T_RUNTIME_FUNCTION),
@@ -334,7 +342,7 @@ void UnwindInfoTable::FlushPendingEntriesUnderGate()
 
         STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
             hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
-        return;
+        return drainedSeq;
     }
 
     // Merge main table and pending entries.
@@ -405,10 +413,12 @@ void UnwindInfoTable::FlushPendingEntriesUnderGate()
     cDeletedEntries = 0;
 
     Register();
+
+    return drainedSeq;
 }
 
 /*****************************************************************************/
-void UnwindInfoTable::FlushPendingEntries()
+void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
 {
     CONTRACTL
     {
@@ -418,21 +428,40 @@ void UnwindInfoTable::FlushPendingEntries()
     CONTRACTL_END;
 
     // This thread attempts to become the sole flusher for this table by taking
-    // the flush gate. If it wins, publish the pending entries, then release the gate,
+    // the flush gate. If it wins, publish the pending entries, signal waiters,
     // re-check if more entries arrived and loop if so.
+    // If it loses, it waits until its sequence has been published.
     while (true)
     {
         // Gate: only one thread flushes at a time.
         if (InterlockedCompareExchange(&m_flushInProgress, 1, 0) != 0)
         {
+            // Another thread is flushing. Wait until our entries are published.
+            while (m_publishedSeq < waitForSeq)
+            {
+                m_flushCompleteEvent.Wait(INFINITE, FALSE);
+            }
             return;
         }
 
+        // Reset the event so waiters that arrive during our flush
+        // will block until we signal completion.
+        m_flushCompleteEvent.Reset();
+
+        LONG drainedSeq;
         // Scope the gate holder so m_flushInProgress is reset when the scope exits.
         {
             FlushGateHolder gateHolder(this);
-            FlushPendingEntriesUnderGate();
+            drainedSeq = FlushPendingEntriesUnderGate();
+
+            // Update published sequence while still holding the gate.
+            // This ensures no new flusher can start (and Reset the event)
+            // between our update and Set below.
+            m_publishedSeq = drainedSeq;
+            m_flushCompleteEvent.Set();
         }
+
+        _ASSERTE(drainedSeq >= waitForSeq);
 
         // Re-check pending table under m_pendingLock.
         // We only stop the retry loop if we see no more pending entries.

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -335,7 +335,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                     data[i].BeginAddress, cPendingCount);
                 i++;
             }
-            currentSeq = m_pendingSeq.Load() + 1;
+            currentSeq = (LONG)((ULONG)m_pendingSeq.Load() + 1u);
             m_pendingSeq.Store(currentSeq);
         }
         // Flush any pending entries if we run out of space, or when we are at the end

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -361,6 +361,15 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     if (hHandle == NULL)
     {
+        if (!m_registrationFailed)
+        {
+            Register();
+            if (hHandle == NULL)
+            {
+                m_registrationFailed = true;
+            }
+        }
+
         if (m_registrationFailed)
         {
             // Registration failed permanently. Discard pending entries.
@@ -368,9 +377,6 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
             cPendingCount = 0;
             return m_pendingSeq;
         }
-
-        // Registration is still in progress on the winning thread.
-        return -1;
     }
 
     // Grab the pending entries under the pending lock, then release it so
@@ -492,60 +498,48 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     // This thread attempts to become the sole flusher for this table by taking
     // the flush gate. If it wins, publish the pending entries and signal waiters.
     // If it loses, it waits until either its sequence has been published or the gate becomes free.
-    while (true)
+    while (InterlockedCompareExchange(&m_flushInProgress, 1, 0) != 0)
     {
-        // Gate: only one thread flushes at a time.
-        if (InterlockedCompareExchange(&m_flushInProgress, 1, 0) != 0)
+        // Another thread is flushing. Wait until either our entries are
+        // published or the gate becomes free.
+        bool isSequenceReached;
+
+        AcquireSRWLockShared(&m_flushLock);
+        while (!SequenceReached(m_publishedSeq, waitForSeq) && VolatileLoad(&m_flushInProgress) != 0)
         {
-            // Another thread is flushing. Wait until either our entries are
-            // published or the gate becomes free.
-            bool isSequenceReached;
-
-            AcquireSRWLockShared(&m_flushLock);
-            while (!SequenceReached(m_publishedSeq, waitForSeq) && VolatileLoad(&m_flushInProgress) != 0)
-            {
-                SleepConditionVariableSRW(&m_flushCV, &m_flushLock, INFINITE, CONDITION_VARIABLE_LOCKMODE_SHARED);
-            }
-            isSequenceReached = SequenceReached(m_publishedSeq, waitForSeq);
-            ReleaseSRWLockShared(&m_flushLock);
-
-            if (isSequenceReached)
-                return;
-            // Retry taking the gate.
-            continue;
+            SleepConditionVariableSRW(&m_flushCV, &m_flushLock, INFINITE, CONDITION_VARIABLE_LOCKMODE_SHARED);
         }
+        isSequenceReached = SequenceReached(m_publishedSeq, waitForSeq);
+        ReleaseSRWLockShared(&m_flushLock);
 
-        LONG drainedSeq;
-        // Scope the gate holder so m_flushInProgress is reset when the scope exits.
-        {
-            FlushGateHolder gateHolder(&m_flushInProgress, &m_flushLock);
-            drainedSeq = FlushPendingEntriesUnderGate();
-
-            // Update published sequence while still holding the gate.
-            // A return of -1 means registration is still in progress.
-            if (drainedSeq != -1)
-            {
-                AcquireSRWLockExclusive(&m_flushLock);
-                m_publishedSeq = drainedSeq;
-                ReleaseSRWLockExclusive(&m_flushLock);
-            }
-        }
-        // The gate was cleared under m_flushLock by ~FlushGateHolder above, which
-        // prevents waiters from missing this wakeup. Calling WakeAll outside the
-        // lock is intentional: if a waiter wakes while the gate is still held and
-        // its seq isn't satisfied, it could sleep again (see waiter loop above),
-        // and we'd never wake it again. By releasing the gate first, the waiter
-        // observes m_flushInProgress == 0 and can take over the flush itself.
-        WakeAllConditionVariable(&m_flushCV);
-
-        // drainedSeq could be -1 if registration is still in progress.
-        // Our entries are guaranteed published (drainedSeq >= waitForSeq) since
-        // FlushPendingEntriesUnderGate drains all pending entries atomically.
-        // Release the gate and let the next producer take over.
-        _ASSERTE(drainedSeq == -1 || SequenceReached(drainedSeq, waitForSeq));
-        if (drainedSeq != -1)
+        if (isSequenceReached)
             return;
+        // Retry taking the gate.
     }
+
+    LONG drainedSeq;
+    // Scope the gate holder so m_flushInProgress is reset when the scope exits.
+    {
+        FlushGateHolder gateHolder(&m_flushInProgress, &m_flushLock);
+        drainedSeq = FlushPendingEntriesUnderGate();
+
+        // Update published sequence while still holding the gate.
+        AcquireSRWLockExclusive(&m_flushLock);
+        m_publishedSeq = drainedSeq;
+        ReleaseSRWLockExclusive(&m_flushLock);
+    }
+
+    // The gate was cleared under m_flushLock by ~FlushGateHolder above, which
+    // prevents waiters from missing this wakeup. Calling WakeAll outside the
+    // lock is intentional: if a waiter wakes while the gate is still held and
+    // its seq isn't satisfied, it could sleep again (see waiter loop above),
+    // and we'd never wake it again. By releasing the gate first, the waiter
+    // observes m_flushInProgress == 0 and can take over the flush itself.
+    WakeAllConditionVariable(&m_flushCV);
+
+    // Our entries are guaranteed published (drainedSeq >= waitForSeq) since
+    // FlushPendingEntriesUnderGate drains all pending entries atomically.
+    _ASSERTE(SequenceReached(drainedSeq, waitForSeq));
 }
 
 /*****************************************************************************/
@@ -625,27 +619,12 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     if (unwindInfo == NULL)
     {
         // Create the table and try to atomically install it.
-        // Only the winner thread calls Register() so exactly one table
-        // is ever registered with the OS for a given range. This avoids
-        // STATUS_CONFLICTING_ADDRESSES failures.
+        // OS registration is deferred to the first flush in FlushPendingEntriesUnderGate.
         NewHolder<UnwindInfoTable> newTable(new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen()));
 
         if (InterlockedCompareExchangeT(&pRS->_pUnwindInfoTable, newTable.GetValue(), (UnwindInfoTable*)NULL) == NULL)
         {
             newTable.SuppressRelease();
-            // Other threads that observe the table before Register()
-            // completes will accumulate entries in the pending buffer.
-            // The first successful flush publishes them.
-            // We take m_publishLock since FlushPendingEntriesUnderGate
-            // checks hHandle under this same lock.
-            {
-                CrstHolder publishLock(&newTable->m_publishLock);
-                newTable->Register();
-                if (newTable->hHandle == NULL)
-                {
-                    newTable->m_registrationFailed = true;
-                }
-            }
         }
         // else another thread won. NewHolder frees our unregistered table (no OS call).
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -591,10 +591,10 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
         if (lo > 0)
         {
             ULONG i = lo - 1;
-            if (unwindInfo->pTable[i].UnwindData != 0 &&
-                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
+            if (relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
             {
-                unwindInfo->cDeletedEntries++;
+                if (unwindInfo->pTable[i].UnwindData != 0)
+                    unwindInfo->cDeletedEntries++;
                 unwindInfo->pTable[i].UnwindData = 0;        // Mark the entry for deletion
                 STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed entry 0x%x\n", i);
                 return;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -492,10 +492,10 @@ void UnwindInfoTable::FlushPendingEntries()
         if (lo > 0)
         {
             ULONG i = lo - 1;
-            if (relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
+            if (unwindInfo->pTable[i].UnwindData != 0 &&
+                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
             {
-                if (unwindInfo->pTable[i].UnwindData != 0)
-                    unwindInfo->cDeletedEntries++;
+                unwindInfo->cDeletedEntries++;
                 unwindInfo->pTable[i].UnwindData = 0;        // Mark the entry for deletion
                 STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed entry 0x%x\n", i);
                 return;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -563,8 +563,8 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
         entryPoint, baseAddress, relativeEntryPoint);
 
-    // AddToUnwindInfoTable guarantees entries are published before returning,
-    // so the entry must be in the published table by the time we get here.
+    // AddToUnwindInfoTable flushes before returning, so once OS registration has succeeded
+    // the entry should be in the published table by the time we get here.
     {
         CrstHolder publishLock(&unwindInfo->m_publishLock);
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -97,18 +97,22 @@ static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
 
 static bool s_publishingActive;              // Publishing to ETW is turned on
 
-// Lock protecting initialization of UnwindInfoTables.
-static CrstStatic s_unwindInfoInitLock;
-
 namespace
 {
+    // Uses unsigned subtraction to handle sequence counter wrapping correctly.
+    inline bool SequenceReached(LONG published, LONG target)
+    {
+        // published >= target
+        return (LONG)((ULONG)published - (ULONG)target) >= 0;
+    }
+
     // RAII helper used by UnwindInfoTable::FlushPendingEntries
     class FlushGateHolder
     {
-        UnwindInfoTable* m_pTable;
+        volatile LONG* m_pFlag;
     public:
-        explicit FlushGateHolder(UnwindInfoTable* pTable) : m_pTable(pTable) {}
-        ~FlushGateHolder() { m_pTable->ReleaseFlushGate(); }
+        explicit FlushGateHolder(volatile LONG* pFlag) : m_pFlag(pFlag) {}
+        ~FlushGateHolder() { InterlockedExchange(m_pFlag, 0); }
 
         FlushGateHolder(const FlushGateHolder&) = delete;
         FlushGateHolder& operator=(const FlushGateHolder&) = delete;
@@ -116,21 +120,58 @@ namespace
         FlushGateHolder& operator=(FlushGateHolder&&) = delete;
     };
 
-    int __cdecl CompareByBeginAddress(const void* a, const void* b)
+    inline void SortPendingByBeginAddress(T_RUNTIME_FUNCTION* p, ULONG n)
     {
-        CONTRACTL
+        auto cmpSwap = [](T_RUNTIME_FUNCTION& x, T_RUNTIME_FUNCTION& y)
         {
-            NOTHROW;
-            GC_NOTRIGGER;
-            FORBID_FAULT;
-        }
-        CONTRACTL_END;
+            if (y.BeginAddress < x.BeginAddress)
+            {
+                T_RUNTIME_FUNCTION tmp = x;
+                x = y;
+                y = tmp;
+            }
+        };
 
-        DWORD aBegin = ((const T_RUNTIME_FUNCTION*)a)->BeginAddress;
-        DWORD bBegin = ((const T_RUNTIME_FUNCTION*)b)->BeginAddress;
-        if (aBegin < bBegin) return -1;
-        if (aBegin > bBegin) return 1;
-        return 0;
+        if (n <= 1)
+            return;
+
+        if (n == 2)
+        {
+            cmpSwap(p[0], p[1]);
+            return;
+        }
+
+        if (n == 3)
+        {
+            cmpSwap(p[0], p[1]);
+            cmpSwap(p[1], p[2]);
+            cmpSwap(p[0], p[1]);
+            return;
+        }
+
+        if (n == 4)
+        {
+            cmpSwap(p[0], p[1]);
+            cmpSwap(p[2], p[3]);
+            cmpSwap(p[0], p[2]);
+            cmpSwap(p[1], p[3]);
+            cmpSwap(p[1], p[2]);
+            return;
+        }
+
+        // Insertion sort for the remaining sizes.
+        for (ULONG i = 1; i < n; i++)
+        {
+            T_RUNTIME_FUNCTION key = p[i];
+            DWORD keyBegin = key.BeginAddress;
+            ULONG j = i;
+            while (j > 0 && p[j - 1].BeginAddress > keyBegin)
+            {
+                p[j] = p[j - 1];
+                j--;
+            }
+            p[j] = key;
+        }
     }
 }
 
@@ -195,7 +236,8 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
     m_flushInProgress = 0;
     m_pendingSeq = 0;
     m_publishedSeq = 0;
-    m_flushCompleteEvent.CreateManualEvent(FALSE);
+    InitializeSRWLock(&m_flushLock);
+    InitializeConditionVariable(&m_flushCV);
     m_registrationFailed = false;
 }
 
@@ -212,7 +254,7 @@ UnwindInfoTable::~UnwindInfoTable()
     // It would be cleaner if we could take the lock (we did not have to be GC_NOTRIGGER)
     UnRegister();
     delete[] pTable;
-    m_flushCompleteEvent.CloseEvent();
+    // SRWLOCK and CONDITION_VARIABLE require no cleanup.
 }
 
 /*****************************************************************************/
@@ -306,40 +348,43 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     if (hHandle == NULL)
     {
-        // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
-        // RtlGrowFunctionTable with a null handle.
-        CrstHolder pendingLock(&m_pendingLock);
-        cPendingCount = 0;
-        return m_pendingSeq;
+        if (m_registrationFailed)
+        {
+            // Registration failed permanently. Discard pending entries.
+            CrstHolder pendingLock(&m_pendingLock);
+            cPendingCount = 0;
+            return m_pendingSeq;
+        }
+
+        // Registration is still in progress on the winning thread.
+        return -1;
     }
 
     // Grab the pending entries under the pending lock, then release it so
     // other threads can keep accumulating new entries while we publish.
-    T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
     ULONG localPendingCount;
     LONG drainedSeq;
     {
         CrstHolder pendingLock(&m_pendingLock);
         localPendingCount = cPendingCount;
-        memcpy(localPending, pendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
-        cPendingCount = 0;
         drainedSeq = m_pendingSeq;
+
+        if (localPendingCount == 0)
+            return drainedSeq;
+
+        memcpy(flushBuffer, pendingTable, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        cPendingCount = 0;
         INDEBUG( memset(pendingTable, 0xcc, sizeof(pendingTable)); )
     }
 
-    if (localPendingCount == 0)
-        return drainedSeq;
-
-    // Sort the pending entries by BeginAddress.
-    qsort(localPending, localPendingCount, sizeof(T_RUNTIME_FUNCTION),
-          CompareByBeginAddress);
+    SortPendingByBeginAddress(flushBuffer, localPendingCount);
 
     // Fast path: if all pending entries can be appended in order with room to spare,
     // we can just append and call RtlGrowFunctionTable.
     if (cTableCurCount + localPendingCount <= cTableMaxCount
-        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
+        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < flushBuffer[0].BeginAddress))
     {
-        memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        memcpy(&pTable[cTableCurCount], flushBuffer, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cTableCurCount += localPendingCount;
         pRtlGrowFunctionTable(hHandle, cTableCurCount);
 
@@ -359,7 +404,7 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
 
-    // Merge-sort the main table and pending buffer into newPTable.
+    // Merge-sort the main table and flush buffer into newPTable.
     ULONG mainIdx = 0;
     ULONG pendIdx = 0;
     ULONG toIdx = 0;
@@ -373,9 +418,9 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
             continue;
         }
 
-        if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+        if (flushBuffer[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
         {
-            newPTable[toIdx++] = localPending[pendIdx++];
+            newPTable[toIdx++] = flushBuffer[pendIdx++];
         }
         else
         {
@@ -392,7 +437,7 @@ LONG UnwindInfoTable::FlushPendingEntriesUnderGate()
 
     while (pendIdx < localPendingCount)
     {
-        newPTable[toIdx++] = localPending[pendIdx++];
+        newPTable[toIdx++] = flushBuffer[pendIdx++];
     }
 
     _ASSERTE(toIdx == newCount);
@@ -431,51 +476,56 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     CONTRACTL_END;
 
     // This thread attempts to become the sole flusher for this table by taking
-    // the flush gate. If it wins, publish the pending entries, signal waiters,
-    // re-check if more entries arrived and loop if so.
-    // If it loses, it waits until its sequence has been published.
+    // the flush gate. If it wins, publish the pending entries and signal waiters.
+    // If it loses, it waits until either its sequence has been published or the gate becomes free.
     while (true)
     {
         // Gate: only one thread flushes at a time.
         if (InterlockedCompareExchange(&m_flushInProgress, 1, 0) != 0)
         {
-            // Another thread is flushing. Wait until our entries are published.
-            while (m_publishedSeq < waitForSeq)
+            // Another thread is flushing. Wait until either our entries are
+            // published or the gate becomes free.
+            AcquireSRWLockExclusive(&m_flushLock);
+            while (!SequenceReached(m_publishedSeq, waitForSeq) && VolatileLoad(&m_flushInProgress) != 0)
             {
-                m_flushCompleteEvent.Wait(INFINITE, FALSE);
+                SleepConditionVariableSRW(&m_flushCV, &m_flushLock, INFINITE, 0);
             }
-            return;
+            ReleaseSRWLockExclusive(&m_flushLock);
+            if (SequenceReached(m_publishedSeq, waitForSeq))
+                return;
+            // Retry taking the gate.
+            continue;
         }
-
-        // Reset the event so waiters that arrive during our flush
-        // will block until we signal completion.
-        m_flushCompleteEvent.Reset();
 
         LONG drainedSeq;
         // Scope the gate holder so m_flushInProgress is reset when the scope exits.
         {
-            FlushGateHolder gateHolder(this);
+            FlushGateHolder gateHolder(&m_flushInProgress);
             drainedSeq = FlushPendingEntriesUnderGate();
 
             // Update published sequence while still holding the gate.
-            // This ensures no new flusher can start (and Reset the event)
-            // between our update and Set below.
-            m_publishedSeq = drainedSeq;
-            m_flushCompleteEvent.Set();
+            // A return of -1 means registration is still in progress.
+            if (drainedSeq != -1)
+            {
+                AcquireSRWLockExclusive(&m_flushLock);
+                m_publishedSeq = drainedSeq;
+                ReleaseSRWLockExclusive(&m_flushLock);
+            }
         }
+        // Gate released BEFORE WakeAll. Critical for correctness: if a waiter
+        // wakes while the gate is still held and its seq isn't satisfied, it
+        // could sleep again (see waiter loop above), and we'd never wake it
+        // again. By releasing the gate first, the waiter observes
+        // m_flushInProgress == 0 and can take over the flush itself.
+        WakeAllConditionVariable(&m_flushCV);
 
-        _ASSERTE(drainedSeq >= waitForSeq);
-
-        // Re-check pending table under m_pendingLock.
-        // We only stop the retry loop if we see no more pending entries.
-        // If producer threads enqueued after we determined we should break the loop,
-        // at least one will surely be able to set m_flushInProgress to 1 and publish its entry.
-        bool needRetry;
-        {
-            CrstHolder pendingLock(&m_pendingLock);
-            needRetry = (cPendingCount != 0);
-        }
-        if (!needRetry) return;
+        // drainedSeq could be -1 if registration is still in progress.
+        // Our entries are guaranteed published (drainedSeq >= waitForSeq) since
+        // FlushPendingEntriesUnderGate drains all pending entries atomically.
+        // Release the gate and let the next producer take over.
+        _ASSERTE(drainedSeq == -1 || SequenceReached(drainedSeq, waitForSeq));
+        if (drainedSeq != -1)
+            return;
     }
 }
 
@@ -555,18 +605,27 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
     if (unwindInfo == NULL)
     {
-        CrstHolder lock(&s_unwindInfoInitLock);
-        unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
-        if (unwindInfo == NULL)
+        // Create the table and try to atomically install it.
+        // Only the winner thread calls Register() so exactly one table
+        // is ever registered with the OS for a given range. This avoids
+        // STATUS_CONFLICTING_ADDRESSES failures.
+        NewHolder<UnwindInfoTable> newTable(new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen()));
+
+        if (InterlockedCompareExchangeT(&pRS->_pUnwindInfoTable, newTable.GetValue(), (UnwindInfoTable*)NULL) == NULL)
         {
-            unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
-            unwindInfo->Register();
-            if (unwindInfo->hHandle == NULL)
+            newTable.SuppressRelease();
+            // Other threads that observe the table before Register()
+            // completes will accumulate entries in the pending buffer.
+            // The first successful flush publishes them.
+            newTable->Register();
+            if (newTable->hHandle == NULL)
             {
-                unwindInfo->m_registrationFailed = true;
+                newTable->m_registrationFailed = true;
             }
-            VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
         }
+        // else another thread won. NewHolder frees our unregistered table (no OS call).
+
+        unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
     }
 
     unwindInfo->AddToUnwindInfoTable(methodUnwindData, methodUnwindDataCount);
@@ -620,7 +679,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     if (!InitUnwindFtns())
         return;
 
-    s_unwindInfoInitLock.Init(CrstUnwindInfoTableInitLock);
     s_publishingActive = true;
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -112,6 +112,23 @@ namespace
         FlushGateHolder(FlushGateHolder&&) = delete;
         FlushGateHolder& operator=(FlushGateHolder&&) = delete;
     };
+
+    int __cdecl CompareByBeginAddress(const void* a, const void* b)
+    {
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+            FORBID_FAULT;
+        }
+        CONTRACTL_END;
+
+        DWORD aBegin = ((const T_RUNTIME_FUNCTION*)a)->BeginAddress;
+        DWORD bBegin = ((const T_RUNTIME_FUNCTION*)b)->BeginAddress;
+        if (aBegin < bBegin) return -1;
+        if (aBegin > bBegin) return 1;
+        return 0;
+    }
 }
 
 /****************************************************************************/
@@ -299,20 +316,8 @@ void UnwindInfoTable::FlushPendingEntriesUnderGate()
         return;
 
     // Sort the pending entries by BeginAddress.
-    // Use a simple insertion sort since cPendingMaxCount is small (32).
-    static_assert(cPendingMaxCount == 32,
-        "cPendingMaxCount was updated and might be too large for insertion sort, consider using a better algorithm");
-    for (ULONG i = 1; i < localPendingCount; i++)
-    {
-        T_RUNTIME_FUNCTION key = localPending[i];
-        ULONG j = i;
-        while (j > 0 && localPending[j - 1].BeginAddress > key.BeginAddress)
-        {
-            localPending[j] = localPending[j - 1];
-            j--;
-        }
-        localPending[j] = key;
-    }
+    qsort(localPending, localPendingCount, sizeof(T_RUNTIME_FUNCTION),
+          CompareByBeginAddress);
 
     // Fast path: if all pending entries can be appended in order with room to spare,
     // we can just append and call RtlGrowFunctionTable.
@@ -465,10 +470,25 @@ void UnwindInfoTable::FlushPendingEntries()
     // before it can be removed.
     {
         CrstHolder publishLock(&unwindInfo->m_publishLock);
-        for (ULONG i = 0; i < unwindInfo->cTableCurCount; i++)
+
+        // pTable is kept sorted by BeginAddress. Soft-deleted entries keep their BeginAddress
+        // intact, so the array remains sorted across removes. Binary search for the largest index
+        // with BeginAddress <= relativeEntryPoint, then check against EndAddress.
+        ULONG lo = 0;
+        ULONG hi = unwindInfo->cTableCurCount;
+        while (lo < hi)
         {
-            if (unwindInfo->pTable[i].BeginAddress <= relativeEntryPoint &&
-                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
+            ULONG mid = lo + (hi - lo) / 2;
+            if (unwindInfo->pTable[mid].BeginAddress <= relativeEntryPoint)
+                lo = mid + 1;
+            else
+                hi = mid;
+        }
+
+        if (lo > 0)
+        {
+            ULONG i = lo - 1;
+            if (relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
             {
                 if (unwindInfo->pTable[i].UnwindData != 0)
                     unwindInfo->cDeletedEntries++;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -97,6 +97,9 @@ static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
 
 static bool s_publishingActive;              // Publishing to ETW is turned on
 
+// Lock protecting initialization of UnwindInfoTables.
+static CrstStatic s_unwindInfoInitLock;
+
 namespace
 {
     // RAII helper used by UnwindInfoTable::FlushPendingEntries
@@ -278,7 +281,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                     data[i].BeginAddress, cPendingCount);
                 i++;
             }
-            currentSeq = ++m_pendingSeq;
+            currentSeq = m_pendingSeq = m_pendingSeq + 1;
         }
         // Flush any pending entries if we run out of space, or when we are at the end
         // of the batch so the OS can unwind this method immediately.
@@ -498,9 +501,8 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
         entryPoint, baseAddress, relativeEntryPoint);
 
-    // Check the main (published) table under the publish lock.
-    // If it wasn't found there, check the pending buffer.
-    // Most removes hit in the published table so this avoids taking the pending lock unnecessarily.
+    // AddToUnwindInfoTable guarantees entries are published before returning,
+    // so the entry must be in the published table by the time we get here.
     {
         CrstHolder publishLock(&unwindInfo->m_publishLock);
 
@@ -530,22 +532,6 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
                 return;
             }
         }
-
-        // Check the pending buffer while still holding publishLock so the
-        // flusher cannot drain entries out from under us between the two searches.
-        {
-            CrstHolder pendingLock(&unwindInfo->m_pendingLock);
-            for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
-            {
-                if (unwindInfo->pendingTable[i].BeginAddress <= relativeEntryPoint &&
-                    relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pendingTable[i], unwindInfo->iRangeStart))
-                {
-                    unwindInfo->pendingTable[i] = unwindInfo->pendingTable[--unwindInfo->cPendingCount];
-                    STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
-                    return;
-                }
-            }
-        }
     }
 
     STRESS_LOG2(LF_JIT, LL_WARNING, "RemoveFromUnwindInfoTable COULD NOT FIND %p BaseAddress %p\n",
@@ -569,28 +555,17 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
     if (unwindInfo == NULL)
     {
-        // Create a candidate table for this RangeSection and try to install it via CAS.
-        // Any losing thread (if any) deletes its candidate table. This avoids
-        // a process-wide lock on the cold path.
-        NewHolder<UnwindInfoTable> candidate(
-            new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen()));
-        candidate->Register();
-        if (candidate->hHandle == NULL)
+        CrstHolder lock(&s_unwindInfoInitLock);
+        unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
+        if (unwindInfo == NULL)
         {
-            candidate->m_registrationFailed = true;
-        }
-
-        UnwindInfoTable* installed = InterlockedCompareExchangeT(
-            &pRS->_pUnwindInfoTable, candidate.GetValue(), (UnwindInfoTable*)NULL);
-        if (installed == NULL)
-        {
-            unwindInfo = candidate.Extract();
-        }
-        else
-        {
-            // Our candidate will be destroyed by the NewHolder,
-            // which also tears down the OS registration via ~UnwindInfoTable.
-            unwindInfo = installed;
+            unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
+            unwindInfo->Register();
+            if (unwindInfo->hHandle == NULL)
+            {
+                unwindInfo->m_registrationFailed = true;
+            }
+            VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
         }
     }
 
@@ -645,6 +620,7 @@ void UnwindInfoTable::FlushPendingEntries(LONG waitForSeq)
     if (!InitUnwindFtns())
         return;
 
+    s_unwindInfoInitLock.Init(CrstUnwindInfoTableInitLock);
     s_publishingActive = true;
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -335,7 +335,8 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                     data[i].BeginAddress, cPendingCount);
                 i++;
             }
-            currentSeq = m_pendingSeq = m_pendingSeq + 1;
+            currentSeq = m_pendingSeq.Load() + 1;
+            m_pendingSeq.Store(currentSeq);
         }
         // Flush any pending entries if we run out of space, or when we are at the end
         // of the batch so the OS can unwind this method immediately.

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -669,7 +669,7 @@ private:
     // Whether initial OS registration failed, used to return early in AddToUnwindInfoTable.
     // We cannot just check if hHandle is null because it's temporarily set to NULL
     // during the flusher's merge path.
-    bool                m_registrationFailed;
+    Volatile<bool>      m_registrationFailed;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -632,6 +632,9 @@ private:
     void Register();
     UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd);
 
+public:
+    void ReleaseFlushGate() { InterlockedExchange(&m_flushInProgress, 0); }
+
 private:
     void FlushPendingEntries();
 
@@ -654,6 +657,8 @@ private:
     // independent RangeSections can publish/unpublish concurrently.
     Crst                m_publishLock; // Protects the main table and OS registration.
     Crst                m_pendingLock; // Protects the pending table only.
+
+    Volatile<LONG>      m_flushInProgress;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -660,6 +660,11 @@ private:
     Crst                m_pendingLock; // Protects the pending table only.
 
     Volatile<LONG>      m_flushInProgress;
+
+    // Whether initial OS registration failed, used to return early in AddToUnwindInfoTable.
+    // We cannot just check if hHandle is null because it's temporarily set to NULL
+    // during the flusher's merge path.
+    bool                m_registrationFailed;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -637,6 +637,7 @@ public:
 
 private:
     void FlushPendingEntries();
+    void FlushPendingEntriesUnderGate();
 
     PVOID               hHandle;          // OS handle for a published RUNTIME_FUNCTION table
     ULONG_PTR           iRangeStart;      // Start of memory described by this table

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -636,8 +636,8 @@ public:
     void ReleaseFlushGate() { InterlockedExchange(&m_flushInProgress, 0); }
 
 private:
-    void FlushPendingEntries();
-    void FlushPendingEntriesUnderGate();
+    void FlushPendingEntries(LONG waitForSeq);
+    LONG FlushPendingEntriesUnderGate();
 
     PVOID               hHandle;          // OS handle for a published RUNTIME_FUNCTION table
     ULONG_PTR           iRangeStart;      // Start of memory described by this table
@@ -660,6 +660,12 @@ private:
     Crst                m_pendingLock; // Protects the pending table only.
 
     Volatile<LONG>      m_flushInProgress;
+
+    // Sequence counters used to ensure callers wait until their entries are
+    // published to the OS before returning
+    Volatile<LONG>      m_pendingSeq;
+    Volatile<LONG>      m_publishedSeq;
+    CLREvent            m_flushCompleteEvent;
 
     // Whether initial OS registration failed, used to return early in AddToUnwindInfoTable.
     // We cannot just check if hHandle is null because it's temporarily set to NULL

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -650,7 +650,7 @@ private:
     // Pending buffer for out-of-order entries that haven't been published to the OS yet.
     // These entries are accumulated and batch-merged into pTable to amortize the cost of
     // RtlDeleteGrowableFunctionTable + RtlAddGrowableFunctionTable.
-    static const ULONG  cPendingMaxCount = 32;
+    static const ULONG  cPendingMaxCount = 128;
     T_RUNTIME_FUNCTION  pendingTable[cPendingMaxCount];
     ULONG               cPendingCount;
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -649,6 +649,11 @@ private:
     static const ULONG  cPendingMaxCount = 32;
     T_RUNTIME_FUNCTION  pendingTable[cPendingMaxCount];
     ULONG               cPendingCount;
+
+    // Per-table locks. Each UnwindInfoTable corresponds to one RangeSection, and
+    // independent RangeSections can publish/unpublish concurrently.
+    Crst                m_publishLock; // Protects the main table and OS registration.
+    Crst                m_pendingLock; // Protects the pending table only.
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -632,9 +632,6 @@ private:
     void Register();
     UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd);
 
-public:
-    void ReleaseFlushGate() { InterlockedExchange(&m_flushInProgress, 0); }
-
 private:
     void FlushPendingEntries(LONG waitForSeq);
     LONG FlushPendingEntriesUnderGate();
@@ -650,9 +647,12 @@ private:
     // Pending buffer for out-of-order entries that haven't been published to the OS yet.
     // These entries are accumulated and batch-merged into pTable to amortize the cost of
     // RtlDeleteGrowableFunctionTable + RtlAddGrowableFunctionTable.
-    static const ULONG  cPendingMaxCount = 128;
+    static const ULONG  cPendingMaxCount = 32;
     T_RUNTIME_FUNCTION  pendingTable[cPendingMaxCount];
     ULONG               cPendingCount;
+
+    // Pre-allocated flush buffer.
+    T_RUNTIME_FUNCTION  flushBuffer[cPendingMaxCount];
 
     // Per-table locks. Each UnwindInfoTable corresponds to one RangeSection, and
     // independent RangeSections can publish/unpublish concurrently.
@@ -662,10 +662,12 @@ private:
     Volatile<LONG>      m_flushInProgress;
 
     // Sequence counters used to ensure callers wait until their entries are
-    // published to the OS before returning
+    // published to the OS before returning.
+    // m_flushLock + m_flushCV form a lightweight condition variable pair.
     Volatile<LONG>      m_pendingSeq;
-    Volatile<LONG>      m_publishedSeq;
-    CLREvent            m_flushCompleteEvent;
+    LONG                m_publishedSeq;   // Protected by m_flushLock.
+    SRWLOCK             m_flushLock;
+    CONDITION_VARIABLE  m_flushCV;
 
     // Whether initial OS registration failed, used to return early in AddToUnwindInfoTable.
     // We cannot just check if hHandle is null because it's temporarily set to NULL

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -651,9 +651,6 @@ private:
     T_RUNTIME_FUNCTION  pendingTable[cPendingMaxCount];
     ULONG               cPendingCount;
 
-    // Pre-allocated flush buffer.
-    T_RUNTIME_FUNCTION  flushBuffer[cPendingMaxCount];
-
     // Per-table locks. Each UnwindInfoTable corresponds to one RangeSection, and
     // independent RangeSections can publish/unpublish concurrently.
     Crst                m_publishLock; // Protects the main table and OS registration.

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -928,7 +928,8 @@ bool DynamicMethodDesc::TryDestroy()
 void LCGMethodResolver::Reset()
 {
     m_DynamicStringLiterals = NULL;
-    m_DynamicCodePointers   = NULL;
+    m_initialCodePointer    = {};
+    m_DynamicCodePointers   = &m_initialCodePointer;
     m_UsedIndCellList       = NULL;
     m_pJumpStubCache        = NULL;
     m_next                  = NULL;
@@ -1583,10 +1584,14 @@ void** LCGMethodResolver::AllocateRecordCodePointer()
     }
     CONTRACTL_END;
 
-    DynamicCodePointer* codePointer = (DynamicCodePointer*)m_jitTempData.New(sizeof(DynamicCodePointer));
-    *codePointer = {};
-    codePointer->m_pNext = m_DynamicCodePointers;
-    m_DynamicCodePointers = codePointer;
+    DynamicCodePointer* codePointer = &m_initialCodePointer;
+    if (codePointer->m_pEntry != NULL)
+    {
+        codePointer = (DynamicCodePointer*)m_jitTempData.New(sizeof(DynamicCodePointer));
+        *codePointer = {};
+        codePointer->m_pNext = m_DynamicCodePointers;
+        m_DynamicCodePointers = codePointer;
+    }
 
     return &codePointer->m_pEntry;
 }

--- a/src/coreclr/vm/dynamicmethod.h
+++ b/src/coreclr/vm/dynamicmethod.h
@@ -142,6 +142,8 @@ public:
     LCGMethodResolver(DynamicMethodDesc* pDynamicMethod, DynamicMethodTable* pDynamicMethodTable)
         : m_pDynamicMethod{ pDynamicMethod }
         , m_pDynamicMethodTable{ pDynamicMethodTable }
+        , m_initialCodePointer{}
+        , m_DynamicCodePointers{ &m_initialCodePointer }
     {
         LIMITED_METHOD_CONTRACT;
     }
@@ -227,6 +229,10 @@ private:
     DynamicMethodDesc* m_next;
     ChunkAllocator m_jitMetaHeap;
     ChunkAllocator m_jitTempData;
+    // m_DynamicCodePointers has its entries allocated in chunks (via m_jitTempData).
+    // Having a field for the initial code pointer avoids the chunk allocation in the common
+    // case of a single code pointer. We want to avoid allocations while taking m_CodeHeapLock to reduce contention.
+    DynamicCodePointer m_initialCodePointer;
     DynamicCodePointer* m_DynamicCodePointers;
     DynamicStringLiteral* m_DynamicStringLiterals;
     IndCellList* m_UsedIndCellList;    // list to keep track of all the indirection cells used by the jitted code


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/123124.

Changes:
- Adds an initial code pointer to `m_DynamicCodePointers` in `LCGMethodResolver`. In most cases the list will contain exactly one pointer but if it starts empty, it does a chunk allocation while taking a lock. The initial pointer avoids that unnecessary chunk allocation for most cases.
- Adds a publish and pending lock per unwind info table rather than using global locks.
- Reduces contention on the publish lock as it's not mandatory for every thread to take the publish lock now. Instead, threads wait for the flusher thread to finish and if it already published its entries, just returns. Otherwise, attempts to become the flusher thread. Several threads never take the publish lock as that work is deferred to other threads.
- Uses swaps to sort pending tables when their size is <= 4.
- Removes entries using binary search instead of linear search.
- Adds a registration failed flag to early-return in `AddToUnwindInfoTable` to avoid taking locks unnecessarily.

I used both the original xUnit test with 30k methods mentioned in the issue and a separate benchmark that stresses LCG method creation to test these changes. I mostly used the LCG benchmark to investigate this since .NET 10 runs ~150% slower than .NET 9 so it was easier to spot if changes were helpful or not.

For the measurements, I built from release/9.0, release/10.0 and release/10.0 + the changes in this PR since the goal is to backport to net 10.

LCG Stress Benchmark (300K methods)

<details>
<summary>LCG stress benchmark code</summary>

```csharp
using System;
using System.Collections.Concurrent;
using System.Collections.Generic;
using System.Diagnostics;
using System.Linq.Expressions;
using System.Threading;
using System.Threading.Tasks;

internal static class Program
{
    private static int Main(string[] args)
    {
        int totalMethods   = args.Length > 0 ? int.Parse(args[0])   : 300_000;
        int testsPerClass  = args.Length > 1 ? int.Parse(args[1])   : 3;
        int threads        = Environment.ProcessorCount;

        Console.WriteLine($"totalMethods={totalMethods} testsPerClass={testsPerClass} threads={threads}");

        var sw = Stopwatch.StartNew();
        Run(totalMethods, threads, testsPerClass);
        sw.Stop();

        Console.WriteLine($"Elapsed: {sw.Elapsed.TotalSeconds:F3} s ");
        return 0;
    }

    private static void Run(int totalMethods, int threads, int testsPerClass)
    {
        Func<int, Func<int, int>> compileBody = k => CompileTestBody(k);
        int classCount = Math.Max(1, totalMethods / testsPerClass);
        var queue = new ConcurrentQueue<int>();
        for (int i = 0; i < classCount; i++) queue.Enqueue(i);

        var workers = new Task[threads];
        for (int w = 0; w < threads; w++)
        {
            workers[w] = Task.Factory.StartNew(() =>
            {
                int seed = 0;
                var classScope = new List<Func<int, int>>(capacity: testsPerClass);

                while (queue.TryDequeue(out int classIndex))
                {
                    classScope.Clear();

                    for (int i = 0; i < testsPerClass; i++)
                    {
                        Func<int, int> formatter = CompileFormatter(seed++);
                        int arg = formatter(classIndex + i);

                        Func<int, int> testBody = compileBody(seed++);
                        testBody(arg);
                        // testBody.DynamicInvoke(arg);

                        classScope.Add(testBody);
                    }

                }
            }, TaskCreationOptions.LongRunning);
        }

        Task.WaitAll(workers);
    }

    private static Func<int, int> CompileFormatter(int k)
    {
        var x = Expression.Parameter(typeof(int), "x");
        Expression body = Expression.ExclusiveOr(x, Expression.Constant(k));
        return Expression.Lambda<Func<int, int>>(body, x).Compile();
    }

    private static Func<int, int> CompileTestBody(int k)
    {
        var x = Expression.Parameter(typeof(int), "x");
        Expression body = Expression.Add(
            Expression.Multiply(x, Expression.Constant(k | 1)),
            Expression.Constant(k));
        body = Expression.Condition(
            Expression.GreaterThan(x, Expression.Constant(0)),
            body,
            Expression.Negate(body));
        return Expression.Lambda<Func<int, int>>(body, x).Compile();
    }
}
```

</details>


| Workload | .NET 9 | .NET 10 | .NET 10 + this PR |
| --- | ---: | ---: | ---: |
| Time (s) | 4.782 | 12.868 | 7.177 |
| vs .NET 9 | - | +169 % | +50 % |
| vs .NET 10 | - | - | -44 % |

Original regression was considerably slower. Still slower than .NET 9 but at the same time I'm dubious if it's a realistic scenario.

Original xUnit Benchmark (30K methods)

| Workload | .NET 9 | .NET 10 | .NET 10 + this PR |
| --- | ---: | ---: | ---: |
| Time (s) | 2.053 | 2.772 | 2.181 |
| vs .NET 9 | - | +35 % | +6 % |
| vs .NET 10 | - | - | -21 % |

Original regression was ~30%. The original benchmark now runs slower than .NET 9 but much better than before.

