### PR TITLE
Add Windows API needed by SafeProcessHandle to WindowsAPIs.txt

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
+++ b/src/coreclr/nativeaot/BuildIntegration/WindowsAPIs.txt
@@ -51,6 +51,7 @@ advapi32!CreatePrivateObjectSecurityEx
 advapi32!CreatePrivateObjectSecurityWithMultipleInheritance
 advapi32!CreateProcessAsUserA
 advapi32!CreateProcessAsUserW
+advapi32!CreateProcessWithLogonW
 advapi32!CreateRestrictedToken
 advapi32!CreateServiceA
 advapi32!CreateServiceW
@@ -819,6 +820,7 @@ kernel32!AllocateUserPhysicalPages
 kernel32!AllocateUserPhysicalPagesNuma
 kernel32!AllocConsole
 kernel32!AreFileApisANSI
+kernel32!AssignProcessToJobObject
 kernel32!AttachConsole
 kernel32!Beep
 kernel32!CallbackMayRunLong
@@ -866,6 +868,8 @@ kernel32!CreateFileW
 kernel32!CreateHardLinkA
 kernel32!CreateHardLinkW
 kernel32!CreateIoCompletionPort
+kernel32!CreateJobObjectA
+kernel32!CreateJobObjectW
 kernel32!CreateMemoryResourceNotification
 kernel32!CreateMutexA
 kernel32!CreateMutexExA
@@ -1415,6 +1419,7 @@ kernel32!SetFileValidData
 kernel32!SetFirmwareEnvironmentVariableA
 kernel32!SetFirmwareEnvironmentVariableW
 kernel32!SetHandleInformation
+kernel32!SetInformationJobObject
 kernel32!SetLastError
 kernel32!SetLocaleInfoW
 kernel32!SetLocalTime


### PR DESCRIPTION
Shrinks `SafeProcessHandle.Start(new ProcessStartInfo("whoami")).WaitForExit()` with native AOT from 1 MB to 972 KB.

The savings come from elimination of the LoadLibrary/GetProcAddress support (with all the `NativeLibrary.SetDllImportResolver`, `DefaultDllImportSearchPathsAttribute`, etc. support). The APIs are now a hard import resolved by the OS before the program starts.

Cc @adamsitnik 