### PR TITLE
Extend timeout of libs legs in nativeaot-outerloop

### DIFF
--- a/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
+++ b/eng/pipelines/coreclr/runtime-nativeaot-outerloop.yml
@@ -71,7 +71,7 @@ extends:
             isSingleFile: true
             nameSuffix: NativeAOT_Libs
             buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) /p:TestNativeAot=true /p:ArchiveTests=true /p:IlcUseServerGc=false /p:RunAnalyzers=false
-            timeoutInMinutes: 300 # doesn't normally take this long, but I've seen Helix queues backed up for 160 minutes
+            timeoutInMinutes: 360 # doesn't normally take this long, but I've seen Helix queues backed up for 160 minutes
             includeAllPlatforms: true
             # extra steps, run tests
             postBuildSteps:
@@ -122,7 +122,7 @@ extends:
             isSingleFile: true
             nameSuffix: NativeAOT_Checked_Libs_SizeOpt
             buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Size /p:IlcUseServerGc=false /p:RunAnalyzers=false
-            timeoutInMinutes: 300
+            timeoutInMinutes: 360
             # extra steps, run tests
             postBuildSteps:
               - template: /eng/pipelines/libraries/helix.yml
@@ -147,7 +147,7 @@ extends:
             isSingleFile: true
             nameSuffix: NativeAOT_Checked_Libs_SpeedOpt
             buildArgs: -s clr.aot+host.native+libs+libs.tests -c $(_BuildConfig) -rc Checked /p:TestNativeAot=true /p:ArchiveTests=true /p:OptimizationPreference=Speed /p:IlcUseServerGc=false /p:RunAnalyzers=false
-            timeoutInMinutes: 300
+            timeoutInMinutes: 360
             # extra steps, run tests
             postBuildSteps:
               - template: /eng/pipelines/libraries/helix.yml


### PR DESCRIPTION
Product & test build takes around 3 hours. If Helix is backed up enough, it can take 2+ hours to process these workitems. Clicking through the past few outerloop runs, this is the number 1 reason when they're red.