### PR TITLE
[Android] Fix X509Store cleanup

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -575,17 +575,14 @@ namespace System.Security.Cryptography.X509Certificates
 
         public void Dispose()
         {
-            if (_privateKey != null)
-            {
-                _privateKey.Dispose();
-                _privateKey = null;
-            }
+            _privateKey?.Dispose();
+            _privateKey = null;
 
-            if (_cert != null)
-            {
-                _cert.Dispose();
-                _cert = null!;
-            }
+            _keyStorePrivateKeyEntry?.Dispose();
+            _keyStorePrivateKeyEntry = null;
+
+            _cert?.Dispose();
+            _cert = null!;
         }
 
         public byte[] Export(X509ContentType contentType, SafePasswordHandle password)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -273,6 +273,7 @@ EnumerateCertificates(JNIEnv* env, jobject /*KeyStore*/ store, EnumCertificatesC
     //     }
     // }
     jboolean hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     while (hasNext)
     {
         INIT_LOCALS(loc, alias, entry, cert, publicKey, privateKey);
@@ -311,6 +312,7 @@ EnumerateCertificates(JNIEnv* env, jobject /*KeyStore*/ store, EnumCertificatesC
         RELEASE_LOCALS(loc, env);
 
         hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
+        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }
 
     ret = SUCCESS;
@@ -365,6 +367,7 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     //     }
     // }
     jboolean hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     while (hasNext)
     {
         jstring alias = (*env)->CallObjectMethod(env, aliases, g_EnumerationNextElement);
@@ -373,17 +376,24 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
         if (filter == NULL || filter(env, alias))
         {
             jobject cert = (*env)->CallObjectMethod(env, store, g_KeyStoreGetCertificate, alias);
-            if (cert != NULL && !CheckJNIExceptions(env))
+            if (cert != NULL)
             {
-                cert = ToGRef(env, cert);
-                cb(cert, context);
+                if (CheckJNIExceptions(env))
+                {
+                    (*env)->DeleteLocalRef(env, cert);
+                }
+                else
+                {
+                    cert = ToGRef(env, cert);
+                    cb(cert, context);
+                }
             }
         }
 
-        hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
-
     loop_cleanup:
         (*env)->DeleteLocalRef(env, alias);
+        hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
+        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }
 
     ret = SUCCESS;
@@ -431,8 +441,11 @@ jobject /*KeyStore*/ AndroidCryptoNative_X509StoreOpenDefault(void)
     (*env)->CallVoidMethod(env, store, g_KeyStoreLoad, NULL, NULL);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     ret = ToGRef(env, store);
+    // ToGRef deletes the input local reference.
+    store = NULL;
 
 cleanup:
+    ReleaseLRef(env, store);
     (*env)->DeleteLocalRef(env, storeType);
     return ret;
 }
@@ -449,6 +462,7 @@ int32_t AndroidCryptoNative_X509StoreRemoveCertificate(jobject /*KeyStore*/ stor
     if (!ContainsMatchingCertificateForAlias(env, store, cert, alias))
     {
         // Certificate is not in store - nothing to do
+        (*env)->DeleteLocalRef(env, alias);
         return SUCCESS;
     }
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -377,8 +377,7 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
         if (filter == NULL || filter(env, alias))
         {
             cert = (*env)->CallObjectMethod(env, store, g_KeyStoreGetCertificate, alias);
-            ON_EXCEPTION_PRINT_AND_GOTO(loop_cleanup);
-            if (cert != NULL)
+            if (!CheckJNIExceptions(env) && cert != NULL)
             {
                 cb(AddGRef(env, cert), context);
             }
@@ -387,6 +386,7 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     loop_cleanup:
         ReleaseLRef(env, cert);
         ReleaseLRef(env, alias);
+
         hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }
@@ -394,7 +394,7 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     ret = SUCCESS;
 
 cleanup:
-    (*env)->DeleteLocalRef(env, aliases);
+    ReleaseLRef(env, aliases);
     return ret;
 }
 
@@ -436,12 +436,11 @@ jobject /*KeyStore*/ AndroidCryptoNative_X509StoreOpenDefault(void)
     (*env)->CallVoidMethod(env, store, g_KeyStoreLoad, NULL, NULL);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     ret = ToGRef(env, store);
-    // ToGRef deletes the input local reference.
     store = NULL;
 
 cleanup:
     ReleaseLRef(env, store);
-    (*env)->DeleteLocalRef(env, storeType);
+    ReleaseLRef(env, storeType);
     return ret;
 }
 
@@ -452,20 +451,23 @@ int32_t AndroidCryptoNative_X509StoreRemoveCertificate(jobject /*KeyStore*/ stor
     abort_if_invalid_pointer_argument (store);
 
     JNIEnv* env = GetJNIEnv();
+    int32_t ret = FAIL;
 
     jstring alias = make_java_string(env, hashString);
     if (!ContainsMatchingCertificateForAlias(env, store, cert, alias))
     {
         // Certificate is not in store - nothing to do
-        (*env)->DeleteLocalRef(env, alias);
-        return SUCCESS;
+        ret = SUCCESS;
+        goto cleanup;
     }
 
     // store.deleteEntry(alias);
     (*env)->CallVoidMethod(env, store, g_KeyStoreDeleteEntry, alias);
+    ret = CheckJNIExceptions(env) ? FAIL : SUCCESS;
 
-    (*env)->DeleteLocalRef(env, alias);
-    return CheckJNIExceptions(env) ? FAIL : SUCCESS;
+cleanup:
+    ReleaseLRef(env, alias);
+    return ret;
 }
 
 jobject AndroidCryptoNative_X509StoreGetPrivateKeyEntry(jobject /*KeyStore*/ store, const char* hashString)

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -370,28 +370,41 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     while (hasNext)
     {
+        bool abortEnumeration = false;
+        jobject cert = NULL;
         jstring alias = (*env)->CallObjectMethod(env, aliases, g_EnumerationNextElement);
-        ON_EXCEPTION_PRINT_AND_GOTO(loop_cleanup);
+        if (CheckJNIExceptions(env))
+        {
+            abortEnumeration = true;
+            goto loop_cleanup;
+        }
 
         if (filter == NULL || filter(env, alias))
         {
-            jobject cert = (*env)->CallObjectMethod(env, store, g_KeyStoreGetCertificate, alias);
+            cert = (*env)->CallObjectMethod(env, store, g_KeyStoreGetCertificate, alias);
+            if (CheckJNIExceptions(env))
+            {
+                abortEnumeration = true;
+                goto loop_cleanup;
+            }
+
             if (cert != NULL)
             {
-                if (CheckJNIExceptions(env))
-                {
-                    (*env)->DeleteLocalRef(env, cert);
-                }
-                else
-                {
-                    cert = ToGRef(env, cert);
-                    cb(cert, context);
-                }
+                cb(AddGRef(env, cert), context);
             }
         }
 
     loop_cleanup:
+        if (cert != NULL)
+        {
+            (*env)->DeleteLocalRef(env, cert);
+        }
         (*env)->DeleteLocalRef(env, alias);
+        if (abortEnumeration)
+        {
+            goto cleanup;
+        }
+
         hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509store.c
@@ -370,24 +370,14 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     while (hasNext)
     {
-        bool abortEnumeration = false;
         jobject cert = NULL;
         jstring alias = (*env)->CallObjectMethod(env, aliases, g_EnumerationNextElement);
-        if (CheckJNIExceptions(env))
-        {
-            abortEnumeration = true;
-            goto loop_cleanup;
-        }
+        ON_EXCEPTION_PRINT_AND_GOTO(loop_cleanup);
 
         if (filter == NULL || filter(env, alias))
         {
             cert = (*env)->CallObjectMethod(env, store, g_KeyStoreGetCertificate, alias);
-            if (CheckJNIExceptions(env))
-            {
-                abortEnumeration = true;
-                goto loop_cleanup;
-            }
-
+            ON_EXCEPTION_PRINT_AND_GOTO(loop_cleanup);
             if (cert != NULL)
             {
                 cb(AddGRef(env, cert), context);
@@ -395,16 +385,8 @@ ARGS_NON_NULL_ALL static int32_t EnumerateTrustedCertificates(
         }
 
     loop_cleanup:
-        if (cert != NULL)
-        {
-            (*env)->DeleteLocalRef(env, cert);
-        }
-        (*env)->DeleteLocalRef(env, alias);
-        if (abortEnumeration)
-        {
-            goto cleanup;
-        }
-
+        ReleaseLRef(env, cert);
+        ReleaseLRef(env, alias);
         hasNext = (*env)->CallBooleanMethod(env, aliases, g_EnumerationHasMoreElements);
         ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }


### PR DESCRIPTION
 > [!NOTE]
 > This PR description was drafted with GitHub Copilot.
 
 Fixes Android X509Store PAL cleanup paths for certificate/private-key entries and JNI local references to avoid memory leaks.
 
 Follow-up to #128284 
 
 ## Changes
 
 - Dispose the Android `KeyStore.PrivateKeyEntry` wrapper held by `AndroidCertificatePal`.
 - Release JNI local references on Android X509Store cleanup paths:
   - trusted certificate enumeration
   - default store open failure/success cleanup
   - remove-certificate early success path
 - Add JNI exception checks when advancing Android KeyStore alias enumerations.