### PR TITLE
createdump: detect cycles in link_map traversal

### DIFF
--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -391,18 +391,28 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
 
     // Add the DSO link_map entries.
     //
-    // Guard against a malformed or cyclic link_map chain (which would otherwise
-    // spin createdump forever on a corrupted target) using Floyd's cycle
-    // detection: a "slow" pointer walks the chain doing the real work, while a
-    // "fast" pointer advances two l_next hops per iteration. If fast ever
-    // catches slow, the chain is cyclic and we abort.
-    struct link_map* slow = debugEntry.r_map;
-    struct link_map* fast = debugEntry.r_map;
-    while (slow != nullptr)
+    // Detect cycles using Brent's algorithm: a single "walker" pointer reads
+    // and visits each module exactly once on a sound chain, while a "checkpoint"
+    // pointer is moved to the walker's position only at exponentially spaced
+    // intervals (powers of two) and never moves between updates. If the walker
+    // ever returns to the checkpoint, the chain is cyclic and we abort. This
+    // gives O(N) work with one ReadMemory per node on the happy path, and on a
+    // ReadMemory failure mid-chain we have already visited every prior
+    // module — matching the original (pre-cycle-detection) behavior.
+    struct link_map* walker = debugEntry.r_map;
+    struct link_map* checkpoint = nullptr;
+    int power = 1;
+    int lam = 0;
+    while (walker != nullptr)
     {
+        if (checkpoint != nullptr && walker == checkpoint)
+        {
+            Trace("ERROR: EnumerateLinkMapEntries detected cycle in link_map chain; aborting\n");
+            return false;
+        }
         struct link_map map;
-        if (!ReadMemory(slow, &map, sizeof(map))) {
-            Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", slow, sizeof(map));
+        if (!ReadMemory(walker, &map, sizeof(map))) {
+            Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", walker, sizeof(map));
             return false;
         }
         // Read the module's name and make sure the memory is added to the core dump
@@ -422,31 +432,19 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
                 moduleName.append(1, ch);
             }
         }
-        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %p l_name %p %s\n", slow, map.l_ld, map.l_addr, map.l_name, moduleName.c_str());
+        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %p l_name %p %s\n", walker, map.l_ld, map.l_addr, map.l_name, moduleName.c_str());
 
         // Call the derived class for each module
         VisitModule(map.l_addr, moduleName);
 
-        slow = map.l_next;
-
-        // Advance fast by up to two l_next hops. Each hop is bounded by the
-        // existing ReadMemory failure path, so a corrupted l_next that points
-        // into unreadable memory still terminates the loop.
-        for (int hop = 0; hop < 2 && fast != nullptr; hop++)
+        if (lam == power)
         {
-            struct link_map fastMap;
-            if (!ReadMemory(fast, &fastMap, sizeof(fastMap))) {
-                Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map (cycle detection) FAILED\n", fast, sizeof(fastMap));
-                return false;
-            }
-            fast = fastMap.l_next;
+            checkpoint = walker;
+            power *= 2;
+            lam = 0;
         }
-
-        if (slow != nullptr && slow == fast)
-        {
-            Trace("ERROR: EnumerateLinkMapEntries detected cycle in link_map chain; aborting\n");
-            return false;
-        }
+        walker = map.l_next;
+        lam++;
     }
 
     return true;

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -391,14 +391,7 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
 
     // Add the DSO link_map entries.
     //
-    // Detect cycles using Brent's algorithm: a single "walker" pointer reads
-    // and visits each module exactly once on a sound chain, while a "checkpoint"
-    // pointer is moved to the walker's position only at exponentially spaced
-    // intervals (powers of two) and never moves between updates. If the walker
-    // ever returns to the checkpoint, the chain is cyclic and we abort. This
-    // gives O(N) work with one ReadMemory per node on the happy path, and on a
-    // ReadMemory failure mid-chain we have already visited every prior
-    // module — matching the original (pre-cycle-detection) behavior.
+    // Detect cycles using Brent's algorithm (variant of Floyd's cycle-finding algorithm)
     struct link_map* walker = debugEntry.r_map;
     struct link_map* checkpoint = nullptr;
     int power = 1;

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -389,9 +389,20 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
         return false;
     }
 
-    // Add the DSO link_map entries
+    // Add the DSO link_map entries.
+    //
+    // Guard against a malformed or cyclic link_map chain: real processes have at
+    // most a few hundred shared libraries, so this cap is well above realistic
+    // while still bounding wall time if l_next forms a cycle or points at
+    // garbage in a corrupted target process.
+    constexpr int LinkMapMaxEntries = 8192;
+    int linkMapCount = 0;
     for (struct link_map* linkMapAddr = debugEntry.r_map; linkMapAddr != nullptr;)
     {
+        if (++linkMapCount > LinkMapMaxEntries) {
+            Trace("ERROR: EnumerateLinkMapEntries exceeded %d entries; aborting (possible cyclic or corrupt link_map)\n", LinkMapMaxEntries);
+            return false;
+        }
         struct link_map map;
         if (!ReadMemory(linkMapAddr, &map, sizeof(map))) {
             Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", linkMapAddr, sizeof(map));

--- a/src/coreclr/debug/dbgutil/elfreader.cpp
+++ b/src/coreclr/debug/dbgutil/elfreader.cpp
@@ -391,21 +391,18 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
 
     // Add the DSO link_map entries.
     //
-    // Guard against a malformed or cyclic link_map chain: real processes have at
-    // most a few hundred shared libraries, so this cap is well above realistic
-    // while still bounding wall time if l_next forms a cycle or points at
-    // garbage in a corrupted target process.
-    constexpr int LinkMapMaxEntries = 8192;
-    int linkMapCount = 0;
-    for (struct link_map* linkMapAddr = debugEntry.r_map; linkMapAddr != nullptr;)
+    // Guard against a malformed or cyclic link_map chain (which would otherwise
+    // spin createdump forever on a corrupted target) using Floyd's cycle
+    // detection: a "slow" pointer walks the chain doing the real work, while a
+    // "fast" pointer advances two l_next hops per iteration. If fast ever
+    // catches slow, the chain is cyclic and we abort.
+    struct link_map* slow = debugEntry.r_map;
+    struct link_map* fast = debugEntry.r_map;
+    while (slow != nullptr)
     {
-        if (++linkMapCount > LinkMapMaxEntries) {
-            Trace("ERROR: EnumerateLinkMapEntries exceeded %d entries; aborting (possible cyclic or corrupt link_map)\n", LinkMapMaxEntries);
-            return false;
-        }
         struct link_map map;
-        if (!ReadMemory(linkMapAddr, &map, sizeof(map))) {
-            Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", linkMapAddr, sizeof(map));
+        if (!ReadMemory(slow, &map, sizeof(map))) {
+            Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map FAILED\n", slow, sizeof(map));
             return false;
         }
         // Read the module's name and make sure the memory is added to the core dump
@@ -425,12 +422,31 @@ ElfReader::EnumerateLinkMapEntries(Elf_Dyn* dynamicAddr)
                 moduleName.append(1, ch);
             }
         }
-        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %p l_name %p %s\n", linkMapAddr, map.l_ld, map.l_addr, map.l_name, moduleName.c_str());
+        Trace("\nDSO: link_map entry %p l_ld %p l_addr (Ehdr) %p l_name %p %s\n", slow, map.l_ld, map.l_addr, map.l_name, moduleName.c_str());
 
         // Call the derived class for each module
         VisitModule(map.l_addr, moduleName);
 
-        linkMapAddr = map.l_next;
+        slow = map.l_next;
+
+        // Advance fast by up to two l_next hops. Each hop is bounded by the
+        // existing ReadMemory failure path, so a corrupted l_next that points
+        // into unreadable memory still terminates the loop.
+        for (int hop = 0; hop < 2 && fast != nullptr; hop++)
+        {
+            struct link_map fastMap;
+            if (!ReadMemory(fast, &fastMap, sizeof(fastMap))) {
+                Trace("ERROR: ReadMemory(%p, %" PRIx ") link_map (cycle detection) FAILED\n", fast, sizeof(fastMap));
+                return false;
+            }
+            fast = fastMap.l_next;
+        }
+
+        if (slow != nullptr && slow == fast)
+        {
+            Trace("ERROR: EnumerateLinkMapEntries detected cycle in link_map chain; aborting\n");
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI-generated (GitHub Copilot CLI).

Fixes #128623.
 
## Problem

`ElfReader::EnumerateLinkMapEntries` in `src/coreclr/debug/dbgutil/elfreader.cpp`
walks the dynamic linker's `link_map` list via `l_next` until `nullptr` with no
cycle detection. If the target process has a cyclic `link_map` — whether from a
memory-corruption bug in native code or deliberate modification — `createdump`
enters a non-terminating loop, pegs a CPU, and never produces a dump.

## Fix

Detect cycles in the `link_map` chain using Brent's algorithm: a single walker
pointer reads and visits each module exactly once on a sound chain, while a
checkpoint pointer is moved to the walker's position at exponentially spaced
intervals (powers of two) and never moves between updates. If the walker ever
returns to the checkpoint, the chain is cyclic and we abort. On `ReadMemory`
failure, the walker has already visited every prior module — matching the
original (pre-cycle-detection) behavior.

## Alternatives considered

- **Iteration cap (e.g. 8192 or 100000)** — bounds wall time but requires
 picking a magic number; per @jkotas, cycle detection avoids the guesswork.
- **Floyd's tortoise-and-hare** — works, but doing the per-node work on the
 slow pointer regresses the `ReadMemory`-failure case (only ~half the modules
 visited before abort vs. all of them with the original walk); doing the work
 on the fast pointer requires O(N) caching of `l_next` values to advance the
 slow pointer without re-reads. Brent's gives 1 read per node on the happy
 path and matches the original failure behavior.
- **Visited-set / `std::unordered_set`** — correct but allocates inside
 post-crash diagnostic code where target heap state is unknown.
