### PR TITLE
Add RuntimeConfiguration parameter to RunDumpTests.ps1

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/RunDumpTests.ps1
+++ b/src/native/managed/cdac/tests/DumpTests/RunDumpTests.ps1
@@ -32,6 +32,12 @@
     Configuration of the testhost used for the "local" runtime version.
     Default: "Release"
 
+.PARAMETER RuntimeConfiguration
+    Configuration of the runtime (CoreCLR) used for the "local" runtime version.
+    This determines where crossgen2 and other runtime tools are located.
+    Common values: "Release", "Checked", "Debug"
+    Default: "Release"
+
 .PARAMETER Filter
     Glob-style filter for test names. Uses substring matching.
     Examples: "*StackWalk*", "*Thread*", "*GC_Heap*"
@@ -92,6 +98,8 @@ param(
     [switch]$Force,
 
     [string]$TestHostConfiguration = "Release",
+
+    [string]$RuntimeConfiguration = "Release",
 
     [string]$Filter = "",
 
@@ -323,6 +331,7 @@ if ($Action -in @("dumps", "all")) {
         "msbuild", $dumpTestsProj,
         "/t:GenerateAllDumps",
         "/p:TestHostConfiguration=$TestHostConfiguration",
+        "/p:RuntimeConfiguration=$RuntimeConfiguration",
         "/p:DumpVersions=`"$($selectedVersions -join ';')`"",
         "/v:$msbuildVerbosity"
     )


### PR DESCRIPTION
Adds a `-RuntimeConfiguration` parameter to `RunDumpTests.ps1` to support testing Checked and Debug runtime builds, not just Release.

### Background

The dump test script currently hardcodes `Release` for the runtime configuration, preventing testing of Checked or Debug builds. Checked builds enable additional assertions that can catch bugs not visible in Release builds.

### Changes

- Added `-RuntimeConfiguration` parameter (defaults to `Release` to preserve existing behavior)
- Passes the configuration to MSBuild via the DumpTests.targets file

### Usage

```powershell
# Test Checked builds
.\RunDumpTests.ps1 -Versions local -RuntimeConfiguration Checked

# Test Debug builds
.\RunDumpTests.ps1 -Versions local -RuntimeConfiguration Debug

# Default behavior (Release)
.\RunDumpTests.ps1 -Versions local
```
