### PR TITLE
Fix format pre-commit hook

### DIFF
--- a/docs/coding-guidelines/code-formatting-tools.md
+++ b/docs/coding-guidelines/code-formatting-tools.md
@@ -80,6 +80,10 @@ In the options view, go to `Text Editor > C/C++ > Code Style > Formatting > Gene
 
 Git provides a number of hooks to enable running scripts before commit, push, pull, etc. This section describes adding a pre-commit hook to automatically format code before committing to make formatting seamless even when your development environment doesn't support "format-on-save" or similar functionality with the formatting tools this repository uses.
 
+### Git Hooks
+
+Git provides a number of hooks to enable running scripts before commit, push, pull, etc. This section describes adding a pre-commit hook to automatically format code before committing to make formatting seamless even when your development environment doesn't support "format-on-save" or similar functionality with the formatting tools this repository uses.
+
 #### Auto-format before committing
 
 To enable auto-formatting before committing, you can create a `.git/hooks/pre-commit` file in your local `dotnet/runtime` clone and add a call to the script located at `eng/formatting/format.sh` to auto-format your code before committing. Since Git for Windows also installs Git Bash, this script will work for both Windows and non-Windows platforms.
@@ -88,6 +92,8 @@ The following code block can be used as the contents of the `pre-commit` file to
 
 ```sh
 #!/bin/sh
-./eng/formatting/format.sh
 
+./eng/formatting/format.sh
 ```
+
+Make sure the file is executable (`chmod +x .git/hooks/pre-commit`). If `git config core.hooksPath` points elsewhere, set it with `git config core.hooksPath .git/hooks`.

--- a/docs/coding-guidelines/code-formatting-tools.md
+++ b/docs/coding-guidelines/code-formatting-tools.md
@@ -80,10 +80,6 @@ In the options view, go to `Text Editor > C/C++ > Code Style > Formatting > Gene
 
 Git provides a number of hooks to enable running scripts before commit, push, pull, etc. This section describes adding a pre-commit hook to automatically format code before committing to make formatting seamless even when your development environment doesn't support "format-on-save" or similar functionality with the formatting tools this repository uses.
 
-### Git Hooks
-
-Git provides a number of hooks to enable running scripts before commit, push, pull, etc. This section describes adding a pre-commit hook to automatically format code before committing to make formatting seamless even when your development environment doesn't support "format-on-save" or similar functionality with the formatting tools this repository uses.
-
 #### Auto-format before committing
 
 To enable auto-formatting before committing, you can create a `.git/hooks/pre-commit` file in your local `dotnet/runtime` clone and add a call to the script located at `eng/formatting/format.sh` to auto-format your code before committing. Since Git for Windows also installs Git Bash, this script will work for both Windows and non-Windows platforms.

--- a/eng/formatting/format.sh
+++ b/eng/formatting/format.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 LC_ALL=C
+
 # Select files to format
 NATIVE_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.h" "*.hpp" "*.c" "*.cpp" "*.inl" | sed 's| |\\ |g')
 MANAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM "*.cs" "*.vb" | sed 's| |\\ |g')
@@ -9,7 +10,7 @@ exec 1>&2
 
 if [ -n "$NATIVE_FILES" ]; then
     # Format all selected files
-    echo "$NATIVE_FILES" | cat | xargs | sed -e 's/ /,/g' | xargs "./artifacts/tools/clang-format" -style=file -i
+    echo "$NATIVE_FILES" | xargs "./artifacts/tools/clang-format" -style=file -i
 
     # Add back the modified files to staging
     echo "$NATIVE_FILES" | xargs git add
@@ -17,7 +18,7 @@ fi
 
 if [ -n "$MANAGED_FILES" ]; then
     # Format all selected files
-    echo "$MANAGED_FILES" | cat | xargs | sed -e 's/ /,/g' | dotnet format whitespace --include - --folder
+    echo "$MANAGED_FILES" | ".dotnet/dotnet" format whitespace --include - --folder
 
     # Add back the modified files to staging
     echo "$MANAGED_FILES" | xargs git add

--- a/eng/formatting/format.sh
+++ b/eng/formatting/format.sh
@@ -18,7 +18,7 @@ fi
 
 if [ -n "$MANAGED_FILES" ]; then
     # Format all selected files
-    echo "$MANAGED_FILES" | ".dotnet/dotnet" format whitespace --include - --folder
+    echo "$MANAGED_FILES" | dotnet format whitespace --include - --folder
 
     # Add back the modified files to staging
     echo "$MANAGED_FILES" | xargs git add


### PR DESCRIPTION
Native format was throwing: `No such file or directory`
Managed format was silent but wasn't formatting anything..

PR fixes both issues.