### PR TITLE
[Android] Handle X509ChainContext creation failures

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -22,9 +22,9 @@ internal static partial class Interop
         {
             SafeX509ChainContextHandle chainContext = X509ChainCreateContext(cert, extraStore, extraStore.Length);
 
-            if (chainContext is null || chainContext.IsInvalid)
+            if (chainContext.IsInvalid)
             {
-                chainContext?.Dispose();
+                chainContext.Dispose();
                 throw new CryptographicException(SR.Cryptography_AndroidX509ChainContextInitializationFailed);
             }
 

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -13,17 +13,14 @@ internal static partial class Interop
     internal static partial class AndroidCrypto
     {
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainCreateContext")]
-        private static partial SafeX509ChainContextHandle X509ChainCreateContext_private(
+        private static partial SafeX509ChainContextHandle X509ChainCreateContext(
             SafeX509Handle cert,
             IntPtr[] extraStore,
             int extraStoreLen);
 
-        internal static SafeX509ChainContextHandle X509ChainCreateContext(
-            SafeX509Handle cert,
-            IntPtr[] extraStore,
-            int extraStoreLen)
+        internal static SafeX509ChainContextHandle X509ChainCreateContext(SafeX509Handle cert, IntPtr[] extraStore)
         {
-            SafeX509ChainContextHandle chainContext = X509ChainCreateContext_private(cert, extraStore, extraStoreLen);
+            SafeX509ChainContextHandle chainContext = X509ChainCreateContext(cert, extraStore, extraStore.Length);
 
             if (chainContext.IsInvalid)
             {

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -13,10 +13,26 @@ internal static partial class Interop
     internal static partial class AndroidCrypto
     {
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainCreateContext")]
-        internal static partial SafeX509ChainContextHandle X509ChainCreateContext(
+        private static partial SafeX509ChainContextHandle X509ChainCreateContext_private(
             SafeX509Handle cert,
             IntPtr[] extraStore,
             int extraStoreLen);
+
+        internal static SafeX509ChainContextHandle X509ChainCreateContext(
+            SafeX509Handle cert,
+            IntPtr[] extraStore,
+            int extraStoreLen)
+        {
+            SafeX509ChainContextHandle chainContext = X509ChainCreateContext_private(cert, extraStore, extraStoreLen);
+
+            if (chainContext.IsInvalid)
+            {
+                chainContext.Dispose();
+                throw new CryptographicException(SR.Cryptography_AndroidX509ChainContextInitializationFailed);
+            }
+
+            return chainContext;
+        }
 
         [LibraryImport(Libraries.AndroidCryptoNative, EntryPoint = "AndroidCryptoNative_X509ChainDestroyContext")]
         internal static partial void X509ChainDestroyContext(IntPtr ctx);

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.X509Chain.cs
@@ -22,9 +22,9 @@ internal static partial class Interop
         {
             SafeX509ChainContextHandle chainContext = X509ChainCreateContext(cert, extraStore, extraStore.Length);
 
-            if (chainContext.IsInvalid)
+            if (chainContext is null || chainContext.IsInvalid)
             {
-                chainContext.Dispose();
+                chainContext?.Dispose();
                 throw new CryptographicException(SR.Cryptography_AndroidX509ChainContextInitializationFailed);
             }
 

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -228,9 +228,6 @@
   <data name="CryptoConfigNotSupported" xml:space="preserve">
     <value>Accessing a hash algorithm by manipulating the HashName property is not supported on this platform. Instead, you must instantiate one of the supplied subtypes (such as HMACSHA1.)</value>
   </data>
-  <data name="Cryptography_AndroidX509ChainContextInitializationFailed" xml:space="preserve">
-    <value>The Android X.509 certificate chain could not be initialized. See logcat for details.</value>
-  </data>
   <data name="Cryptography_AlgKdfRequiresChars" xml:space="preserve">
     <value>The KDF for algorithm '{0}' requires a char-based password input.</value>
   </data>
@@ -239,6 +236,9 @@
   </data>
   <data name="Cryptography_AlgorithmTypesMustBeVisible" xml:space="preserve">
     <value>Algorithms added to CryptoConfig must be accessible from outside their assembly.</value>
+  </data>
+  <data name="Cryptography_AndroidX509ChainContextInitializationFailed" xml:space="preserve">
+    <value>The Android X.509 certificate chain could not be initialized.</value>
   </data>
   <data name="Cryptography_ArgDSARequiresDSAKey" xml:space="preserve">
     <value>Keys used with the DSACng algorithm must have an algorithm group of DSA.</value>

--- a/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
+++ b/src/libraries/System.Security.Cryptography/src/Resources/Strings.resx
@@ -228,6 +228,9 @@
   <data name="CryptoConfigNotSupported" xml:space="preserve">
     <value>Accessing a hash algorithm by manipulating the HashName property is not supported on this platform. Instead, you must instantiate one of the supplied subtypes (such as HMACSHA1.)</value>
   </data>
+  <data name="Cryptography_AndroidX509ChainContextInitializationFailed" xml:space="preserve">
+    <value>The Android X.509 certificate chain could not be initialized. See logcat for details.</value>
+  </data>
   <data name="Cryptography_AlgKdfRequiresChars" xml:space="preserve">
     <value>The KDF for algorithm '{0}' requires a char-based password input.</value>
   </data>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
@@ -141,8 +141,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     _chainContext = Interop.AndroidCrypto.X509ChainCreateContext(
                         ((AndroidCertificatePal)cert).SafeHandle,
-                        extraCerts,
-                        extraCerts.Length);
+                        extraCerts);
 
                     if (useCustomRootTrust)
                     {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
@@ -143,6 +143,7 @@ namespace System.Security.Cryptography.X509Certificates
                         ((AndroidCertificatePal)cert).SafeHandle,
                         extraCerts,
                         extraCerts.Length);
+                    ThrowIfInvalidChainContext(_chainContext);
 
                     if (useCustomRootTrust)
                     {
@@ -179,6 +180,14 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         customTrustCertHandles[customIdx].DangerousRelease();
                     }
+                }
+            }
+
+            private static void ThrowIfInvalidChainContext(SafeX509ChainContextHandle chainContext)
+            {
+                if (chainContext.IsInvalid)
+                {
+                    throw new CryptographicException(SR.Cryptography_AndroidX509ChainContextInitializationFailed);
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ChainPal.Android.cs
@@ -143,7 +143,6 @@ namespace System.Security.Cryptography.X509Certificates
                         ((AndroidCertificatePal)cert).SafeHandle,
                         extraCerts,
                         extraCerts.Length);
-                    ThrowIfInvalidChainContext(_chainContext);
 
                     if (useCustomRootTrust)
                     {
@@ -180,14 +179,6 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         customTrustCertHandles[customIdx].DangerousRelease();
                     }
-                }
-            }
-
-            private static void ThrowIfInvalidChainContext(SafeX509ChainContextHandle chainContext)
-            {
-                if (chainContext.IsInvalid)
-                {
-                    throw new CryptographicException(SR.Cryptography_AndroidX509ChainContextInitializationFailed);
                 }
             }
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
@@ -39,7 +39,7 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     JNIEnv* env = GetJNIEnv();
 
     X509ChainContext* ret = NULL;
-    INIT_LOCALS(loc, keyStoreType, keyStore, targetSel, params, certList, certStoreType, certStoreParams, certStore);
+    INIT_LOCALS(loc, keyStoreType, keyStore, targetSel, params, certList, certStoreType, certStoreParams, certStore, errorList);
 
     // String keyStoreType = "AndroidCAStore";
     // KeyStore keyStore = KeyStore.getInstance(keyStoreType);
@@ -53,7 +53,9 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     // X509CertSelector targetSel = new X509CertSelector();
     // targetSel.setCertificate(cert);
     loc[targetSel] = (*env)->NewObject(env, g_X509CertSelectorClass, g_X509CertSelectorCtor);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallVoidMethod(env, loc[targetSel], g_X509CertSelectorSetCertificate, cert);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // PKIXBuilderParameters params = new PKIXBuilderParameters(keyStore, targetSelector);
     loc[params] = (*env)->NewObject(
@@ -66,10 +68,13 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     //     certList.add(extraStore[i]);
     // }
     loc[certList] = (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtorWithCapacity, extraStoreLen);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     (*env)->CallBooleanMethod(env, loc[certList], g_ArrayListAdd, cert);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     for (int i = 0; i < extraStoreLen; ++i)
     {
         (*env)->CallBooleanMethod(env, loc[certList], g_ArrayListAdd, extraStore[i]);
+        ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     }
 
     // String certStoreType = "Collection";
@@ -78,16 +83,21 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
     loc[certStoreType] = make_java_string(env, "Collection");
     loc[certStoreParams] = (*env)->NewObject(
         env, g_CollectionCertStoreParametersClass, g_CollectionCertStoreParametersCtor, loc[certList]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
     loc[certStore] = (*env)->CallStaticObjectMethod(
         env, g_CertStoreClass, g_CertStoreGetInstance, loc[certStoreType], loc[certStoreParams]);
     ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     // params.addCertStore(certStore);
     (*env)->CallVoidMethod(env, loc[params], g_PKIXBuilderParametersAddCertStore, loc[certStore]);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
+
+    loc[errorList] = (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtor);
+    ON_EXCEPTION_PRINT_AND_GOTO(cleanup);
 
     ret = xcalloc(1, sizeof(X509ChainContext));
     ret->params = AddGRef(env, loc[params]);
-    ret->errorList = ToGRef(env, (*env)->NewObject(env, g_ArrayListClass, g_ArrayListCtor));
+    ret->errorList = AddGRef(env, loc[errorList]);
 
 cleanup:
     RELEASE_LOCALS(loc, env);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
@@ -97,7 +97,23 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
 
     ret = xcalloc(1, sizeof(X509ChainContext));
     ret->params = AddGRef(env, loc[params]);
+    if (ret->params == NULL)
+    {
+        CheckJNIExceptions(env);
+        free(ret);
+        ret = NULL;
+        goto cleanup;
+    }
+
     ret->errorList = AddGRef(env, loc[errorList]);
+    if (ret->errorList == NULL)
+    {
+        CheckJNIExceptions(env);
+        ReleaseGRef(env, ret->params);
+        free(ret);
+        ret = NULL;
+        goto cleanup;
+    }
 
 cleanup:
     RELEASE_LOCALS(loc, env);

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c
@@ -97,23 +97,7 @@ X509ChainContext* AndroidCryptoNative_X509ChainCreateContext(jobject /*X509Certi
 
     ret = xcalloc(1, sizeof(X509ChainContext));
     ret->params = AddGRef(env, loc[params]);
-    if (ret->params == NULL)
-    {
-        CheckJNIExceptions(env);
-        free(ret);
-        ret = NULL;
-        goto cleanup;
-    }
-
     ret->errorList = AddGRef(env, loc[errorList]);
-    if (ret->errorList == NULL)
-    {
-        CheckJNIExceptions(env);
-        ReleaseGRef(env, ret->params);
-        free(ret);
-        ret = NULL;
-        goto cleanup;
-    }
 
 cleanup:
     RELEASE_LOCALS(loc, env);


### PR DESCRIPTION
>   [!NOTE]
>   This PR description was drafted with GitHub Copilot.

An Android production app reported a native abort while building an X.509 chain on arm64. The available tombstone snippet showed the process aborting in `AndroidCryptoNative_X509ChainBuild` from `pal_x509chain.c`, with the native guard reporting that parameter `ctx` was not a valid pointer. The report did not include a repro or full tombstone, but the observed failure mode means managed code reached the native build entry point with a null `X509ChainContext*`.

```
Thread
/__w/1/s/src/native/libs/System.Security.Cryptography.Native.Android/pal_x509chain.c:113 (AndroidCryptoNative_X509ChainBuild): Parameter 'ctx' must be a valid pointer
 
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 31609 >>> com.app.name <<<
 
backtrace:
  #00  pc 0x000000000002232c  /system/lib64/libc.so (abort+116)
  #01  pc 0x0000000000021fe8  [removed]-KwPZdoEumri00C7kBm3pQw==/lib/arm64/libSystem.Security.Cryptography.Native.Android.so
  #02  pc 0x00000000000220b0  [removed]-KwPZdoEumri00C7kBm3pQw==/lib/arm64/libSystem.Security.Cryptography.Native.Android.so (AndroidCryptoNative_X509ChainBuild+88)
  #03  pc 0x000000000000cfcc
```

`X509ChainContext` is created by `AndroidCryptoNative_X509ChainCreateContext`. That initialization can fail if Android certificate store setup or PKIX parameter construction throws, or if required JNI global references cannot be created. Previously, the managed Android chain path stored the returned `SafeHandle` without checking whether context creation failed, so a later build could pass a null native context to `AndroidCryptoNative_X509ChainBuild` and terminate the app process.

This change makes context creation fail gracefully:

   - The native create path checks Java exceptions around object creation and method calls more consistently.
   - Partial native contexts are destroyed if global-reference creation fails.
   - The Android interop wrapper checks the returned chain context immediately, including a null safe-handle return, and throws `CryptographicException` if initialization failed.

No regression test is included because the reliable failure modes depend on Android platform/provider state or artificial fault injection, and a test hook would be fragile and not representative.
