### PR TITLE
JIT: Fix bug in GenTree::Equals

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2531,6 +2531,12 @@ bool GenTreeCall::Equals(GenTreeCall* c1, GenTreeCall* c2)
         {
             return false;
         }
+
+        // For virtual stub calls the stub addresses must agree.
+        if (c1->IsVirtualStub() && (c1->gtStubCallStubAddr != c2->gtStubCallStubAddr))
+        {
+            return false;
+        }
     }
     else
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
@@ -17,7 +17,7 @@ public class Impl : IFoo<string>, IFoo<byte[]>
     [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<string>.Get() => "STRING_VALUE";
     [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<byte[]>.Get() => new byte[] { 1, 2, 3 };
 
-    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
     public object Dispatch(string tag)
     {
         if (tag == "bytes")  return ((IFoo<byte[]>)this).Get();

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Two shared-generic interface call sites that canonicalize to __Canon must
+// not be merged by head/tail merge: each call has a distinct virtual stub
+// dispatch cell, so the calls are not interchangeable.
+
+namespace Runtime_128631;
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public interface IFoo<T> { object Get(); }
+
+public class Impl : IFoo<string>, IFoo<byte[]>
+{
+    [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<string>.Get() => "STRING_VALUE";
+    [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<byte[]>.Get() => new byte[] { 1, 2, 3 };
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public object Dispatch(string tag)
+    {
+        if (tag == "bytes")  return ((IFoo<byte[]>)this).Get();
+        if (tag == "string") return ((IFoo<string>)this).Get();
+        return null;
+    }
+}
+
+public class Runtime_128631
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        var d = new Impl();
+        for (int i = 0; i < 200; i++)
+        {
+            d.Dispatch("bytes");
+            d.Dispatch("string");
+        }
+        object r = d.Dispatch("string");
+        return r is string ? 100 : -1;
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -98,6 +98,7 @@
     <Compile Include="JitBlue\Runtime_126060\Runtime_126060.cs" />
     <Compile Include="JitBlue\Runtime_127260\Runtime_127260.cs" />
     <Compile Include="JitBlue\Runtime_127446\Runtime_127446.cs" />
+    <Compile Include="JitBlue\Runtime_128631\Runtime_128631.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Make sure we properly distinguish virtual stub calls to avoid incorrect head/tail merges.

Fixes #128631.