### PR TITLE
Add breadcrumb READMEs under src/ for test-doc discoverability

### DIFF
--- a/src/coreclr/README.md
+++ b/src/coreclr/README.md
@@ -1,0 +1,23 @@
+# CoreCLR
+
+This folder contains the source for CoreCLR, the .NET runtime implementation
+used by most workloads. CoreCLR tests live in [`../tests`](../tests/) (the
+`src/tests` subtree).
+
+## Building and testing
+
+See the workflow docs for the authoritative instructions — they cover the
+specific subset, configuration, and incremental-iteration flags that the
+top-level `build.sh`/`build.cmd` help text does not. For up-front baseline
+build requirements (mandatory under CCA, probe-and-fall-back under CLI), see
+[`.github/copilot-instructions.md`](/.github/copilot-instructions.md).
+
+- [Building CoreCLR](/docs/workflow/building/coreclr/README.md)
+- [Testing CoreCLR](/docs/workflow/testing/coreclr/testing.md)
+- [Test configuration options](/docs/workflow/testing/coreclr/test-configuration.md)
+- [Unix test instructions](/docs/workflow/testing/coreclr/unix-test-instructions.md) · [Windows test instructions](/docs/workflow/testing/coreclr/windows-test-instructions.md)
+- [Disasm checks](/docs/workflow/testing/coreclr/disasm-checks.md) · [GC stress runs](/docs/workflow/testing/coreclr/gc-stress-run-readme.md)
+- [Using `corerun` and `Core_Root`](/docs/workflow/testing/using-corerun-and-coreroot.md)
+
+Some subdirectories contain their own `README.md` with component-specific
+guidance — read any you find before making changes.

--- a/src/libraries/README.md
+++ b/src/libraries/README.md
@@ -38,3 +38,14 @@ Some libraries are under more active development than others. Depending on the l
 Some libraries are included in the .NET SDK as part of the runtime's [shared framework](https://learn.microsoft.com/dotnet/standard/glossary#shared-framework). Other libraries are deployed as out-of-band (OOB) NuGet packages and need to be installed separately.
 
 For more information, see the [Runtime libraries overview](https://learn.microsoft.com/dotnet/standard/runtime-libraries-overview).
+
+## Building and testing
+
+Library tests are driven by `dotnet build /t:test <TestProject>.csproj` (not `dotnet test`), and many useful flags are not visible from `--help`. For up-front baseline build requirements (mandatory under CCA, probe-and-fall-back under CLI), see [`.github/copilot-instructions.md`](../../.github/copilot-instructions.md). See the workflow docs for the rest:
+
+- [Building libraries](../../docs/workflow/building/libraries/README.md)
+- [Testing libraries](../../docs/workflow/testing/libraries/testing.md) — includes inner-loop iteration flags such as `/p:testnobuild=true`, `/p:XunitMethodName=...`, `/p:XUnitOptions=...`, and `/p:Outerloop=true`
+- [Filtering tests](../../docs/workflow/testing/libraries/filtering-tests.md)
+- [Testing on WebAssembly](../../docs/workflow/testing/libraries/testing-wasm.md) · [Android](../../docs/workflow/testing/libraries/testing-android.md) · [Apple platforms](../../docs/workflow/testing/libraries/testing-apple.md)
+
+For changes to `System.Private.CoreLib`, also rebuild the `libs.pretest` subset so the new CoreLib is copied into the testhost before running tests.

--- a/src/mono/README.md
+++ b/src/mono/README.md
@@ -1,0 +1,22 @@
+# Mono
+
+This folder contains the source for Mono, the .NET runtime implementation used
+for mobile (iOS, Android), browser (WebAssembly), and WASI workloads.
+
+## Building and testing
+
+Mono uses different build subsets and host configurations than CoreCLR. See
+the workflow docs for the authoritative instructions — they cover the
+configuration matrix (LLVM, AOT, interpreter, WASM, mobile) that the top-level
+`build.sh`/`build.cmd` help text does not. For up-front baseline build
+requirements (mandatory under CCA, probe-and-fall-back under CLI), see
+[`.github/copilot-instructions.md`](/.github/copilot-instructions.md).
+
+- [Building Mono](/docs/workflow/building/mono/README.md)
+- [Testing Mono](/docs/workflow/testing/mono/testing.md)
+- [Testing libraries on WebAssembly](/docs/workflow/testing/libraries/testing-wasm.md)
+- [Testing libraries on Android](/docs/workflow/testing/libraries/testing-android.md)
+- [Testing libraries on Apple platforms](/docs/workflow/testing/libraries/testing-apple.md)
+
+CoreCLR-style runtime tests under [`../tests`](../tests/) can also be run
+against Mono — see the testing doc above.

--- a/src/tests/README.md
+++ b/src/tests/README.md
@@ -1,0 +1,38 @@
+# Runtime Tests
+
+This folder is the **CoreCLR / runtime test tree**. Tests here exercise the
+runtime itself (JIT, GC, EE, interop, threading, tracing, …) rather than the
+managed libraries — for those, see `src/libraries/<Name>/tests/`.
+
+Tests are driven by `src/tests/build.sh` and `src/tests/run.sh`, not by
+`dotnet test`. The wrong tool will silently report "0 test projects" or fail
+to find a testhost.
+
+## Building and running
+
+For up-front baseline build requirements (mandatory under CCA,
+probe-and-fall-back under CLI), see
+[`.github/copilot-instructions.md`](/.github/copilot-instructions.md).
+
+- [Testing CoreCLR](/docs/workflow/testing/coreclr/testing.md) — the
+  authoritative guide for this tree, including `Core_Root` setup, single-test
+  builds, and `corerun`
+- [Test configuration options](/docs/workflow/testing/coreclr/test-configuration.md)
+- [`<RequiresProcessIsolation>` tests](/docs/workflow/testing/coreclr/requiresprocessisolation.md)
+- [Disasm checks](/docs/workflow/testing/coreclr/disasm-checks.md)
+- [Unix test instructions](/docs/workflow/testing/coreclr/unix-test-instructions.md) · [Windows test instructions](/docs/workflow/testing/coreclr/windows-test-instructions.md)
+- [Running ARM32 tests](/docs/workflow/testing/coreclr/running-arm32-tests.md)
+- [GC stress runs](/docs/workflow/testing/coreclr/gc-stress-run-readme.md)
+
+Run `src/tests/build.sh -h` for the full flag list. A few commonly-missed
+flags:
+
+| Flag | Description |
+|------|-------------|
+| `-Test <path>` | Build one project |
+| `-Tree <path>` | Build a subtree recursively |
+| `-priority1` (`-Priority 1` on Windows) | Required for tests with `<CLRTestPriority>1</CLRTestPriority>`; without it the build silently reports "0 test projects" |
+| `-GenerateLayoutOnly` | Generate `Core_Root` only (required before running individual tests with `corerun`) |
+
+Many subdirectories under `src/tests/` have their own `README.md` with
+area-specific authoring and run guidance — read them before making changes.


### PR DESCRIPTION
Adds lightweight README.md files at the four component roots that AI agents walk up to but currently find nothing at:

- src/coreclr/README.md  (new)
- src/mono/README.md     (new)
- src/tests/README.md    (new) - explicitly identifies this as the CoreCLR
  runtime test tree, called out that it uses src/tests/build.sh (not
  'dotnet test'), and surfaces commonly-missed flags (-priority1,
  -GenerateLayoutOnly)
- src/libraries/README.md - appends a 'Building and testing' section

Each README is a pure link breadcrumb to the authoritative docs under docs/workflow/{building,testing}/. 

Addresses #125558.