### PR TITLE
Add async validation support for System.ComponentModel.DataAnnotations

### DIFF
--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -38,6 +38,7 @@ namespace System.ComponentModel.DataAnnotations
         protected AsyncValidationAttribute(System.Func<string> errorMessageAccessor) { }
         protected AsyncValidationAttribute(string errorMessage) { }
         public System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> GetValidationResultAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        public sealed override bool IsValid(object? value) { throw null; }
         protected abstract override System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext);
         protected abstract System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> IsValidAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken);
     }

--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -196,6 +196,19 @@ namespace System.ComponentModel.DataAnnotations
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
     }
+    public abstract partial class AsyncValidationAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
+    {
+        protected AsyncValidationAttribute() { }
+        protected AsyncValidationAttribute(System.Func<string> errorMessageAccessor) { }
+        protected AsyncValidationAttribute(string errorMessage) { }
+        public System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> GetValidationResultAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract override System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext);
+        protected abstract System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> IsValidAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken);
+    }
+    public partial interface IAsyncValidatableObject : System.ComponentModel.DataAnnotations.IValidatableObject
+    {
+        System.Collections.Generic.IAsyncEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> ValidateAsync(System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+    }
     public partial interface IValidatableObject
     {
         System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationResult> Validate(System.ComponentModel.DataAnnotations.ValidationContext validationContext);
@@ -386,16 +399,30 @@ namespace System.ComponentModel.DataAnnotations
         public static bool TryValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
         public static bool TryValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, bool validateAllProperties) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+        public static System.Threading.Tasks.Task<bool> TryValidateObjectAsync(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+        public static System.Threading.Tasks.Task<bool> TryValidateObjectAsync(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, bool validateAllProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of validationContext.ObjectType cannot be statically discovered.")]
         public static bool TryValidateProperty(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of validationContext.ObjectType cannot be statically discovered.")]
+        public static System.Threading.Tasks.Task<bool> TryValidatePropertyAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static bool TryValidateValue(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationAttribute> validationAttributes) { throw null; }
+        public static System.Threading.Tasks.Task<bool> TryValidateValueAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.ICollection<System.ComponentModel.DataAnnotations.ValidationResult>? validationResults, System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationAttribute> validationAttributes, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
         public static void ValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
         public static void ValidateObject(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, bool validateAllProperties) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+        public static System.Threading.Tasks.Task ValidateObjectAsync(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("Constructing a ValidationContext without a display name is not trim-safe because it uses reflection to discover the type of the instance being validated in order to resolve the DisplayNameAttribute when a display name is not provided.")]
+        public static System.Threading.Tasks.Task ValidateObjectAsync(object instance, System.ComponentModel.DataAnnotations.ValidationContext validationContext, bool validateAllProperties, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of validationContext.ObjectType cannot be statically discovered.")]
         public static void ValidateProperty(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext) { }
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCodeAttribute("The Type of validationContext.ObjectType cannot be statically discovered.")]
+        public static System.Threading.Tasks.Task ValidatePropertyAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
         public static void ValidateValue(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationAttribute> validationAttributes) { }
+        public static System.Threading.Tasks.Task ValidateValueAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Collections.Generic.IEnumerable<System.ComponentModel.DataAnnotations.ValidationAttribute> validationAttributes, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
     }
 }
 namespace System.ComponentModel.DataAnnotations.Schema

--- a/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/libraries/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -32,6 +32,15 @@ namespace System.ComponentModel.DataAnnotations
         public string ThisKey { get { throw null; } }
         public System.Collections.Generic.IEnumerable<string> ThisKeyMembers { get { throw null; } }
     }
+    public abstract partial class AsyncValidationAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
+    {
+        protected AsyncValidationAttribute() { }
+        protected AsyncValidationAttribute(System.Func<string> errorMessageAccessor) { }
+        protected AsyncValidationAttribute(string errorMessage) { }
+        public System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> GetValidationResultAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
+        protected abstract override System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext);
+        protected abstract System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> IsValidAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken);
+    }
     [System.AttributeUsageAttribute(System.AttributeTargets.Field | System.AttributeTargets.Parameter | System.AttributeTargets.Property, AllowMultiple=false)]
     public partial class Base64StringAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
     {
@@ -195,15 +204,6 @@ namespace System.ComponentModel.DataAnnotations
         public string? PresentationLayer { get { throw null; } }
         public override bool Equals([System.Diagnostics.CodeAnalysis.NotNullWhenAttribute(true)] object? obj) { throw null; }
         public override int GetHashCode() { throw null; }
-    }
-    public abstract partial class AsyncValidationAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
-    {
-        protected AsyncValidationAttribute() { }
-        protected AsyncValidationAttribute(System.Func<string> errorMessageAccessor) { }
-        protected AsyncValidationAttribute(string errorMessage) { }
-        public System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> GetValidationResultAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) { throw null; }
-        protected abstract override System.ComponentModel.DataAnnotations.ValidationResult? IsValid(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext);
-        protected abstract System.Threading.Tasks.Task<System.ComponentModel.DataAnnotations.ValidationResult?> IsValidAsync(object? value, System.ComponentModel.DataAnnotations.ValidationContext validationContext, System.Threading.CancellationToken cancellationToken);
     }
     public partial interface IAsyncValidatableObject : System.ComponentModel.DataAnnotations.IValidatableObject
     {

--- a/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -14,8 +14,8 @@
     <Compile Include="System\ComponentModel\DataAnnotations\AllowedValuesAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProvider.cs" />
-    <Compile Include="System\ComponentModel\DataAnnotations\AsyncValidationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociationAttribute.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\AsyncValidationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\Base64StringAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\CompareAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\ConcurrencyCheckAttribute.cs" />

--- a/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/libraries/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -14,6 +14,7 @@
     <Compile Include="System\ComponentModel\DataAnnotations\AllowedValuesAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptor.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociatedMetadataTypeTypeDescriptionProvider.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\AsyncValidationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\AssociationAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\Base64StringAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\CompareAttribute.cs" />
@@ -31,6 +32,7 @@
     <Compile Include="System\ComponentModel\DataAnnotations\EnumDataTypeAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\FileExtensionsAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\FilterUIHintAttribute.cs" />
+    <Compile Include="System\ComponentModel\DataAnnotations\IAsyncValidatableObject.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\IValidatableObject.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\KeyAttribute.cs" />
     <Compile Include="System\ComponentModel\DataAnnotations\LengthAttribute.cs" />

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -45,7 +45,8 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="value">The value to validate.</param>
         /// <param name="validationContext">
         ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
-        ///     such as the object and member being validated.
+        ///     such as the object and member being validated. Provides access to services required to perform
+        ///     validation using <see cref="IServiceProvider" />.
         /// </param>
         /// <returns>
         ///     <see cref="ValidationResult.Success" /> when validation is valid.
@@ -59,12 +60,13 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="value">The value to validate.</param>
         /// <param name="validationContext">
         ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
-        ///     such as the object and member being validated.
+        ///     such as the object and member being validated. Provides access to services required to perform
+        ///     validation using <see cref="IServiceProvider" />.
         /// </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A <see cref="Task{ValidationResult}" /> representing the asynchronous validation operation.
-        ///     When validation is valid, the result is <see langword="null" /> (i.e. <see cref="ValidationResult.Success" />).
+        ///     When validation is valid, the result is <see cref="ValidationResult.Success" />.
         ///     When validation is invalid, the result is an instance of <see cref="ValidationResult" />.
         /// </returns>
         protected abstract Task<ValidationResult?> IsValidAsync(
@@ -92,12 +94,13 @@ namespace System.ComponentModel.DataAnnotations
         /// <param name="value">The value to validate.</param>
         /// <param name="validationContext">
         ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
-        ///     such as the object and member being validated.
+        ///     such as the object and member being validated. Provides access to services required to perform
+        ///     validation using <see cref="IServiceProvider" />.
         /// </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
         ///     A <see cref="Task{ValidationResult}" /> representing the asynchronous validation operation.
-        ///     When validation is valid, the result is <see langword="null" /> (i.e. <see cref="ValidationResult.Success" />).
+        ///     When validation is valid, the result is <see cref="ValidationResult.Success" />.
         ///     When validation is invalid, the result is an instance of <see cref="ValidationResult" />.
         /// </returns>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is malformed.</exception>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -1,0 +1,115 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    ///     Base class for validation attributes that require asynchronous operations, such as database lookups or API calls.
+    /// </summary>
+    public abstract class AsyncValidationAttribute : ValidationAttribute
+    {
+        /// <summary>
+        ///     Default constructor for any async validation attribute.
+        /// </summary>
+        protected AsyncValidationAttribute()
+        {
+        }
+
+        /// <summary>
+        ///     Constructor that accepts a fixed validation error message.
+        /// </summary>
+        /// <param name="errorMessage">A non-localized error message to use in <see cref="ValidationAttribute.ErrorMessageString" />.</param>
+        protected AsyncValidationAttribute(string errorMessage)
+            : base(errorMessage)
+        {
+        }
+
+        /// <summary>
+        ///     Allows for providing a resource accessor function that will be used by the <see cref="ValidationAttribute.ErrorMessageString" />
+        ///     property to retrieve the error message.
+        /// </summary>
+        /// <param name="errorMessageAccessor">The <see cref="Func{T}" /> that will return an error message.</param>
+        protected AsyncValidationAttribute(Func<string> errorMessageAccessor)
+            : base(errorMessageAccessor)
+        {
+        }
+
+        /// <summary>
+        ///     Override of the base class <see cref="ValidationAttribute.IsValid(object?, ValidationContext)" /> method.
+        ///     Subclasses must provide a synchronous validation implementation or throw an appropriate exception
+        ///     to indicate that synchronous validation is not supported.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="validationContext">
+        ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
+        ///     such as the object and member being validated.
+        /// </param>
+        /// <returns>
+        ///     <see cref="ValidationResult.Success" /> when validation is valid.
+        ///     An instance of <see cref="ValidationResult" /> when validation is invalid.
+        /// </returns>
+        protected abstract override ValidationResult? IsValid(object? value, ValidationContext validationContext);
+
+        /// <summary>
+        ///     Override this method in subclasses to implement asynchronous validation logic.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="validationContext">
+        ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
+        ///     such as the object and member being validated.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A <see cref="Task{TResult}" /> representing the asynchronous validation operation.
+        ///     When validation is valid, <see cref="ValidationResult.Success" />.
+        ///     When validation is invalid, an instance of <see cref="ValidationResult" />.
+        /// </returns>
+        protected abstract Task<ValidationResult?> IsValidAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken);
+
+        /// <summary>
+        ///     Tests whether the given <paramref name="value" /> is valid asynchronously with respect to the current
+        ///     validation attribute without throwing a <see cref="ValidationException" />.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <param name="validationContext">
+        ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
+        ///     such as the object and member being validated.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     A <see cref="Task{TResult}" /> whose result is <see cref="ValidationResult.Success" /> when valid,
+        ///     or a <see cref="ValidationResult" /> instance when invalid.
+        /// </returns>
+        public async Task<ValidationResult?> GetValidationResultAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(validationContext);
+
+            ValidationResult? result = await IsValidAsync(value, validationContext, cancellationToken).ConfigureAwait(false);
+
+            return EnsureValidationResultErrorMessage(result, validationContext);
+        }
+
+        private ValidationResult? EnsureValidationResultErrorMessage(
+            ValidationResult? result,
+            ValidationContext validationContext)
+        {
+            if (result is not null && string.IsNullOrEmpty(result.ErrorMessage))
+            {
+                string errorMessage = FormatErrorMessage(validationContext.DisplayName);
+
+                return new ValidationResult(errorMessage, result.MemberNames);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -73,6 +73,19 @@ namespace System.ComponentModel.DataAnnotations
             CancellationToken cancellationToken);
 
         /// <summary>
+        ///     Sealed override of <see cref="ValidationAttribute.IsValid(object?)" /> that delegates to the
+        ///     <see cref="ValidationContext" /> overload so that <see cref="AsyncValidationAttribute" /> implementations
+        ///     only need to provide a single synchronous fallback via
+        ///     <see cref="ValidationAttribute.IsValid(object?, ValidationContext)" />.
+        /// </summary>
+        /// <param name="value">The value to validate.</param>
+        /// <returns>
+        ///     <see langword="true" /> if the value is valid; otherwise, <see langword="false" />.
+        /// </returns>
+        public sealed override bool IsValid(object? value)
+            => IsValid(value, null!) == ValidationResult.Success;
+
+        /// <summary>
         ///     Tests whether the given <paramref name="value" /> is valid asynchronously with respect to the current
         ///     validation attribute without throwing a <see cref="ValidationException" />.
         /// </summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/AsyncValidationAttribute.cs
@@ -63,9 +63,9 @@ namespace System.ComponentModel.DataAnnotations
         /// </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
-        ///     A <see cref="Task{TResult}" /> representing the asynchronous validation operation.
-        ///     When validation is valid, <see cref="ValidationResult.Success" />.
-        ///     When validation is invalid, an instance of <see cref="ValidationResult" />.
+        ///     A <see cref="Task{ValidationResult}" /> representing the asynchronous validation operation.
+        ///     When validation is valid, the result is <see langword="null" /> (i.e. <see cref="ValidationResult.Success" />).
+        ///     When validation is invalid, the result is an instance of <see cref="ValidationResult" />.
         /// </returns>
         protected abstract Task<ValidationResult?> IsValidAsync(
             object? value,
@@ -83,9 +83,12 @@ namespace System.ComponentModel.DataAnnotations
         /// </param>
         /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
         /// <returns>
-        ///     A <see cref="Task{TResult}" /> whose result is <see cref="ValidationResult.Success" /> when valid,
-        ///     or a <see cref="ValidationResult" /> instance when invalid.
+        ///     A <see cref="Task{ValidationResult}" /> representing the asynchronous validation operation.
+        ///     When validation is valid, the result is <see langword="null" /> (i.e. <see cref="ValidationResult.Success" />).
+        ///     When validation is invalid, the result is an instance of <see cref="ValidationResult" />.
         /// </returns>
+        /// <exception cref="InvalidOperationException"> is thrown if the current attribute is malformed.</exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="validationContext" /> is null.</exception>
         public async Task<ValidationResult?> GetValidationResultAsync(
             object? value,
             ValidationContext validationContext,
@@ -98,18 +101,5 @@ namespace System.ComponentModel.DataAnnotations
             return EnsureValidationResultErrorMessage(result, validationContext);
         }
 
-        private ValidationResult? EnsureValidationResultErrorMessage(
-            ValidationResult? result,
-            ValidationContext validationContext)
-        {
-            if (result is not null && string.IsNullOrEmpty(result.ErrorMessage))
-            {
-                string errorMessage = FormatErrorMessage(validationContext.DisplayName);
-
-                return new ValidationResult(errorMessage, result.MemberNames);
-            }
-
-            return result;
-        }
     }
 }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/IAsyncValidatableObject.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/IAsyncValidatableObject.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading;
+
+namespace System.ComponentModel.DataAnnotations
+{
+    /// <summary>
+    ///     Provides a way for an object to be validated asynchronously.
+    ///     Inherits from <see cref="IValidatableObject"/>. Implementors must provide both
+    ///     <see cref="IValidatableObject.Validate"/> and <see cref="ValidateAsync"/>.
+    /// </summary>
+    public interface IAsyncValidatableObject : IValidatableObject
+    {
+        /// <summary>
+        ///     Determines whether the specified object is valid asynchronously, yielding
+        ///     validation results as each check completes.
+        /// </summary>
+        /// <param name="validationContext">
+        ///     A <see cref="ValidationContext" /> instance that provides context about the validation operation,
+        ///     such as the object and member being validated.
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>
+        ///     An <see cref="IAsyncEnumerable{T}" /> that yields <see cref="ValidationResult" /> instances
+        ///     as each validation check completes.
+        /// </returns>
+        IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/IAsyncValidatableObject.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/IAsyncValidatableObject.cs
@@ -8,9 +8,21 @@ namespace System.ComponentModel.DataAnnotations
 {
     /// <summary>
     ///     Provides a way for an object to be validated asynchronously.
-    ///     Inherits from <see cref="IValidatableObject"/>. Implementors must provide both
-    ///     <see cref="IValidatableObject.Validate"/> and <see cref="ValidateAsync"/>.
     /// </summary>
+    /// <remarks>
+    ///     When an object implements <see cref="IAsyncValidatableObject"/>, the asynchronous
+    ///     <see cref="Validator"/> APIs (such as
+    ///     <see cref="Validator.TryValidateObjectAsync(object, ValidationContext, System.Collections.Generic.ICollection{ValidationResult}?, System.Threading.CancellationToken)"/>)
+    ///     invoke only <see cref="ValidateAsync"/>; <see cref="IValidatableObject.Validate"/>
+    ///     is not called on the async path. The synchronous <see cref="Validator"/>
+    ///     APIs continue to invoke <see cref="IValidatableObject.Validate"/>.
+    ///     <para>
+    ///         Implementors should provide a synchronous fallback in
+    ///         <see cref="IValidatableObject.Validate"/> for compatibility with callers that
+    ///         do not use the async APIs, or throw <see cref="InvalidOperationException"/>
+    ///         if no synchronous implementation is feasible.
+    ///     </para>
+    /// </remarks>
     public interface IAsyncValidatableObject : IValidatableObject
     {
         /// <summary>
@@ -26,6 +38,12 @@ namespace System.ComponentModel.DataAnnotations
         ///     An <see cref="IAsyncEnumerable{T}" /> that yields <see cref="ValidationResult" /> instances
         ///     as each validation check completes.
         /// </returns>
+        /// <remarks>
+        ///     Implementors should also provide a synchronous implementation of
+        ///     <see cref="IValidatableObject.Validate"/> for compatibility with callers that
+        ///     do not use the async APIs, or throw <see cref="InvalidOperationException"/>
+        ///     if no synchronous implementation is feasible.
+        /// </remarks>
         IAsyncEnumerable<ValidationResult> ValidateAsync(
             ValidationContext validationContext,
             CancellationToken cancellationToken = default);

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -136,6 +136,13 @@ namespace System.ComponentModel.DataAnnotations
         ///     <see cref="ValidationContext" /> to perform validation.
         ///     Base class returns false. Override in child classes as appropriate.
         /// </summary>
+        /// <remarks>
+        ///     This property is only consulted by the synchronous validation path.
+        ///     The asynchronous validation entry point
+        ///     <see cref="AsyncValidationAttribute.GetValidationResultAsync(object?, ValidationContext, System.Threading.CancellationToken)" />
+        ///     always requires a non-null <see cref="ValidationContext" /> parameter,
+        ///     so this property has no effect when validating via the asynchronous pipeline.
+        /// </remarks>
         public virtual bool RequiresValidationContext => false;
 
         #endregion

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -137,11 +137,11 @@ namespace System.ComponentModel.DataAnnotations
         ///     Base class returns false. Override in child classes as appropriate.
         /// </summary>
         /// <remarks>
-        ///     This property is only consulted by the synchronous validation path.
-        ///     The asynchronous validation entry point
+        ///     This property is a hint for callers deciding whether a <see cref="ValidationContext" />
+        ///     must be supplied. The asynchronous validation entry point
         ///     <see cref="AsyncValidationAttribute.GetValidationResultAsync(object?, ValidationContext, System.Threading.CancellationToken)" />
         ///     always requires a non-null <see cref="ValidationContext" /> parameter,
-        ///     so this property has no effect when validating via the asynchronous pipeline.
+        ///     so this property is not applicable to the asynchronous pipeline.
         /// </remarks>
         public virtual bool RequiresValidationContext => false;
 

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationAttribute.cs
@@ -304,6 +304,20 @@ namespace System.ComponentModel.DataAnnotations
             return new ValidationResult(FormatErrorMessage(validationContext.DisplayName), memberNames);
         }
 
+        private protected ValidationResult? EnsureValidationResultErrorMessage(
+            ValidationResult? result,
+            ValidationContext validationContext)
+        {
+            if (result is not null && string.IsNullOrEmpty(result.ErrorMessage))
+            {
+                string errorMessage = FormatErrorMessage(validationContext.DisplayName);
+
+                return new ValidationResult(errorMessage, result.MemberNames);
+            }
+
+            return result;
+        }
+
         #endregion
 
         #region Protected & Public Methods
@@ -433,17 +447,7 @@ namespace System.ComponentModel.DataAnnotations
 
             var result = IsValid(value, validationContext);
 
-            // If validation fails, we want to ensure we have a ValidationResult that guarantees it has an ErrorMessage
-            if (result != null)
-            {
-                if (string.IsNullOrEmpty(result.ErrorMessage))
-                {
-                    var errorMessage = FormatErrorMessage(validationContext.DisplayName);
-                    result = new ValidationResult(errorMessage, result.MemberNames);
-                }
-            }
-
-            return result;
+            return EnsureValidationResultErrorMessage(result, validationContext);
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/ValidationContext.cs
@@ -205,6 +205,14 @@ namespace System.ComponentModel.DataAnnotations
         ///     This property will never be null, but the dictionary may be empty.  Changes made
         ///     to items in this dictionary will never affect the original dictionary specified in the constructor.
         /// </value>
+        /// <remarks>
+        ///     <see cref="Items" /> is designed as a read-only input channel populated before validation
+        ///     begins. The validation pipeline does not guarantee attribute execution order (beyond
+        ///     <see cref="RequiredAttribute" /> priority), and no built-in attribute mutates
+        ///     <see cref="Items" /> during validation. Custom validators should treat <see cref="Items" />
+        ///     as read-only during validation execution. Mutating <see cref="Items" /> from within a
+        ///     validator is unsupported and may produce race conditions under parallel async validation.
+        /// </remarks>
         public IDictionary<object, object?> Items => _items;
 
         #endregion

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -381,8 +381,10 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <remarks>
         ///     This method evaluates all <see cref="ValidationAttribute" />s attached to the object instance's type.  It also
-        ///     checks to ensure all properties marked with <see cref="RequiredAttribute" /> are set.  It does not validate the
-        ///     property values of the object.
+        ///     checks to ensure all properties marked with <see cref="RequiredAttribute" /> are set.  It does not validate
+        ///     the <see cref="ValidationAttribute" />s on individual properties of the object unless
+        ///     <see cref="TryValidateObjectAsync(object, ValidationContext, ICollection{ValidationResult}?, bool, CancellationToken)" />
+        ///     is called with <c>validateAllProperties</c> set to <see langword="true" />.
         /// </remarks>
         /// <param name="instance">The object instance to test.  It cannot be <c>null</c>.</param>
         /// <param name="validationContext">Describes the object to validate and provides services and context for the validators.</param>
@@ -667,11 +669,16 @@ namespace System.ComponentModel.DataAnnotations
             // Step 3: Test for IAsyncValidatableObject implementation (preferred), fall back to IValidatableObject
             if (instance is IAsyncValidatableObject asyncValidatable)
             {
-                await foreach (ValidationResult result in asyncValidatable.ValidateAsync(validationContext, cancellationToken).ConfigureAwait(false))
+                IAsyncEnumerable<ValidationResult>? results = asyncValidatable.ValidateAsync(validationContext, cancellationToken);
+
+                if (results is not null)
                 {
-                    if (result != ValidationResult.Success)
+                    await foreach (ValidationResult result in results.ConfigureAwait(false))
                     {
-                        errors.Add(new ValidationError(null, instance, result));
+                        if (result != ValidationResult.Success)
+                        {
+                            errors.Add(new ValidationError(null, instance, result));
+                        }
                     }
                 }
             }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -713,7 +713,7 @@ namespace System.ComponentModel.DataAnnotations
             {
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-                var tasks = new HashSet<Task<List<ValidationError>>>(properties.Count);
+                var tasks = new List<Task<List<ValidationError>>>(properties.Count);
                 foreach (var property in properties)
                 {
                     var attributes = _store.GetPropertyValidationAttributes(property.Key);
@@ -722,37 +722,47 @@ namespace System.ComponentModel.DataAnnotations
                         breakOnFirstError, linkedCts.Token));
                 }
 
-                while (tasks.Count > 0)
+                try
                 {
-                    Task<List<ValidationError>> completed = await Task.WhenAny(tasks).ConfigureAwait(false);
-                    tasks.Remove(completed);
-
-                    List<ValidationError> propertyErrors;
-                    try
+                    while (tasks.Count > 0)
                     {
-                        propertyErrors = await completed.ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                    {
-                        continue;
-                    }
+                        Task<List<ValidationError>> completed = await Task.WhenAny(tasks).ConfigureAwait(false);
+                        tasks.Remove(completed);
 
-                    if (propertyErrors.Count > 0)
-                    {
-                        errors.AddRange(propertyErrors);
-
-                        if (breakOnFirstError)
+                        List<ValidationError> propertyErrors;
+                        try
                         {
-                            linkedCts.Cancel();
+                            propertyErrors = await completed.ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                        {
+                            continue;
+                        }
 
-                            // Observe remaining tasks to prevent UnobservedTaskException
-                            foreach (Task<List<ValidationError>> remaining in tasks)
+                        if (propertyErrors.Count > 0)
+                        {
+                            errors.AddRange(propertyErrors);
+
+                            if (breakOnFirstError)
                             {
-                                try { await remaining.ConfigureAwait(false); }
-                                catch { }
+                                linkedCts.Cancel();
+                                break;
                             }
-
-                            break;
+                        }
+                    }
+                }
+                finally
+                {
+                    // Observe any remaining in-flight tasks on every exit path
+                    // (success short-circuit, external cancellation, or unexpected exception)
+                    // to prevent UnobservedTaskException from the finalizer thread.
+                    if (tasks.Count > 0)
+                    {
+                        linkedCts.Cancel();
+                        foreach (Task<List<ValidationError>> remaining in tasks)
+                        {
+                            try { await remaining.ConfigureAwait(false); }
+                            catch { }
                         }
                     }
                 }
@@ -847,44 +857,54 @@ namespace System.ComponentModel.DataAnnotations
             {
                 using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-                var tasks = new HashSet<Task<(AsyncValidationAttribute Attr, ValidationResult? Result)>>(asyncAttributes.Count);
+                var tasks = new List<Task<(AsyncValidationAttribute Attr, ValidationResult? Result)>>(asyncAttributes.Count);
                 foreach (AsyncValidationAttribute asyncAttr in asyncAttributes)
                 {
                     tasks.Add(RunAsyncValidation(asyncAttr, value, validationContext, linkedCts.Token));
                 }
 
-                while (tasks.Count > 0)
+                try
                 {
-                    Task<(AsyncValidationAttribute Attr, ValidationResult? Result)> completed =
-                        await Task.WhenAny(tasks).ConfigureAwait(false);
-                    tasks.Remove(completed);
-
-                    (AsyncValidationAttribute attr, ValidationResult? result) completedResult;
-                    try
+                    while (tasks.Count > 0)
                     {
-                        completedResult = await completed.ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
-                    {
-                        continue;
-                    }
+                        Task<(AsyncValidationAttribute Attr, ValidationResult? Result)> completed =
+                            await Task.WhenAny(tasks).ConfigureAwait(false);
+                        tasks.Remove(completed);
 
-                    if (completedResult.result != ValidationResult.Success)
-                    {
-                        errors.Add(new ValidationError(completedResult.attr, value, completedResult.result!));
-
-                        if (breakOnFirstError)
+                        (AsyncValidationAttribute attr, ValidationResult? result) completedResult;
+                        try
                         {
-                            linkedCts.Cancel();
+                            completedResult = await completed.ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                        {
+                            continue;
+                        }
 
-                            // Observe remaining tasks to prevent UnobservedTaskException
-                            foreach (var remaining in tasks)
+                        if (completedResult.result != ValidationResult.Success)
+                        {
+                            errors.Add(new ValidationError(completedResult.attr, value, completedResult.result!));
+
+                            if (breakOnFirstError)
                             {
-                                try { await remaining.ConfigureAwait(false); }
-                                catch { }
+                                linkedCts.Cancel();
+                                break;
                             }
-
-                            break;
+                        }
+                    }
+                }
+                finally
+                {
+                    // Observe any remaining in-flight tasks on every exit path
+                    // (success short-circuit, external cancellation, or unexpected exception)
+                    // to prevent UnobservedTaskException from the finalizer thread.
+                    if (tasks.Count > 0)
+                    {
+                        linkedCts.Cancel();
+                        foreach (var remaining in tasks)
+                        {
+                            try { await remaining.ConfigureAwait(false); }
+                            catch { }
                         }
                     }
                 }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -744,6 +744,14 @@ namespace System.ComponentModel.DataAnnotations
                         if (breakOnFirstError)
                         {
                             linkedCts.Cancel();
+
+                            // Observe remaining tasks to prevent UnobservedTaskException
+                            foreach (Task<List<ValidationError>> remaining in tasks)
+                            {
+                                try { await remaining.ConfigureAwait(false); }
+                                catch { }
+                            }
+
                             break;
                         }
                     }
@@ -868,6 +876,14 @@ namespace System.ComponentModel.DataAnnotations
                         if (breakOnFirstError)
                         {
                             linkedCts.Cancel();
+
+                            // Observe remaining tasks to prevent UnobservedTaskException
+                            foreach (var remaining in tasks)
+                            {
+                                try { await remaining.ConfigureAwait(false); }
+                                catch { }
+                            }
+
                             break;
                         }
                     }

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -423,7 +423,7 @@ namespace System.ComponentModel.DataAnnotations
         ///         is non-null, all properties complete and all errors are collected.
         ///     </para>
         ///     <para>
-        ///         Returns <see cref="Task{TResult}" /> for interoperability with standard async
+        ///         Returns <see cref="Task{Boolean}" /> for interoperability with standard async
         ///         composition patterns such as <c>Task.WhenAll</c> and <c>Task.WhenAny</c>.
         ///     </para>
         /// </remarks>

--- a/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
+++ b/src/libraries/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/Validator.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.ComponentModel.DataAnnotations
 {
@@ -319,6 +321,570 @@ namespace System.ComponentModel.DataAnnotations
             {
                 errors[0].ThrowValidationException();
             }
+        }
+
+        /// <summary>
+        ///     Asynchronously tests whether the given property value is valid.
+        /// </summary>
+        /// <remarks>
+        ///     This method will test each <see cref="ValidationAttribute" /> associated with the property
+        ///     identified by <paramref name="validationContext" />.  If <paramref name="validationResults" /> is non-null,
+        ///     this method will add a <see cref="ValidationResult" /> to it for each validation failure.
+        ///     <para>
+        ///         If there is a <see cref="RequiredAttribute" /> found on the property, it will be evaluated before all other
+        ///         validation attributes.  If the required validator fails then validation will abort, adding that single
+        ///         failure into the <paramref name="validationResults" /> when applicable, returning a value of <c>false</c>.
+        ///     </para>
+        ///     <para>
+        ///         Any <see cref="AsyncValidationAttribute" /> instances will be evaluated asynchronously after all synchronous
+        ///         validation attributes have passed.
+        ///     </para>
+        /// </remarks>
+        /// <param name="value">The value to test.</param>
+        /// <param name="validationContext">
+        ///     Describes the property member to validate and provides services and context for the validators.
+        /// </param>
+        /// <param name="validationResults">Optional collection to receive <see cref="ValidationResult" />s for the failures.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task{Boolean}" /> that is <c>true</c> if the value is valid, <c>false</c> if any validation errors are encountered.</returns>
+        /// <exception cref="ArgumentException">
+        ///     When the <see cref="ValidationContext.MemberName" /> of <paramref name="validationContext" /> is not a valid property.
+        /// </exception>
+        [RequiresUnreferencedCode("The Type of validationContext.ObjectType cannot be statically discovered.")]
+        public static async Task<bool> TryValidatePropertyAsync(
+            object? value,
+            ValidationContext validationContext,
+            ICollection<ValidationResult>? validationResults,
+            CancellationToken cancellationToken = default)
+        {
+            var propertyType = _store.GetPropertyType(validationContext);
+            var propertyName = validationContext.MemberName!;
+            EnsureValidPropertyType(propertyName, propertyType, value);
+
+            var result = true;
+            var breakOnFirstError = (validationResults == null);
+
+            var attributes = _store.GetPropertyValidationAttributes(validationContext);
+
+            foreach (var err in await GetValidationErrorsAsync(value, validationContext, attributes, breakOnFirstError, cancellationToken).ConfigureAwait(false))
+            {
+                result = false;
+
+                validationResults?.Add(err.ValidationResult);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Asynchronously tests whether the given object instance is valid.
+        /// </summary>
+        /// <remarks>
+        ///     This method evaluates all <see cref="ValidationAttribute" />s attached to the object instance's type.  It also
+        ///     checks to ensure all properties marked with <see cref="RequiredAttribute" /> are set.  It does not validate the
+        ///     property values of the object.
+        /// </remarks>
+        /// <param name="instance">The object instance to test.  It cannot be <c>null</c>.</param>
+        /// <param name="validationContext">Describes the object to validate and provides services and context for the validators.</param>
+        /// <param name="validationResults">Optional collection to receive <see cref="ValidationResult" />s for the failures.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task{Boolean}" /> that is <c>true</c> if the object is valid, <c>false</c> if any validation errors are encountered.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="instance" /> is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     When <paramref name="instance" /> doesn't match the
+        ///     <see cref="ValidationContext.ObjectInstance" /> on <paramref name="validationContext" />.
+        /// </exception>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        public static Task<bool> TryValidateObjectAsync(
+            object instance,
+            ValidationContext validationContext,
+            ICollection<ValidationResult>? validationResults,
+            CancellationToken cancellationToken = default) =>
+            TryValidateObjectAsync(instance, validationContext, validationResults, validateAllProperties: false, cancellationToken);
+
+        /// <summary>
+        ///     Asynchronously tests whether the given object instance is valid.
+        /// </summary>
+        /// <remarks>
+        ///     This method evaluates all <see cref="ValidationAttribute" />s attached to the object instance's type.  It also
+        ///     checks to ensure all properties marked with <see cref="RequiredAttribute" /> are set.  If
+        ///     <paramref name="validateAllProperties" />
+        ///     is <c>true</c>, this method will also evaluate the <see cref="ValidationAttribute" />s for all the immediate
+        ///     properties of this object.  This process is not recursive.
+        ///     <para>
+        ///         When <paramref name="validateAllProperties" /> is <c>true</c>, properties are validated
+        ///         in parallel. Within each property, synchronous attributes run first; asynchronous
+        ///         attributes run only if all synchronous attributes pass.
+        ///     </para>
+        ///     <para>
+        ///         When <paramref name="validationResults" /> is <c>null</c>, validation stops after the
+        ///         first property error (cross-property short-circuit). Any in-flight async validators on
+        ///         other properties are cancelled cooperatively. When <paramref name="validationResults" />
+        ///         is non-null, all properties complete and all errors are collected.
+        ///     </para>
+        ///     <para>
+        ///         Returns <see cref="Task{TResult}" /> for interoperability with standard async
+        ///         composition patterns such as <c>Task.WhenAll</c> and <c>Task.WhenAny</c>.
+        ///     </para>
+        /// </remarks>
+        /// <param name="instance">The object instance to test.  It cannot be null.</param>
+        /// <param name="validationContext">Describes the object to validate and provides services and context for the validators.</param>
+        /// <param name="validationResults">Optional collection to receive <see cref="ValidationResult" />s for the failures.</param>
+        /// <param name="validateAllProperties">
+        ///     If <c>true</c>, also evaluates all properties of the object (this process is not recursive over properties of the properties).
+        /// </param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task{Boolean}" /> that is <c>true</c> if the object is valid, <c>false</c> if any validation errors are encountered.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="instance" /> is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     When <paramref name="instance" /> doesn't match the
+        ///     <see cref="ValidationContext.ObjectInstance" /> on <paramref name="validationContext" />.
+        /// </exception>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        public static async Task<bool> TryValidateObjectAsync(
+            object instance,
+            ValidationContext validationContext,
+            ICollection<ValidationResult>? validationResults,
+            bool validateAllProperties,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(instance);
+
+            if (validationContext != null && instance != validationContext.ObjectInstance)
+            {
+                throw new ArgumentException(SR.Validator_InstanceMustMatchValidationContextInstance, nameof(instance));
+            }
+
+            var result = true;
+            var breakOnFirstError = (validationResults == null);
+
+            foreach (ValidationError err in await GetObjectValidationErrorsAsync(instance, validationContext!, validateAllProperties, breakOnFirstError, cancellationToken).ConfigureAwait(false))
+            {
+                result = false;
+
+                validationResults?.Add(err.ValidationResult);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Asynchronously tests whether the given value is valid against a specified list of <see cref="ValidationAttribute" />s.
+        /// </summary>
+        /// <remarks>
+        ///     This method will test each <see cref="ValidationAttribute" />s specified.  If
+        ///     <paramref name="validationResults" /> is non-null, this method will add a <see cref="ValidationResult" />
+        ///     to it for each validation failure.
+        ///     <para>
+        ///         Any <see cref="AsyncValidationAttribute" /> instances will be evaluated asynchronously after all synchronous
+        ///         validation attributes have passed.
+        ///     </para>
+        /// </remarks>
+        /// <param name="value">The value to test.</param>
+        /// <param name="validationContext">Describes the object being validated and provides services and context for the validators.</param>
+        /// <param name="validationResults">Optional collection to receive <see cref="ValidationResult" />s for the failures.</param>
+        /// <param name="validationAttributes">The list of <see cref="ValidationAttribute" />s to validate this <paramref name="value" /> against.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task{Boolean}" /> that is <c>true</c> if the object is valid, <c>false</c> if any validation errors are encountered.</returns>
+        public static async Task<bool> TryValidateValueAsync(
+            object? value,
+            ValidationContext validationContext,
+            ICollection<ValidationResult>? validationResults,
+            IEnumerable<ValidationAttribute> validationAttributes,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(validationAttributes);
+
+            var result = true;
+            var breakOnFirstError = validationResults == null;
+
+            foreach (var err in await GetValidationErrorsAsync(value, validationContext, validationAttributes, breakOnFirstError, cancellationToken).ConfigureAwait(false))
+            {
+                result = false;
+
+                validationResults?.Add(err.ValidationResult);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Asynchronously throws a <see cref="ValidationException" /> if the given property <paramref name="value" /> is not valid.
+        /// </summary>
+        /// <param name="value">The value to test.</param>
+        /// <param name="validationContext">Describes the object being validated and provides services and context for the validators.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task" /> representing the asynchronous validation operation.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="validationContext" /> is null.</exception>
+        /// <exception cref="ValidationException">When <paramref name="value" /> is invalid for this property.</exception>
+        [RequiresUnreferencedCode("The Type of validationContext.ObjectType cannot be statically discovered.")]
+        public static async Task ValidatePropertyAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken = default)
+        {
+            var propertyType = _store.GetPropertyType(validationContext);
+            EnsureValidPropertyType(validationContext.MemberName!, propertyType, value);
+
+            var attributes = _store.GetPropertyValidationAttributes(validationContext);
+
+            List<ValidationError> errors = await GetValidationErrorsAsync(value, validationContext, attributes, false, cancellationToken).ConfigureAwait(false);
+            if (errors.Count > 0)
+            {
+                errors[0].ThrowValidationException();
+            }
+        }
+
+        /// <summary>
+        ///     Asynchronously throws a <see cref="ValidationException" /> if the given <paramref name="instance" /> is not valid.
+        /// </summary>
+        /// <remarks>
+        ///     This method evaluates all <see cref="ValidationAttribute" />s attached to the object's type.
+        /// </remarks>
+        /// <param name="instance">The object instance to test.  It cannot be null.</param>
+        /// <param name="validationContext">Describes the object being validated and provides services and context for the validators.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task" /> representing the asynchronous validation operation.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="instance" /> is null.</exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="validationContext" /> is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     When <paramref name="instance" /> doesn't match the
+        ///     <see cref="ValidationContext.ObjectInstance" /> on <paramref name="validationContext" />.
+        /// </exception>
+        /// <exception cref="ValidationException">When <paramref name="instance" /> is found to be invalid.</exception>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        public static Task ValidateObjectAsync(
+            object instance,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken = default)
+        {
+            return ValidateObjectAsync(instance, validationContext, false, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Asynchronously throws a <see cref="ValidationException" /> if the given object instance is not valid.
+        /// </summary>
+        /// <remarks>
+        ///     This method evaluates all <see cref="ValidationAttribute" />s attached to the object's type.
+        ///     If <paramref name="validateAllProperties" /> is <c>true</c> it also validates all the object's properties.
+        /// </remarks>
+        /// <param name="instance">The object instance to test.  It cannot be null.</param>
+        /// <param name="validationContext">Describes the object being validated and provides services and context for the validators.</param>
+        /// <param name="validateAllProperties">If <c>true</c>, also validates all the <paramref name="instance" />'s properties.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task" /> representing the asynchronous validation operation.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="instance" /> is null.</exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="validationContext" /> is null.</exception>
+        /// <exception cref="ArgumentException">
+        ///     When <paramref name="instance" /> doesn't match the
+        ///     <see cref="ValidationContext.ObjectInstance" /> on <paramref name="validationContext" />.
+        /// </exception>
+        /// <exception cref="ValidationException">When <paramref name="instance" /> is found to be invalid.</exception>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        public static async Task ValidateObjectAsync(
+            object instance,
+            ValidationContext validationContext,
+            bool validateAllProperties,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(instance);
+            ArgumentNullException.ThrowIfNull(validationContext);
+
+            if (instance != validationContext.ObjectInstance)
+            {
+                throw new ArgumentException(SR.Validator_InstanceMustMatchValidationContextInstance, nameof(instance));
+            }
+
+            List<ValidationError> errors = await GetObjectValidationErrorsAsync(instance, validationContext, validateAllProperties, false, cancellationToken).ConfigureAwait(false);
+            if (errors.Count > 0)
+            {
+                errors[0].ThrowValidationException();
+            }
+        }
+
+        /// <summary>
+        ///     Asynchronously throws a <see cref="ValidationException" /> if the given value is not valid for the
+        ///     <see cref="ValidationAttribute" />s.
+        /// </summary>
+        /// <param name="value">The value to test.</param>
+        /// <param name="validationContext">Describes the object being tested.</param>
+        /// <param name="validationAttributes">The list of <see cref="ValidationAttribute" />s to validate against this instance.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken" /> to observe while waiting for the task to complete.</param>
+        /// <returns>A <see cref="Task" /> representing the asynchronous validation operation.</returns>
+        /// <exception cref="ArgumentNullException">When <paramref name="validationContext" /> is null.</exception>
+        /// <exception cref="ValidationException">When <paramref name="value" /> is found to be invalid.</exception>
+        public static async Task ValidateValueAsync(
+            object? value,
+            ValidationContext validationContext,
+            IEnumerable<ValidationAttribute> validationAttributes,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(validationContext);
+            ArgumentNullException.ThrowIfNull(validationAttributes);
+
+            List<ValidationError> errors = await GetValidationErrorsAsync(value, validationContext, validationAttributes, false, cancellationToken).ConfigureAwait(false);
+            if (errors.Count > 0)
+            {
+                errors[0].ThrowValidationException();
+            }
+        }
+
+        /// <summary>
+        ///     Asynchronous version of <see cref="GetObjectValidationErrors" />.
+        ///     Implements a 3-step pipeline: properties → type attrs → IAsyncValidatableObject or IValidatableObject.
+        /// </summary>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        private static async Task<List<ValidationError>> GetObjectValidationErrorsAsync(
+            object instance,
+            ValidationContext validationContext,
+            bool validateAllProperties,
+            bool breakOnFirstError,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(validationContext);
+
+            Debug.Assert(instance != null);
+
+            // Step 1: Validate the object properties' validation attributes
+            List<ValidationError> errors = await GetObjectPropertyValidationErrorsAsync(instance, validationContext, validateAllProperties, breakOnFirstError, cancellationToken).ConfigureAwait(false);
+
+            // We only proceed to Step 2 if there are no errors
+            if (errors.Count > 0)
+            {
+                return errors;
+            }
+
+            // Step 2: Validate the object's validation attributes
+            var attributes = _store.GetTypeValidationAttributes(validationContext);
+            errors.AddRange(await GetValidationErrorsAsync(instance, validationContext, attributes, breakOnFirstError, cancellationToken).ConfigureAwait(false));
+
+            // We only proceed to Step 3 if there are no errors
+            if (errors.Count > 0)
+            {
+                return errors;
+            }
+
+            // Step 3: Test for IAsyncValidatableObject implementation (preferred), fall back to IValidatableObject
+            if (instance is IAsyncValidatableObject asyncValidatable)
+            {
+                await foreach (ValidationResult result in asyncValidatable.ValidateAsync(validationContext, cancellationToken).ConfigureAwait(false))
+                {
+                    if (result != ValidationResult.Success)
+                    {
+                        errors.Add(new ValidationError(null, instance, result));
+                    }
+                }
+            }
+            else if (instance is IValidatableObject validatable)
+            {
+                var results = validatable.Validate(validationContext);
+
+                if (results != null)
+                {
+                    foreach (ValidationResult result in results)
+                    {
+                        if (result != ValidationResult.Success)
+                        {
+                            errors.Add(new ValidationError(null, instance, result));
+                        }
+                    }
+                }
+            }
+
+            return errors;
+        }
+
+        /// <summary>
+        ///     Asynchronous version of <see cref="GetObjectPropertyValidationErrors" />.
+        ///     Iterates all properties and validates each using <see cref="GetValidationErrorsAsync" />.
+        /// </summary>
+        [RequiresUnreferencedCode(ValidationContext.InstanceTypeNotStaticallyDiscovered)]
+        private static async Task<List<ValidationError>> GetObjectPropertyValidationErrorsAsync(
+            object instance,
+            ValidationContext validationContext,
+            bool validateAllProperties,
+            bool breakOnFirstError,
+            CancellationToken cancellationToken)
+        {
+            var properties = GetPropertyValues(instance, validationContext);
+            var errors = new List<ValidationError>();
+
+            if (validateAllProperties)
+            {
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                var tasks = new HashSet<Task<List<ValidationError>>>(properties.Count);
+                foreach (var property in properties)
+                {
+                    var attributes = _store.GetPropertyValidationAttributes(property.Key);
+                    tasks.Add(GetValidationErrorsAsync(
+                        property.Value, property.Key, attributes,
+                        breakOnFirstError, linkedCts.Token));
+                }
+
+                while (tasks.Count > 0)
+                {
+                    Task<List<ValidationError>> completed = await Task.WhenAny(tasks).ConfigureAwait(false);
+                    tasks.Remove(completed);
+
+                    List<ValidationError> propertyErrors;
+                    try
+                    {
+                        propertyErrors = await completed.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        continue;
+                    }
+
+                    if (propertyErrors.Count > 0)
+                    {
+                        errors.AddRange(propertyErrors);
+
+                        if (breakOnFirstError)
+                        {
+                            linkedCts.Cancel();
+                            break;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                foreach (var property in properties)
+                {
+                    var attributes = _store.GetPropertyValidationAttributes(property.Key);
+                    foreach (ValidationAttribute attribute in attributes)
+                    {
+                        if (attribute is RequiredAttribute reqAttr)
+                        {
+                            var validationResult = reqAttr.GetValidationResult(property.Value, property.Key);
+                            if (validationResult != ValidationResult.Success)
+                            {
+                                errors.Add(new ValidationError(reqAttr, property.Value, validationResult!));
+                            }
+                            break;
+                        }
+                    }
+
+                    if (breakOnFirstError && errors.Count > 0)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return errors;
+        }
+
+        /// <summary>
+        ///     Asynchronous version of <see cref="GetValidationErrors" />.
+        ///     Implements two-phase validation: sync attributes first, async attributes only if no sync errors.
+        /// </summary>
+        private static async Task<List<ValidationError>> GetValidationErrorsAsync(
+            object? value,
+            ValidationContext validationContext,
+            IEnumerable<ValidationAttribute> attributes,
+            bool breakOnFirstError,
+            CancellationToken cancellationToken)
+        {
+            ArgumentNullException.ThrowIfNull(validationContext);
+
+            var errors = new List<ValidationError>();
+            List<AsyncValidationAttribute>? asyncAttributes = null;
+            ValidationError? validationError;
+
+            // Get the required validator if there is one and test it first, aborting on failure
+            RequiredAttribute? required = null;
+            foreach (ValidationAttribute attribute in attributes)
+            {
+                required = attribute as RequiredAttribute;
+                if (required is not null)
+                {
+                    if (!TryValidate(value, validationContext, required, out validationError))
+                    {
+                        errors.Add(validationError);
+                        return errors;
+                    }
+                    break;
+                }
+            }
+
+            // Phase 1: Iterate through sync validators, collecting async ones for later
+            foreach (ValidationAttribute attr in attributes)
+            {
+                if (attr != required)
+                {
+                    if (attr is AsyncValidationAttribute asyncAttr)
+                    {
+                        (asyncAttributes ??= new List<AsyncValidationAttribute>()).Add(asyncAttr);
+                    }
+                    else
+                    {
+                        if (!TryValidate(value, validationContext, attr, out validationError))
+                        {
+                            errors.Add(validationError);
+
+                            if (breakOnFirstError)
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Phase 2: Only run async validators if all sync validators passed — run in parallel
+            if (errors.Count == 0 && asyncAttributes is not null)
+            {
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                var tasks = new HashSet<Task<(AsyncValidationAttribute Attr, ValidationResult? Result)>>(asyncAttributes.Count);
+                foreach (AsyncValidationAttribute asyncAttr in asyncAttributes)
+                {
+                    tasks.Add(RunAsyncValidation(asyncAttr, value, validationContext, linkedCts.Token));
+                }
+
+                while (tasks.Count > 0)
+                {
+                    Task<(AsyncValidationAttribute Attr, ValidationResult? Result)> completed =
+                        await Task.WhenAny(tasks).ConfigureAwait(false);
+                    tasks.Remove(completed);
+
+                    (AsyncValidationAttribute attr, ValidationResult? result) completedResult;
+                    try
+                    {
+                        completedResult = await completed.ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                    {
+                        continue;
+                    }
+
+                    if (completedResult.result != ValidationResult.Success)
+                    {
+                        errors.Add(new ValidationError(completedResult.attr, value, completedResult.result!));
+
+                        if (breakOnFirstError)
+                        {
+                            linkedCts.Cancel();
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return errors;
+        }
+
+        private static async Task<(AsyncValidationAttribute Attr, ValidationResult? Result)> RunAsyncValidation(
+            AsyncValidationAttribute attr,
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken)
+        {
+            ValidationResult? result = await attr.GetValidationResultAsync(value, validationContext, cancellationToken).ConfigureAwait(false);
+            return (attr, result);
         }
 
         /// <summary>

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidationAttributeTests.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.ComponentModel.DataAnnotations.Tests
@@ -391,6 +393,241 @@ namespace System.ComponentModel.DataAnnotations.Tests
         public class ValidationAttributeAlwaysInvalidEmptyErrorMessage : ValidationAttribute
         {
             protected override ValidationResult IsValid(object value, ValidationContext validationContext) => new ValidationResult(string.Empty);
+        }
+
+        [Fact]
+        public static void AsyncValidationAttribute_IsValid_SubclassCanThrowForSyncUse()
+        {
+            var attribute = new TestAsyncAlwaysFailsAttribute();
+            var context = new ValidationContext(new object());
+            Assert.Throws<InvalidOperationException>(() => attribute.GetValidationResult("test", context));
+        }
+
+        [Fact]
+        public static void AsyncValidationAttribute_IsValid_SubclassCanProvideSyncFallback()
+        {
+            var attribute = new TestAsyncWithSyncFallbackAttribute();
+            var context = new ValidationContext(new object());
+            var result = attribute.GetValidationResult("sync-valid", context);
+            Assert.Equal(ValidationResult.Success, result);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_ReturnsFailure()
+        {
+            var attribute = new TestAsyncAlwaysFailsAttribute();
+            var context = new ValidationContext(new object());
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.NotEqual(ValidationResult.Success, result);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_ReturnsSuccess()
+        {
+            var attribute = new TestAsyncAlwaysSucceedsAttribute();
+            var context = new ValidationContext(new object());
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.Equal(ValidationResult.Success, result);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_FormatsErrorMessage()
+        {
+            var attribute = new TestAsyncAlwaysFailsAttribute();
+            var context = new ValidationContext(new object()) { DisplayName = "TestField" };
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.Contains("TestField", result.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_CustomErrorMessage()
+        {
+            var attribute = new TestAsyncAlwaysFailsAttribute { ErrorMessage = "Custom: {0}" };
+            var context = new ValidationContext(new object()) { DisplayName = "MyProp" };
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.Equal("Custom: MyProp", result.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_ErrorMessageAccessor()
+        {
+            var attribute = new TestAsyncAlwaysFailsWithAccessorAttribute();
+            var context = new ValidationContext(new object()) { DisplayName = "Field1" };
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.Contains("Field1", result.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_ThrowsOnNullContext()
+        {
+            var attribute = new TestAsyncAlwaysSucceedsAttribute();
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await attribute.GetValidationResultAsync("test", null));
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_PreservesExplicitErrorMessage()
+        {
+            var attribute = new TestAsyncFailsWithExplicitMessageAttribute();
+            var context = new ValidationContext(new object()) { DisplayName = "Ignored" };
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.Equal("Explicit error message", result.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_GetValidationResultAsync_TrulyAsync()
+        {
+            var attribute = new TestAsyncDelayedValidationAttribute();
+            var context = new ValidationContext(new object());
+            var result = await attribute.GetValidationResultAsync("test", context);
+            Assert.NotNull(result);
+            Assert.NotEqual(ValidationResult.Success, result);
+        }
+
+        public class TestAsyncAlwaysFailsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(new ValidationResult(null));
+            }
+        }
+
+        public class TestAsyncAlwaysSucceedsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(ValidationResult.Success);
+            }
+        }
+
+        public class TestAsyncAlwaysFailsWithAccessorAttribute : AsyncValidationAttribute
+        {
+            public TestAsyncAlwaysFailsWithAccessorAttribute() : base(() => "Accessor error for {0}") { }
+
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(new ValidationResult(null));
+            }
+        }
+
+        public class TestAsyncFailsWithExplicitMessageAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(new ValidationResult("Explicit error message"));
+            }
+        }
+
+        public class TestAsyncDelayedValidationAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                return new ValidationResult(null);
+            }
+        }
+
+        public class TestAsyncWithSyncFallbackAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+            {
+                if (value is string s && s == "sync-valid")
+                {
+                    return ValidationResult.Success;
+                }
+                return new ValidationResult("Sync fallback failed");
+            }
+
+            protected override Task<ValidationResult?> IsValidAsync(object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(ValidationResult.Success);
+            }
+        }
+
+        private class TestAsyncCancellable : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+
+                return ValidationResult.Success;
+            }
+        }
+
+        private class TestAsyncWithMessage : AsyncValidationAttribute
+        {
+            public TestAsyncWithMessage(string errorMessage) : base(errorMessage) { }
+
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(null);
+            }
+        }
+
+        [Fact]
+        public static void AsyncValidationAttribute_SyncFallbackOverride_Works()
+        {
+            var attribute = new TestAsyncWithSyncFallbackAttribute();
+            var context = new ValidationContext(new object());
+            var result = attribute.GetValidationResult("sync-valid", context);
+            Assert.Equal(ValidationResult.Success, result);
+        }
+
+        [Fact]
+        public static void AsyncValidationAttribute_SyncFallbackOverride_FailsCorrectly()
+        {
+            var attribute = new TestAsyncWithSyncFallbackAttribute();
+            var context = new ValidationContext(new object());
+            var result = attribute.GetValidationResult("other", context);
+            Assert.NotNull(result);
+            Assert.Equal("Sync fallback failed", result.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task AsyncValidationAttribute_CancellationToken_Propagated()
+        {
+            var attribute = new TestAsyncCancellable();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await attribute.GetValidationResultAsync("value", s_testValidationContext, cts.Token));
+        }
+
+        [Fact]
+        public static void AsyncValidationAttribute_Constructor_WithErrorMessage()
+        {
+            var attribute = new TestAsyncWithMessage("Custom error");
+            Assert.Throws<InvalidOperationException>(
+                () => attribute.GetValidationResult("any", s_testValidationContext));
         }
 
         public class ToBeTested

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -1584,7 +1584,8 @@ namespace System.ComponentModel.DataAnnotations.Tests
             protected override async Task<ValidationResult?> IsValidAsync(
                 object? value, ValidationContext validationContext, CancellationToken cancellationToken)
             {
-                await Task.Delay(100, cancellationToken);
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 return ValidationResult.Success;
             }
@@ -1599,7 +1600,8 @@ namespace System.ComponentModel.DataAnnotations.Tests
             protected override async Task<ValidationResult?> IsValidAsync(
                 object? value, ValidationContext validationContext, CancellationToken cancellationToken)
             {
-                await Task.Delay(100, cancellationToken);
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 return new ValidationResult("Async delayed validation failed");
             }
@@ -1609,13 +1611,13 @@ namespace System.ComponentModel.DataAnnotations.Tests
         public class AsyncConcurrencyProbeAttribute : AsyncValidationAttribute
         {
             public static int ConcurrentCount;
-            public static TaskCompletionSource<bool> AllRunningGate = new();
+            public static TaskCompletionSource<bool> AllRunningGate = new(TaskCreationOptions.RunContinuationsAsynchronously);
             public static int ExpectedCount;
 
             public static void Reset(int expectedCount)
             {
                 ConcurrentCount = 0;
-                AllRunningGate = new TaskCompletionSource<bool>();
+                AllRunningGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 ExpectedCount = expectedCount;
             }
 

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -3,6 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
@@ -1449,6 +1451,1263 @@ namespace System.ComponentModel.DataAnnotations.Tests
                 => value.SecondPropertyToBeTested == "TypeInvalid"
                     ? new ValidationResult("The SecondPropertyToBeTested field mustn't be \"TypeInvalid\".")
                     : ValidationResult.Success;
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public class AsyncAlwaysFailsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(new ValidationResult("Async validation always fails"));
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public class AsyncAlwaysSucceedsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(null);
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public class AsyncDelayedAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                await Task.Yield();
+                if (value is string s && s == "Valid Value")
+                    return ValidationResult.Success;
+
+                return new ValidationResult("Async delayed validation failed");
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+        public class AsyncCancellableAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+
+                return ValidationResult.Success;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+        public class AsyncClassAlwaysFailsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                return Task.FromResult<ValidationResult?>(new ValidationResult("Async class validation failed"));
+            }
+        }
+
+        public class HasAsyncProperty
+        {
+            [AsyncAlwaysFails]
+            public string AsyncProp { get; set; }
+        }
+
+        public class HasAsyncSucceedingProperty
+        {
+            [AsyncAlwaysSucceeds]
+            public string AsyncProp { get; set; }
+        }
+
+        public class HasTrulyAsyncProperty
+        {
+            [AsyncDelayed]
+            public string AsyncProp { get; set; }
+        }
+
+        public class HasAsyncCancellableProperty
+        {
+            [AsyncCancellable]
+            public string CancellableProp { get; set; }
+        }
+
+        public class HasMixedValidation
+        {
+            [ValidValueStringProperty]
+            [AsyncAlwaysFails]
+            public string MixedProp { get; set; }
+        }
+
+        public class HasMixedPassingValidation
+        {
+            [ValidValueStringProperty]
+            [AsyncAlwaysSucceeds]
+            public string MixedProp { get; set; }
+        }
+
+        public class HasRequiredAndAsyncProperty
+        {
+            [Required]
+            [AsyncAlwaysFails]
+            public string Prop { get; set; }
+        }
+
+        [AsyncClassAlwaysFails]
+        public class HasAsyncClassLevelAttr
+        {
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+        public class AsyncDelayedSucceedsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                await Task.Delay(100, cancellationToken);
+
+                return ValidationResult.Success;
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+        public class AsyncDelayedFailsAttribute : AsyncValidationAttribute
+        {
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                await Task.Delay(100, cancellationToken);
+
+                return new ValidationResult("Async delayed validation failed");
+            }
+        }
+
+        public class HasMultipleAsyncProperties
+        {
+            [AsyncDelayedSucceeds]
+            public string Prop1 { get; set; } = "value";
+
+            [AsyncDelayedSucceeds]
+            public string Prop2 { get; set; } = "value";
+        }
+
+        public class HasMultipleFailingAsyncProperties
+        {
+            [AsyncDelayedFails]
+            public string Prop1 { get; set; } = "value";
+
+            [AsyncDelayedFails]
+            public string Prop2 { get; set; } = "value";
+        }
+
+        public class AsyncValidatableSuccess : IAsyncValidatableObject
+        {
+            IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+                ValidationContext validationContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                await Task.CompletedTask;
+                yield return ValidationResult.Success;
+            }
+        }
+
+        public class AsyncValidatableError : IAsyncValidatableObject
+        {
+            IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+                ValidationContext validationContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                await Task.CompletedTask;
+                yield return new ValidationResult("async object error");
+            }
+        }
+
+        public class AsyncValidatableNull : IAsyncValidatableObject
+        {
+            IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+#pragma warning disable CS1998
+            public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+                ValidationContext validationContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                yield break;
+            }
+#pragma warning restore CS1998
+        }
+
+        public class DualValidatableModel : IAsyncValidatableObject
+        {
+            IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+            {
+                return new ValidationResult[] { new ValidationResult("sync error from dual model") };
+            }
+
+            public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+                ValidationContext validationContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                await Task.CompletedTask;
+                yield return new ValidationResult("async error from dual model");
+            }
+        }
+
+        public class AsyncValidatableWithRequired : IAsyncValidatableObject
+        {
+            [Required]
+            public string RequiredProp { get; set; }
+
+            IEnumerable<ValidationResult> IValidatableObject.Validate(ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+                ValidationContext validationContext, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+            {
+                await Task.CompletedTask;
+                yield return new ValidationResult("async object error");
+            }
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsyncThrowsIf_instance_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateObjectAsync(null, s_estValidationContext, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateObjectAsync(null, s_estValidationContext, null, false));
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsyncThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateObjectAsync(new object(), null, null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateObjectAsync(new object(), null, null, false));
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_ThrowsIf_instance_does_not_match_ValidationContext()
+        {
+            await AssertExtensions.ThrowsAsync<ArgumentException>("instance",
+                async () => await Validator.TryValidateObjectAsync(new object(), s_estValidationContext, null));
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_returns_true_if_no_errors()
+        {
+            var objectToBeValidated = "ToBeValidated";
+            var validationContext = new ValidationContext(objectToBeValidated);
+            Assert.True(await Validator.TryValidateObjectAsync(objectToBeValidated, validationContext, null));
+            Assert.True(await Validator.TryValidateObjectAsync(objectToBeValidated, validationContext, null, true));
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_returns_false_with_sync_errors()
+        {
+            var objectToBeValidated = new ToBeValidated()
+            {
+                PropertyToBeTested = "Invalid Value",
+                PropertyWithRequiredAttribute = "Valid Value"
+            };
+            var validationContext = new ValidationContext(objectToBeValidated);
+            var validationResults = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(objectToBeValidated, validationContext, validationResults, true));
+            Assert.Equal(1, validationResults.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", validationResults[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_returns_false_with_async_attr_failure()
+        {
+            var obj = new HasAsyncProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Async validation always fails", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_returns_true_with_async_attr_success()
+        {
+            var obj = new HasAsyncSucceedingProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_validateAllProperties_false_only_checks_Required()
+        {
+            var obj = new HasAsyncProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, false));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_Required_fails_before_async()
+        {
+            var obj = new HasRequiredAndAsyncProperty { Prop = null };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_collection_can_have_multiple_results()
+        {
+            HasDoubleFailureProperty obj = new HasDoubleFailureProperty();
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(2, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_returns_false_if_class_level_attribute_fails()
+        {
+            var obj = new InvalidToBeValidated() { PropertyWithRequiredAttribute = "Valid Value" };
+            var ctx = new ValidationContext(obj);
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, null, true));
+
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidClassAttribute.IsValid failed for class of type " + typeof(InvalidToBeValidated).FullName, results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IValidatableObject_Null()
+        {
+            var instance = new ValidatableNull();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Equal(0, results.Count);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsyncThrowsIf_instance_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateObjectAsync(null, s_estValidationContext));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateObjectAsync(null, s_estValidationContext, false));
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsyncThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateObjectAsync(new object(), null));
+
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateObjectAsync(new object(), null, false));
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_ThrowsIf_instance_does_not_match()
+        {
+            await AssertExtensions.ThrowsAsync<ArgumentException>("instance",
+                async () => await Validator.ValidateObjectAsync(new object(), s_estValidationContext));
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_succeeds_if_no_errors()
+        {
+            var obj = "ToBeValidated";
+            var ctx = new ValidationContext(obj);
+            await Validator.ValidateObjectAsync(obj, ctx);
+            await Validator.ValidateObjectAsync(obj, ctx, true);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_throws_ValidationException_if_sync_errors()
+        {
+            var obj = new ToBeValidated()
+            {
+                PropertyToBeTested = "Invalid Value",
+                PropertyWithRequiredAttribute = "Valid Value"
+            };
+            var ctx = new ValidationContext(obj);
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateObjectAsync(obj, ctx, true));
+            Assert.IsType<ValidValueStringPropertyAttribute>(ex.ValidationAttribute);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_throws_ValidationException_if_async_attr_fails()
+        {
+            var obj = new HasAsyncProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateObjectAsync(obj, ctx, true));
+            Assert.Equal("Async validation always fails", ex.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_succeeds_validateAllProperties_false()
+        {
+            var obj = new HasAsyncProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            await Validator.ValidateObjectAsync(obj, ctx, false);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_throws_if_class_level_sync_attribute_fails()
+        {
+            var obj = new InvalidToBeValidated() { PropertyWithRequiredAttribute = "Valid Value" };
+            var ctx = new ValidationContext(obj);
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateObjectAsync(obj, ctx, true));
+            Assert.IsType<ValidClassAttribute>(ex.ValidationAttribute);
+            Assert.Equal("ValidClassAttribute.IsValid failed for class of type " + typeof(InvalidToBeValidated).FullName, ex.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidatePropertyAsync(new object(), null, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_true_if_no_errors()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NoAttributesProperty";
+            Assert.True(await Validator.TryValidatePropertyAsync("Any Value", ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_false_with_sync_attr_failure()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyToBeTested";
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidatePropertyAsync("Invalid Value", ctx, results));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_false_with_async_attr_failure()
+        {
+            var obj = new HasAsyncProperty();
+            var ctx = new ValidationContext(obj);
+            ctx.MemberName = nameof(HasAsyncProperty.AsyncProp);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidatePropertyAsync("anything", ctx, results));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Async validation always fails", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_true_with_async_attr_success()
+        {
+            var obj = new HasAsyncSucceedingProperty();
+            var ctx = new ValidationContext(obj);
+            ctx.MemberName = nameof(HasAsyncSucceedingProperty.AsyncProp);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidatePropertyAsync("anything", ctx, results));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_value_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidatePropertyAsync(null, s_estValidationContext, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_MemberName_is_null_or_empty()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = null;
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+
+            ctx.MemberName = string.Empty;
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_MemberName_does_not_exist()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NonExist";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_MemberName_is_not_public()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "InternalProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+
+            ctx.MemberName = "ProtectedProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+
+            ctx.MemberName = "PrivateProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_MemberName_is_indexer()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "Item";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_value_is_wrong_type()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NoAttributesProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.TryValidatePropertyAsync(123, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_ThrowsIf_null_passed_to_non_nullable_property()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+
+            ctx.MemberName = "EnumProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+
+            ctx.MemberName = "NonNullableProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_true_if_null_passed_to_nullable_property()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NullableProperty";
+            Assert.True(await Validator.TryValidatePropertyAsync(null, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_false_if_Required_fails()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            Assert.False(await Validator.TryValidatePropertyAsync(null, ctx, null));
+
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidatePropertyAsync(null, ctx, results));
+            Assert.Equal(1, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_collection_can_have_multiple_results()
+        {
+            var ctx = new ValidationContext(new HasDoubleFailureProperty());
+            ctx.MemberName = nameof(HasDoubleFailureProperty.WillAlwaysFailTwice);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidatePropertyAsync("Nope", ctx, results));
+            Assert.Equal(2, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidatePropertyAsync_returns_true_if_all_attributes_are_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            Assert.True(await Validator.TryValidatePropertyAsync("Valid Value", ctx, null));
+
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidatePropertyAsync("Valid Value", ctx, results));
+            Assert.Equal(0, results.Count);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidatePropertyAsync(new object(), null));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_succeeds_if_no_errors()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NoAttributesProperty";
+            await Validator.ValidatePropertyAsync("Any Value", ctx);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_throws_ValidationException_with_sync_attr_failure()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyToBeTested";
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidatePropertyAsync("Invalid Value", ctx));
+            Assert.IsType<ValidValueStringPropertyAttribute>(ex.ValidationAttribute);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_throws_ValidationException_with_async_attr_failure()
+        {
+            var obj = new HasAsyncProperty();
+            var ctx = new ValidationContext(obj);
+            ctx.MemberName = nameof(HasAsyncProperty.AsyncProp);
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidatePropertyAsync("anything", ctx));
+            Assert.Equal("Async validation always fails", ex.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_value_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidatePropertyAsync(null, s_estValidationContext));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_MemberName_is_null_or_empty()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = null;
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+
+            ctx.MemberName = string.Empty;
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_MemberName_does_not_exist()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NonExist";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_MemberName_is_not_public()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "InternalProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+
+            ctx.MemberName = "ProtectedProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+
+            ctx.MemberName = "PrivateProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_MemberName_is_indexer()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "Item";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("propertyName",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_value_is_wrong_type()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NoAttributesProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.ValidatePropertyAsync(123, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_ThrowsIf_null_passed_to_non_nullable()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+
+            ctx.MemberName = "EnumProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+
+            ctx.MemberName = "NonNullableProperty";
+            await AssertExtensions.ThrowsAsync<ArgumentException>("value",
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_succeeds_if_null_passed_to_nullable()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "NullableProperty";
+            await Validator.ValidatePropertyAsync(null, ctx);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_throws_if_Required_fails()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidatePropertyAsync(null, ctx));
+            Assert.IsType<RequiredAttribute>(ex.ValidationAttribute);
+            Assert.Null(ex.Value);
+        }
+
+        [Fact]
+        public static async Task ValidatePropertyAsync_succeeds_if_all_attributes_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            await Validator.ValidatePropertyAsync("Valid Value", ctx);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_ThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateValueAsync(
+                    new object(), null, null, Enumerable.Empty<ValidationAttribute>()));
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_ThrowsIf_attributes_is_null()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.TryValidateValueAsync(new object(), ctx, null, null));
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_true_if_no_attributes()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            Assert.True(await Validator.TryValidateValueAsync(
+                "any", ctx, null, Enumerable.Empty<ValidationAttribute>()));
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_false_with_async_attr_failure()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new AsyncAlwaysFailsAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("anything", ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Async validation always fails", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_true_with_async_attr_success()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new AsyncAlwaysSucceedsAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateValueAsync("anything", ctx, results, attrs));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_sync_Required_failure_blocks_async()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new AsyncAlwaysFailsAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync(null, ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_sync_attr_failure_blocks_async()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute(), new AsyncAlwaysFailsAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("Invalid Value", ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_sync_passes_then_async_runs()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute(), new AsyncAlwaysFailsAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("Valid Value", ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Async validation always fails", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_true_if_Required_and_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new ValidValueStringPropertyAttribute() };
+            Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, null, attrs));
+
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, results, attrs));
+            Assert.Equal(0, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_false_if_Required_and_invalid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new ValidValueStringPropertyAttribute() };
+            Assert.False(await Validator.TryValidateValueAsync("Invalid Value", ctx, null, attrs));
+
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("Invalid Value", ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_true_if_no_Required_and_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyToBeTested";
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute() };
+            Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, null, attrs));
+
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, results, attrs));
+            Assert.Equal(0, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_returns_false_if_no_Required_and_invalid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyToBeTested";
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute() };
+            Assert.False(await Validator.TryValidateValueAsync("Invalid Value", ctx, null, attrs));
+
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("Invalid Value", ctx, results, attrs));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_collection_can_have_multiple_results()
+        {
+            var ctx = new ValidationContext(new HasDoubleFailureProperty());
+            ctx.MemberName = nameof(HasDoubleFailureProperty.WillAlwaysFailTwice);
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute(), new ValidValueStringPropertyDuplicateAttribute() };
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateValueAsync("Not Valid", ctx, results, attrs));
+            Assert.Equal(2, results.Count);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_ThrowsIf_ValidationContext_is_null()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateValueAsync(
+                    new object(), null, Enumerable.Empty<ValidationAttribute>()));
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_ThrowsIf_attributes_is_null()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await Validator.ValidateValueAsync(new object(), ctx, null));
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_succeeds_if_no_attributes()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            await Validator.ValidateValueAsync("any", ctx, Enumerable.Empty<ValidationAttribute>());
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_throws_ValidationException_with_async_attr_failure()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new AsyncAlwaysFailsAttribute() };
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateValueAsync("anything", ctx, attrs));
+            Assert.Equal("Async validation always fails", ex.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_succeeds_with_async_attr_success()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new AsyncAlwaysSucceedsAttribute() };
+            await Validator.ValidateValueAsync("anything", ctx, attrs);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_throws_if_Required_and_null()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new ValidValueStringPropertyAttribute() };
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateValueAsync(null, ctx, attrs));
+            Assert.IsType<RequiredAttribute>(ex.ValidationAttribute);
+            Assert.Null(ex.Value);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_throws_if_Required_and_invalid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new ValidValueStringPropertyAttribute() };
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateValueAsync("Invalid Value", ctx, attrs));
+            Assert.IsType<ValidValueStringPropertyAttribute>(ex.ValidationAttribute);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", ex.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", ex.Value);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_succeeds_if_Required_and_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new RequiredAttribute(), new ValidValueStringPropertyAttribute() };
+            await Validator.ValidateValueAsync("Valid Value", ctx, attrs);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_throws_if_no_Required_and_invalid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyWithRequiredAttribute";
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute() };
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateValueAsync("Invalid Value", ctx, attrs));
+            Assert.IsType<ValidValueStringPropertyAttribute>(ex.ValidationAttribute);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", ex.ValidationResult.ErrorMessage);
+            Assert.Equal("Invalid Value", ex.Value);
+        }
+
+        [Fact]
+        public static async Task ValidateValueAsync_succeeds_if_no_Required_and_valid()
+        {
+            var ctx = new ValidationContext(new ToBeValidated());
+            ctx.MemberName = "PropertyToBeTested";
+            var attrs = new ValidationAttribute[] { new ValidValueStringPropertyAttribute() };
+            await Validator.ValidateValueAsync("Valid Value", ctx, attrs);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IAsyncValidatableObject_Success()
+        {
+            var instance = new AsyncValidatableSuccess();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IAsyncValidatableObject_Error()
+        {
+            var instance = new AsyncValidatableError();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Equal("async object error", Assert.Single(results).ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IAsyncValidatableObject_Null_Result()
+        {
+            var instance = new AsyncValidatableNull();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IAsyncValidatableObject_Preferred_Over_IValidatableObject()
+        {
+            var instance = new DualValidatableModel();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Equal("async error from dual model", Assert.Single(results).ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IValidatableObject_Fallback()
+        {
+            var instance = new ValidatableError();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(instance, ctx, results));
+            Assert.Equal("error", Assert.Single(results).ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_IAsyncValidatableObject_SkippedIfPropertyErrors()
+        {
+            var instance = new AsyncValidatableWithRequired { RequiredProp = null };
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(instance, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.DoesNotContain(results, r => r.ErrorMessage == "async object error");
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_CancellationToken_Propagated()
+        {
+            var obj = new HasAsyncCancellableProperty { CancellableProp = "value" };
+            var ctx = new ValidationContext(obj);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await Validator.TryValidateObjectAsync(obj, ctx, null, true, cts.Token));
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_CancellationToken_Propagated()
+        {
+            var ctx = new ValidationContext(new object());
+            var attrs = new ValidationAttribute[] { new AsyncCancellableAttribute() };
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await Validator.TryValidateValueAsync("value", ctx, null, attrs, cts.Token));
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_CancellationToken_Propagated()
+        {
+            var obj = new HasAsyncCancellableProperty { CancellableProp = "value" };
+            var ctx = new ValidationContext(obj);
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await Validator.ValidateObjectAsync(obj, ctx, true, cts.Token));
+        }
+
+        [Fact]
+        public static async Task TwoPhase_SyncFailure_BlocksAsyncExecution()
+        {
+            var obj = new HasMixedValidation { MixedProp = "Invalid Value" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("ValidValueStringPropertyAttribute.IsValid failed for value Invalid Value", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TwoPhase_SyncPasses_AsyncRuns()
+        {
+            var obj = new HasMixedValidation { MixedProp = "Valid Value" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.Equal("Async validation always fails", results[0].ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TwoPhase_AllPass()
+        {
+            var obj = new HasMixedPassingValidation { MixedProp = "Valid Value" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TwoPhase_Required_Fails_AsyncSkipped()
+        {
+            var obj = new HasRequiredAndAsyncProperty { Prop = null };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+            Assert.DoesNotContain(results, r => r.ErrorMessage == "Async validation always fails");
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_EmptyObject_ReturnsTrue()
+        {
+            var obj = new object();
+            var ctx = new ValidationContext(obj);
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, null));
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_OnlyAsyncAttrs_Success()
+        {
+            var obj = new HasAsyncSucceedingProperty { AsyncProp = "anything" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_TrulyAsyncAttr_Success()
+        {
+            var obj = new HasTrulyAsyncProperty { AsyncProp = "Valid Value" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_TrulyAsyncAttr_Failure()
+        {
+            var obj = new HasTrulyAsyncProperty { AsyncProp = "Invalid" };
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(1, results.Count);
+        }
+
+        [Fact]
+        public static async Task ValidateObjectAsync_ClassLevel_AsyncAttr()
+        {
+            var obj = new HasAsyncClassLevelAttr();
+            var ctx = new ValidationContext(obj);
+            var ex = await Assert.ThrowsAsync<ValidationException>(
+                async () => await Validator.ValidateObjectAsync(obj, ctx, true));
+            Assert.Equal("Async class validation failed", ex.ValidationResult.ErrorMessage);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_MultipleAsyncProperties_RunInParallel()
+        {
+            var obj = new HasMultipleAsyncProperties();
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            sw.Stop();
+
+            // If parallel: ~100ms. If sequential: ~200ms (2 properties × 100ms each).
+            Assert.True(sw.ElapsedMilliseconds < 180,
+                $"Properties should validate in parallel. Elapsed: {sw.ElapsedMilliseconds}ms");
+            Assert.Empty(results);
+        }
+
+        [Fact]
+        public static async Task TryValidateObjectAsync_MultipleAsyncProperties_CollectsAllFailures()
+        {
+            var obj = new HasMultipleFailingAsyncProperties();
+            var ctx = new ValidationContext(obj);
+            var results = new List<ValidationResult>();
+            Assert.False(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
+            Assert.Equal(2, results.Count);
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_MultipleAsyncAttrs_RunInParallel()
+        {
+            var ctx = new ValidationContext(new object()) { MemberName = "TestProp" };
+            var results = new List<ValidationResult>();
+            var attrs = new ValidationAttribute[] { new AsyncDelayedSucceedsAttribute(), new AsyncDelayedSucceedsAttribute() };
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, results, attrs));
+            sw.Stop();
+
+            // If parallel: ~100ms. If sequential: ~200ms.
+            Assert.True(sw.ElapsedMilliseconds < 180,
+                $"Async attributes should validate in parallel. Elapsed: {sw.ElapsedMilliseconds}ms");
+        }
+
+        [Fact]
+        public static async Task TryValidateValueAsync_MultipleAsyncAttrs_CollectsAllFailures()
+        {
+            var ctx = new ValidationContext(new object()) { MemberName = "TestProp" };
+            var results = new List<ValidationResult>();
+            var attrs = new ValidationAttribute[] { new AsyncAlwaysFailsAttribute(), new AsyncAlwaysFailsAttribute() };
+            Assert.False(await Validator.TryValidateValueAsync("anything", ctx, results, attrs));
+            Assert.Equal(2, results.Count);
+        }
+
+        [Fact]
+        public static void TryValidateObject_IAsyncValidatableObject_SyncPath_ThrowsInvalidOperation()
+        {
+            var instance = new AsyncValidatableError();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.Throws<InvalidOperationException>(
+                () => Validator.TryValidateObject(instance, ctx, results));
+        }
+
+        [Fact]
+        public static void TryValidateObject_DualModel_SyncPath_UsesExplicitValidate()
+        {
+            var instance = new DualValidatableModel();
+            var ctx = new ValidationContext(instance);
+            var results = new List<ValidationResult>();
+            Assert.False(Validator.TryValidateObject(instance, ctx, results));
+            Assert.Equal("sync error from dual model", Assert.Single(results).ErrorMessage);
+        }
+
+        [Fact]
+        public static void IAsyncValidatableObject_InheritsIValidatableObject()
+        {
+            var instance = new AsyncValidatableSuccess();
+            Assert.IsAssignableFrom<IValidatableObject>(instance);
         }
     }
 }

--- a/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
+++ b/src/libraries/System.ComponentModel.Annotations/tests/System/ComponentModel/DataAnnotations/ValidatorTests.cs
@@ -1605,12 +1605,52 @@ namespace System.ComponentModel.DataAnnotations.Tests
             }
         }
 
+        [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true)]
+        public class AsyncConcurrencyProbeAttribute : AsyncValidationAttribute
+        {
+            public static int ConcurrentCount;
+            public static TaskCompletionSource<bool> AllRunningGate = new();
+            public static int ExpectedCount;
+
+            public static void Reset(int expectedCount)
+            {
+                ConcurrentCount = 0;
+                AllRunningGate = new TaskCompletionSource<bool>();
+                ExpectedCount = expectedCount;
+            }
+
+            protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+                => throw new InvalidOperationException("Use async validation");
+
+            protected override async Task<ValidationResult?> IsValidAsync(
+                object? value, ValidationContext validationContext, CancellationToken cancellationToken)
+            {
+                int current = Interlocked.Increment(ref ConcurrentCount);
+                if (current >= ExpectedCount)
+                    AllRunningGate.TrySetResult(true);
+
+                await AllRunningGate.Task.WaitAsync(TimeSpan.FromSeconds(5), cancellationToken);
+                Interlocked.Decrement(ref ConcurrentCount);
+
+                return ValidationResult.Success;
+            }
+        }
+
         public class HasMultipleAsyncProperties
         {
             [AsyncDelayedSucceeds]
             public string Prop1 { get; set; } = "value";
 
             [AsyncDelayedSucceeds]
+            public string Prop2 { get; set; } = "value";
+        }
+
+        public class HasMultipleConcurrencyProbeProperties
+        {
+            [AsyncConcurrencyProbe]
+            public string Prop1 { get; set; } = "value";
+
+            [AsyncConcurrencyProbe]
             public string Prop2 { get; set; } = "value";
         }
 
@@ -2635,16 +2675,11 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Fact]
         public static async Task TryValidateObjectAsync_MultipleAsyncProperties_RunInParallel()
         {
-            var obj = new HasMultipleAsyncProperties();
+            AsyncConcurrencyProbeAttribute.Reset(expectedCount: 2);
+            var obj = new HasMultipleConcurrencyProbeProperties();
             var ctx = new ValidationContext(obj);
             var results = new List<ValidationResult>();
-            var sw = System.Diagnostics.Stopwatch.StartNew();
             Assert.True(await Validator.TryValidateObjectAsync(obj, ctx, results, true));
-            sw.Stop();
-
-            // If parallel: ~100ms. If sequential: ~200ms (2 properties × 100ms each).
-            Assert.True(sw.ElapsedMilliseconds < 180,
-                $"Properties should validate in parallel. Elapsed: {sw.ElapsedMilliseconds}ms");
             Assert.Empty(results);
         }
 
@@ -2661,16 +2696,12 @@ namespace System.ComponentModel.DataAnnotations.Tests
         [Fact]
         public static async Task TryValidateValueAsync_MultipleAsyncAttrs_RunInParallel()
         {
+            AsyncConcurrencyProbeAttribute.Reset(expectedCount: 2);
             var ctx = new ValidationContext(new object()) { MemberName = "TestProp" };
             var results = new List<ValidationResult>();
-            var attrs = new ValidationAttribute[] { new AsyncDelayedSucceedsAttribute(), new AsyncDelayedSucceedsAttribute() };
-            var sw = System.Diagnostics.Stopwatch.StartNew();
+            var attrs = new ValidationAttribute[] { new AsyncConcurrencyProbeAttribute(), new AsyncConcurrencyProbeAttribute() };
             Assert.True(await Validator.TryValidateValueAsync("Valid Value", ctx, results, attrs));
-            sw.Stop();
-
-            // If parallel: ~100ms. If sequential: ~200ms.
-            Assert.True(sw.ElapsedMilliseconds < 180,
-                $"Async attributes should validate in parallel. Elapsed: {sw.ElapsedMilliseconds}ms");
+            Assert.Empty(results);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/128096

Implements async validation support for `System.ComponentModel.DataAnnotations` as approved in [API review](https://github.com/dotnet/runtime/issues/128096#issuecomment-4547451853).

### What's included

- `AsyncValidationAttribute` — abstract base class deriving from `ValidationAttribute` for async validation scenarios (database lookups, API calls). `IsValid` is `abstract override` so subclasses must decide how to handle synchronous callers. `IsValidAsync` is the primary async entry point. `GetValidationResultAsync` mirrors the sync `GetValidationResult` with error message formatting.
- `IAsyncValidatableObject` — interface extending `IValidatableObject` for object-level async validation via `IAsyncEnumerable<ValidationResult>`. No default interface method — implementors provide both `Validate` and `ValidateAsync`.
- Eight async `Validator` methods — `TryValidateObjectAsync` (2 overloads), `TryValidatePropertyAsync`, `TryValidateValueAsync`, `ValidateObjectAsync` (2 overloads), `ValidatePropertyAsync`, `ValidateValueAsync`. All return `Task`/`Task<bool>`.
- Ref assembly updates for the full async API surface
- `ValidationContext.Items` XML doc remark about thread safety under concurrent async validation
- Tests covering all async `Validator` methods, mixed sync/async attributes, `breakOnFirstError` with parallel async, cancellation propagation, `IAsyncValidatableObject`, class-level async attributes, error message formatting, and sync fallback via `IsValid` override

### Implementation notes

- The async pipeline follows a 3-step approach matching the sync structure: property validation → type attributes → `IAsyncValidatableObject`/`IValidatableObject`
- Property validation runs in parallel using `Task.WhenAny` with a linked `CancellationTokenSource` for cooperative `breakOnFirstError` cancellation
- Per-value validation is two-phase: sync attributes first (abort early on errors), then async attributes in parallel
- `breakOnFirstError` behavior is consistent between sync and async paths

### API review decisions reflected

- `Task`/`Task<T>` return types (not `ValueTask`)
- `IsValid` as `abstract override`
- No default interface method on `IAsyncValidatableObject`
