### PR TITLE
JIT: Preserve async continuation arg across EnC remap

### DIFF
--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -385,10 +385,11 @@ public:
         VARARGS_HND_ILNUM   = -1, // Value for the CORINFO_VARARGS_HANDLE varNumber
         RETBUF_ILNUM        = -2, // Pointer to the return-buffer
         TYPECTXT_ILNUM      = -3, // ParamTypeArg for CORINFO_GENERICS_CTXT_FROM_PARAMTYPEARG
+        ASYNC_CONTINUATION_ILNUM = -4, // Async continuation argument
 
-        UNKNOWN_ILNUM       = -4, // Unknown variable
+        UNKNOWN_ILNUM       = -5, // Unknown variable
 
-        MAX_ILNUM           = -4  // Sentinel value. This should be set to the largest magnitude value in th enum
+        MAX_ILNUM           = -5  // Sentinel value. This should be set to the largest magnitude value in the enum
                                   // so that the compression routines know the enum's range.
     };
 

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -19,10 +19,10 @@
 //  src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
 // If you update this, ensure you run `git grep MINIMUM_READYTORUN_MAJOR_VERSION`
 // and handle pending work.
-#define READYTORUN_MAJOR_VERSION 19
+#define READYTORUN_MAJOR_VERSION 20
 #define READYTORUN_MINOR_VERSION 0x0000
 
-#define MINIMUM_READYTORUN_MAJOR_VERSION 19
+#define MINIMUM_READYTORUN_MAJOR_VERSION 20
 
 // R2R Version 2.1 adds the InliningInfo section
 // R2R Version 2.2 adds the ProfileDataInfo section
@@ -59,6 +59,7 @@
 // R2R Version 18.6 adds READYTORUN_FIXUP_InjectStringThunks for mapping strings to pregenerated code thunks
 // R2R Version 18.7 adds READYTORUN_HELPER_R2RToInterpreter
 // R2R Version 19 removes the READYTORUN_HELPER_ByRefWriteBarrier helper
+// R2R Version 20 changes NativeVarInfo encoding to include ASYNC_CONTINUATION_ILNUM
 
 struct READYTORUN_CORE_HEADER
 {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -1181,6 +1181,11 @@ unsigned Compiler::compMapILvarNum(unsigned ILvarNum)
         noway_assert(info.compTypeCtxtArg >= 0);
         varNum = info.compTypeCtxtArg;
     }
+    else if (ILvarNum == (unsigned)ICorDebugInfo::ASYNC_CONTINUATION_ILNUM)
+    {
+        noway_assert(lvaAsyncContinuationArg != BAD_VAR_NUM);
+        varNum = lvaAsyncContinuationArg;
+    }
     else if (ILvarNum < info.compILargsCount)
     {
         // Parameter
@@ -1205,7 +1210,7 @@ unsigned Compiler::compMapILvarNum(unsigned ILvarNum)
 
 /*****************************************************************************
  * Returns the IL variable number given our internal varNum.
- * Special return values are VARG_ILNUM, RETBUF_ILNUM, TYPECTXT_ILNUM.
+ * Special return values are VARG_ILNUM, RETBUF_ILNUM, TYPECTXT_ILNUM, ASYNC_CONTINUATION_ILNUM.
  *
  * Returns UNKNOWN_ILNUM if it can't be mapped.
  */
@@ -1246,7 +1251,7 @@ unsigned Compiler::compMap2ILvarNum(unsigned varNum) const
 
     if (varNum == lvaAsyncContinuationArg)
     {
-        return (unsigned)ICorDebugInfo::UNKNOWN_ILNUM;
+        return (unsigned)ICorDebugInfo::ASYNC_CONTINUATION_ILNUM;
     }
 
 #if defined(TARGET_WASM)

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -11,7 +11,7 @@ struct ReadyToRunHeaderConstants
 {
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
-    static const uint32_t CurrentMajorVersion = 19;
+    static const uint32_t CurrentMajorVersion = 20;
     static const uint32_t CurrentMinorVersion = 0;
 };
 

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -15,7 +15,7 @@ namespace Internal.Runtime
     {
         public const uint Signature = 0x00525452; // 'RTR'
 
-        public const ushort CurrentMajorVersion = 19;
+        public const ushort CurrentMajorVersion = 20;
         public const ushort CurrentMinorVersion = 0;
     }
 #if READYTORUN

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1364,10 +1364,11 @@ namespace Internal.JitInterface
         VARARGS_HND_ILNUM   = -1, // Value for the CORINFO_VARARGS_HANDLE varNumber
         RETBUF_ILNUM        = -2, // Pointer to the return-buffer
         TYPECTXT_ILNUM      = -3, // ParamTypeArg for CORINFO_GENERICS_CTXT_FROM_PARAMTYPEARG
+        ASYNC_CONTINUATION_ILNUM = -4, // Async continuation argument
 
-        UNKNOWN_ILNUM       = -4, // Unknown variable
+        UNKNOWN_ILNUM       = -5, // Unknown variable
 
-        MAX_ILNUM           = -4  // Sentinel value. This should be set to the largest magnitude value in the enum
+        MAX_ILNUM           = -5  // Sentinel value. This should be set to the largest magnitude value in the enum
                                   // so that the compression routines know the enum's range.
     };
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfoHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfoHelpers.cs
@@ -41,7 +41,7 @@ internal static class DebugInfoHelpers
     private const uint SOURCE_TYPE_BITS_V2 = 3;
 
     // ICorDebugInfo::MAX_ILNUM sentinel value used for adjusted encoding of var numbers.
-    private const uint MAX_ILNUM = unchecked((uint)-4);
+    private const uint MAX_ILNUM = unchecked((uint)-5);
 
     internal static IEnumerable<OffsetMapping> DoBounds(NativeReader nativeReader, uint version)
     {


### PR DESCRIPTION
The async continuation argument was homed in the local frame area which gets zeroed by FixContextForEnC during EnC remap. On platforms with shadow space, the continuation accidentally survived because it was homed above callerSP, outside the zeroed region. On platforms without shadow space, the continuation was destroyed.

Fix: Assign a dedicated IL number (ASYNC_CONTINUATION_ILNUM = -4) so the continuation arg appears in NativeVarInfo and survives EnC remap on all platforms.

This shifts MAX_ILNUM from -4 to -5, changing the NativeVarInfo encoding bias. R2R major version bumped accordingly.