### PR TITLE
[cDAC] Prepare for dacdbi stackwalk

### DIFF
--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -20,8 +20,10 @@ public enum StackWalkState
     // Current Context is native, produced by unwinding a managed frame down to
     // an M2U boundary. FrameIter is on the explicit Frame at the transition.
     SW_NATIVE_MARKER,
-    // Context has been bridged through the explicit Frame at FrameIter
-    // (FrameAddress is valid). The next step advances past this Frame.
+    // FrameIter is on an explicit Frame (FrameAddress is valid), but the
+    // current Context has not yet been bridged through that Frame. Bridging
+    // occurs via UpdateContextFromCurrentFrame; the next step advances past
+    // this Frame.
     SW_FRAME,
     SW_SKIPPED_FRAME,
 }

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -5,36 +5,36 @@ This contract encapsulates support for walking the stack of managed threads.
 ## APIs of contract
 
 ```csharp
-public interface IStackDataFrameHandle { };
+public interface IStackDataFrameHandle
+{
+    // Describes what the current Context/FrameIter of this handle represents.
+    StackWalkState State { get; }
+}
 
-// Describes what the current Context/FrameIter of a handle represents.
 public enum StackWalkState
 {
-    SW_COMPLETE,
-    SW_ERROR,
+    Complete,
+    Error,
     // Current Context represents a managed method.
-    SW_FRAMELESS,
+    Frameless,
     // Current Context is the seed native context from init (the thread's saved
     // CONTEXT). FrameIter may or may not be on a Frame.
-    SW_INITIAL_NATIVE_CONTEXT,
+    InitialNativeContext,
     // Current Context is native, produced by unwinding a managed frame down to
     // an M2U boundary. FrameIter is on the explicit Frame at the transition.
-    SW_NATIVE_MARKER,
+    NativeMarker,
     // FrameIter is on an explicit Frame (FrameAddress is valid), but the
     // current Context has not yet been bridged through that Frame. Bridging
     // occurs via UpdateContextFromCurrentFrame; the next step advances past
     // this Frame.
-    SW_FRAME,
-    SW_SKIPPED_FRAME,
+    Frame,
+    SkippedFrame,
 }
 ```
 
 ```csharp
 // Creates a stack walk and returns a handle
 IEnumerable<IStackDataFrameHandle> CreateStackWalk(ThreadData threadData);
-
-// Gets the StackWalkState that produced the current handle.
-StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle);
 
 // Gets the thread context at the given stack dataframe.
 byte[] GetRawContext(IStackDataFrameHandle stackDataFrameHandle);
@@ -481,7 +481,7 @@ TargetPointer GetMethodDescPtr(TargetPointer framePtr)
 * This API can either be at a capital 'F' frame or a managed frame unlike the TargetPointer overload which only works at capital 'F' frames.
 * This API handles the special ReportInteropMD case which happens under the following conditions
     1. The dataFrame is at an `InlinedCallFrame`
-    2. The dataFrame is in a `SW_SKIPPED_FRAME` state
+    2. The dataFrame is in a `SkippedFrame` state
     3. The InlinedCallFrame's return address is managed code
     4. The InlinedCallFrame's return address method has a MDContext arg
 
@@ -569,12 +569,6 @@ DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress)
 TargetPointer GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle)
 ```
 
-`GetState` returns the `StackWalkState` that produced the given handle. The state classifies what the handle's Context and FrameIter represent at the point it was yielded:
-
-```csharp
-StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle)
-```
-
 `WalkStackReferences` walks the entire managed stack and enumerates all live GC references at each frame. It returns a list of `StackReferenceData` describing each GC-tracked slot (its address, whether it's an interior pointer, and the register/stack location). This API is the primary consumer for `SOSDacImpl.GetStackReferences`.
 
 ```csharp
@@ -594,9 +588,9 @@ The GC reference walk uses the `Filter` function to drive the stack walk. `Filte
 Key state tracked during the walk:
 
 - **IsInterrupted**: Set when transitioning to a managed frame from a `FaultingExceptionFrame` or `SoftwareExceptionFrame` (frames with `FRAME_ATTR_EXCEPTION`). When true, the managed frame's GC enumeration uses `ExecutionAborted` mode, which causes the GcInfoDecoder to skip live slot reporting at non-interruptible offsets.
-- **LastProcessedFrameType**: Records the frame type when processing `SW_FRAME` state, so `UpdateState` can detect exception frames during the transition to `SW_FRAMELESS`.
+- **LastProcessedFrameType**: Records the frame type when processing `Frame` state, so `UpdateState` can detect exception frames during the transition to `Frameless`.
 - **IsFirst**: Preserved during skipped frame processing (native `SFITER_SKIPPED_FRAME_FUNCTION` does not modify `IsFirst`), ensuring the subsequent managed frame is still treated as the leaf/active frame.
-- **GetReturnAddress gating**: In `SW_FRAME` state, `UpdateContextFromFrame` is only called when `GetReturnAddress()` returns a non-null value. This matches native behavior where the context is only updated when the frame has a valid return address.
+- **GetReturnAddress gating**: In `Frame` state, `UpdateContextFromFrame` is only called when `GetReturnAddress()` returns a non-null value. This matches native behavior where the context is only updated when the frame has a valid return address.
 
 #### Per-Frame GC Enumeration
 

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -6,11 +6,33 @@ This contract encapsulates support for walking the stack of managed threads.
 
 ```csharp
 public interface IStackDataFrameHandle { };
+
+// Describes what the current Context/FrameIter of a handle represents.
+public enum StackWalkState
+{
+    SW_COMPLETE,
+    SW_ERROR,
+    // Current Context represents a managed method.
+    SW_FRAMELESS,
+    // Current Context is the seed native context from init (the thread's saved
+    // CONTEXT). FrameIter may or may not be on a Frame.
+    SW_INITIAL_NATIVE_CONTEXT,
+    // Current Context is native, produced by unwinding a managed frame down to
+    // an M2U boundary. FrameIter is on the explicit Frame at the transition.
+    SW_NATIVE_MARKER,
+    // Context has been bridged through the explicit Frame at FrameIter
+    // (FrameAddress is valid). The next step advances past this Frame.
+    SW_FRAME,
+    SW_SKIPPED_FRAME,
+}
 ```
 
 ```csharp
 // Creates a stack walk and returns a handle
 IEnumerable<IStackDataFrameHandle> CreateStackWalk(ThreadData threadData);
+
+// Gets the StackWalkState that produced the current handle.
+StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle);
 
 // Gets the thread context at the given stack dataframe.
 byte[] GetRawContext(IStackDataFrameHandle stackDataFrameHandle);
@@ -543,6 +565,12 @@ DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress)
 `GetInstructionPointer` returns the instruction pointer (IP) from the current frame's context. This is the address of the instruction being executed (or about to be executed) in the method associated with this frame.
 ```csharp
 TargetPointer GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle)
+```
+
+`GetState` returns the `StackWalkState` that produced the given handle. The state classifies what the handle's Context and FrameIter represent at the point it was yielded:
+
+```csharp
+StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle)
 ```
 
 `WalkStackReferences` walks the entire managed stack and enumerates all live GC references at each frame. It returns a list of `StackReferenceData` describing each GC-tracked slot (its address, whether it's an interior pointer, and the register/stack location). This API is the primary consumer for `SOSDacImpl.GetStackReferences`.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -8,6 +8,28 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 public interface IStackDataFrameHandle { };
 
+public enum StackWalkState
+{
+    SW_COMPLETE,
+    SW_ERROR,
+
+    // The current Context represents a managed method.
+    SW_FRAMELESS,
+
+    // The current Context is the seed native context from init (the
+    // thread's saved CONTEXT). FrameIter may or may not be on a Frame.
+    SW_INITIAL_NATIVE_CONTEXT,
+
+    // The current Context is native, produced by unwinding a managed
+    // frame down to an M2U boundary. FrameIter is on the explicit Frame.
+    SW_NATIVE_MARKER,
+
+    // Context has been bridged through the explicit Frame at FrameIter
+    // (FrameAddress is valid). The next step advances past this Frame.
+    SW_FRAME,
+    SW_SKIPPED_FRAME,
+}
+
 public class StackReferenceData
 {
     public bool HasRegisterInformation { get; init; }
@@ -48,6 +70,7 @@ public interface IStackWalk : IContract
 
     public virtual IEnumerable<IStackDataFrameHandle> CreateStackWalk(ThreadData threadData) => throw new NotImplementedException();
     IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData) => throw new NotImplementedException();
+    StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     byte[] GetRawContext(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     TargetPointer GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     string GetFrameName(TargetPointer frameIdentifier) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -6,29 +6,32 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-public interface IStackDataFrameHandle { };
+public interface IStackDataFrameHandle
+{
+    StackWalkState State { get; }
+}
 
 public enum StackWalkState
 {
-    SW_COMPLETE,
-    SW_ERROR,
+    Complete,
+    Error,
 
     // The current Context represents a managed method.
-    SW_FRAMELESS,
+    Frameless,
 
     // The current Context is the seed native context from init (the
     // thread's saved CONTEXT). FrameIter may or may not be on a Frame.
-    SW_INITIAL_NATIVE_CONTEXT,
+    InitialNativeContext,
 
     // The current Context is native, produced by unwinding a managed
     // frame down to an M2U boundary. FrameIter is on the explicit Frame.
-    SW_NATIVE_MARKER,
+    NativeMarker,
 
     // FrameAddress is valid and identifies the explicit Frame at FrameIter.
     // The current Context has not yet been bridged through that Frame; the
-    // next step uses it to update the Context, after which SW_FRAMELESS is yielded.
-    SW_FRAME,
-    SW_SKIPPED_FRAME,
+    // next step uses it to update the Context, after which Frameless is yielded.
+    Frame,
+    SkippedFrame,
 }
 
 public class StackReferenceData
@@ -71,7 +74,6 @@ public interface IStackWalk : IContract
 
     public virtual IEnumerable<IStackDataFrameHandle> CreateStackWalk(ThreadData threadData) => throw new NotImplementedException();
     IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData) => throw new NotImplementedException();
-    StackWalkState GetState(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     byte[] GetRawContext(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     TargetPointer GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
     string GetFrameName(TargetPointer frameIdentifier) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -24,8 +24,9 @@ public enum StackWalkState
     // frame down to an M2U boundary. FrameIter is on the explicit Frame.
     SW_NATIVE_MARKER,
 
-    // Context has been bridged through the explicit Frame at FrameIter
-    // (FrameAddress is valid). The next step advances past this Frame.
+    // FrameAddress is valid and identifies the explicit Frame at FrameIter.
+    // The current Context has not yet been bridged through that Frame; the
+    // next step uses it to update the Context, after which SW_FRAMELESS is yielded.
     SW_FRAME,
     SW_SKIPPED_FRAME,
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/FrameHelpers.cs
@@ -137,7 +137,7 @@ internal sealed class FrameHelpers
     /// <summary>
     /// Updates <paramref name="context"/> based on <paramref name="frame"/>'s type, replicating
     /// the per-frame context update performed by the native stack walker before it yields a
-    /// SW_FRAME (or transitions to SW_FRAMELESS for InterpreterFrame).
+    /// Frame (or transitions to Frameless for InterpreterFrame).
     /// </summary>
     public void UpdateContextFromFrame(Data.Frame frame, IPlatformAgnosticContext context)
     {
@@ -170,7 +170,7 @@ internal sealed class FrameHelpers
                 {
                     // Mirrors native InterpreterFrame::SetContextToInterpMethodContextFrame
                     // (frames.cpp). Sets context to the top InterpMethodContextFrame so the
-                    // walker transitions to SW_FRAMELESS and yields each interpreted method
+                    // walker transitions to Frameless and yields each interpreted method
                     // individually via virtual unwind.
                     Data.InterpreterFrame interpreterFrame = _target.ProcessedData.GetOrAdd<Data.InterpreterFrame>(frame.Address);
                     SetContextToInterpMethodContextFrame(context, interpreterFrame);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.ExceptionHandling.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.ExceptionHandling.cs
@@ -104,7 +104,7 @@ internal partial class StackWalk_1 : IStackWalk
     private bool IsFunclet(StackDataFrameHandle handle)
     {
         // Only frames whose Context represents a managed method can be funclets.
-        if (handle.State is not StackWalkState.SW_FRAMELESS)
+        if (handle.State is not StackWalkState.Frameless)
         {
             return false;
         }
@@ -118,7 +118,7 @@ internal partial class StackWalk_1 : IStackWalk
     private bool IsFilterFunclet(StackDataFrameHandle handle)
     {
         // Only frames whose Context represents a managed method can be filter funclets.
-        if (handle.State is not StackWalkState.SW_FRAMELESS)
+        if (handle.State is not StackWalkState.Frameless)
         {
             return false;
         }
@@ -142,7 +142,7 @@ internal partial class StackWalk_1 : IStackWalk
         StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
 
         TargetPointer callerStackPointer;
-        if (handle.State is StackWalkState.SW_FRAMELESS)
+        if (handle.State is StackWalkState.Frameless)
         {
             IPlatformAgnosticContext callerContext = handle.Context.Clone();
             callerContext.Unwind(_target);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.ExceptionHandling.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.ExceptionHandling.cs
@@ -103,7 +103,8 @@ internal partial class StackWalk_1 : IStackWalk
 
     private bool IsFunclet(StackDataFrameHandle handle)
     {
-        if (handle.State is StackWalkState.SW_FRAME or StackWalkState.SW_SKIPPED_FRAME)
+        // Only frames whose Context represents a managed method can be funclets.
+        if (handle.State is not StackWalkState.SW_FRAMELESS)
         {
             return false;
         }
@@ -116,7 +117,8 @@ internal partial class StackWalk_1 : IStackWalk
 
     private bool IsFilterFunclet(StackDataFrameHandle handle)
     {
-        if (handle.State is StackWalkState.SW_FRAME or StackWalkState.SW_SKIPPED_FRAME)
+        // Only frames whose Context represents a managed method can be filter funclets.
+        if (handle.State is not StackWalkState.SW_FRAMELESS)
         {
             return false;
         }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -694,20 +694,28 @@ internal partial class StackWalk_1 : IStackWalk
             case StackWalkState.SW_NATIVE_MARKER:
                 break;
             case StackWalkState.SW_FRAME:
+                // Native SFITER_FRAME_FUNCTION gates ProcessIp + UpdateRegDisplay on
+                // GetReturnAddress() != 0, and gates GotoNextFrame on !pInlinedFrame.
+                // pInlinedFrame is set only for active InlinedCallFrames.
                 {
-                    FrameType frameType = handle.FrameIter.GetCurrentFrameType();
+                    var frameType = handle.FrameIter.GetCurrentFrameType();
                     TargetPointer returnAddress = handle.FrameIter.GetCurrentReturnAddress();
                     bool isActiveICF = frameType == FrameType.InlinedCallFrame
-                                        && returnAddress != TargetPointer.Null;
+                                       && returnAddress != TargetPointer.Null;
 
+                    // Record the frame type so UpdateState can detect exception frames
+                    // and set IsInterrupted when transitioning to the managed frame.
                     handle.LastProcessedFrameType = frameType;
 
+                    // For InterpreterFrame the FrameIterator has no GetReturnAddress
+                    // (interpreter virtual unwind manages the IP), but we still need
+                    // UpdateContextFromFrame to transition to SW_FRAMELESS in the
+                    // interpreted method.
                     if (returnAddress != TargetPointer.Null
                         || frameType == FrameType.InterpreterFrame)
                     {
                         handle.FrameIter.UpdateContextFromCurrentFrame(handle.Context);
                     }
-
                     if (!isActiveICF)
                     {
                         handle.FrameIter.Next();
@@ -770,8 +778,8 @@ internal partial class StackWalk_1 : IStackWalk
                 return;
             }
 
-            // No-op step. If there is a Frame, yield SW_FRAME so the consumer
-            // sees it (and the next Next() will bridge); otherwise terminate.
+            // The step that just ran bridged through a Frame. Yield SW_FRAME
+            // so the consumer sees the bridged Frame; if there was no Frame, terminate.
             case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
             case StackWalkState.SW_NATIVE_MARKER:
                 handle.State = handle.FrameIter.IsValid() ? StackWalkState.SW_FRAME : StackWalkState.SW_COMPLETE;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -28,21 +28,6 @@ internal partial class StackWalk_1 : IStackWalk
         _frameHelpers = new FrameHelpers(target);
     }
 
-    public enum StackWalkState
-    {
-        SW_COMPLETE,
-        SW_ERROR,
-
-        // The current Context is managed
-        SW_FRAMELESS,
-
-        // The current Context is unmanaged.
-        // The next update will use a Frame to get a managed context
-        // When SW_FRAME, the FrameAddress is valid
-        SW_FRAME,
-        SW_SKIPPED_FRAME,
-    }
-
     private record StackDataFrameHandle(
         IPlatformAgnosticContext Context,
         StackWalkState State,
@@ -142,7 +127,7 @@ internal partial class StackWalk_1 : IStackWalk
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
         uint contextFlags = context.AllContextFlags;
         FillContextFromThread(context, threadData, contextFlags);
-        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_FRAME;
+        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_INITIAL_NATIVE_CONTEXT;
         FrameIterator frameIterator = new(_target, threadData);
 
         // Skip the head InterpreterFrame when entering with a context already
@@ -156,12 +141,6 @@ internal partial class StackWalk_1 : IStackWalk
             && frameIterator.GetCurrentFrameType() == FrameType.InterpreterFrame)
         {
             frameIterator.Next();
-        }
-
-        // if the next Frame is not valid and we are not in managed code, there is nothing to return
-        if (state == StackWalkState.SW_FRAME && !frameIterator.IsValid())
-        {
-            yield break;
         }
 
         StackWalkData stackWalkData = new(context, state, frameIterator, threadData);
@@ -190,7 +169,7 @@ internal partial class StackWalk_1 : IStackWalk
         // Initialize the walk data directly
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
         FillContextFromThread(context, threadData, context.FullContextFlags);
-        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_FRAME;
+        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_INITIAL_NATIVE_CONTEXT;
         FrameIterator frameIterator = new(_target, threadData);
 
         // See CreateStackWalk: skip the head InterpreterFrame when entering
@@ -202,9 +181,6 @@ internal partial class StackWalk_1 : IStackWalk
         {
             frameIterator.Next();
         }
-
-        if (state == StackWalkState.SW_FRAME && !frameIterator.IsValid())
-            return [];
 
         StackWalkData walkData = new(context, state, frameIterator, threadData);
 
@@ -643,6 +619,9 @@ internal partial class StackWalk_1 : IStackWalk
                         stop = true;
                     }
                     break;
+                case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
+                case StackWalkState.SW_NATIVE_MARKER:
+                    break;
                 default:
                     stop = true;
                     break;
@@ -711,29 +690,36 @@ internal partial class StackWalk_1 : IStackWalk
                 // whether there are more skipped frames or we've reached the managed method.
                 handle.FrameIter.Next();
                 break;
-            case StackWalkState.SW_FRAME:
-                // Native SFITER_FRAME_FUNCTION gates ProcessIp + UpdateRegDisplay on
-                // GetReturnAddress() != 0, and gates GotoNextFrame on !pInlinedFrame.
-                // pInlinedFrame is set only for active InlinedCallFrames.
+            case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
+            case StackWalkState.SW_NATIVE_MARKER:
+                // Copy the explicit Frame's saved managed registers back
+                // into Context, transitioning from native IP to managed IP.
+                if (handle.FrameIter.IsValid())
                 {
-                    var frameType = handle.FrameIter.GetCurrentFrameType();
                     TargetPointer returnAddress = handle.FrameIter.GetCurrentReturnAddress();
-                    bool isActiveICF = frameType == FrameType.InlinedCallFrame
-                                       && returnAddress != TargetPointer.Null;
-
-                    // Record the frame type so UpdateState can detect exception frames
-                    // and set IsInterrupted when transitioning to the managed frame.
-                    handle.LastProcessedFrameType = frameType;
+                    FrameType frameType = handle.FrameIter.GetCurrentFrameType();
 
                     // For InterpreterFrame the FrameIterator has no GetReturnAddress
                     // (interpreter virtual unwind manages the IP), but we still need
-                    // UpdateContextFromFrame to transition to SW_FRAMELESS in the
-                    // interpreted method.
+                    // UpdateContextFromFrame to transition to the interpreted method.
                     if (returnAddress != TargetPointer.Null
                         || frameType == FrameType.InterpreterFrame)
                     {
                         handle.FrameIter.UpdateContextFromCurrentFrame(handle.Context);
                     }
+                }
+                break;
+            case StackWalkState.SW_FRAME:
+                {
+                    FrameType frameType = handle.FrameIter.GetCurrentFrameType();
+                    TargetPointer returnAddress = handle.FrameIter.GetCurrentReturnAddress();
+                    bool isActiveICF = frameType == FrameType.InlinedCallFrame
+                                        && returnAddress != TargetPointer.Null;
+
+                    // Record the frame type so UpdateState can detect exception frames
+                    // and set IsInterrupted when transitioning to the managed frame.
+                    handle.LastProcessedFrameType = frameType;
+
                     if (!isActiveICF)
                     {
                         handle.FrameIter.Next();
@@ -757,33 +743,51 @@ internal partial class StackWalk_1 : IStackWalk
             return;
         }
 
-        bool isManaged = IsManaged(handle.Context.InstructionPointer, out _);
-        bool validFrame = handle.FrameIter.IsValid();
-
-        if (isManaged)
+        switch (handle.State)
         {
-            handle.State = StackWalkState.SW_FRAMELESS;
-
-            // Detect exception frames (FRAME_ATTR_EXCEPTION) when transitioning to managed.
-            // Both FaultingExceptionFrame (hardware) and SoftwareExceptionFrame (managed throw)
-            // have FRAME_ATTR_EXCEPTION set. The resulting managed frame gets ExecutionAborted,
-            // causing GcInfoDecoder to skip live slot reporting at non-interruptible offsets.
-            if (handle.LastProcessedFrameType is FrameType.FaultingExceptionFrame
-                                              or FrameType.SoftwareExceptionFrame)
+            // The step that just ran moved Context (an unwind out of a
+            // managed frame, or an advance past a Frame). Reclassify from the
+            // observed Context+FrameIter.
+            case StackWalkState.SW_FRAMELESS:
+            case StackWalkState.SW_FRAME:
+            case StackWalkState.SW_SKIPPED_FRAME:
             {
-                handle.IsInterrupted = true;
-            }
-            handle.LastProcessedFrameType = null;
+                bool isManaged = IsManaged(handle.Context.InstructionPointer, out _);
+                bool validFrame = handle.FrameIter.IsValid();
 
-            if (CheckForSkippedFrames(handle))
-            {
-                handle.State = StackWalkState.SW_SKIPPED_FRAME;
+                if (isManaged)
+                {
+                    handle.State = StackWalkState.SW_FRAMELESS;
+
+                    // Detect exception frames (FRAME_ATTR_EXCEPTION) when transitioning to managed.
+                    // Both FaultingExceptionFrame (hardware) and SoftwareExceptionFrame (managed throw)
+                    // have FRAME_ATTR_EXCEPTION set. The resulting managed frame gets ExecutionAborted,
+                    // causing GcInfoDecoder to skip live slot reporting at non-interruptible offsets.
+                    if (handle.LastProcessedFrameType is FrameType.FaultingExceptionFrame
+                                                      or FrameType.SoftwareExceptionFrame)
+                    {
+                        handle.IsInterrupted = true;
+                    }
+                    handle.LastProcessedFrameType = null;
+
+                    if (CheckForSkippedFrames(handle))
+                    {
+                        handle.State = StackWalkState.SW_SKIPPED_FRAME;
+                    }
+                }
+                else
+                {
+                    handle.State = validFrame ? StackWalkState.SW_NATIVE_MARKER : StackWalkState.SW_COMPLETE;
+                }
                 return;
             }
-        }
-        else
-        {
-            handle.State = validFrame ? StackWalkState.SW_FRAME : StackWalkState.SW_COMPLETE;
+
+            // The step that just ran bridged through a Frame. Yield SW_FRAME
+            // so the consumer sees the bridged Frame; if there was no Frame, terminate.
+            case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
+            case StackWalkState.SW_NATIVE_MARKER:
+                handle.State = handle.FrameIter.IsValid() ? StackWalkState.SW_FRAME : StackWalkState.SW_COMPLETE;
+                return;
         }
     }
 
@@ -814,6 +818,12 @@ internal partial class StackWalk_1 : IStackWalk
     {
         StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
         return handle.Context.GetBytes();
+    }
+
+    StackWalkState IStackWalk.GetState(IStackDataFrameHandle stackDataFrameHandle)
+    {
+        StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
+        return handle.State;
     }
 
     TargetPointer IStackWalk.GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -692,22 +692,6 @@ internal partial class StackWalk_1 : IStackWalk
                 break;
             case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
             case StackWalkState.SW_NATIVE_MARKER:
-                // Copy the explicit Frame's saved managed registers back
-                // into Context, transitioning from native IP to managed IP.
-                if (handle.FrameIter.IsValid())
-                {
-                    TargetPointer returnAddress = handle.FrameIter.GetCurrentReturnAddress();
-                    FrameType frameType = handle.FrameIter.GetCurrentFrameType();
-
-                    // For InterpreterFrame the FrameIterator has no GetReturnAddress
-                    // (interpreter virtual unwind manages the IP), but we still need
-                    // UpdateContextFromFrame to transition to the interpreted method.
-                    if (returnAddress != TargetPointer.Null
-                        || frameType == FrameType.InterpreterFrame)
-                    {
-                        handle.FrameIter.UpdateContextFromCurrentFrame(handle.Context);
-                    }
-                }
                 break;
             case StackWalkState.SW_FRAME:
                 {
@@ -716,9 +700,13 @@ internal partial class StackWalk_1 : IStackWalk
                     bool isActiveICF = frameType == FrameType.InlinedCallFrame
                                         && returnAddress != TargetPointer.Null;
 
-                    // Record the frame type so UpdateState can detect exception frames
-                    // and set IsInterrupted when transitioning to the managed frame.
                     handle.LastProcessedFrameType = frameType;
+
+                    if (returnAddress != TargetPointer.Null
+                        || frameType == FrameType.InterpreterFrame)
+                    {
+                        handle.FrameIter.UpdateContextFromCurrentFrame(handle.Context);
+                    }
 
                     if (!isActiveICF)
                     {
@@ -782,8 +770,8 @@ internal partial class StackWalk_1 : IStackWalk
                 return;
             }
 
-            // The step that just ran bridged through a Frame. Yield SW_FRAME
-            // so the consumer sees the bridged Frame; if there was no Frame, terminate.
+            // No-op step. If there is a Frame, yield SW_FRAME so the consumer
+            // sees it (and the next Next() will bridge); otherwise terminate.
             case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
             case StackWalkState.SW_NATIVE_MARKER:
                 handle.State = handle.FrameIter.IsValid() ? StackWalkState.SW_FRAME : StackWalkState.SW_COMPLETE;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -50,21 +50,21 @@ internal partial class StackWalk_1 : IStackWalk
         public bool IsFirst { get; set; } = true;
 
         // Track isInterrupted like native CrawlFrame::isInterrupted.
-        // Set in UpdateState when transitioning to SW_FRAMELESS after processing a Frame
+        // Set in UpdateState when transitioning to Frameless after processing a Frame
         // with FRAME_ATTR_EXCEPTION (e.g., FaultingExceptionFrame). When true, the managed
         // frame reached via that Frame's return address was interrupted by an exception,
         // and EnumGcRefs should use ExecutionAborted to skip live slot reporting at
         // non-interruptible offsets.
         public bool IsInterrupted { get; set; }
 
-        // The frame type of the last SW_FRAME processed by Next().
+        // The frame type of the last Frame processed by Next().
         // Used by UpdateState to detect exception frames (FRAME_ATTR_EXCEPTION) and
         // set IsInterrupted when transitioning to a managed frame.
         public FrameType? LastProcessedFrameType { get; set; }
 
         public bool IsCurrentFrameResumable()
         {
-            if (State is not (StackWalkState.SW_FRAME or StackWalkState.SW_SKIPPED_FRAME))
+            if (State is not (StackWalkState.Frame or StackWalkState.SkippedFrame))
                 return false;
 
             var ft = FrameIter.GetCurrentFrameType();
@@ -90,11 +90,11 @@ internal partial class StackWalk_1 : IStackWalk
         /// </summary>
         public void AdvanceIsFirst()
         {
-            if (State == StackWalkState.SW_FRAMELESS)
+            if (State == StackWalkState.Frameless)
             {
                 IsFirst = false;
             }
-            else if (State == StackWalkState.SW_SKIPPED_FRAME)
+            else if (State == StackWalkState.SkippedFrame)
             {
                 // Native SFITER_SKIPPED_FRAME_FUNCTION in stackwalk.cpp does NOT
                 // modify isFirst. It stays true from Init() so the subsequent managed frame
@@ -111,7 +111,7 @@ internal partial class StackWalk_1 : IStackWalk
         public StackDataFrameHandle ToDataFrame()
         {
             bool isResumable = IsCurrentFrameResumable();
-            bool isActiveFrame = IsFirst && State == StackWalkState.SW_FRAMELESS;
+            bool isActiveFrame = IsFirst && State == StackWalkState.Frameless;
             return new(Context.Clone(), State, FrameIter.CurrentFrameAddress, ThreadData, isResumable, isActiveFrame);
         }
     }
@@ -127,15 +127,15 @@ internal partial class StackWalk_1 : IStackWalk
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
         uint contextFlags = context.AllContextFlags;
         FillContextFromThread(context, threadData, contextFlags);
-        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_INITIAL_NATIVE_CONTEXT;
+        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.Frameless : StackWalkState.InitialNativeContext;
         FrameIterator frameIterator = new(_target, threadData);
 
         // Skip the head InterpreterFrame when entering with a context already
         // inside an interpreter execution (e.g. a managed-debugger breakpoint
-        // synthesized callback context). Without this, SW_FRAME would later
+        // synthesized callback context). Without this, Frame would later
         // re-process it and re-walk the same InterpMethodContextFrame chain.
         // Mirrors the native walker fix in dotnet/runtime#126953.
-        if (state == StackWalkState.SW_FRAMELESS
+        if (state == StackWalkState.Frameless
             && IsInterpreterCode(context.InstructionPointer)
             && frameIterator.IsValid()
             && frameIterator.GetCurrentFrameType() == FrameType.InterpreterFrame)
@@ -146,12 +146,12 @@ internal partial class StackWalk_1 : IStackWalk
         StackWalkData stackWalkData = new(context, state, frameIterator, threadData);
 
         // Mirror native Init() -> ProcessCurrentFrame() -> CheckForSkippedFrames():
-        // When the initial frame is managed (SW_FRAMELESS), check if there are explicit
+        // When the initial frame is managed (Frameless), check if there are explicit
         // Frames below the caller SP that should be reported first. The native walker
         // yields skipped frames BEFORE the containing managed frame.
-        if (state == StackWalkState.SW_FRAMELESS && CheckForSkippedFrames(stackWalkData))
+        if (state == StackWalkState.Frameless && CheckForSkippedFrames(stackWalkData))
         {
-            stackWalkData.State = StackWalkState.SW_SKIPPED_FRAME;
+            stackWalkData.State = StackWalkState.SkippedFrame;
         }
 
         yield return stackWalkData.ToDataFrame();
@@ -169,12 +169,12 @@ internal partial class StackWalk_1 : IStackWalk
         // Initialize the walk data directly
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
         FillContextFromThread(context, threadData, context.FullContextFlags);
-        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.SW_FRAMELESS : StackWalkState.SW_INITIAL_NATIVE_CONTEXT;
+        StackWalkState state = IsManaged(context.InstructionPointer, out _) ? StackWalkState.Frameless : StackWalkState.InitialNativeContext;
         FrameIterator frameIterator = new(_target, threadData);
 
         // See CreateStackWalk: skip the head InterpreterFrame when entering
         // already inside an interpreter execution to avoid double-walking.
-        if (state == StackWalkState.SW_FRAMELESS
+        if (state == StackWalkState.Frameless
             && IsInterpreterCode(context.InstructionPointer)
             && frameIterator.IsValid()
             && frameIterator.GetCurrentFrameType() == FrameType.InterpreterFrame)
@@ -185,11 +185,11 @@ internal partial class StackWalk_1 : IStackWalk
         StackWalkData walkData = new(context, state, frameIterator, threadData);
 
         // Mirror native Init() -> ProcessCurrentFrame() -> CheckForSkippedFrames():
-        // When the initial frame is managed (SW_FRAMELESS), check if there are explicit
+        // When the initial frame is managed (Frameless), check if there are explicit
         // Frames below the caller SP that should be reported first. The native walker
         // yields skipped frames BEFORE the containing managed frame.
-        if (walkData.State == StackWalkState.SW_FRAMELESS && CheckForSkippedFrames(walkData))
-            walkData.State = StackWalkState.SW_SKIPPED_FRAME;
+        if (walkData.State == StackWalkState.Frameless && CheckForSkippedFrames(walkData))
+            walkData.State = StackWalkState.SkippedFrame;
 
         GcScanContext scanContext = new(_target, resolveInteriorPointers: false);
 
@@ -209,7 +209,7 @@ internal partial class StackWalk_1 : IStackWalk
 
                 if (reportGcReferences)
                 {
-                    if (gcFrame.Frame.State == StackWalkState.SW_FRAMELESS)
+                    if (gcFrame.Frame.State == StackWalkState.Frameless)
                     {
                         if (!IsManaged(gcFrame.Frame.Context.InstructionPointer, out CodeBlockHandle? cbh))
                             throw new InvalidOperationException("Expected managed code");
@@ -322,7 +322,7 @@ internal partial class StackWalk_1 : IStackWalk
         TargetPointer intermediaryFuncletParentStackFrame = TargetPointer.Null;
 
         // Process the initial frame, then advance with Next()
-        bool isValid = walkData.State is not (StackWalkState.SW_ERROR or StackWalkState.SW_COMPLETE);
+        bool isValid = walkData.State is not (StackWalkState.Error or StackWalkState.Complete);
         while (isValid)
         {
             StackDataFrameHandle handle = walkData.ToDataFrame();
@@ -360,7 +360,7 @@ internal partial class StackWalk_1 : IStackWalk
 
             switch (handle.State)
             {
-                case StackWalkState.SW_FRAMELESS:
+                case StackWalkState.Frameless:
                     do
                     {
                         recheckCurrentFrame = false;
@@ -510,7 +510,7 @@ internal partial class StackWalk_1 : IStackWalk
                                     {
                                         // We have reached another funclet.  Reexamine this frame.
                                         recheckCurrentFrame = true;
-                                        goto case StackWalkState.SW_FRAMELESS;
+                                        goto case StackWalkState.Frameless;
                                     }
                                 }
                             }
@@ -577,7 +577,7 @@ internal partial class StackWalk_1 : IStackWalk
                             if (parentStackFrame == TargetPointer.Null && IsFunclet(handle))
                             {
                                 recheckCurrentFrame = true;
-                                goto case StackWalkState.SW_FRAMELESS;
+                                goto case StackWalkState.Frameless;
                             }
 
                             if (skipFuncletCallback)
@@ -607,8 +607,8 @@ internal partial class StackWalk_1 : IStackWalk
                     stop = true;
                     break;
 
-                case StackWalkState.SW_FRAME:
-                case StackWalkState.SW_SKIPPED_FRAME:
+                case StackWalkState.Frame:
+                case StackWalkState.SkippedFrame:
                     if (!skippingFunclet)
                     {
                         if (HasFrameBeenUnwoundByAnyActiveException(handle))
@@ -619,8 +619,8 @@ internal partial class StackWalk_1 : IStackWalk
                         stop = true;
                     }
                     break;
-                case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
-                case StackWalkState.SW_NATIVE_MARKER:
+                case StackWalkState.InitialNativeContext:
+                case StackWalkState.NativeMarker:
                     break;
                 default:
                     stop = true;
@@ -640,7 +640,7 @@ internal partial class StackWalk_1 : IStackWalk
 
     private bool IsUnwoundToTargetParentFrame(StackDataFrameHandle handle, TargetPointer targetParentFrame)
     {
-        Debug.Assert(handle.State is StackWalkState.SW_FRAMELESS);
+        Debug.Assert(handle.State is StackWalkState.Frameless);
 
         IPlatformAgnosticContext callerContext = handle.Context.Clone();
         callerContext.Unwind(_target);
@@ -652,7 +652,7 @@ internal partial class StackWalk_1 : IStackWalk
     {
         switch (handle.State)
         {
-            case StackWalkState.SW_FRAMELESS:
+            case StackWalkState.Frameless:
                 // Native assertion (stackwalk.cpp): current SP must be below the next Frame.
                 // FaultingExceptionFrame is a special case where it gets pushed after the frame is running.
                 Debug.Assert(
@@ -680,20 +680,20 @@ internal partial class StackWalk_1 : IStackWalk
                     }
                     catch
                     {
-                        handle.State = StackWalkState.SW_ERROR;
+                        handle.State = StackWalkState.Error;
                         throw;
                     }
                 }
                 break;
-            case StackWalkState.SW_SKIPPED_FRAME:
+            case StackWalkState.SkippedFrame:
                 // Advance past the skipped frame, then let UpdateState detect
                 // whether there are more skipped frames or we've reached the managed method.
                 handle.FrameIter.Next();
                 break;
-            case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
-            case StackWalkState.SW_NATIVE_MARKER:
+            case StackWalkState.InitialNativeContext:
+            case StackWalkState.NativeMarker:
                 break;
-            case StackWalkState.SW_FRAME:
+            case StackWalkState.Frame:
                 // Native SFITER_FRAME_FUNCTION gates ProcessIp + UpdateRegDisplay on
                 // GetReturnAddress() != 0, and gates GotoNextFrame on !pInlinedFrame.
                 // pInlinedFrame is set only for active InlinedCallFrames.
@@ -709,7 +709,7 @@ internal partial class StackWalk_1 : IStackWalk
 
                     // For InterpreterFrame the FrameIterator has no GetReturnAddress
                     // (interpreter virtual unwind manages the IP), but we still need
-                    // UpdateContextFromFrame to transition to SW_FRAMELESS in the
+                    // UpdateContextFromFrame to transition to Frameless in the
                     // interpreted method.
                     if (returnAddress != TargetPointer.Null
                         || frameType == FrameType.InterpreterFrame)
@@ -722,38 +722,39 @@ internal partial class StackWalk_1 : IStackWalk
                     }
                 }
                 break;
-            case StackWalkState.SW_ERROR:
-            case StackWalkState.SW_COMPLETE:
+            case StackWalkState.Error:
+            case StackWalkState.Complete:
                 return false;
         }
         UpdateState(handle);
 
-        return handle.State is not (StackWalkState.SW_ERROR or StackWalkState.SW_COMPLETE);
+        return handle.State is not (StackWalkState.Error or StackWalkState.Complete);
     }
 
     private void UpdateState(StackWalkData handle)
     {
         // If we are complete or in a bad state, no updating is required.
-        if (handle.State is StackWalkState.SW_ERROR or StackWalkState.SW_COMPLETE)
+        if (handle.State is StackWalkState.Error or StackWalkState.Complete)
         {
             return;
         }
+
+        bool validFrame = handle.FrameIter.IsValid();
 
         switch (handle.State)
         {
             // The step that just ran moved Context (an unwind out of a
             // managed frame, or an advance past a Frame). Reclassify from the
             // observed Context+FrameIter.
-            case StackWalkState.SW_FRAMELESS:
-            case StackWalkState.SW_FRAME:
-            case StackWalkState.SW_SKIPPED_FRAME:
+            case StackWalkState.Frameless:
+            case StackWalkState.Frame:
+            case StackWalkState.SkippedFrame:
             {
                 bool isManaged = IsManaged(handle.Context.InstructionPointer, out _);
-                bool validFrame = handle.FrameIter.IsValid();
 
                 if (isManaged)
                 {
-                    handle.State = StackWalkState.SW_FRAMELESS;
+                    handle.State = StackWalkState.Frameless;
 
                     // Detect exception frames (FRAME_ATTR_EXCEPTION) when transitioning to managed.
                     // Both FaultingExceptionFrame (hardware) and SoftwareExceptionFrame (managed throw)
@@ -768,21 +769,21 @@ internal partial class StackWalk_1 : IStackWalk
 
                     if (CheckForSkippedFrames(handle))
                     {
-                        handle.State = StackWalkState.SW_SKIPPED_FRAME;
+                        handle.State = StackWalkState.SkippedFrame;
                     }
                 }
                 else
                 {
-                    handle.State = validFrame ? StackWalkState.SW_NATIVE_MARKER : StackWalkState.SW_COMPLETE;
+                    handle.State = validFrame ? StackWalkState.NativeMarker : StackWalkState.Complete;
                 }
                 return;
             }
 
-            // The step that just ran bridged through a Frame. Yield SW_FRAME
+            // The step that just ran bridged through a Frame. Yield Frame
             // so the consumer sees the bridged Frame; if there was no Frame, terminate.
-            case StackWalkState.SW_INITIAL_NATIVE_CONTEXT:
-            case StackWalkState.SW_NATIVE_MARKER:
-                handle.State = handle.FrameIter.IsValid() ? StackWalkState.SW_FRAME : StackWalkState.SW_COMPLETE;
+            case StackWalkState.InitialNativeContext:
+            case StackWalkState.NativeMarker:
+                handle.State = validFrame ? StackWalkState.Frame : StackWalkState.Complete;
                 return;
         }
     }
@@ -816,16 +817,10 @@ internal partial class StackWalk_1 : IStackWalk
         return handle.Context.GetBytes();
     }
 
-    StackWalkState IStackWalk.GetState(IStackDataFrameHandle stackDataFrameHandle)
-    {
-        StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
-        return handle.State;
-    }
-
     TargetPointer IStackWalk.GetFrameAddress(IStackDataFrameHandle stackDataFrameHandle)
     {
         StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
-        if (handle.State is StackWalkState.SW_FRAME or StackWalkState.SW_SKIPPED_FRAME)
+        if (handle.State is StackWalkState.Frame or StackWalkState.SkippedFrame)
         {
             return handle.FrameAddress;
         }
@@ -854,7 +849,7 @@ internal partial class StackWalk_1 : IStackWalk
         {
             // reportInteropMD if
             // 1) we are an InlinedCallFrame
-            // 2) the StackDataFrame is at a SW_SKIPPED_FRAME state
+            // 2) the StackDataFrame is at a SkippedFrame state
             // 3) the return address is managed
             // 4) the return address method has a MDContext arg
             bool reportInteropMD = false;
@@ -863,7 +858,7 @@ internal partial class StackWalk_1 : IStackWalk
             FrameType frameType = _frameHelpers.GetFrameType(frameData.Identifier);
 
             if (frameType == FrameType.InlinedCallFrame &&
-                handle.State == StackWalkState.SW_SKIPPED_FRAME)
+                handle.State == StackWalkState.SkippedFrame)
             {
                 IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
 
@@ -880,7 +875,7 @@ internal partial class StackWalk_1 : IStackWalk
             {
                 // Special reportInteropMD case
                 // This can't be handled in the GetMethodDescPtr(TargetPointer) because it relies on
-                // the state of the stack walk (SW_SKIPPED_FRAME) which is not available there.
+                // the state of the stack walk (SkippedFrame) which is not available there.
                 // The MethodDesc pointer immediately follows the InlinedCallFrame
                 TargetPointer methodDescPtr = framePtr + _target.GetTypeInfo(DataType.InlinedCallFrame).Size
                     ?? throw new InvalidOperationException("InlinedCallFrame type size is not defined.");

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -34,7 +34,27 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
 
         // IEnumerator<T> begins before the first element.
         // Call MoveNext() to set _dataFrames.Current to the first element.
-        _currentFrameIsValid = _dataFrames.MoveNext();
+        _currentFrameIsValid = MoveNextLegacyVisible();
+    }
+
+    /// <summary>
+    /// Advance the enumerator to the next frame that the legacy SOSDAC stack walker
+    /// would have surfaced.
+    /// </summary>
+    private bool MoveNextLegacyVisible()
+    {
+        IStackWalk sw = _target.Contracts.StackWalk;
+        while (_dataFrames.MoveNext())
+        {
+            StackWalkState state = sw.GetState(_dataFrames.Current);
+            if (state is StackWalkState.SW_FRAMELESS
+                      or StackWalkState.SW_FRAME
+                      or StackWalkState.SW_SKIPPED_FRAME)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
     int IXCLRDataStackWalk.GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, [MarshalUsing(CountElementName = "contextBufSize"), Out] byte[] contextBuf)
@@ -121,7 +141,7 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         int hr;
         try
         {
-            _currentFrameIsValid = _dataFrames.MoveNext();
+            _currentFrameIsValid = MoveNextLegacyVisible();
             hr = _currentFrameIsValid ? HResults.S_OK : HResults.S_FALSE;
         }
         catch (System.Exception ex)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -43,19 +43,20 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
     /// </summary>
     private bool MoveNextLegacyVisible()
     {
-        IStackWalk sw = _target.Contracts.StackWalk;
         while (_dataFrames.MoveNext())
         {
-            StackWalkState state = sw.GetState(_dataFrames.Current);
-            if (state is StackWalkState.SW_FRAMELESS
-                      or StackWalkState.SW_FRAME
-                      or StackWalkState.SW_SKIPPED_FRAME)
+            if (IsLegacyVisible(_dataFrames.Current))
             {
                 return true;
             }
         }
         return false;
     }
+
+    internal static bool IsLegacyVisible(IStackDataFrameHandle frame)
+        => frame.State is StackWalkState.Frameless
+                       or StackWalkState.Frame
+                       or StackWalkState.SkippedFrame;
 
     int IXCLRDataStackWalk.GetContext(uint contextFlags, uint contextBufSize, uint* contextSize, [MarshalUsing(CountElementName = "contextBufSize"), Out] byte[] contextBuf)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -212,10 +212,12 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
                 hrLocal = _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, localOutBufferPtr);
             }
             Debug.ValidateHResult(hr, hrLocal);
-
-            for (int i = 0; i < outBufferSize; i++)
+            if (hr == HResults.S_OK)
             {
-                Debug.Assert(localOutBuffer[i] == outBuffer[i], $"cDAC: {outBuffer[i]:x}, DAC: {localOutBuffer[i]:x}");
+                for (int i = 0; i < outBufferSize; i++)
+                {
+                    Debug.Assert(localOutBuffer[i] == outBuffer[i], $"cDAC: {outBuffer[i]:x}, DAC: {localOutBuffer[i]:x}");
+                }
             }
         }
 #endif

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -169,22 +169,37 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         const uint DACSTACKPRIV_REQUEST_FRAME_DATA = 0xf0000000;
 
         int hr = HResults.S_OK;
-
-        switch (reqCode)
+        try
         {
-            case DACSTACKPRIV_REQUEST_FRAME_DATA:
-                if (outBufferSize < sizeof(ulong))
-                    hr = HResults.E_INVALIDARG;
+            if (inBufferSize != 0 || inBuffer != null)
+                throw new ArgumentException("Invalid input buffer parameters");
+            switch (reqCode)
+            {
+                case (uint)CLRDataGeneralRequest.CLRDATA_REQUEST_REVISION:
+                    if (outBufferSize != sizeof(uint))
+                        throw new ArgumentException("Invalid buffer parameters for CLRDATA_REQUEST_REVISION");
+                    *(uint*)outBuffer = 1;
+                    hr = HResults.S_OK;
+                    break;
+                case DACSTACKPRIV_REQUEST_FRAME_DATA:
+                    if (outBufferSize != sizeof(ulong))
+                        throw new ArgumentException("Invalid buffer parameters for DACSTACKPRIV_REQUEST_FRAME_DATA");
+                    if (!_currentFrameIsValid)
+                        throw new ArgumentException("Invalid frame");
 
-                IStackWalk sw = _target.Contracts.StackWalk;
-                IStackDataFrameHandle frameData = _dataFrames.Current;
-                TargetPointer frameAddr = sw.GetFrameAddress(frameData);
-                *(ulong*)outBuffer = frameAddr.ToClrDataAddress(_target);
-                hr = HResults.S_OK;
-                break;
-            default:
-                hr = HResults.E_NOTIMPL;
-                break;
+                    IStackWalk sw = _target.Contracts.StackWalk;
+                    IStackDataFrameHandle frameData = _dataFrames.Current;
+                    TargetPointer frameAddr = sw.GetFrameAddress(frameData);
+                    *(ulong*)outBuffer = frameAddr.ToClrDataAddress(_target);
+                    hr = HResults.S_OK;
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
         }
 
 #if DEBUG

--- a/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiStackWalkDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiStackWalkDumpTests.cs
@@ -115,6 +115,7 @@ public class DacDbiStackWalkDumpTests : DumpTestBase
 
         // Find a frame whose SP+IP differs from the leaf context
         byte[]? nonLeafContext = sw.CreateStackWalk(crashingThread)
+            .Where(ClrDataStackWalk.IsLegacyVisible)
             .Select(sw.GetRawContext)
             .FirstOrDefault(ctx =>
             {

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestHelpers.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestHelpers.cs
@@ -1,9 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
@@ -71,7 +73,7 @@ internal static class DumpTestHelpers
         {
             ThreadData threadData = threadContract.GetThreadData(currentThreadPtr);
 
-            foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(threadData))
+            foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(threadData).Where(ClrDataStackWalk.IsLegacyVisible))
             {
                 TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(frame);
                 string? name = GetMethodName(target, methodDescPtr);

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestStackWalker.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestStackWalker.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
@@ -99,7 +100,7 @@ internal sealed class DumpTestStackWalker
         IStackWalk stackWalk = target.Contracts.StackWalk;
         List<ResolvedFrame> frames = [];
 
-        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(threadData))
+        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(threadData).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(frame);
             string? name = DumpTestHelpers.GetMethodName(target, methodDescPtr);

--- a/src/native/managed/cdac/tests/DumpTests/ExceptionHandlingInfoDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ExceptionHandlingInfoDumpTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Xunit;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
@@ -34,7 +35,7 @@ public class ExceptionHandlingInfoDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(frame);
             string? name = DumpTestHelpers.GetMethodName(Target, methodDescPtr);

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Xunit;

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
@@ -193,7 +193,7 @@ public unsafe class IXCLRDataAppDomainDumpTests : DumpTestBase
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
         IStackDataFrameHandle? managedFrame = null;
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md != TargetPointer.Null)

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
@@ -185,7 +185,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -221,7 +221,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -260,7 +260,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -292,7 +292,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -327,7 +327,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -365,7 +365,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -401,7 +401,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -436,7 +436,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -474,7 +474,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -509,7 +509,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md != TargetPointer.Null)

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using Microsoft.Diagnostics.DataContractReader.Contracts;

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataMethodDefinitionDumpTests.cs
@@ -197,7 +197,7 @@ public unsafe class IXCLRDataMethodDefinitionDumpTests : DumpTestBase
         IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle frame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(frame);
             if (methodDescPtr == TargetPointer.Null)

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
@@ -537,7 +537,7 @@ public unsafe class IXCLRDataValueDumpTests : DumpTestBase
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
         int totalValues = 0;
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)
@@ -730,7 +730,7 @@ public unsafe class IXCLRDataValueDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible))
         {
             TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
             if (md == TargetPointer.Null)

--- a/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
@@ -31,7 +31,7 @@ public class StackWalkDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
         List<IStackDataFrameHandle> frameList = frames.ToList();
 
         Assert.True(frameList.Count > 0, "Expected at least one stack frame on the crashing thread");
@@ -47,7 +47,7 @@ public class StackWalkDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
         List<IStackDataFrameHandle> frameList = frames.ToList();
 
         // The debuggee has Main → MethodA → MethodB → MethodC → FailFast,
@@ -68,7 +68,7 @@ public class StackWalkDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
 
         foreach (IStackDataFrameHandle frame in frames)
         {
@@ -92,7 +92,7 @@ public class StackWalkDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
         IStackDataFrameHandle? firstFrame = frames.FirstOrDefault();
         Assert.NotNull(firstFrame);
 
@@ -130,7 +130,7 @@ public class StackWalkDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
         List<IStackDataFrameHandle> frameList = frames.ToList();
 
         Assert.True(frameList.Count > 0, "Expected at least one stack frame on the crashing thread");
@@ -165,7 +165,7 @@ public class StackWalkDumpTests : DumpTestBase
         IStackWalk stackWalk = Target.Contracts.StackWalk;
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
         List<IStackDataFrameHandle> frameList = frames.ToList();
 
         Assert.True(frameList.Count > 0, "Expected at least one stack frame on the crashing thread");
@@ -202,7 +202,7 @@ public class StackWalkDumpTests : DumpTestBase
         IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
 
         bool foundILStub = false;
         foreach (IStackDataFrameHandle frame in frames)
@@ -234,7 +234,7 @@ public class StackWalkDumpTests : DumpTestBase
         ISOSDacInterface sosDac = new SOSDacImpl(Target, legacyObj: null);
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
 
         foreach (IStackDataFrameHandle frame in frames)
         {
@@ -268,7 +268,7 @@ public class StackWalkDumpTests : DumpTestBase
         IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
 
         foreach (IStackDataFrameHandle frame in frames)
         {
@@ -304,7 +304,7 @@ public class StackWalkDumpTests : DumpTestBase
         ISOSDacInterface sosDac = new SOSDacImpl(Target, legacyObj: null);
 
         ThreadData crashingThread = DumpTestHelpers.FindThreadWithMethod(Target, "Main");
-        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread);
+        IEnumerable<IStackDataFrameHandle> frames = stackWalk.CreateStackWalk(crashingThread).Where(ClrDataStackWalk.IsLegacyVisible);
 
         foreach (IStackDataFrameHandle frame in frames)
         {


### PR DESCRIPTION
This PR attempts to prepare for the DacDbi stackwalk APIs by refactoring the stackwalking iterator to return all frames. Specifically, we want to surface from the cDAC API the native marker frames that the SosDac does not consume but the DacDbi stack walk will consume. We then filter at the consumer level which frames we want to see.

In addition, we fill out a couple branches of a StackWalk Request API.