### PR TITLE
[Wasm RyuJIT] "Partial containment" for GT_LCL_ADDR

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2371,6 +2371,20 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
     WasmProduceReg(tree);
 }
 
+static cnsval_ssize_t getOffsetForPossiblyContainedAddress(Compiler *comp, GenTree *addr)
+{
+    if (addr->isContained() && addr->OperIs(GT_LCL_ADDR))
+    {
+            bool FPBased;
+            int  lclOffset = comp->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
+            cnsval_ssize_t offset = lclOffset + addr->AsLclFld()->GetLclOffs();
+            noway_assert(offset >= 0); // WASM address modes are unsigned.
+            return offset;
+    }
+
+    return 0;
+}
+
 //------------------------------------------------------------------------
 // genCodeForIndir: Produce code for a GT_IND node.
 //
@@ -2384,24 +2398,12 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
     var_types   type      = tree->TypeGet();
     instruction ins       = ins_Load(type);
     GenTree*    addr      = tree->Addr();
-    cnsval_ssize_t offset = 0;
 
     genConsumeAddress(addr);
 
     // TODO-WASM: Memory barriers
 
-    if (addr->isContained())
-    {
-        if (addr->OperIs(GT_LCL_ADDR))
-        {
-            bool FPBased;
-            int  lclOffset = m_compiler->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
-            offset    = lclOffset + addr->AsLclFld()->GetLclOffs();
-            noway_assert(offset >= 0); // WASM address modes are unsigned.
-        }
-    }
-
-    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), offset);
+    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), getOffsetForPossiblyContainedAddress(m_compiler, addr));
 
     WasmProduceReg(tree);
 }
@@ -2438,22 +2440,10 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     {
         var_types   type      = tree->TypeGet();
         instruction ins       = ins_Store(type);
-        cnsval_ssize_t offset = 0;
-
-        if (addr->isContained())
-        {
-            if (addr->OperIs(GT_LCL_ADDR))
-            {
-                bool FPBased;
-                int  lclOffset = m_compiler->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
-                offset    = lclOffset + addr->AsLclFld()->GetLclOffs();
-                noway_assert(offset >= 0); // WASM address modes are unsigned.
-            }
-        }
 
         // TODO-WASM: Memory barriers
 
-        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), offset);
+        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), getOffsetForPossiblyContainedAddress(m_compiler, addr));
     }
 
     genUpdateLife(tree);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -699,7 +699,8 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     assert(!treeNode->IsReuseRegVal()); // TODO-WASM-CQ: enable.
 
     // Contained nodes are part of the parent for codegen purposes.
-    if (treeNode->isContained())
+    // Except for 'partially contained' address nodes, which still need to push FP/SP onto the stack at the right spot.
+    if (treeNode->isContained() && !treeNode->OperIs(GT_LCL_ADDR))
     {
         return;
     }
@@ -2263,8 +2264,14 @@ void CodeGen::genCodeForLclAddr(GenTreeLclFld* lclAddrNode)
     unsigned lclNum    = lclAddrNode->GetLclNum();
     unsigned lclOffset = lclAddrNode->GetLclOffs();
 
+    // Even if contained, we always load the frame pointer at the right place so that containing get/set
+    // opcodes have a base address to work from.
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-    if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
+    if (lclAddrNode->isContained())
+    {
+        printf("skipping const+add for contained GT_LCL_ADDR [%06u]\n", Compiler::dspTreeID(lclAddrNode));
+    }
+    else if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
     {
         GetEmitter()->emitIns_S(INS_I_const, EA_PTRSIZE, lclNum, lclOffset);
         GetEmitter()->emitIns(INS_I_add);
@@ -2374,14 +2381,27 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_IND));
 
-    var_types   type = tree->TypeGet();
-    instruction ins  = ins_Load(type);
+    var_types   type      = tree->TypeGet();
+    instruction ins       = ins_Load(type);
+    GenTree*    addr      = tree->Addr();
+    cnsval_ssize_t offset = 0;
 
-    genConsumeAddress(tree->Addr());
+    genConsumeAddress(addr);
 
     // TODO-WASM: Memory barriers
 
-    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+    if (addr->isContained())
+    {
+        if (addr->OperIs(GT_LCL_ADDR))
+        {
+            bool FPBased;
+            int  lclOffset = m_compiler->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
+            offset    = lclOffset + addr->AsLclFld()->GetLclOffs();
+            noway_assert(offset >= 0); // WASM address modes are unsigned.
+        }
+    }
+
+    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), offset);
 
     WasmProduceReg(tree);
 }
@@ -2397,8 +2417,6 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree* data = tree->Data();
     GenTree* addr = tree->Addr();
 
-    assert(!addr->isContained());
-
     // We must consume the operands in the proper execution order,
     // so that liveness is updated appropriately.
     genConsumeAddress(addr);
@@ -2413,16 +2431,29 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)
     {
+        assert(!addr->isContained());
         genGCWriteBarrier(tree, writeBarrierForm);
     }
     else // A normal store, not a WriteBarrier store
     {
-        var_types   type = tree->TypeGet();
-        instruction ins  = ins_Store(type);
+        var_types   type      = tree->TypeGet();
+        instruction ins       = ins_Store(type);
+        cnsval_ssize_t offset = 0;
+
+        if (addr->isContained())
+        {
+            if (addr->OperIs(GT_LCL_ADDR))
+            {
+                bool FPBased;
+                int  lclOffset = m_compiler->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
+                offset    = lclOffset + addr->AsLclFld()->GetLclOffs();
+                noway_assert(offset >= 0); // WASM address modes are unsigned.
+            }
+        }
 
         // TODO-WASM: Memory barriers
 
-        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), offset);
     }
 
     genUpdateLife(tree);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2369,13 +2369,13 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
     WasmProduceReg(tree);
 }
 
-static bool getOffsetForPossiblyContainedAddress(Compiler *comp, GenTree *addr, int *varx, int *offs)
+static bool getOffsetForPossiblyContainedAddress(Compiler* comp, GenTree* addr, int* varx, int* offs)
 {
     if (addr->OperIs(GT_PARTIALLY_CONTAINED_LCL_ADDR))
     {
-        GenTreeLclFld * lclFld = addr->gtGetOp1()->AsLclFld();
-        *varx = lclFld->GetLclNum();
-        *offs = lclFld->GetLclOffs();
+        GenTreeLclFld* lclFld = addr->gtGetOp1()->AsLclFld();
+        *varx                 = lclFld->GetLclNum();
+        *offs                 = lclFld->GetLclOffs();
         return true;
     }
     else
@@ -2396,9 +2396,9 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 {
     assert(tree->OperIs(GT_IND));
 
-    var_types   type      = tree->TypeGet();
-    instruction ins       = ins_Load(type);
-    GenTree*    addr      = tree->Addr();
+    var_types   type = tree->TypeGet();
+    instruction ins  = ins_Load(type);
+    GenTree*    addr = tree->Addr();
 
     genConsumeAddress(addr);
 
@@ -2449,8 +2449,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     }
     else // A normal store, not a WriteBarrier store
     {
-        var_types   type      = tree->TypeGet();
-        instruction ins       = ins_Store(type);
+        var_types   type = tree->TypeGet();
+        instruction ins  = ins_Store(type);
 
         // TODO-WASM: Memory barriers
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2369,19 +2369,21 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
     WasmProduceReg(tree);
 }
 
-static cnsval_ssize_t getOffsetForPossiblyContainedAddress(Compiler *comp, GenTree *addr)
+static bool getOffsetForPossiblyContainedAddress(Compiler *comp, GenTree *addr, int *varx, int *offs)
 {
     if (addr->OperIs(GT_PARTIALLY_CONTAINED_LCL_ADDR))
     {
         GenTreeLclFld * lclFld = addr->gtGetOp1()->AsLclFld();
-        bool FPBased;
-        int  lclOffset = comp->lvaFrameAddress(lclFld->GetLclNum(), &FPBased);
-        cnsval_ssize_t offset = lclOffset + lclFld->GetLclOffs();
-        noway_assert(offset >= 0); // WASM address modes are unsigned.
-        return offset;
+        *varx = lclFld->GetLclNum();
+        *offs = lclFld->GetLclOffs();
+        return true;
     }
-
-    return 0;
+    else
+    {
+        *varx = 0;
+        *offs = 0;
+        return false;
+    }
 }
 
 //------------------------------------------------------------------------
@@ -2402,7 +2404,15 @@ void CodeGen::genCodeForIndir(GenTreeIndir* tree)
 
     // TODO-WASM: Memory barriers
 
-    GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), getOffsetForPossiblyContainedAddress(m_compiler, addr));
+    int varx, offs;
+    if (getOffsetForPossiblyContainedAddress(m_compiler, addr, &varx, &offs))
+    {
+        GetEmitter()->emitIns_S(ins, emitActualTypeSize(type), varx, offs);
+    }
+    else
+    {
+        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+    }
 
     WasmProduceReg(tree);
 }
@@ -2434,6 +2444,7 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)
     {
+        assert(!addr->OperIs(GT_PARTIALLY_CONTAINED_LCL_ADDR));
         genGCWriteBarrier(tree, writeBarrierForm);
     }
     else // A normal store, not a WriteBarrier store
@@ -2443,7 +2454,16 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
 
         // TODO-WASM: Memory barriers
 
-        GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), getOffsetForPossiblyContainedAddress(m_compiler, addr));
+        int varx, offs;
+
+        if (getOffsetForPossiblyContainedAddress(m_compiler, addr, &varx, &offs))
+        {
+            GetEmitter()->emitIns_S(ins, emitActualTypeSize(type), varx, offs);
+        }
+        else
+        {
+            GetEmitter()->emitIns_I(ins, emitActualTypeSize(type), 0);
+        }
     }
 
     genUpdateLife(tree);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -699,8 +699,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
     assert(!treeNode->IsReuseRegVal()); // TODO-WASM-CQ: enable.
 
     // Contained nodes are part of the parent for codegen purposes.
-    // Except for 'partially contained' address nodes, which still need to push FP/SP onto the stack at the right spot.
-    if (treeNode->isContained() && !treeNode->OperIs(GT_LCL_ADDR))
+    if (treeNode->isContained())
     {
         return;
     }
@@ -742,6 +741,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_LCL_ADDR:
             genCodeForLclAddr(treeNode->AsLclFld());
+            break;
+
+        case GT_PARTIALLY_CONTAINED_LCL_ADDR:
+            GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
             break;
 
         case GT_LCL_FLD:
@@ -2267,11 +2270,7 @@ void CodeGen::genCodeForLclAddr(GenTreeLclFld* lclAddrNode)
     // Even if contained, we always load the frame pointer at the right place so that containing get/set
     // opcodes have a base address to work from.
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
-    if (lclAddrNode->isContained())
-    {
-        printf("skipping const+add for contained GT_LCL_ADDR [%06u]\n", Compiler::dspTreeID(lclAddrNode));
-    }
-    else if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
+    if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
     {
         GetEmitter()->emitIns_S(INS_I_const, EA_PTRSIZE, lclNum, lclOffset);
         GetEmitter()->emitIns(INS_I_add);
@@ -2373,13 +2372,14 @@ void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
 
 static cnsval_ssize_t getOffsetForPossiblyContainedAddress(Compiler *comp, GenTree *addr)
 {
-    if (addr->isContained() && addr->OperIs(GT_LCL_ADDR))
+    if (addr->OperIs(GT_PARTIALLY_CONTAINED_LCL_ADDR))
     {
-            bool FPBased;
-            int  lclOffset = comp->lvaFrameAddress(addr->AsLclFld()->GetLclNum(), &FPBased);
-            cnsval_ssize_t offset = lclOffset + addr->AsLclFld()->GetLclOffs();
-            noway_assert(offset >= 0); // WASM address modes are unsigned.
-            return offset;
+        GenTreeLclFld * lclFld = addr->gtGetOp1()->AsLclFld();
+        bool FPBased;
+        int  lclOffset = comp->lvaFrameAddress(lclFld->GetLclNum(), &FPBased);
+        cnsval_ssize_t offset = lclOffset + lclFld->GetLclOffs();
+        noway_assert(offset >= 0); // WASM address modes are unsigned.
+        return offset;
     }
 
     return 0;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2267,8 +2267,6 @@ void CodeGen::genCodeForLclAddr(GenTreeLclFld* lclAddrNode)
     unsigned lclNum    = lclAddrNode->GetLclNum();
     unsigned lclOffset = lclAddrNode->GetLclOffs();
 
-    // Even if contained, we always load the frame pointer at the right place so that containing get/set
-    // opcodes have a base address to work from.
     GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
     if ((lclOffset != 0) || (m_compiler->lvaFrameAddress(lclNum, &FPBased) != 0))
     {
@@ -2419,6 +2417,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree* data = tree->Data();
     GenTree* addr = tree->Addr();
 
+    assert(!addr->isContained());
+
     // We must consume the operands in the proper execution order,
     // so that liveness is updated appropriately.
     genConsumeAddress(addr);
@@ -2433,7 +2433,6 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GCInfo::WriteBarrierForm writeBarrierForm = gcInfo.gcIsWriteBarrierCandidate(tree);
     if (writeBarrierForm != GCInfo::WBF_NoBarrier)
     {
-        assert(!addr->isContained());
         genGCWriteBarrier(tree, writeBarrierForm);
     }
     else // A normal store, not a WriteBarrier store

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -745,6 +745,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_PARTIALLY_CONTAINED_LCL_ADDR:
             GetEmitter()->emitIns_I(INS_local_get, EA_PTRSIZE, GetFramePointerRegIndex());
+            WasmProduceReg(treeNode);
             break;
 
         case GT_LCL_FLD:

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -899,6 +899,9 @@ bool Compiler::fgAddrCouldBeNull(GenTree* addr)
         case GT_CNS_STR:
         case GT_FIELD_ADDR:
         case GT_LCL_ADDR:
+#ifdef TARGET_WASM
+        case GT_PARTIALLY_CONTAINED_LCL_ADDR:
+#endif
             return false;
 
         case GT_IND:
@@ -1000,7 +1003,11 @@ bool Compiler::fgAddrCouldBeHeap(GenTree* addr)
 
     // Ignore the offset for locals
 
+#ifdef TARGET_WASM
+    if (op->OperIs(GT_LCL_ADDR, GT_PARTIALLY_CONTAINED_LCL_ADDR))
+#else
     if (op->OperIs(GT_LCL_ADDR))
+#endif
     {
         return false;
     }

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -276,7 +276,11 @@ GCInfo::WriteBarrierForm GCInfo::gcIsWriteBarrierCandidate(GenTreeStoreInd* stor
 //
 GCInfo::WriteBarrierForm GCInfo::gcWriteBarrierFormFromTargetAddress(GenTree* tgtAddr)
 {
+#ifdef TARGET_WASM
+    if (tgtAddr->OperIs(GT_LCL_ADDR, GT_PARTIALLY_CONTAINED_LCL_ADDR))
+#else
     if (tgtAddr->OperIs(GT_LCL_ADDR))
+#endif
     {
         // No need for a GC barrier when writing to a local variable.
         return GCInfo::WBF_NoBarrier;

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -33248,6 +33248,12 @@ bool GenTreeLclFld::IsOffsetMisaligned() const
 
 bool GenTree::IsInvariant() const
 {
+#ifdef TARGET_WASM
+    if (OperIs(GT_PARTIALLY_CONTAINED_LCL_ADDR))
+    {
+        return true;
+    }
+#endif
     return OperIsConst() || OperIs(GT_LCL_ADDR) || OperIs(GT_FTN_ADDR);
 }
 

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11760,6 +11760,9 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_RETURN_SUSPEND:
         case GT_PATCHPOINT_FORCED:
         case GT_NONLOCAL_JMP:
+#ifdef TARGET_WASM
+        case GT_PARTIALLY_CONTAINED_LCL_ADDR:
+#endif
             m_edge = &m_node->AsUnOp()->gtOp1;
             assert(*m_edge != nullptr);
             m_advance = &GenTreeUseEdgeIterator::Terminate;

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -107,6 +107,10 @@ GTNODE(LZCNT            , GenTreeOp          ,0,0,GTK_UNOP)               // Lea
 
 GTNODE(NONLOCAL_JMP     , GenTreeOp          ,0,0,GTK_UNOP|GTK_NOVALUE)   // Non-local jump to specified address
 
+#ifdef TARGET_WASM
+GTNODE(PARTIALLY_CONTAINED_LCL_ADDR, GenTreeOp, 0,0,GTK_UNOP)             // Unary wrapper around a LCL_ADDR
+#endif
+
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -2426,6 +2426,17 @@ void Liveness<TLiveness>::ComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VAR
                 break;
             }
 
+#ifdef TARGET_WASM
+            case GT_PARTIALLY_CONTAINED_LCL_ADDR:
+                // WASM-TODO: Implement removal for dead partially contained lcl_addrs and their containers
+                if (TLiveness::EliminateDeadCode && node->IsUnusedValue())
+                {
+                    JITDUMP("WASM-TODO: Not removing unused partially contained local address:");
+                    DISPNODE(node);
+                }
+                break;
+#endif // TARGET_WASM
+
             case GT_LABEL:
             case GT_FTN_ADDR:
             case GT_CNS_INT:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11997,20 +11997,24 @@ void Lowering::UnmarkTree(GenTree* node)
 // Both of these requirements are imposed by the emitter.
 //
 // Arguments:
-//    lclAddr    - The local address node
-//    accessSize - The access size (of an indirection)
+//    lclAddr          - The local address node
+//    accessSize       - The access size (of an indirection)
+//    disableAssertion - Disable checking whether the local's address-exposed
 //
 // Return Value:
 //    Whether an indirection of "accessSize" may contain "lclAddr".
 //
-bool Lowering::IsContainableLclAddr(GenTreeLclFld* lclAddr, unsigned accessSize) const
+bool Lowering::IsContainableLclAddr(GenTreeLclFld* lclAddr, unsigned accessSize DEBUGARG(bool disableAssertion)) const
 {
     if (CheckedOps::AddOverflows<int32_t>(lclAddr->GetLclOffs(), accessSize, CheckedOps::Unsigned) ||
         !m_compiler->IsValidLclAddr(lclAddr->GetLclNum(), lclAddr->GetLclOffs() + accessSize - 1))
     {
+#if DEBUG
         // We depend on containment for correctness of liveness updates in codegen. Therefore, all
         // locals that may "return false" here MUST be address-exposed. Local morph ensures this.
-        assert(m_compiler->lvaGetDesc(lclAddr)->IsAddressExposed());
+        if (!disableAssertion)
+            assert(m_compiler->lvaGetDesc(lclAddr)->IsAddressExposed());
+#endif
         return false;
     }
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -570,7 +570,8 @@ public:
         return false;
     }
 
-    bool IsContainableLclAddr(GenTreeLclFld* lclAddr, unsigned accessSize DEBUGARG(bool disableAssertion = false)) const;
+    bool IsContainableLclAddr(GenTreeLclFld*      lclAddr,
+                              unsigned accessSize DEBUGARG(bool disableAssertion = false)) const;
 
 #ifdef TARGET_ARM64
     bool IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childNode) const;

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -570,7 +570,7 @@ public:
         return false;
     }
 
-    bool IsContainableLclAddr(GenTreeLclFld* lclAddr, unsigned accessSize) const;
+    bool IsContainableLclAddr(GenTreeLclFld* lclAddr, unsigned accessSize DEBUGARG(bool disableAssertion = false)) const;
 
 #ifdef TARGET_ARM64
     bool IsContainableUnaryOrBinaryOp(GenTree* parentNode, GenTree* childNode) const;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -449,6 +449,12 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     GenTree * addr = indirNode->Addr();
     if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size()))
     {
+        // An indir through a lcl_addr should never have a multiply-used address since it doesn't need a null check
+        //  and can't fault. If it does, this transform is incorrect.
+        assert((addr->gtLIRFlags & LIR::Flags::MultiplyUsed) == LIR::Flags::None);
+        // For containable lcl addresses we want to 'partially contain' them, where we replace them with a node
+        //  that pushes the frame pointer onto the stack but doesn't emit an i32.const + i32.add. We do this by
+        //  wrapping and containing the LCL_ADDR inside of a node that emits the FP.
         GenTreeUnOp* wrapper = m_compiler->gtNewOperNode(GT_PARTIALLY_CONTAINED_LCL_ADDR, addr->TypeGet(), addr);
         addr->SetContained();
         indirNode->SetAddr(wrapper);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -446,10 +446,15 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 
-    if (indirNode->Addr()->OperIs(GT_LCL_ADDR))
+    GenTree * addr = indirNode->Addr();
+    if (addr->OperIs(GT_LCL_ADDR))
     {
-        printf("Containing GT_LCL_ADDR addr of indirection [%06u]\n", Compiler::dspTreeID(indirNode));
-        indirNode->Addr()->SetContained();
+        GenTreeUnOp * wrapper = m_compiler->gtNewOperNode(
+            GT_PARTIALLY_CONTAINED_LCL_ADDR, addr->TypeGet(), addr
+        );
+        addr->SetContained();
+        indirNode->SetAddr(wrapper);
+        BlockRange().InsertAfter(addr, wrapper);
     }
 }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -447,7 +447,7 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 
     GenTree * addr = indirNode->Addr();
-    if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size()))
+    if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size() DEBUGARG(true /* disableAssertion */)))
     {
         // An indir through a lcl_addr should never have a multiply-used address since it doesn't need a null check
         //  and can't fault. If it does, this transform is incorrect.

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -447,11 +447,9 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 
     GenTree * addr = indirNode->Addr();
-    if (addr->OperIs(GT_LCL_ADDR))
+    if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size()))
     {
-        GenTreeUnOp * wrapper = m_compiler->gtNewOperNode(
-            GT_PARTIALLY_CONTAINED_LCL_ADDR, addr->TypeGet(), addr
-        );
+        GenTreeUnOp* wrapper = m_compiler->gtNewOperNode(GT_PARTIALLY_CONTAINED_LCL_ADDR, addr->TypeGet(), addr);
         addr->SetContained();
         indirNode->SetAddr(wrapper);
         BlockRange().InsertAfter(addr, wrapper);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -446,8 +446,9 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 
-    GenTree * addr = indirNode->Addr();
-    if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size() DEBUGARG(true /* disableAssertion */)))
+    GenTree* addr = indirNode->Addr();
+    if (addr->OperIs(GT_LCL_ADDR) &&
+        IsContainableLclAddr(addr->AsLclFld(), indirNode->Size() DEBUGARG(true /* disableAssertion */)))
     {
         // An indir through a lcl_addr should never have a multiply-used address since it doesn't need a null check
         //  and can't fault. If it does, this transform is incorrect.

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -445,6 +445,12 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
 
     // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
     // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
+
+    if (indirNode->Addr()->OperIs(GT_LCL_ADDR))
+    {
+        printf("Containing GT_LCL_ADDR addr of indirection [%06u]\n", Compiler::dspTreeID(indirNode));
+        indirNode->Addr()->SetContained();
+    }
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
Experimenting with an approach for folding offsets into GT_IND and GT_STOREIND. Seems to work so far and doesn't complicate the code much, but the need to change codegenwasm.cpp:702 makes me wonder if this approach is fundamentally doomed...

cc @AndyAyersMS @SingleAccretion thoughts? I found a comment somewhere suggesting we need a new "nuw" frontend node but I'm not sure what a nuw is and whether that is the right solution for these scenarios.

LEAs are the next candidate but they seem trickier to get right. I'm not sure how common 'partially containable' LEAs and LCL_ADDRs are in a larger codebase, might do some instrumented runs over SPC to find out.