### PR TITLE
Fix JsonSerializer throws when serializing null value in a value-type nullable union case

### DIFF
--- a/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Union/JsonUnionConverter.cs
+++ b/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/Converters/Union/JsonUnionConverter.cs
@@ -182,6 +182,14 @@ namespace System.Text.Json.Serialization.Converters
                 return true;
             }
 
+            // If the deconstructor reports a value-type case holding null, 
+            // write JSON null directly rather than dispatching to the value-type's converter
+            // (which cannot unbox null).
+            if (caseValue is null && caseType.IsValueType) {
+                writer.WriteNullValue();
+                return true;
+            }
+
             JsonTypeInfo caseTypeInfo = options.GetTypeInfoInternal(caseType);
             state.Current.JsonPropertyInfo = caseTypeInfo.PropertyInfoForTypeInfo;
             return caseTypeInfo.Converter.TryWriteAsObject(writer, caseValue, options, ref state);

--- a/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
+++ b/src/libraries/System.Text.Json/tests/Common/UnionTests.cs
@@ -565,6 +565,21 @@ namespace System.Text.Json.Serialization.Tests
             Assert.Null(GetUnionValue(nullUnion));
         }
 
+        [Fact]
+        public async Task UnionWithValueTypeNullableCase_SerializesNullAsJsonNull()
+        {
+            string json = await Serializer.SerializeWrapper<ValueTypeNullablePairUnion>(new ValueTypeNullablePairUnion((int?)null));
+            Assert.Equal("null", json);
+        }
+
+        [Fact]
+        public async Task UnionWithValueTypeNullableCase_RoundTripsNullValue()
+        {
+            string json = await Serializer.SerializeWrapper<ValueTypeNullablePairUnion>(new ValueTypeNullablePairUnion((int?)null));
+            ValueTypeNullablePairUnion roundTripped = await Serializer.DeserializeWrapper<ValueTypeNullablePairUnion>(json);
+            Assert.Null(roundTripped.Value);
+        }
+
         public class PayloadCase
         {
             public string? Name { get; set; }


### PR DESCRIPTION
I've added roundtrip test on existing `union ValueTypeNullablePairUnion(int, int?);` to verify that nullable case value works well for valueType. There are existing tests checking the same for `string?`.

Fixes #128688