### PR TITLE
JIT: avoid redundant nullcheck in LowerBlockStoreAsGcBulkCopyCall

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -10151,9 +10151,6 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
     assert(!blk->Data()->OperIs(GT_IND) || !blk->Data()->AsIndir()->IsVolatile());
 
     // Capture whether the original block store could throw (e.g. NRE from a null address).
-    // Must be sampled before gtBashToNOP below, which clears GTF_ALL_EFFECT.
-    // If GTF_EXCEPT is clear, assertion prop / morph has proven the indirection cannot fault,
-    // so the explicit nullchecks we would otherwise insert around the helper call are redundant.
     const bool blockStoreMayThrow = (blk->gtFlags & GTF_EXCEPT) != 0;
 
     GenTree* dest = blk->Addr();

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -10150,6 +10150,12 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
     assert(!blk->IsVolatile());
     assert(!blk->Data()->OperIs(GT_IND) || !blk->Data()->AsIndir()->IsVolatile());
 
+    // Capture whether the original block store could throw (e.g. NRE from a null address).
+    // Must be sampled before gtBashToNOP below, which clears GTF_ALL_EFFECT.
+    // If GTF_EXCEPT is clear, assertion prop / morph has proven the indirection cannot fault,
+    // so the explicit nullchecks we would otherwise insert around the helper call are redundant.
+    const bool blockStoreMayThrow = (blk->gtFlags & GTF_EXCEPT) != 0;
+
     GenTree* dest = blk->Addr();
     GenTree* data = blk->Data();
 
@@ -10228,8 +10234,12 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
             LowerNode(nullcheck);
         }
     };
-    wrapWithNullcheck(dest);
-    wrapWithNullcheck(data);
+
+    if (blockStoreMayThrow)
+    {
+        wrapWithNullcheck(dest);
+        wrapWithNullcheck(data);
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -10151,14 +10151,17 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
     assert(!blk->Data()->OperIs(GT_IND) || !blk->Data()->AsIndir()->IsVolatile());
 
     // Capture whether the original block store could throw (e.g. NRE from a null address).
-    const bool blockStoreMayThrow = (blk->gtFlags & GTF_EXCEPT) != 0;
 
     GenTree* dest = blk->Addr();
     GenTree* data = blk->Data();
 
+    bool destMayFault = blk->IndirMayFault(m_compiler);
+    bool dataMayFault;
+
     if (data->OperIs(GT_IND))
     {
         // Drop GT_IND nodes
+        dataMayFault = data->IndirMayFault(m_compiler);
         BlockRange().Remove(data);
         data = data->AsIndir()->Addr();
     }
@@ -10167,6 +10170,7 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
         assert(data->OperIs(GT_LCL_VAR, GT_LCL_FLD));
 
         // Convert local to LCL_ADDR
+        dataMayFault       = false;
         unsigned lclOffset = data->AsLclVarCommon()->GetLclOffs();
         data->ChangeOper(GT_LCL_ADDR);
         data->ChangeType(TYP_I_IMPL);
@@ -10232,9 +10236,13 @@ void Lowering::LowerBlockStoreAsGcBulkCopyCall(GenTreeBlk* blk)
         }
     };
 
-    if (blockStoreMayThrow)
+    if (destMayFault)
     {
         wrapWithNullcheck(dest);
+    }
+
+    if (dataMayFault)
+    {
         wrapWithNullcheck(data);
     }
 }


### PR DESCRIPTION
Trivial fix for https://github.com/dotnet/runtime/issues/128696 ([diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1439447&view=ms.vss-build-web.run-extensions-tab))