### PR TITLE
Use a distinct wasm machine type for R2R dumps

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcSlotTable.cs
@@ -74,6 +74,8 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                     case Machine.RiscV64:
                         return ((RiscV64.Registers)registerNumber).ToString();
 
+                    case WasmMachine.Wasm32:
+                        throw new NotImplementedException("No implementation for machine type Wasm32.");
                     default:
                         throw new NotImplementedException(machine.ToString());
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/Amd64/GcTransition.cs
@@ -75,6 +75,9 @@ namespace ILCompiler.Reflection.ReadyToRun.Amd64
                         regType = typeof(RiscV64.Registers);
                         break;
 
+                    case WasmMachine.Wasm32:
+                        throw new NotImplementedException($"No implementation for machine type Wasm32.");
+
                     default:
                         throw new NotImplementedException();
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/DebugInfo.cs
@@ -86,6 +86,8 @@ namespace ILCompiler.Reflection.ReadyToRun
                     return ((LoongArch64.Registers)regnum).ToString();
                 case Machine.RiscV64:
                     return ((RiscV64.Registers)regnum).ToString();
+                case WasmMachine.Wasm32:
+                    throw new NotImplementedException($"No implementation for machine type {machine}.");
                 default:
                     throw new NotImplementedException($"No implementation for machine type {machine}.");
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/GCInfoTypes.cs
@@ -149,6 +149,34 @@ namespace ILCompiler.Reflection.ReadyToRun
                     STACK_BASE_REGISTER_ENCBASE = 2;
                     NUM_REGISTERS_ENCBASE = 3;
                     break;
+                case WasmMachine.Wasm32:
+                    PSP_SYM_STACK_SLOT_ENCBASE = 6;
+                    GENERICS_INST_CONTEXT_STACK_SLOT_ENCBASE = 6;
+                    SECURITY_OBJECT_STACK_SLOT_ENCBASE = 6;
+                    GS_COOKIE_STACK_SLOT_ENCBASE = 6;
+                    CODE_LENGTH_ENCBASE = 6;
+                    STACK_BASE_REGISTER_ENCBASE = 3;
+                    SIZE_OF_STACK_AREA_ENCBASE = 6;
+                    SIZE_OF_EDIT_AND_CONTINUE_PRESERVED_AREA_ENCBASE = 3;
+                    REVERSE_PINVOKE_FRAME_ENCBASE = 6;
+                    NUM_REGISTERS_ENCBASE = 3;
+                    NUM_STACK_SLOTS_ENCBASE = 5;
+                    NUM_UNTRACKED_SLOTS_ENCBASE = 5;
+                    NORM_PROLOG_SIZE_ENCBASE = 4;
+                    NORM_EPILOG_SIZE_ENCBASE = 3;
+                    INTERRUPTIBLE_RANGE_DELTA1_ENCBASE = 5;
+                    INTERRUPTIBLE_RANGE_DELTA2_ENCBASE = 5;
+                    REGISTER_ENCBASE = 3;
+                    REGISTER_DELTA_ENCBASE = REGISTER_ENCBASE;
+                    STACK_SLOT_ENCBASE = 6;
+                    STACK_SLOT_DELTA_ENCBASE = 4;
+                    NUM_SAFE_POINTS_ENCBASE = 4;
+                    NUM_INTERRUPTIBLE_RANGES_ENCBASE = 1;
+                    POINTER_SIZE_ENCBASE = 3;
+                    LIVESTATE_RLE_RUN_ENCBASE = 2;
+                    LIVESTATE_RLE_SKIP_ENCBASE = 4;
+                    break;
+
                 case Machine.I386:
                     CODE_LENGTH_ENCBASE = 6;
                     NORM_PROLOG_SIZE_ENCBASE = 4;

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -33,6 +33,11 @@ namespace ILCompiler.Reflection.ReadyToRun
         Unknown = -1
     }
 
+    public static class WasmMachine
+    {
+        public const Machine Wasm32 = (Machine)0xFFFE;
+    }
+
     public struct InstanceMethod
     {
         public byte Bucket;
@@ -683,6 +688,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case Machine.Arm:
                 case Machine.Thumb:
                 case Machine.ArmThumb2:
+                case WasmMachine.Wasm32:
                     _pointerSize = 4;
                     break;
 
@@ -1532,6 +1538,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     {
                         case Machine.I386:
                         case Machine.ArmThumb2:
+                        case WasmMachine.Wasm32:
                             entrySize = 4;
                             break;
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -112,11 +112,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             public override int NumCalleeSavedRegisters => 0;
             // Argument registers, callee-save registers, return address
             public override int SizeOfTransitionBlock => 8;
-            public override int OffsetOfArgumentRegisters => 0;
+            public override int OffsetOfArgumentRegisters => SizeOfTransitionBlock;
 
             public override int OffsetFromGCRefMapPos(int pos)
             {
-                return SizeOfTransitionBlock + pos * PointerSize;
+                return OffsetOfArgumentRegisters + pos * PointerSize;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/TransitionBlock.cs
@@ -37,6 +37,9 @@ namespace ILCompiler.Reflection.ReadyToRun
                 case Machine.RiscV64:
                     return RiscV64TransitionBlock.Instance;
 
+                case WasmMachine.Wasm32:
+                    return Wasm32TransitionBlock.Instance;
+
                 default:
                     throw new NotImplementedException();
             }
@@ -97,6 +100,23 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     return OffsetOfArgs + (pos - NumArgumentRegisters) * PointerSize;
                 }
+            }
+        }
+
+        private sealed class Wasm32TransitionBlock : TransitionBlock
+        {
+            public static readonly TransitionBlock Instance = new Wasm32TransitionBlock();
+
+            public override int PointerSize => 4;
+            public override int NumArgumentRegisters => 0;
+            public override int NumCalleeSavedRegisters => 0;
+            // Argument registers, callee-save registers, return address
+            public override int SizeOfTransitionBlock => 8;
+            public override int OffsetOfArgumentRegisters => 0;
+
+            public override int OffsetFromGCRefMapPos(int pos)
+            {
+                return SizeOfTransitionBlock + pos * PointerSize;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/WebcilImageReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/WebcilImageReader.cs
@@ -28,7 +28,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         private readonly CorFlags _corFlags;
         private readonly DirectoryEntry _managedNativeHeaderDirectory;
 
-        public Machine Machine => Machine.I386; // Webcil doesn't encode machine type; wasm targets use a placeholder
+        public Machine Machine => WasmMachine.Wasm32; // Webcil doesn't encode machine type; wasm targets use a placeholder
         public OperatingSystem OperatingSystem => OperatingSystem.Unknown;
         public ulong ImageBase => 0;
 

--- a/src/coreclr/tools/r2rdump/CoreDisTools.cs
+++ b/src/coreclr/tools/r2rdump/CoreDisTools.cs
@@ -78,6 +78,8 @@ namespace R2RDump
                 case Machine.RiscV64:
                     target = TargetArch.Target_RiscV64;
                     break;
+                case WasmMachine.Wasm32:
+                    return IntPtr.Zero;
                 default:
                     Program.WriteWarning($"{machine} not supported on CoreDisTools");
                     return IntPtr.Zero;
@@ -187,6 +189,7 @@ namespace R2RDump
                     // to 7 * 3 characters; see https://github.com/dotnet/llilc/blob/master/lib/CoreDisTools/coredistools.cpp.
                     Machine.I386 => 7 * 3,
                     Machine.Amd64 => 7 * 3,
+                    WasmMachine.Wasm32 => 7 * 3,
 
                     // Instructions are either 2 or 4 bytes long
                     Machine.ArmThumb2 => 4 * 3,

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -212,6 +212,7 @@ namespace R2RDump
                     Machine.Arm64 => TargetArchitecture.ARM64,
                     Machine.LoongArch64 => TargetArchitecture.LoongArch64,
                     Machine.RiscV64 => TargetArchitecture.RiscV64,
+                    WasmMachine.Wasm32 => TargetArchitecture.Wasm32,
                     _ => throw new NotImplementedException(r2r.Machine.ToString()),
                 };
                 TargetOS os = r2r.OperatingSystem switch
@@ -466,7 +467,7 @@ namespace R2RDump
                     // parse the ReadyToRun image
                     ReadyToRunReader r2r = new(model, filename);
                     r2r.ValidateDebugInfo = Get(_command.ValidateDebugInfo);
-                    if (disasm && !(r2r.CompositeReader is WebcilImageReader))
+                    if (disasm)
                     {
                         disassembler = new Disassembler(r2r, model);
                     }


### PR DESCRIPTION
Webcil images currently report Machine.I386 to the ReadyToRun reflection reader, which makes wasm R2R images reuse x86-specific decoding paths. Introduce a wasm machine sentinel and route pointer-size, import-section, transition-block, GC-info, and r2rdump architecture handling through wasm-specific cases instead.