### PR TITLE
[Wasm RyuJIT] Fix declared local off-by-one in reverse P-Invoke case

### DIFF
--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -935,7 +935,7 @@ void WasmRegAlloc::ResolveReferences()
                             indexBase              = max(indexBase, argIndex + 1);
 
                             LclVarDsc* argVarDsc = m_compiler->lvaGetDesc(argLclNum);
-                            if ((argVarDsc->GetRegNum() == argReg) || (data->m_spReg == argReg))
+                            if ((argVarDsc->GetRegNum() == argReg) || (argLclNum == m_compiler->lvaWasmSpArg))
                             {
                                 assert(abiInfo.HasExactlyOneRegisterSegment());
                                 virtToPhysRegMap[static_cast<unsigned>(argType)].DeclaredCount--;


### PR DESCRIPTION
We assign `m_spReg` as virtual register `0` for RPI and non-RPI cases. However, for RPI the stack pointer needs to live in an explicitly declared local instead of an arg, since we don't pass the stack pointer in RPI. To distinguish between these cases, we can check what local index `lvaWasmSpArg` actually refers to and see if it matches the local index of an incoming arg.