### PR TITLE
Include relocation addend in IMAGE_REL_SYMBOL_SIZE resolution

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
@@ -209,7 +209,8 @@ namespace ILCompiler.ObjectWriter
             {
                 fixed (byte* pData = data)
                 {
-                    Relocation.WriteValue(relocType, (void*)pData, definedSymbol.Size);
+                    long adjustedAddend = addend + Relocation.ReadValue(relocType, (void*)pData);
+                    Relocation.WriteValue(relocType, (void*)pData, definedSymbol.Size + adjustedAddend);
                 }
             }
             else

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun.Tests/TestCases/R2RTestSuites.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Reflection.PortableExecutable;
 using ILCompiler.ReadyToRun.Tests.TestCasesRunner;
 using ILCompiler.Reflection.ReadyToRun;
 using Internal.ReadyToRunConstants;
+using Internal.Runtime;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -54,6 +56,39 @@ public class R2RTestSuites
             Assert.True(R2RAssert.HasCrossModuleInlinedMethod(reader, "TestGetValue", "GetValue", out diag), diag);
             Assert.True(R2RAssert.HasCrossModuleInlinedMethod(reader, "TestGetString", "GetString", out diag), diag);
             Assert.True(R2RAssert.HasCrossModuleInliningInfo(reader, out diag), diag);
+        }
+    }
+
+    [Fact]
+    public void RuntimeFunctionsSectionSizeExcludesSentinel()
+    {
+        var lib = new CompiledAssembly
+        {
+            AssemblyName = nameof(RuntimeFunctionsSectionSizeExcludesSentinel),
+            SourceResourceNames = ["ThumbBit/HotColdSplitting.cs"],
+        };
+
+        new R2RTestRunner(_output).Run(new R2RTestCase(
+            nameof(RuntimeFunctionsSectionSizeExcludesSentinel),
+            [
+                new(nameof(RuntimeFunctionsSectionSizeExcludesSentinel), [new CrossgenAssembly(lib)])
+                {
+                    Validate = Validate,
+                },
+            ]));
+
+        static void Validate(ReadyToRunReader reader)
+        {
+            Assert.True(reader.ReadyToRunHeader.Sections.TryGetValue(
+                ReadyToRunSectionType.RuntimeFunctions, out ReadyToRunSection section));
+
+            // The header entry records the runtime-functions table size *excluding* the trailing
+            // 0xffffffff sentinel word. Each entry is 12 bytes on x64 and 8 bytes on other targets.
+            int entrySize = reader.Machine == Machine.Amd64 ? 12 : 8;
+            Assert.True(section.Size > 0, "RuntimeFunctions section should not be empty");
+            Assert.True(
+                section.Size % entrySize == 0,
+                $"RuntimeFunctions section size {section.Size} is not a multiple of entry size {entrySize} (machine: {reader.Machine}); remainder {section.Size % entrySize} suggests the trailing sentinel was included.");
         }
     }
 


### PR DESCRIPTION
The PE/COFF resolution path for IMAGE_REL_SYMBOL_SIZE wrote the symbol's data length directly into the slot, ignoring both the caller's addend and any value already inlined into the data. This caused the R2R header entry for RuntimeFunctions to report a size that incorrectly included the 4-byte trailing sentinel: RuntimeFunctionsTableNode applies a -4 adjustment through the addend, but the addend was discarded.

Fix: combine the addend with the inline value before writing, so the final size equals definedSymbol.Size + addend + inline. This restores the intended behavior on every COFF/PE target.

Adds RuntimeFunctionsSectionSizeExcludesSentinel to ILCompiler.ReadyToRun.Tests, which verifies that the RuntimeFunctions section size in the R2R header is a multiple of the per-target entry size (12 on x64, 8 elsewhere). Without the fix, the test fails with a remainder of 4 (the sentinel word leaks into the reported size).