### PR TITLE
[Release/10.0] JIT: Fix bug in GenTree::Equals (#128654)

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2485,6 +2485,12 @@ bool GenTreeCall::Equals(GenTreeCall* c1, GenTreeCall* c2)
         {
             return false;
         }
+
+        // For virtual stub calls the stub addresses must agree.
+        if (c1->IsVirtualStub() && (c1->gtStubCallStubAddr != c2->gtStubCallStubAddr))
+        {
+            return false;
+        }
     }
     else
     {

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Two shared-generic interface call sites that canonicalize to __Canon must
+// not be merged by head/tail merge: each call has a distinct virtual stub
+// dispatch cell, so the calls are not interchangeable.
+
+namespace Runtime_128631;
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public interface IFoo<T> { object Get(); }
+
+public class Impl : IFoo<string>, IFoo<byte[]>
+{
+    [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<string>.Get() => "STRING_VALUE";
+    [MethodImpl(MethodImplOptions.NoInlining)] object IFoo<byte[]>.Get() => new byte[] { 1, 2, 3 };
+
+    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.AggressiveOptimization)]
+    public object Dispatch(string tag)
+    {
+        if (tag == "bytes")  return ((IFoo<byte[]>)this).Get();
+        if (tag == "string") return ((IFoo<string>)this).Get();
+        return null;
+    }
+}
+
+public class Runtime_128631
+{
+    [Fact]
+    public static int TestEntryPoint()
+    {
+        var d = new Impl();
+        for (int i = 0; i < 200; i++)
+        {
+            d.Dispatch("bytes");
+            d.Dispatch("string");
+        }
+        object r = d.Dispatch("string");
+        return r is string ? 100 : -1;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_128631/Runtime_128631.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Make sure to properly distinguish virtual stub calls to avoid incorrect head/tail merges.

Fixes #128631.

Backport of #128654 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

A bug in the JIT's tail merge optimization can cause the wrong method to be invoked.

The pattern required is a shared generic method invoked at two sibling tail call sites on differently typed objects with otherwise identical arguments. These calls are only distinguishable by the different virtual stub addresses, and the JIT was not considering these when checking if the calls were identical.

EG in a case like

```C#
        if (tag == "bytes")  return ((IFoo<byte[]>)this).Get();
        if (tag == "string") return ((IFoo<string>)this).Get();
```

The JIT can collapse the two calls into one and so invoke the wrong method for one of the cases.

## Regression

- [x] Yes - introduced in .NET 8 by #77103.
- [ ] No

It is harder to reproduce in .NET 8 as the optimization was less general back then.

## Testing

Verified fix with customer repro and locally crafted repro case.

## Risk

Low. Adds some extra checking to the method that tail merging uses to determine if two calls are identical. Overall the JIT becomes (properly) more cautions about this optimization. No diffs in SPMI.