### PR TITLE
Simplify/Improve the HashMap/PtrHashMap/EEHashTable

### DIFF
--- a/src/coreclr/vm/asynccontinuations.cpp
+++ b/src/coreclr/vm/asynccontinuations.cpp
@@ -387,9 +387,4 @@ DWORD ContinuationLayoutKeyHashTableHelper::Hash(ContinuationLayoutKey key)
     return dwHash;
 }
 
-void ContinuationLayoutKeyHashTableHelper::ReplaceKey(EEHashEntry_t *pEntry, ContinuationLayoutKey newKey)
-{
-    memcpy(pEntry->Key, &newKey, sizeof(ContinuationLayoutKey));
-}
-
 #endif

--- a/src/coreclr/vm/asynccontinuations.h
+++ b/src/coreclr/vm/asynccontinuations.h
@@ -36,7 +36,6 @@ struct ContinuationLayoutKeyHashTableHelper
     static void            DeleteEntry(EEHashEntry_t *pEntry, AllocationHeap heap);
     static BOOL            CompareKeys(EEHashEntry_t *pEntry, ContinuationLayoutKey key);
     static DWORD           Hash(ContinuationLayoutKey key);
-    static void            ReplaceKey(EEHashEntry_t *pEntry, ContinuationLayoutKey newKey);
 };
 
 typedef EEHashTable<ContinuationLayoutKey, ContinuationLayoutKeyHashTableHelper, FALSE> ContinuationLayoutHashTable;

--- a/src/coreclr/vm/contractimpl.cpp
+++ b/src/coreclr/vm/contractimpl.cpp
@@ -61,7 +61,7 @@ UINT32 TypeIDMap::LookupTypeID(PTR_MethodTable pMT)
         if (GetThread()->PreemptiveGCDisabled()) { GC_NOTRIGGER; } else { GC_TRIGGERS; }
     } CONTRACTL_END;
 
-    UINT32 id = (UINT32) m_mtMap.Gethash((UPTR)dac_cast<TADDR>(pMT));
+    UINT32 id = (UINT32) m_mtMap.GetHash((UPTR)dac_cast<TADDR>(pMT));
 
     return id;
 }
@@ -76,7 +76,7 @@ PTR_MethodTable TypeIDMap::LookupType(UINT32 id)
         PRECONDITION(id <= TypeIDProvider::MAX_TYPE_ID);
     } CONTRACTL_END;
 
-    UPTR ret = m_idMap.Gethash((UPTR)id);
+    UPTR ret = m_idMap.GetHash((UPTR)id);
     if (ret == static_cast<UPTR>(INVALIDENTRY))
         return NULL;
 

--- a/src/coreclr/vm/contractimpl.cpp
+++ b/src/coreclr/vm/contractimpl.cpp
@@ -61,7 +61,7 @@ UINT32 TypeIDMap::LookupTypeID(PTR_MethodTable pMT)
         if (GetThread()->PreemptiveGCDisabled()) { GC_NOTRIGGER; } else { GC_TRIGGERS; }
     } CONTRACTL_END;
 
-    UINT32 id = (UINT32) m_mtMap.GetHash((UPTR)dac_cast<TADDR>(pMT));
+    UINT32 id = (UINT32) m_mtMap.LookupValueByUniqueKey((UPTR)dac_cast<TADDR>(pMT));
 
     return id;
 }
@@ -76,7 +76,7 @@ PTR_MethodTable TypeIDMap::LookupType(UINT32 id)
         PRECONDITION(id <= TypeIDProvider::MAX_TYPE_ID);
     } CONTRACTL_END;
 
-    UPTR ret = m_idMap.GetHash((UPTR)id);
+    UPTR ret = m_idMap.LookupValueByUniqueKey((UPTR)id);
     if (ret == static_cast<UPTR>(INVALIDENTRY))
         return NULL;
 

--- a/src/coreclr/vm/contractimpl.cpp
+++ b/src/coreclr/vm/contractimpl.cpp
@@ -61,7 +61,7 @@ UINT32 TypeIDMap::LookupTypeID(PTR_MethodTable pMT)
         if (GetThread()->PreemptiveGCDisabled()) { GC_NOTRIGGER; } else { GC_TRIGGERS; }
     } CONTRACTL_END;
 
-    UINT32 id = (UINT32) m_mtMap.LookupValue((UPTR)dac_cast<TADDR>(pMT), 0);
+    UINT32 id = (UINT32) m_mtMap.Gethash((UPTR)dac_cast<TADDR>(pMT));
 
     return id;
 }
@@ -76,7 +76,7 @@ PTR_MethodTable TypeIDMap::LookupType(UINT32 id)
         PRECONDITION(id <= TypeIDProvider::MAX_TYPE_ID);
     } CONTRACTL_END;
 
-    UPTR ret = m_idMap.LookupValue((UPTR)id, 0);
+    UPTR ret = m_idMap.Gethash((UPTR)id);
     if (ret == static_cast<UPTR>(INVALIDENTRY))
         return NULL;
 

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -963,9 +963,9 @@ DispatchMemberInfo* DispatchInfo::FindMember(DISPID DispID)
     if ((DispID == DISPID_UNKNOWN) || (DispID == -2))
         RETURN NULL;
 
-    // Lookup in the hashtable to find member with the specified DISPID. Note: this hash is unsynchronized, but Gethash
+    // Lookup in the hashtable to find member with the specified DISPID. Note: this hash is unsynchronized, but GetHash
     // doesn't require synchronization.
-    UPTR Data = (UPTR)m_DispIDToMemberInfoMap.Gethash(DispID2HashKey(DispID));
+    UPTR Data = (UPTR)m_DispIDToMemberInfoMap.GetHash(DispID2HashKey(DispID));
     if (Data != -1)
     {
         // We have found the member, so ensure it is initialized and return it.
@@ -2968,8 +2968,8 @@ DISPID DispatchInfo::GenerateDispID()
     }
     CONTRACTL_END;
 
-    // Find the next unused DISPID. Note, the hash is unsynchronized, but Gethash doesn't require synchronization.
-    for (; (UPTR)m_DispIDToMemberInfoMap.Gethash(DispID2HashKey(m_CurrentDispID)) != -1; m_CurrentDispID++);
+    // Find the next unused DISPID. Note, the hash is unsynchronized, but GetHash doesn't require synchronization.
+    for (; (UPTR)m_DispIDToMemberInfoMap.GetHash(DispID2HashKey(m_CurrentDispID)) != -1; m_CurrentDispID++);
     return m_CurrentDispID++;
 }
 

--- a/src/coreclr/vm/dispatchinfo.cpp
+++ b/src/coreclr/vm/dispatchinfo.cpp
@@ -963,9 +963,9 @@ DispatchMemberInfo* DispatchInfo::FindMember(DISPID DispID)
     if ((DispID == DISPID_UNKNOWN) || (DispID == -2))
         RETURN NULL;
 
-    // Lookup in the hashtable to find member with the specified DISPID. Note: this hash is unsynchronized, but GetHash
+    // Lookup in the hashtable to find member with the specified DISPID. Note: this hash is unsynchronized, but LookupValueByUniqueKey
     // doesn't require synchronization.
-    UPTR Data = (UPTR)m_DispIDToMemberInfoMap.GetHash(DispID2HashKey(DispID));
+    UPTR Data = (UPTR)m_DispIDToMemberInfoMap.LookupValueByUniqueKey(DispID2HashKey(DispID));
     if (Data != -1)
     {
         // We have found the member, so ensure it is initialized and return it.
@@ -2968,8 +2968,8 @@ DISPID DispatchInfo::GenerateDispID()
     }
     CONTRACTL_END;
 
-    // Find the next unused DISPID. Note, the hash is unsynchronized, but GetHash doesn't require synchronization.
-    for (; (UPTR)m_DispIDToMemberInfoMap.GetHash(DispID2HashKey(m_CurrentDispID)) != -1; m_CurrentDispID++);
+    // Find the next unused DISPID. Note, the hash is unsynchronized, but LookupValueByUniqueKey doesn't require synchronization.
+    for (; (UPTR)m_DispIDToMemberInfoMap.LookupValueByUniqueKey(DispID2HashKey(m_CurrentDispID)) != -1; m_CurrentDispID++);
     return m_CurrentDispID++;
 }
 

--- a/src/coreclr/vm/eehash.cpp
+++ b/src/coreclr/vm/eehash.cpp
@@ -143,15 +143,6 @@ EEStringData *EEUnicodeHashTableHelper::GetKey(EEHashEntry_t *pEntry)
     return (EEStringData*)pEntry->Key;
 }
 
-void EEUnicodeHashTableHelper::ReplaceKey(EEHashEntry_t *pEntry, EEStringData *pNewKey)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    ((EEStringData*)pEntry->Key)->SetStringBuffer (pNewKey->GetStringBuffer());
-    ((EEStringData*)pEntry->Key)->SetCharCount (pNewKey->GetCharCount());
-    ((EEStringData*)pEntry->Key)->SetIsOnlyLowChars (pNewKey->GetIsOnlyLowChars());
-}
-
 // ============================================================================
 // Unicode stringliteral hash table helper.
 // ============================================================================

--- a/src/coreclr/vm/eehash.h
+++ b/src/coreclr/vm/eehash.h
@@ -13,9 +13,7 @@
 //
 // 1. Any number of threads can be reading the hash table while another thread is writing, without error.
 // 2. Only one thread can write at a time.
-// 3. When calling ReplaceValue(), a reader will get the old value, or the new value, but not something
-//    in between.
-// 4. DeleteValue() is an unsafe operation - no other threads can be in the hash table when this happens.
+// 3. DeleteValue() is an unsafe operation - no other threads can be in the hash table when this happens.
 //
 
 #ifndef _EE_HASH_H
@@ -82,8 +80,6 @@ public:
     void            InsertValue(KeyType pKey, HashDatum Data, BOOL bDeepCopyKey = bDefaultCopyIsDeep);
     void            InsertKeyAsValue(KeyType pKey, BOOL bDeepCopyKey = bDefaultCopyIsDeep);
     BOOL            DeleteValue(KeyType pKey);
-    BOOL            ReplaceValue(KeyType pKey, HashDatum Data);
-    BOOL            ReplaceKey(KeyType pOldKey, KeyType pNewKey);
     void            ClearHashTable();
     void            EmptyHashTable();
     BOOL            IsEmpty();
@@ -450,7 +446,6 @@ public:
     static BOOL            CompareKeys(EEHashEntry_t *pEntry, EEStringData *pKey);
     static DWORD           Hash(EEStringData *pKey);
     static EEStringData *  GetKey(EEHashEntry_t *pEntry);
-    static void            ReplaceKey(EEHashEntry_t *pEntry, EEStringData *pNewKey);
 };
 
 typedef EEHashTable<EEStringData *, EEUnicodeHashTableHelper, TRUE> EEUnicodeStringHashTable;
@@ -463,7 +458,6 @@ public:
     static void            DeleteEntry(EEHashEntry_t *pEntry, AllocationHeap Heap);
     static BOOL            CompareKeys(EEHashEntry_t *pEntry, EEStringData *pKey);
     static DWORD           Hash(EEStringData *pKey);
-    static void            ReplaceKey(EEHashEntry_t *pEntry, EEStringData *pNewKey);
 };
 
 typedef EEHashTable<EEStringData *, EEUnicodeStringLiteralHashTableHelper, TRUE> EEUnicodeStringLiteralHashTable;

--- a/src/coreclr/vm/eehash.inl
+++ b/src/coreclr/vm/eehash.inl
@@ -336,60 +336,6 @@ BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::DeleteValue(KeyType p
     return FALSE;
 }
 
-
-template <class KeyType, class Helper, BOOL bDefaultCopyIsDeep>
-BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::ReplaceValue(KeyType pKey, HashDatum Data)
-{
-    CONTRACTL
-    {
-        WRAPPER(THROWS);
-        WRAPPER(GC_NOTRIGGER);
-        FORBID_FAULT;
-    }
-    CONTRACTL_END
-
-    _ASSERTE (OwnLock());
-
-    EEHashEntry_t *pItem = FindItem(pKey);
-
-    if (pItem != NULL)
-    {
-        // Required to be atomic
-        pItem->Data = Data;
-        return TRUE;
-    }
-    else
-    {
-        return FALSE;
-    }
-}
-
-
-template <class KeyType, class Helper, BOOL bDefaultCopyIsDeep>
-BOOL EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::ReplaceKey(KeyType pOldKey, KeyType pNewKey)
-{
-    CONTRACTL
-    {
-        WRAPPER(THROWS);
-        WRAPPER(GC_NOTRIGGER);
-        FORBID_FAULT;
-    }
-    CONTRACTL_END
-
-    _ASSERTE (OwnLock());
-
-    EEHashEntry_t *pItem = FindItem(pOldKey);
-
-    if (pItem != NULL)
-    {
-        Helper::ReplaceKey (pItem, pNewKey);
-        return TRUE;
-    }
-    else
-    {
-        return FALSE;
-    }
-}
 #endif // !DACCESS_COMPILE
 
 template <class KeyType, class Helper, BOOL bDefaultCopyIsDeep>

--- a/src/coreclr/vm/hash.cpp
+++ b/src/coreclr/vm/hash.cpp
@@ -599,7 +599,7 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
 
 //---------------------------------------------------------------------
 //  UPTR HashMap::LookupValueByUniqueKey(UPTR key)
-//  Lookup value in the hash table assumes that there is no Comparison function and the keys are unique, returns the value directly using the Comparison function.
+//  Lookup value in the hash table assumes that there is no Comparison function and the keys are unique, returns the value or INVALIDENTRY if not present
 //
 UPTR HashMap::LookupValueByUniqueKey(UPTR key)
 {

--- a/src/coreclr/vm/hash.cpp
+++ b/src/coreclr/vm/hash.cpp
@@ -79,7 +79,7 @@ BOOL Bucket::InsertValue(const UPTR key, const UPTR value)
 
             // Release store: ensures the value is visible before the
             // key that publishes it. Pairs with the acquire load in
-            // LookupValue/ReplaceValue/DeleteValue.
+            // LookupValue/DeleteValue.
             VolatileStore(&m_rgKeys[i], key);
             return true;
         }
@@ -214,28 +214,6 @@ HashMap::HashMap()
 #endif // _DEBUG
 }
 
-//---------------------------------------------------------------------
-//  void HashMap::Init(unsigned cbInitialSize, CompareFnPtr ptr, bool fAsyncMode)
-//  set the initial size of the hash table and provide the comparison
-//  function pointer
-//
-void HashMap::Init(DWORD cbInitialSize, CompareFnPtr ptr, BOOL fAsyncMode, LockOwner *pLock)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_NOTRIGGER;
-        INJECT_FAULT(COMPlusThrowOM());
-    }
-    CONTRACTL_END
-
-    Compare* pCompare = NULL;
-    if (ptr != NULL)
-    {
-        pCompare = new Compare(ptr);
-    }
-    Init(cbInitialSize, pCompare, fAsyncMode, pLock);
-}
 
 DWORD HashMap::GetNearestIndex(DWORD cbInitialSize)
 {
@@ -274,11 +252,11 @@ DWORD HashMap::GetNearestIndex(DWORD cbInitialSize)
 }
 
 //---------------------------------------------------------------------
-//  void HashMap::Init(unsigned cbInitialSize, Compare* pCompare, bool fAsyncMode)
+//  void HashMap::Init(unsigned cbInitialSize, bool fAsyncMode)
 //  set the initial size of the hash table and provide the comparison
 //  function pointer
 //
-void HashMap::Init(DWORD cbInitialSize, Compare* pCompare, BOOL fAsyncMode, LockOwner *pLock)
+void HashMap::Init(DWORD cbInitialSize, ComparePtr* pCompare, BOOL fAsyncMode, LockOwner *pLock)
 {
     CONTRACTL
     {
@@ -619,20 +597,23 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
     return INVALIDENTRY;
 }
 
-#ifndef DACCESS_COMPILE
-
 //---------------------------------------------------------------------
-//  UPTR HashMap::ReplaceValue(UPTR key, UPTR value)
-//  Replace existing value in the hash table, use the comparison function
+//  UPTR HashMap::LookupValue(UPTR key)
+//  Lookup value in the hash table, use the comparison function
 //  to verify the values match
 //
-UPTR HashMap::ReplaceValue(UPTR key, UPTR value)
+UPTR HashMap::Gethash(UPTR key)
 {
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_FORBID_FAULT;
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+    }
+    CONTRACTL_END;
 
-    _ASSERTE(OwnLock());
+    _ASSERTE(m_pCompare == NULL); // This function should only be called when no compare function is provided
+#ifndef DACCESS_COMPILE
+    _ASSERTE (m_fAsyncMode || OwnLock());
 
     EbrCriticalRegionHolder ebrHolder(&g_EbrCollector, m_fAsyncMode);
 
@@ -640,12 +621,10 @@ UPTR HashMap::ReplaceValue(UPTR key, UPTR value)
     // This is necessary in case some other thread
     // replaces m_rgBuckets
     ASSERT (key > DELETED);
+#endif // !DACCESS_COMPILE
 
-    // perform this check during replacing as well
-    ASSERT(value <= VALUE_MASK);
-
-    Bucket* rgBuckets = Buckets(); //atomic fetch
-    DWORD  cbSize = GetSize(rgBuckets);
+    PTR_Bucket rgBuckets = Buckets(); //atomic fetch
+    DWORD cbSize = GetSize(rgBuckets);
 
     UINT seed, incr;
     HashFunction(key, cbSize, seed, incr);
@@ -653,33 +632,20 @@ UPTR HashMap::ReplaceValue(UPTR key, UPTR value)
     UPTR ntry;
     for(ntry =0; ntry < cbSize; ntry++)
     {
-        Bucket* pBucket = &rgBuckets[seed % cbSize];
+        PTR_Bucket pBucket = rgBuckets+(seed % cbSize);
         for (unsigned int i = 0; i < SLOTS_PER_BUCKET; i++)
         {
-            // Acquire load: ensures the value load below observes the
-            // value that was stored when this key was first published
-            // via Bucket::InsertValue.
+            // Acquire load: ensures the value load below is ordered
+            // after the key load. Pairs with the release store in
+            // Bucket::InsertValue.
             if (VolatileLoad(&pBucket->m_rgKeys[i]) == key) // keys match
             {
                 UPTR storedVal = pBucket->GetValue(i);
-                // if compare function is provided
-                // dupe keys are possible, check if the value matches,
-                if (CompareValues(value,storedVal))
-                {
-                    ProfileLookup(ntry,storedVal); //no-op in non HASHTABLE_PROFILE code
 
-                    // Plain store the new value, then release-store the
-                    // key to re-publish it. Readers acquire-load the key
-                    // via VolatileLoad(&m_rgKeys[i]), forming a proper
-                    // release-acquire pair on the same address and
-                    // ensuring they observe either the old or fully-
-                    // updated new value.
-                    pBucket->SetValue(value, i);
-                    VolatileStore(&pBucket->m_rgKeys[i], key);
+                ProfileLookup(ntry,storedVal); //no-op in non HASHTABLE_PROFILE code
 
-                    // return the previous stored value
-                    return storedVal;
-                }
+                // return the stored value
+                return storedVal;
             }
         }
 
@@ -694,6 +660,7 @@ UPTR HashMap::ReplaceValue(UPTR key, UPTR value)
     return INVALIDENTRY;
 }
 
+#ifndef DACCESS_COMPILE
 //---------------------------------------------------------------------
 //  UPTR HashMap::DeleteValue (UPTR key, UPTR value)
 //  if found mark the entry deleted and return the stored value
@@ -774,21 +741,6 @@ UPTR HashMap::DeleteValue (UPTR key, UPTR value)
 #endif // _DEBUG
 
     return INVALIDENTRY;
-}
-
-
-//---------------------------------------------------------------------
-//  UPTR HashMap::Gethash (UPTR key)
-//  use this for lookups with unique keys
-// don't need to pass an input value to perform the lookup
-//
-UPTR HashMap::Gethash (UPTR key)
-{
-    STATIC_CONTRACT_NOTHROW;
-    STATIC_CONTRACT_GC_NOTRIGGER;
-    STATIC_CONTRACT_FORBID_FAULT;
-
-    return LookupValue(key,0);
 }
 
 

--- a/src/coreclr/vm/hash.cpp
+++ b/src/coreclr/vm/hash.cpp
@@ -598,11 +598,10 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
 }
 
 //---------------------------------------------------------------------
-//  UPTR HashMap::LookupValue(UPTR key)
-//  Lookup value in the hash table, use the comparison function
-//  to verify the values match
+//  UPTR HashMap::LookupValueByUniqueKey(UPTR key)
+//  Lookup value in the hash table assumes that there is no Comparison function and the keys are unique, returns the value directly using the Comparison function.
 //
-UPTR HashMap::GetHash(UPTR key)
+UPTR HashMap::LookupValueByUniqueKey(UPTR key)
 {
     CONTRACTL
     {
@@ -953,7 +952,7 @@ LDone:
             ASSERT (keyv != DELETED);
             if (m_pCompare == NULL && keyv != EMPTY)
             {
-                ASSERT ((Buckets()[nb].GetValue (i)) == GetHash (keyv));
+                ASSERT ((Buckets()[nb].GetValue (i)) == LookupValueByUniqueKey (keyv));
             }
         }
     }

--- a/src/coreclr/vm/hash.cpp
+++ b/src/coreclr/vm/hash.cpp
@@ -602,7 +602,7 @@ UPTR HashMap::LookupValue(UPTR key, UPTR value)
 //  Lookup value in the hash table, use the comparison function
 //  to verify the values match
 //
-UPTR HashMap::Gethash(UPTR key)
+UPTR HashMap::GetHash(UPTR key)
 {
     CONTRACTL
     {
@@ -953,7 +953,7 @@ LDone:
             ASSERT (keyv != DELETED);
             if (m_pCompare == NULL && keyv != EMPTY)
             {
-                ASSERT ((Buckets()[nb].GetValue (i)) == Gethash (keyv));
+                ASSERT ((Buckets()[nb].GetValue (i)) == GetHash (keyv));
             }
         }
     }

--- a/src/coreclr/vm/hash.h
+++ b/src/coreclr/vm/hash.h
@@ -234,7 +234,7 @@ public:
 
     // for unique keys, use this function to get the value that is
     // stored in the hash table, returns INVALIDENTRY if key not found
-    UPTR GetHash(UPTR key);
+    UPTR LookupValueByUniqueKey(UPTR key);
 
     // Called only when all threads are frozed, like during GC
     // for a SINGLE user mode, call compact after every delete
@@ -593,13 +593,13 @@ public:
 
     // for unique keys, use this function to get the value that is
     // stored in the hash table, returns INVALIDENTRY if key not found
-    LPVOID GetHash(UPTR key)
+    LPVOID LookupValueByUniqueKey(UPTR key)
     {
         WRAPPER_NO_CONTRACT;
 
         key = SanitizeKey(key);
 
-        UPTR val = m_HashMap.GetHash(key);
+        UPTR val = m_HashMap.LookupValueByUniqueKey(key);
         if (val != (UPTR) INVALIDENTRY)
         {
             val <<= 1;

--- a/src/coreclr/vm/hash.h
+++ b/src/coreclr/vm/hash.h
@@ -234,7 +234,7 @@ public:
 
     // for unique keys, use this function to get the value that is
     // stored in the hash table, returns INVALIDENTRY if key not found
-    UPTR Gethash(UPTR key);
+    UPTR GetHash(UPTR key);
 
     // Called only when all threads are frozed, like during GC
     // for a SINGLE user mode, call compact after every delete
@@ -593,13 +593,13 @@ public:
 
     // for unique keys, use this function to get the value that is
     // stored in the hash table, returns INVALIDENTRY if key not found
-    LPVOID Gethash(UPTR key)
+    LPVOID GetHash(UPTR key)
     {
         WRAPPER_NO_CONTRACT;
 
         key = SanitizeKey(key);
 
-        UPTR val = m_HashMap.Gethash(key);
+        UPTR val = m_HashMap.GetHash(key);
         if (val != (UPTR) INVALIDENTRY)
         {
             val <<= 1;

--- a/src/coreclr/vm/hash.h
+++ b/src/coreclr/vm/hash.h
@@ -119,51 +119,11 @@ public:
 //------------------------------------------------------------------------------
 typedef  BOOL (*CompareFnPtr)(UPTR,UPTR);
 
-class Compare
+class ComparePtr final
 {
-protected:
-    Compare()
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        m_ptr = NULL;
-    }
 public:
     CompareFnPtr m_ptr;
 
-    Compare(CompareFnPtr ptr)
-    {
-        LIMITED_METHOD_CONTRACT;
-
-        _ASSERTE(ptr != NULL);
-        m_ptr = ptr;
-    }
-
-    virtual ~Compare()
-    {
-        LIMITED_METHOD_CONTRACT;
-    }
-
-    virtual UPTR CompareHelper(UPTR val1, UPTR storedval)
-    {
-        WRAPPER_NO_CONTRACT;
-
-#ifndef _DEBUG
-        CONTRACTL
-        {
-            DISABLED(THROWS);       // This is not a bug, we cannot decide, since the function ptr called may be either.
-            DISABLED(GC_NOTRIGGER); // This is not a bug, we cannot decide, since the function ptr called may be either.
-        }
-        CONTRACTL_END;
-#endif // !_DEBUG
-
-        return (*m_ptr)(val1,storedval);
-    }
-};
-
-class ComparePtr : public Compare
-{
-public:
     ComparePtr (CompareFnPtr ptr)
     {
         LIMITED_METHOD_CONTRACT;
@@ -172,7 +132,7 @@ public:
         m_ptr = ptr;
     }
 
-    virtual UPTR CompareHelper(UPTR val1, UPTR storedval)
+    UPTR CompareHelper(UPTR val1, UPTR storedval)
     {
         WRAPPER_NO_CONTRACT;
 
@@ -243,29 +203,18 @@ public:
     {
         WRAPPER_NO_CONTRACT;
 
-        Init(0, (Compare *)NULL,fAsyncMode, pLock);
+        Init(0, fAsyncMode, pLock);
     }
     // Init
     void Init(DWORD cbInitialSize, BOOL fAsyncMode, LockOwner *pLock)
     {
         WRAPPER_NO_CONTRACT;
 
-        Init(cbInitialSize, (Compare*)NULL, fAsyncMode, pLock);
+        Init(cbInitialSize, (ComparePtr*)NULL, fAsyncMode, pLock);
     }
-    // Init
-    void Init(CompareFnPtr ptr, BOOL fAsyncMode, LockOwner *pLock)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        Init(0, ptr, fAsyncMode, pLock);
-    }
-
-    // Init method
-    void Init(DWORD cbInitialSize, CompareFnPtr ptr, BOOL fAsyncMode, LockOwner *pLock);
-
 
     //Init method
-    void Init(DWORD cbInitialSize, Compare* pCompare, BOOL fAsyncMode, LockOwner *pLock);
+    void Init(DWORD cbInitialSize, ComparePtr* pCompare, BOOL fAsyncMode, LockOwner *pLock);
 
     // check to see if the value is already in the Hash Table
     // key should be > DELETED
@@ -278,12 +227,6 @@ public:
     // do a lookup to verify the value is not already present
 
     void InsertValue(UPTR key, UPTR value);
-
-    // Replace the value if present
-    // returns the previous value, or INVALIDENTRY if not present
-    // does not insert a new value under any circumstances
-
-    UPTR ReplaceValue(UPTR key, UPTR value);
 
     // mark the entry as deleted and return the stored value
     // returns INVALIDENTRY, if not found
@@ -357,7 +300,7 @@ private:
     // H(key, i) = H1(key) + i * H2(key), where 0 <= i < numBuckets
     static void     HashFunction(const UPTR key, const UINT numBuckets, UINT &seed, UINT &incr);
 
-    Compare*        m_pCompare;         // compare object to be used in lookup
+    ComparePtr*     m_pCompare;         // compare object to be used in lookup
     SIZE_T          m_iPrimeIndex;      // current size (index into prime array)
     PTR_Bucket      m_rgBuckets;        // array of buckets
 
@@ -627,30 +570,6 @@ public:
         _ASSERTE((value & 0x1) == 0);
         value>>=1;
         m_HashMap.InsertValue (key, value);
-    }
-
-    // Replace the value if present
-    // returns the previous value, or INVALIDENTRY if not present
-    // does not insert a new value under any circumstances
-
-    LPVOID ReplaceValue(UPTR key, LPVOID pv)
-    {
-        WRAPPER_NO_CONTRACT;
-
-        key = SanitizeKey(key);
-
-        // gmalloc allocator, always allocates 8 byte aligned
-        // so we can shift out the lowest bit
-        // ptr right shift by 1
-        UPTR value = (UPTR)pv;
-        _ASSERTE((value & 0x1) == 0);
-        value>>=1;
-        UPTR val = m_HashMap.ReplaceValue (key, value);
-        if (val != (UPTR) INVALIDENTRY)
-        {
-            val<<=1;
-        }
-        return (LPVOID)val;
     }
 
     // mark the entry as deleted and return the stored value

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -2254,7 +2254,7 @@ InteropMethodTableData *LoaderAllocator::LookupComInteropData(MethodTable *pMT)
     CrstHolder holder(&m_InteropDataCrst);
 
     // Lookup
-    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.GetHash((UPTR)pMT);
+    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.LookupValueByUniqueKey((UPTR)pMT);
 
     // Not there...
     if (pData == (InteropMethodTableData*)INVALIDENTRY)
@@ -2274,7 +2274,7 @@ BOOL LoaderAllocator::InsertComInteropData(MethodTable* pMT, InteropMethodTableD
     CrstHolder holder(&m_InteropDataCrst);
 
     // Check to see that it's not already in there
-    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.GetHash((UPTR)pMT);
+    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.LookupValueByUniqueKey((UPTR)pMT);
     if (pDupData != (InteropMethodTableData*)INVALIDENTRY)
         return FALSE;
 

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -2254,7 +2254,7 @@ InteropMethodTableData *LoaderAllocator::LookupComInteropData(MethodTable *pMT)
     CrstHolder holder(&m_InteropDataCrst);
 
     // Lookup
-    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.Gethash((UPTR)pMT);
+    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.GetHash((UPTR)pMT);
 
     // Not there...
     if (pData == (InteropMethodTableData*)INVALIDENTRY)
@@ -2274,7 +2274,7 @@ BOOL LoaderAllocator::InsertComInteropData(MethodTable* pMT, InteropMethodTableD
     CrstHolder holder(&m_InteropDataCrst);
 
     // Check to see that it's not already in there
-    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.Gethash((UPTR)pMT);
+    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.GetHash((UPTR)pMT);
     if (pDupData != (InteropMethodTableData*)INVALIDENTRY)
         return FALSE;
 

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -2254,7 +2254,7 @@ InteropMethodTableData *LoaderAllocator::LookupComInteropData(MethodTable *pMT)
     CrstHolder holder(&m_InteropDataCrst);
 
     // Lookup
-    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.LookupValue((UPTR)pMT, (LPVOID)NULL);
+    InteropMethodTableData *pData = (InteropMethodTableData*)m_interopDataHash.Gethash((UPTR)pMT);
 
     // Not there...
     if (pData == (InteropMethodTableData*)INVALIDENTRY)
@@ -2274,7 +2274,7 @@ BOOL LoaderAllocator::InsertComInteropData(MethodTable* pMT, InteropMethodTableD
     CrstHolder holder(&m_InteropDataCrst);
 
     // Check to see that it's not already in there
-    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.LookupValue((UPTR)pMT, (LPVOID)NULL);
+    InteropMethodTableData *pDupData = (InteropMethodTableData*)m_interopDataHash.Gethash((UPTR)pMT);
     if (pDupData != (InteropMethodTableData*)INVALIDENTRY)
         return FALSE;
 

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -375,7 +375,7 @@ PTR_MethodDesc ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage(PCODE ent
         return NULL;
 #endif
 
-    TADDR val = (TADDR)m_entryPointToMethodDescMap.GetHash(PCODEToPINSTR(entryPoint));
+    TADDR val = (TADDR)m_entryPointToMethodDescMap.LookupValueByUniqueKey(PCODEToPINSTR(entryPoint));
     if (val == (TADDR)INVALIDENTRY)
         return NULL;
 
@@ -394,7 +394,7 @@ bool ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, M
     CONTRACTL_END;
 
     CrstHolder ch(&m_Crst);
-    if ((TADDR)m_entryPointToMethodDescMap.GetHash(PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
+    if ((TADDR)m_entryPointToMethodDescMap.LookupValueByUniqueKey(PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
     {
         m_entryPointToMethodDescMap.InsertValue(PCODEToPINSTR(entryPoint), methodDesc);
         return true;

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -375,7 +375,7 @@ PTR_MethodDesc ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage(PCODE ent
         return NULL;
 #endif
 
-    TADDR val = (TADDR)m_entryPointToMethodDescMap.LookupValue(PCODEToPINSTR(entryPoint), (LPVOID)PCODEToPINSTR(entryPoint));
+    TADDR val = (TADDR)m_entryPointToMethodDescMap.Gethash(PCODEToPINSTR(entryPoint));
     if (val == (TADDR)INVALIDENTRY)
         return NULL;
 
@@ -394,7 +394,7 @@ bool ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, M
     CONTRACTL_END;
 
     CrstHolder ch(&m_Crst);
-    if ((TADDR)m_entryPointToMethodDescMap.LookupValue(PCODEToPINSTR(entryPoint), (LPVOID)PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
+    if ((TADDR)m_entryPointToMethodDescMap.Gethash(PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
     {
         m_entryPointToMethodDescMap.InsertValue(PCODEToPINSTR(entryPoint), methodDesc);
         return true;

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -375,7 +375,7 @@ PTR_MethodDesc ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage(PCODE ent
         return NULL;
 #endif
 
-    TADDR val = (TADDR)m_entryPointToMethodDescMap.Gethash(PCODEToPINSTR(entryPoint));
+    TADDR val = (TADDR)m_entryPointToMethodDescMap.GetHash(PCODEToPINSTR(entryPoint));
     if (val == (TADDR)INVALIDENTRY)
         return NULL;
 
@@ -394,7 +394,7 @@ bool ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, M
     CONTRACTL_END;
 
     CrstHolder ch(&m_Crst);
-    if ((TADDR)m_entryPointToMethodDescMap.Gethash(PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
+    if ((TADDR)m_entryPointToMethodDescMap.GetHash(PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
     {
         m_entryPointToMethodDescMap.InsertValue(PCODEToPINSTR(entryPoint), methodDesc);
         return true;


### PR DESCRIPTION
- Remove replacement functions from these hash tables, as they aren't used
- Use Gethash where appropriate for PtrHashMap/HashMap instead of LookupValue as it can be implemented slightly more efficiently
- Replace HashMap::Gethash implementation with slightly more efficient one that doesn't attempt to use the Compare functor
- Replace Compare Functor which used virtual functions with non-virtual ComparePtr functor.