### PR TITLE
[cdac] Cache negative lookups in ManagedTypeSource_1

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 internal sealed class ManagedTypeSource_1 : IManagedTypeSource
 {
     private readonly Target _target;
-    private readonly Dictionary<string, Target.TypeInfo> _typeInfoCache = new();
+    private readonly Dictionary<string, Target.TypeInfo?> _typeInfoCache = new();
     private readonly Dictionary<string, TypeHandle> _typeHandleCache = new();
     private readonly Dictionary<(string Fqn, string FieldName), TargetPointer> _fieldDescCache = new();
     private bool _inSearch;
@@ -40,12 +40,16 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
 
     public bool TryGetTypeInfo(string fullyQualifiedName, out Target.TypeInfo info)
     {
-        if (_typeInfoCache.TryGetValue(fullyQualifiedName, out info))
-            return true;
+        if (_typeInfoCache.TryGetValue(fullyQualifiedName, out Target.TypeInfo? cached))
+        {
+            info = cached ?? default;
+            return cached.HasValue;
+        }
 
         // Re-entrancy guard: if we're already searching for a type and we recurse
         // (e.g., LayoutPair -> ManagedTypeSource -> IData -> LayoutPair), short-circuit
-        // to break the cycle. The outer search will continue and may succeed.
+        // to break the cycle. Do NOT cache the negative result here — the outer search
+        // may legitimately succeed for this same name once the recursion unwinds.
         if (_inSearch)
         {
             info = default;
@@ -56,7 +60,10 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
         try
         {
             if (!TryBuildTypeInfo(fullyQualifiedName, out info))
+            {
+                _typeInfoCache[fullyQualifiedName] = null;
                 return false;
+            }
 
             _typeInfoCache[fullyQualifiedName] = info;
             return true;
@@ -78,10 +85,13 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
     public bool TryGetTypeHandle(string fullyQualifiedName, out TypeHandle typeHandle)
     {
         if (_typeHandleCache.TryGetValue(fullyQualifiedName, out typeHandle))
-            return true;
+            return !typeHandle.IsNull;
 
         if (!TryResolveType(fullyQualifiedName, out typeHandle, out _, out _))
+        {
+            _typeHandleCache[fullyQualifiedName] = new TypeHandle(TargetPointer.Null);
             return false;
+        }
 
         _typeHandleCache[fullyQualifiedName] = typeHandle;
         return true;


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with assistance from GitHub Copilot.

Fixes a hot-path inefficiency in the managed cDAC contributing to #128717.

`TryGetTypeInfo` and `TryGetTypeHandle` on `ManagedTypeSource_1` previously only cached *successful* lookups. Every failing lookup re-walked all `TypeDefinition` rows in `System.Private.CoreLib` via `TryFindTypeDefinition`, dominating cold-iteration time for SOS commands. On the SOS WebApp3 heap dump from #128717, `TryFindTypeDefinition` accounted for ~87% of `!dumpheap -stat` inclusive time.

## Fix

Store `null` in `_typeInfoCache` and a `TypeHandle(TargetPointer.Null)` sentinel in `_typeHandleCache` to short-circuit repeated negative lookups. Matches the existing pattern used by `TryGetFieldDesc`.

The re-entrancy guard (`_inSearch`) still does **not** cache its short-circuit `false` — the outer search may legitimately succeed for the same name once the recursion unwinds.

## Measurements

Measured on the SOS WebApp3 heap dump (Debug cDAC, in-process benchmark harness driving SOSDac entry points iteratively):

| Workload | Before | After | Speedup |
|---|---:|---:|---:|
| Cold `!dumpheap -stat` (9239 objects) | 5.90 s | 0.35 s | ~17x |
| Cold heap walk | 1.61 s | 0.16 s | ~10x |
| Warm iteration | unchanged | unchanged | - |

Read counts in the warm pass are unchanged (the algorithm above `ReadVirtual` is unaffected); cold-path savings come entirely from avoiding repeated metadata scans for type names that don't resolve in SPC.

## Test

- `Microsoft.Diagnostics.DataContractReader.Tests`: 2381 passed / 16 skipped / 0 failed.
- Functional output of SOSDac entry points (`GetObjectData`, `GetMethodTableName`, `GetMethodTableData`, `GetMethodTableFieldData`) verified byte-identical pre/post fix on the WebApp3 dump.