### PR TITLE
Enable the cmake cache for WebAssembly builds on Windows

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -57,6 +57,8 @@ if /i "%__Arch%" == "wasm" (
     )
     if /i "%__Os%" == "browser" (
         set CMakeToolPrefix=emcmake
+        rem Use WASM-specific tryrun cache to speed up CMake configure
+        set __ExtraCmakeParams="-C %__repoRoot%/eng/native/tryrun.browser.cmake" !__ExtraCmakeParams!
     )
     if /i "%__Os%" == "wasi" (
         if "%WASI_SDK_PATH%" == "" (


### PR DESCRIPTION
@steveisok added this some time ago for builds on non-Windows, so this fixes the gap for those of us who primarily develop on Windows.