### PR TITLE
Fix for 127141 - Remove unneeded spilling around profiler hooks

### DIFF
--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5902,8 +5902,6 @@ void LinearScan::allocateRegisters()
                 RefPosition* nextRefPosition        = currentRefPosition.nextRefPosition;
                 bool         isExtraUpperVectorSave = currentRefPosition.IsExtraUpperVectorSave();
 
-                // Normally, the only live physReg here would be callee-save (lower half only) d8-d15.
-                // But PROF_HOOK fully preserves q0-q7, so an UpperVectorSave here does not require a spill.
                 bool profHookUpperHalfPreserved = CanSkipUpperVectorSave(&currentRefPosition, lclVarInterval);
 
                 if ((lclVarInterval->physReg == REG_NA) || isExtraUpperVectorSave || profHookUpperHalfPreserved ||
@@ -7425,6 +7423,7 @@ bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclV
 {
     assert(refPosition->refType == RefTypeUpperVectorSave);
 
+#ifdef TARGET_ARM64
     // PROF_HOOK preserves upper halves of q0-q7, LSRA must be told explicitly that saving these is not needed
     // So skip the save if reg is assigned, ref is a PROF_HOOK, kill set does not contain reg, and reg is not
     // a upper-half-only-callee saved reg
@@ -7432,6 +7431,11 @@ bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclV
            refPosition->treeNode->OperIs(GT_PROF_HOOK) &&
            !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&
            !RBM_FLT_CALLEE_SAVED.IsRegNumInMask(lclVarInterval->physReg);
+#else
+    // Tail call profiler stub for amd64 target explicitly calls out that upper halves of ymm registers are not
+    // preserved
+    return false;
+#endif
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7427,7 +7427,7 @@ bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclV
 
     // PROF_HOOK preserves upper halves of q0-q7, LSRA must be told explicitly that saving these is not needed
     // So skip the save if reg is assigned, ref is a PROF_HOOK, kill set does not contain reg, and reg is not
-    // a upper-half-only-called saved reg
+    // a upper-half-only-callee saved reg
     return (lclVarInterval->physReg != REG_NA) && (refPosition->treeNode != nullptr) &&
            refPosition->treeNode->OperIs(GT_PROF_HOOK) &&
            !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5904,11 +5904,7 @@ void LinearScan::allocateRegisters()
 
                 // Normally, the only live physReg here would be callee-save (lower half only) d8-d15.
                 // But PROF_HOOK fully preserves q0-q7, so an UpperVectorSave here does not require a spill.
-                bool profHookUpperHalfPreserved = (lclVarInterval->physReg != REG_NA) &&
-                                                  (currentRefPosition.treeNode != nullptr) &&
-                                                  currentRefPosition.treeNode->OperIs(GT_PROF_HOOK) &&
-                                                  !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&
-                                                  !RBM_FLT_CALLEE_SAVED.IsRegNumInMask(lclVarInterval->physReg);
+                bool profHookUpperHalfPreserved = CanSkipUpperVectorSave(&currentRefPosition, lclVarInterval);
 
                 if ((lclVarInterval->physReg == REG_NA) || isExtraUpperVectorSave || profHookUpperHalfPreserved ||
                     (lclVarInterval->isPartiallySpilled && (currentInterval->physReg == REG_STK)))
@@ -7418,6 +7414,25 @@ void LinearScan::insertCopyOrReload(BasicBlock* block, GenTree* tree, unsigned m
 }
 
 #if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
+//------------------------------------------------------------------------
+// CanSkipUpperVectorSave: Determine whether an UpperVectorSave ref position doesn't actually require a save.
+//
+// Arguments:
+//    refPosition             - The RefTypeUpperVectorSave RefPosition.
+//    lclVarInterval          - The Interval for the local variable whose upper vector half might be saved.
+//
+bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclVarInterval)
+{
+    assert(refPosition->refType == RefTypeUpperVectorSave);
+
+    // PROF_HOOK preserves upper halves of q0-q7, LSRA must be told explicitly that saving these is not needed
+    return (lclVarInterval->physReg != REG_NA) &&
+           (refPosition->treeNode != nullptr) &&
+           refPosition->treeNode->OperIs(GT_PROF_HOOK) &&
+           !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&
+           !RBM_FLT_CALLEE_SAVED.IsRegNumInMask(lclVarInterval->physReg);
+}
+
 //------------------------------------------------------------------------
 // insertUpperVectorSave: Insert code to save the upper half of a vector that lives
 //                        in a callee-save register at the point of a kill (the upper half is

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -5902,17 +5902,31 @@ void LinearScan::allocateRegisters()
                 RefPosition* nextRefPosition        = currentRefPosition.nextRefPosition;
                 bool         isExtraUpperVectorSave = currentRefPosition.IsExtraUpperVectorSave();
 
-                if ((lclVarInterval->physReg == REG_NA) || isExtraUpperVectorSave ||
+                // Normally, the only live physReg here would be callee-save (lower half only) d8-d15.
+                // But PROF_HOOK fully preserves q0-q7, so an UpperVectorSave here does not require a spill.
+                bool profHookUpperHalfPreserved = (lclVarInterval->physReg != REG_NA) &&
+                                                  (currentRefPosition.treeNode != nullptr) &&
+                                                  currentRefPosition.treeNode->OperIs(GT_PROF_HOOK) &&
+                                                  !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&
+                                                  !RBM_FLT_CALLEE_SAVED.IsRegNumInMask(lclVarInterval->physReg);
+
+                if ((lclVarInterval->physReg == REG_NA) || isExtraUpperVectorSave || profHookUpperHalfPreserved ||
                     (lclVarInterval->isPartiallySpilled && (currentInterval->physReg == REG_STK)))
                 {
-                    if (!currentRefPosition.liveVarUpperSave)
+                    if (!currentRefPosition.liveVarUpperSave || profHookUpperHalfPreserved)
                     {
                         if (isExtraUpperVectorSave)
                         {
-                            // If this was just an extra upperVectorSave that do not have corresponding
+                            // If this was just an extra upperVectorSave that does not have a corresponding
                             // upperVectorRestore, we do not need to mark this as isPartiallySpilled
                             // or need to insert the save/restore.
                             currentRefPosition.skipSaveRestore = true;
+                        }
+                        else if (profHookUpperHalfPreserved)
+                        {
+                            currentRefPosition.skipSaveRestore = true;
+                            assert(nextRefPosition->refType == RefTypeUpperVectorRestore);
+                            nextRefPosition->skipSaveRestore = true;
                         }
 
                         if (assignedRegister != REG_NA)

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7428,8 +7428,7 @@ bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclV
     // PROF_HOOK preserves upper halves of q0-q7, LSRA must be told explicitly that saving these is not needed
     // So skip the save if reg is assigned, ref is a PROF_HOOK, kill set does not contain reg, and reg is not
     // a upper-half-only-called saved reg
-    return (lclVarInterval->physReg != REG_NA) &&
-           (refPosition->treeNode != nullptr) &&
+    return (lclVarInterval->physReg != REG_NA) && (refPosition->treeNode != nullptr) &&
            refPosition->treeNode->OperIs(GT_PROF_HOOK) &&
            !getKillSetForProfilerHook().IsRegNumInMask(lclVarInterval->physReg) &&
            !RBM_FLT_CALLEE_SAVED.IsRegNumInMask(lclVarInterval->physReg);

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -7426,6 +7426,8 @@ bool LinearScan::CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclV
     assert(refPosition->refType == RefTypeUpperVectorSave);
 
     // PROF_HOOK preserves upper halves of q0-q7, LSRA must be told explicitly that saving these is not needed
+    // So skip the save if reg is assigned, ref is a PROF_HOOK, kill set does not contain reg, and reg is not
+    // a upper-half-only-called saved reg
     return (lclVarInterval->physReg != REG_NA) &&
            (refPosition->treeNode != nullptr) &&
            refPosition->treeNode->OperIs(GT_PROF_HOOK) &&

--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -694,6 +694,8 @@ public:
                                   RefPosition* refPosition,
                                   Interval*    upperVectorInterval,
                                   BasicBlock*  block);
+    // Check for an unnecessary UpperVectorSave ref position around profiler hooks
+    bool CanSkipUpperVectorSave(RefPosition* refPosition, Interval* lclVarInterval);
 #endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
     // resolve along one block-block edge


### PR DESCRIPTION
On ARM64, only the lower halves of q8-q15 (128b) are callee save.  LSRA spills upper halves of these into d8-d15 (64b subreg)

"UpperVectorSave" ref position tracks these around calls.  LSRA currently just does this "upper-half-save-into-d8_d15" for all enregistered uppersave refs around calls.

Problem is `PROF_HOOK` does NOT kill q0-q7.  So we end up with more enregistered refs around a profiler hook than may be handled by d8-d15.

Fix is that q0-q7 do not need their upper halves spilled around PROF_HOOK.  I double checked with Noah that this is the case.  And the asm stub does call out q0-q7 being preserved.

I was not able to recreate a repro, a profiled tail call taking v512 params seems to not be enough.

fixes #127141 