### PR TITLE
Skipping EDI in the runtime-async case as well

### DIFF
--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -66,6 +66,14 @@ namespace System.Diagnostics
         {
             throw new NullReferenceException("Exception from Test2");
         }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
+#line 1 "EdiOuter.cs"
+        public static async Task EdiOuter()
+        {
+            await V2Methods.EdiMiddle();
+        }
     }
 
     public class V2Methods
@@ -205,6 +213,22 @@ namespace System.Diagnostics
         {
             if (Random.Shared.Next(1) == 100) await Task.Yield();
             throw new Exception("Exception from Baz method.");
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+#line 1 "EdiMiddle.cs"
+        public static async Task EdiMiddle()
+        {
+            await EdiInner();
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+#line 1 "EdiInner.cs"
+        public static async Task EdiInner()
+        {
+            throw new InvalidOperationException("Exception from EdiInner");
         }
     }
 }
@@ -640,6 +664,12 @@ namespace System.Diagnostics.Tests
                 @"V2Methods\.Baz\(\)" + FileInfoPattern(@".*Baz.*\.cs:line 4"),
                 @"V2Methods\.Bux\(\)" + FileInfoPattern(@".*Bux.*\.cs:line 6")
             }},
+            { "EdiOuter", new[] {
+                @"Exception from EdiInner",
+                @"V2Methods\.EdiInner\(\)" + FileInfoPattern(@".*EdiInner.*\.cs:line 3"),
+                @"V2Methods\.EdiMiddle\(\)" + FileInfoPattern(@".*EdiMiddle.*\.cs:line 3"),
+                @"V1Methods.*EdiOuter"
+            }},
         };
 
         public static IEnumerable<object[]> Ctor_Async_TestData()
@@ -649,6 +679,7 @@ namespace System.Diagnostics.Tests
             yield return new object[] { () => V2Methods.Quux(), MethodExceptionStrings["Quux"] };
             yield return new object[] { () => V2Methods.Quuux(), MethodExceptionStrings["Quuux"] };
             yield return new object[] { () => V2Methods.Bux(), MethodExceptionStrings["Bux"] };
+            yield return new object[] { () => V1Methods.EdiOuter(), MethodExceptionStrings["EdiOuter"] };
         }
 
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRuntimeAsyncSupported))]
@@ -677,6 +708,7 @@ namespace System.Diagnostics.Tests
                 Assert.True(match.Success, $"Could not find expected pattern '{pattern}' in exception text:\n{exceptionText} starting at index {startIndex}.");
                 startIndex = match.Index + match.Length;
             }
+            Assert.DoesNotContain("--- End of stack trace from previous location ---", exceptionText);
         }
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -358,7 +358,7 @@ namespace System.Diagnostics
                     }
 
                     // Skip EDI boundary for async
-                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
+                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync && (mb.MethodImplementationFlags & MethodImplAttributes.Async) == 0)
                     {
                         sb.AppendLine();
                         // Passing default for Exception_EndStackTraceFromPreviousThrow in case SR.UsingResourceKeys is set.

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs
@@ -237,11 +237,11 @@ namespace System.Diagnostics
 
                     sb.Append("   ").Append(word_At).Append(' ');
 
-                    bool isAsync = false;
+                    bool isAsync = (mb.MethodImplementationFlags & MethodImplAttributes.Async) != 0;
                     Type? declaringType = mb.DeclaringType;
                     string methodName = mb.Name;
                     bool methodChanged = false;
-                    if (declaringType != null && IsDefinedSafe(declaringType, typeof(CompilerGeneratedAttribute), inherit: false))
+                    if (!isAsync && declaringType != null && IsDefinedSafe(declaringType, typeof(CompilerGeneratedAttribute), inherit: false))
                     {
                         isAsync = declaringType.IsAssignableTo(typeof(IAsyncStateMachine));
                         if (isAsync || declaringType.IsAssignableTo(typeof(IEnumerator)))
@@ -358,7 +358,7 @@ namespace System.Diagnostics
                     }
 
                     // Skip EDI boundary for async
-                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync && (mb.MethodImplementationFlags & MethodImplAttributes.Async) == 0)
+                    if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
                     {
                         sb.AppendLine();
                         // Passing default for Exception_EndStackTraceFromPreviousThrow in case SR.UsingResourceKeys is set.


### PR DESCRIPTION
In stacktrace pretty-printing we skip the EDI boundary for async methods, so as not to clutter stacktraces with `--- End of stack trace from previous location ---`. We should do the same for runtime-async.

Fixes #128723