### PR TITLE
Fix race between zlib Inflate/Deflate and Dispose

### DIFF
--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -363,7 +363,7 @@ namespace System.IO.Compression
                 }
             }
 
-            public unsafe ErrorCode DeflateEnd()
+            private unsafe ErrorCode DeflateEnd()
             {
                 EnsureState(State.InitializedForDeflate);
 
@@ -442,7 +442,7 @@ namespace System.IO.Compression
                 }
             }
 
-            public unsafe ErrorCode InflateEnd()
+            private unsafe ErrorCode InflateEnd()
             {
                 EnsureState(State.InitializedForInflate);
 

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -348,12 +348,23 @@ namespace System.IO.Compression
 
             public unsafe ErrorCode Deflate(FlushCode flush)
             {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForDeflate);
-
-                fixed (ZStream* stream = &_zStream)
+                bool refAdded = false;
+                try
                 {
-                    return Interop.ZLib.Deflate(stream, flush);
+                    DangerousAddRef(ref refAdded);
+                    EnsureState(State.InitializedForDeflate);
+
+                    fixed (ZStream* stream = &_zStream)
+                    {
+                        return Interop.ZLib.Deflate(stream, flush);
+                    }
+                }
+                finally
+                {
+                    if (refAdded)
+                    {
+                        DangerousRelease();
+                    }
                 }
             }
 
@@ -395,23 +406,45 @@ namespace System.IO.Compression
 
             public unsafe ErrorCode InflateReset2_(int windowBits)
             {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForInflate);
-
-                fixed (ZStream* stream = &_zStream)
+                bool refAdded = false;
+                try
                 {
-                    return Interop.ZLib.InflateReset2_(stream, windowBits);
+                    DangerousAddRef(ref refAdded);
+                    EnsureState(State.InitializedForInflate);
+
+                    fixed (ZStream* stream = &_zStream)
+                    {
+                        return Interop.ZLib.InflateReset2_(stream, windowBits);
+                    }
+                }
+                finally
+                {
+                    if (refAdded)
+                    {
+                        DangerousRelease();
+                    }
                 }
             }
 
             public unsafe ErrorCode Inflate(FlushCode flush)
             {
-                EnsureNotDisposed();
-                EnsureState(State.InitializedForInflate);
-
-                fixed (ZStream* stream = &_zStream)
+                bool refAdded = false;
+                try
                 {
-                    return Interop.ZLib.Inflate(stream, flush);
+                    DangerousAddRef(ref refAdded);
+                    EnsureState(State.InitializedForInflate);
+
+                    fixed (ZStream* stream = &_zStream)
+                    {
+                        return Interop.ZLib.Inflate(stream, flush);
+                    }
+                }
+                finally
+                {
+                    if (refAdded)
+                    {
+                        DangerousRelease();
+                    }
                 }
             }
 

--- a/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
+++ b/src/libraries/Common/src/System/IO/Compression/ZLibNative.cs
@@ -288,11 +288,6 @@ namespace System.IO.Compression
                 set { _zStream.availOut = value; }
             }
 
-            private void EnsureNotDisposed()
-            {
-                ObjectDisposedException.ThrowIf(InitializationState == State.Disposed, this);
-            }
-
             private void EnsureState(State requiredState)
             {
                 if (InitializationState != requiredState)
@@ -370,7 +365,6 @@ namespace System.IO.Compression
 
             public unsafe ErrorCode DeflateEnd()
             {
-                EnsureNotDisposed();
                 EnsureState(State.InitializedForDeflate);
 
                 fixed (ZStream* stream = &_zStream)
@@ -450,7 +444,6 @@ namespace System.IO.Compression
 
             public unsafe ErrorCode InflateEnd()
             {
-                EnsureNotDisposed();
                 EnsureState(State.InitializedForInflate);
 
                 fixed (ZStream* stream = &_zStream)


### PR DESCRIPTION
Fixes #128550.

`Inflater`/`Deflater` synchronize their native zlib calls via a managed `lock`, but `Dispose` is not synchronized, so a concurrent `Dispose` on one thread could run `InflateEnd`/`DeflateEnd` and free the underlying `z_stream` while another thread was mid-call inside the native `inflate`/`deflate`, leading to use-after-free crashes.

The fix moves the protection down into `ZLibStreamHandle`. `Inflate`, `InflateReset2_`, and `Deflate` now bracket their native invocations with `DangerousAddRef`/`DangerousRelease`, which is exactly what `SafeHandle` is designed for: it defers `ReleaseHandle` (and therefore the `InflateEnd`/`DeflateEnd` P/Invoke) until all in-flight callers have released their refs. The redundant `EnsureNotDisposed` check is removed from these methods since `DangerousAddRef` already throws `ObjectDisposedException` for a closed handle.

The other `ZLibStreamHandle` members (`DeflateEnd`, `InflateEnd`, `InflateInit2_`, `DeflateInit2_`) are intentionally left as-is: they only run from initialization or from `ReleaseHandle`/`Dispose` paths that are not the racing party.