### PR TITLE
[ci-scan] Fix feedback workflow safe outputs and redesign KPI tracker

### DIFF
--- a/.github/workflows/ci-failure-scan-feedback.lock.yml
+++ b/.github/workflows/ci-failure-scan-feedback.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"436ca2efc5842078cf4262ae31abc8fe5fbea015f98f6bfaa5f10eb7f55452ce","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"20bbe5bb28dc877720ee8aabf6f23ffe12083aaea3787d014ef69802a0d7ccc4","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -208,24 +208,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_42864c16dd29f5fa_EOF'
+          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
           <system>
-          GH_AW_PROMPT_42864c16dd29f5fa_EOF
+          GH_AW_PROMPT_de2ba8db3d836d02_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_42864c16dd29f5fa_EOF'
+          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, create_pull_request, update_pull_request, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_42864c16dd29f5fa_EOF
+          GH_AW_PROMPT_de2ba8db3d836d02_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_42864c16dd29f5fa_EOF'
+          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_42864c16dd29f5fa_EOF
+          GH_AW_PROMPT_de2ba8db3d836d02_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_42864c16dd29f5fa_EOF'
+          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,12 +257,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_42864c16dd29f5fa_EOF
+          GH_AW_PROMPT_de2ba8db3d836d02_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_42864c16dd29f5fa_EOF'
+          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
           </system>
           {{#runtime-import .github/workflows/ci-failure-scan-feedback.md}}
-          GH_AW_PROMPT_42864c16dd29f5fa_EOF
+          GH_AW_PROMPT_de2ba8db3d836d02_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_64eb22cffe9262a3_EOF'
-          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"]},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_64eb22cffe9262a3_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7e5b3f7064b1cdde_EOF'
+          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_7e5b3f7064b1cdde_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -812,7 +812,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e28de3cfa5505fa3_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e163068c4041be38_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -856,7 +856,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e28de3cfa5505fa3_EOF
+          GH_AW_MCP_CONFIG_e163068c4041be38_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1691,7 +1691,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"]},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-failure-scan-feedback.lock.yml
+++ b/.github/workflows/ci-failure-scan-feedback.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"20bbe5bb28dc877720ee8aabf6f23ffe12083aaea3787d014ef69802a0d7ccc4","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2e1c800f18e97303502871201083b668124fa7908f8eb8291f65226193f7283a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -208,24 +208,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
+          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
           <system>
-          GH_AW_PROMPT_de2ba8db3d836d02_EOF
+          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
+          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, create_pull_request, update_pull_request, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_de2ba8db3d836d02_EOF
+          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
+          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_de2ba8db3d836d02_EOF
+          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
+          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,12 +257,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_de2ba8db3d836d02_EOF
+          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_de2ba8db3d836d02_EOF'
+          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
           </system>
           {{#runtime-import .github/workflows/ci-failure-scan-feedback.md}}
-          GH_AW_PROMPT_de2ba8db3d836d02_EOF
+          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7e5b3f7064b1cdde_EOF'
-          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_7e5b3f7064b1cdde_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF'
+          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -467,7 +467,7 @@ jobs:
                 "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Labels [\"agentic-workflows\"] will be automatically added. Only these labels are allowed: [\"agentic-workflows\"].",
                 "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[ci-scan-feedback] \". Labels [\"agentic-workflows\"] will be automatically added. Only these labels are allowed: [\"agentic-workflows\"]. PRs will be created as drafts.",
                 "push_to_pull_request_branch": " CONSTRAINTS: Maximum 1 push(es) can be made.",
-                "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated.",
+                "update_issue": " CONSTRAINTS: Maximum 1 issue(s) can be updated. Target: *.",
                 "update_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be updated."
               },
               "repo_params": {},
@@ -812,7 +812,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e163068c4041be38_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -856,7 +856,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e163068c4041be38_EOF
+          GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1691,7 +1691,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -177,11 +177,11 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    ### A) Acceptance classification (primary)
 
-   Each artifact (issue or PR) is classified into one of three buckets:
+   Each artifact (issue or PR) is classified into exactly one of three buckets. Evaluate the rules in order; the first matching rule wins.
 
    - **Accepted** — PR merged; OR issue closed with `state_reason: completed`; OR issue still open and >= 7 days old AND touched by a MEMBER/OWNER (commented, labeled, assigned, milestoned, or linked from another issue/PR).
    - **Rejected** — PR closed unmerged; OR issue closed with `state_reason` in `{not_planned, duplicate}`; OR ANY MEMBER/OWNER comment on the artifact matches (case-insensitive) one of: `don't disable`, `do not disable`, `do not mute`, `please don't`, `false positive`, `fix forward`, `fix-forward`, `investigation in progress`, `will investigate`, `stop filing`, `noise`, `not a real failure`, `flaky test`.
-   - **Pending** — younger than 7 days AND no MEMBER/OWNER touch. Excluded from the rate.
+   - **Pending** — every other artifact (no Accepted or Rejected rule has matched yet, e.g. a young untouched issue or an older open issue with only non-rejection maintainer activity). Excluded from the rate.
 
    Compute the classification over both the 30-day and 90-day rolling windows from `now`. For each window emit:
 
@@ -191,7 +191,24 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    ### B) Environment / scanner activity (volume)
 
-   Source CI failure counts from the same scanner runs the feedback workflow inspects (Step 1): each scanner run's agent log records the failures it observed; sum those over the window. The signature tuple is `(pipeline_definition_id, job_or_test_name, normalized_error_fingerprint)` as the scanner already produces it for filing.
+   Source CI failure counts from the scanner's own agent logs over the window. Step 1 (latest 10 runs) and Step 2 (tallies for the latest 2) are sized for the rubric-scoring path and do NOT cover 30 days, the prior-7d comparison period, or anything beyond the most recent two tallies — this section MUST enumerate scanner runs independently. Paginate `ci-failure-scan.lock.yml` runs created in the last 30 days and download the tally for each (reuse the Step 2 `awk` extractor; skip downloads when the tally file already exists from Step 2). The signature tuple is `(pipeline_definition_id, job_or_test_name, normalized_error_fingerprint)` as the scanner already produces it for filing.
+
+   ```bash
+   SINCE_30D=$(date -u -d '30 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
+   gh api --paginate \
+     "/repos/dotnet/runtime/actions/workflows/ci-failure-scan.lock.yml/runs?per_page=100&created=>=${SINCE_30D}" \
+     | jq -r '.workflow_runs[] | "\(.id) \(.created_at)"' \
+     | tee /tmp/gh-aw/agent/runs_30d.txt
+   while read -r RUN_ID RUN_CREATED; do
+     OUT="/tmp/gh-aw/agent/tally_${RUN_ID}.txt"
+     test -s "$OUT" && continue
+     gh run view "$RUN_ID" --log \
+       | awk '/^\| pipeline \|/{flag=1} flag && /^\|/{print; next} flag{exit}' \
+       > "$OUT"
+   done < /tmp/gh-aw/agent/runs_30d.txt
+   ```
+
+   Bucket each tally row by its source run's `created_at` into `last 7d`, `prior 7d` (the 7-day window ending 7 days ago), and `last 30d`. Sum failure counts within each bucket; de-duplicate signature tuples within each bucket before counting distinct signatures.
 
    - `ci_failures_7d`, `ci_failures_30d` — total failure observations across all pipelines the scanner monitors.
    - `ci_failures_delta_pct` — `(ci_failures_7d / ci_failures_prev_7d) - 1`, formatted as a signed percentage. Use the 7-day window ending 7 days ago as the prior period. Emit as `—` if either window has < 20 failures (too few to call a spike).
@@ -221,7 +238,7 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    ## Snapshot — <UTC timestamp>
 
-   Primary metric: **scanner artifact acceptance rate** = accepted / (accepted + rejected), measured over a rolling window. Pending artifacts (< 7 days old and not yet touched by a MEMBER/OWNER) are excluded.
+   Primary metric: **scanner artifact acceptance rate** = accepted / (accepted + rejected), measured over a rolling window. Pending artifacts (no accepted/rejected rule has matched yet) are excluded from the denominator.
 
    | window | accepted | rejected | pending | acceptance | Wilson 95% lower |
    |---|---|---|---|---|---|

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -171,17 +171,47 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    Collect the full universe of `[ci-scan]` issues and PRs (open + closed) since `window_start` via `gh search issues` / `gh search prs` with `created:>=<window_start>`. This produces a list of issue/PR numbers and metadata; do NOT read bodies with `gh`.
 
-   For metrics that require body content (`top_pipelines`), fetch the bodies of the discovered items through the `github` MCP `issue_read get` / `pull_request_read get` tool, one per item, respecting `min-integrity: approved`. Skip `[Filtered]` items.
+   For metrics that require body or comment content (rejection-keyword detection, maintainer-touch signal), fetch through the `github` MCP `issue_read get`, `pull_request_read get`, and the corresponding comments tools, one per item, respecting `min-integrity: approved`. Skip `[Filtered]` items.
 
-   Compute these KPIs:
+   Compute these KPIs.
 
-   - `issues_total`, `issues_open`, `issues_closed`
-   - `closed_last_7d`, `closed_last_30d`
-   - `median_time_to_close_30d` (hours; from `createdAt` to `closedAt` for issues closed in last 30d)
-   - `p90_time_to_close_30d`
-   - `pct_closed_as_not_planned` (state_reason `not_planned` / total closed) — proxy for false positives flagged by maintainers
-   - `prs_total`, `prs_merged`, `prs_closed_unmerged`
-   - `top_pipelines` (top 3 `definition_id` values appearing in issue bodies fetched via the `github` MCP tool per the step above; if a fetched body is `[Filtered]`, count it under `integrity_filtered_pipelines` and exclude from the top 3)
+   ### A) Acceptance classification (primary)
+
+   Each artifact (issue or PR) is classified into one of three buckets:
+
+   - **Accepted** — PR merged; OR issue closed with `state_reason: completed`; OR issue still open and >= 7 days old AND touched by a MEMBER/OWNER (commented, labeled, assigned, milestoned, or linked from another issue/PR).
+   - **Rejected** — PR closed unmerged; OR issue closed with `state_reason` in `{not_planned, duplicate}`; OR ANY MEMBER/OWNER comment on the artifact matches (case-insensitive) one of: `don't disable`, `do not disable`, `do not mute`, `please don't`, `false positive`, `fix forward`, `fix-forward`, `investigation in progress`, `will investigate`, `stop filing`, `noise`, `not a real failure`, `flaky test`.
+   - **Pending** — younger than 7 days AND no MEMBER/OWNER touch. Excluded from the rate.
+
+   Compute the classification over both the 30-day and 90-day rolling windows from `now`. For each window emit:
+
+   - `accepted_n`, `rejected_n`, `pending_n`.
+   - `acceptance_rate = accepted_n / (accepted_n + rejected_n)`. Emit as `n/a` when `accepted_n + rejected_n < 10`.
+   - `acceptance_lower_bound` — Wilson score 95% lower bound on the same numerator/denominator (only when N >= 10). Use this for any single-number summary so 5/5 (N=5) does not read as 100% better than 50/55 (N=55).
+
+   ### B) Environment / scanner activity (volume)
+
+   Source CI failure counts from the same scanner runs the feedback workflow inspects (Step 1): each scanner run's agent log records the failures it observed; sum those over the window. The signature tuple is `(pipeline_definition_id, job_or_test_name, normalized_error_fingerprint)` as the scanner already produces it for filing.
+
+   - `ci_failures_7d`, `ci_failures_30d` — total failure observations across all pipelines the scanner monitors.
+   - `ci_failures_delta_pct` — `(ci_failures_7d / ci_failures_prev_7d) - 1`, formatted as a signed percentage. Use the 7-day window ending 7 days ago as the prior period. Emit as `—` if either window has < 20 failures (too few to call a spike).
+   - `distinct_signatures_7d`, `distinct_signatures_30d` — count of distinct signature tuples observed in the window.
+   - `top_failing_pipelines_7d` — top 3 `pipeline_definition_id` values by failure count in the last 7d, with their counts.
+   - `kbes_created_7d`, `kbes_closed_7d`, `kbes_created_30d`, `kbes_closed_30d` — issues created/closed by the scanner in each window (titles prefixed `[ci-scan]`).
+   - `prs_created_7d`, `prs_merged_7d`, `prs_closed_unmerged_7d`, and the matching 30d trio — PRs created by the scanner in each window.
+
+   ### C) Coverage and latency
+
+   - `coverage_30d = kbes_created_30d / distinct_signatures_30d`. Emit as `n/a` when `distinct_signatures_30d < 10`. A drop here means the scanner is missing repeated failures.
+   - `time_to_kbe_median_30d`, `time_to_kbe_p90_30d` — for each signature first observed in the window that did get a KBE filed, hours between first observation and the KBE's `createdAt`. Skip signatures with no KBE.
+
+   ### D) Diagnostics
+
+   Drill-down counts (last 30d) — surface them so rubric findings have quantitative grounding, do not headline them:
+
+   - `complaint_count` — MEMBER/OWNER comments on scanner artifacts matching the rejection-keyword set in section A.
+   - `duplicate_count` — issues closed with `state_reason: duplicate` or labeled `duplicate`.
+   - `scanner_pr_ci_fail_count` — PRs whose most recent commit had any required-status check report `failure`/`error` before maintainer review (proxy for "should the pre-emit checklist have caught it").
 
    Emit a body with this exact shape (regenerate every tick):
 
@@ -191,49 +221,50 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
 
    ## Snapshot — <UTC timestamp>
 
+   Primary metric: **scanner artifact acceptance rate** = accepted / (accepted + rejected), measured over a rolling window. Pending artifacts (< 7 days old and not yet touched by a MEMBER/OWNER) are excluded.
+
+   | window | accepted | rejected | pending | acceptance | Wilson 95% lower |
+   |---|---|---|---|---|---|
+   | last 30d | <a30> | <r30> | <p30> | <pct30 or `n/a (<n><10)`> | <wilson30 or `—`> |
+   | last 90d | <a90> | <r90> | <p90> | <pct90 or `n/a (<n><10)`> | <wilson90 or `—`> |
+
+   ### CI environment
+
+   | metric | 7d | 30d |
+   |---|---|---|
+   | Failures observed | <ci_failures_7d> (Δ <ci_failures_delta_pct> vs prior 7d) | <ci_failures_30d> |
+   | Distinct signatures | <distinct_signatures_7d> | <distinct_signatures_30d> |
+   | Top failing pipelines (7d) | <name1> (<n1>), <name2> (<n2>), <name3> (<n3>) | — |
+
+   ### Scanner activity
+
+   | artifact | 7d created | 7d resolved | 30d created | 30d resolved |
+   |---|---|---|---|---|
+   | KBE issues | <kbes_created_7d> | <kbes_closed_7d> | <kbes_created_30d> | <kbes_closed_30d> |
+   | Test-disable PRs | <prs_created_7d> | merged <prs_merged_7d>, closed <prs_closed_unmerged_7d> | <prs_created_30d> | merged <prs_merged_30d>, closed <prs_closed_unmerged_30d> |
+
+   ### Coverage and latency (30d)
+
    | metric | value |
    |---|---|
-   | Window | <window_start> -> now (<N> days) |
-   | Issues filed | <issues_total> (open <issues_open>, closed <issues_closed>) |
-   | Closed last 7d / 30d | <closed_last_7d> / <closed_last_30d> |
-   | Median time-to-close (30d) | <h>h |
-   | P90 time-to-close (30d) | <h>h |
-   | Closed as `not planned` | <pct>% (proxy for false-positive rate) |
-   | PRs filed | <prs_total> (merged <prs_merged>, closed-unmerged <prs_closed_unmerged>) |
-   | Top pipelines | <name1> (<n1>), <name2> (<n2>), <name3> (<n3>) |
+   | Coverage (KBEs filed / distinct signatures) | <coverage_30d or `n/a (<n><10)`> |
+   | Time to KBE (median / P90) | <ttk_med>h / <ttk_p90>h |
 
-   ## Weekly volume (last 12 weeks)
+   ### Diagnostics (30d)
 
-   ```mermaid
-   xychart-beta
-       title "[ci-scan] issues filed vs closed per ISO week"
-       x-axis [<w1>, <w2>, ..., <w12>]
-       y-axis "count" 0 --> <max>
-       bar [<filed_w1>, ..., <filed_w12>]
-       line [<closed_w1>, ..., <closed_w12>]
-   ```
-
-   ## Median time-to-close (last 12 weeks)
-
-   ```mermaid
-   xychart-beta
-       title "median hours from created to closed, per ISO week"
-       x-axis [<w1>, ..., <w12>]
-       y-axis "hours" 0 --> <max>
-       line [<med_w1>, ..., <med_w12>]
-   ```
-
-   <details>
-   <summary>Raw weekly buckets (last 12 weeks)</summary>
-
-   | iso-week | filed | closed | median-hrs |
-   |---|---|---|---|
-   | <w1> | <n> | <n> | <h> |
-   ...
-   </details>
-
-   The raw weekly buckets table MUST be windowed to the same 12 weeks the mermaid charts use — emit at most 12 rows. Older buckets are dropped on each regeneration; this is intentional (the tracker body is a current snapshot, not a permanent ledger).
+   | signal | count |
+   |---|---|
+   | Maintainer complaint comments | <complaint_count> |
+   | Duplicate KBEs | <duplicate_count> |
+   | Scanner PRs failing CI before review | <scanner_pr_ci_fail_count> |
    ````
+
+   Suppression rules:
+
+   - If both windows have `accepted + rejected < 10`, replace the acceptance-rate table with the line `Insufficient data: <n> graded artifacts in the last 90 days; need at least 10 before reporting a rate.` Still print the other tables.
+   - If `distinct_signatures_30d < 10`, omit the coverage row (do not emit a misleading ratio).
+   - Do NOT emit charts (mermaid or otherwise). Rates over small N look like signal when they are noise.
+   - Do NOT emit historical weekly buckets. The body is a current snapshot.
 
    If the tracker exists -> emit one `update_issue` with the new body. If not -> emit one `create_issue` titled `[ci-scan-feedback] KPI Tracker`. Either way, this step ALWAYS fires (never call `noop` for the tracker — a daily snapshot is the point).
 

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -73,6 +73,7 @@ safe-outputs:
     labels: [agentic-workflows]
     allowed-labels: [agentic-workflows]
   update-issue:
+    target: "*"
     max: 1
   noop:
     report-as-issue: false

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -52,12 +52,20 @@ safe-outputs:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+    protected-files:
+      policy: blocked
+      exclude:
+        - .github/
     labels: [agentic-workflows]
     allowed-labels: [agentic-workflows]
   push-to-pull-request-branch:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+    protected-files:
+      policy: blocked
+      exclude:
+        - .github/
   update-pull-request:
     max: 1
   create-issue:


### PR DESCRIPTION
## Description

Three changes to make the ci-failure-scan-feedback workflow actually useful.

The first is operational: the workflow's safe-outputs were not landing. Opt the `.github/` folder out of gh-aw's `protect_top_level_dot_folders` rule on the create-pull-request and push-to-pull-request-branch outputs (per gh-aw ADR-28486 the dot-folder rule is folder-granular and the compiler silently drops file-level entries; the per-file gate `allowed-files: [.github/workflows/ci-failure-scan.md]` was already in place and stays in place — net writable scope is exactly one file). Set `target: "*"` on update-issue so the scheduled run can update the long-lived KPI tracker (#128742) by number instead of failing with "no triggering issue".

The second is a redesign of the KPI tracker contents. The original metrics (issues filed, median time-to-close, top pipelines, weekly mermaid charts) did not measure scanner quality and were statistically meaningless at the current sample size (N=6 closures over 12 days drove "17% not_planned"). Replace with sections that distinguish "is the scanner net useful" from "is CI itself getting worse":

- Primary metric: scanner artifact acceptance rate over 30d and 90d rolling windows, with Wilson 95% lower bound, gated to N >= 10. Classification rules are explicit and grep-able (accepted / rejected / pending, with a keyword set for maintainer rejection signals).
- CI environment: failures observed (7d / 30d with Δ% vs prior 7d), distinct signatures, top failing pipelines. Detects regression spikes independent of scanner quality.
- Scanner activity: KBE and PR created/resolved counts per window.
- Coverage and latency: KBEs filed / distinct signatures observed; time from first observation to KBE filed (median + P90).
- Diagnostics: maintainer complaint count, duplicate count, scanner-PR CI failure count.

Suppression rules forbid charts and weekly buckets, and gate any rate on N >= 10 so noise is not read as signal.

Verified with the safe-outputs portion on dispatched run 26633745456: all 7 jobs green, both safe outputs landed (tracker updated, proposal issue #128755 created). The redesigned tracker body will populate on the next scheduled tick.
