### PR TITLE
[mobile] Switch iOS device test legs in runtime.yml to simulators

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1149,8 +1149,10 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # iOS devices - Full AOT + AggressiveTrimming to reduce size
+      # iOS simulators - Full AOT + AggressiveTrimming to reduce size
       # Build the whole product using Mono and run libraries tests
+      # Temporarily switched from ios_arm64 (devices) to iossimulator_arm64 due to
+      # device queue infrastructure failure: https://github.com/dotnet/runtime/issues/125135
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -1159,7 +1161,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-            - ios_arm64
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1195,8 +1197,10 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # iOS devices
+      # iOS simulators
       # Build the whole product using Native AOT and run libraries tests
+      # Temporarily switched from ios_arm64 (devices) to iossimulator_arm64 due to
+      # device queue infrastructure failure: https://github.com/dotnet/runtime/issues/125135
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -1205,7 +1209,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1238,8 +1242,10 @@ extends:
                     eq(variables['isRollingBuild'], true))
 
       #
-      # iOS devices
+      # iOS simulators
       # Build the whole product using CoreCLR and run libraries tests
+      # Temporarily switched from ios_arm64 (devices) to iossimulator_arm64 due to
+      # device queue infrastructure failure: https://github.com/dotnet/runtime/issues/125135
       #
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -1248,7 +1254,7 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            - iossimulator_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange


### PR DESCRIPTION
## Description
Due to infrastructure issues with the `osx.15.amd64.iphone.open` Helix device queue https://github.com/dotnet/runtime/issues/123796, switching the `ios_arm64` library-test legs in `eng/pipelines/runtime.yml` to `iossimulator_arm64`.