### PR TITLE
[Apple mobile] Handle missing IL-to-native map in DebuggerJitInfo

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -2066,6 +2066,11 @@ BOOL DebuggerController::AddBindAndActivateILReplicaPatch(DebuggerControllerPatc
             BOOL   fExact;
             SIZE_T offsetNative = it.Current(&fExact);
 
+            if (offsetNative == ((SIZE_T)-1))
+            {
+                continue;
+            }
+
             // We special case offset 0, which is when a breakpoint is set
             // at the beginning of a method that hasn't been jitted yet.  In
             // that case it's possible that offset 0 has been optimized out,

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -302,46 +302,47 @@ DebuggerILToNativeMap *DebuggerJitInfo::MapILOffsetToMapEntry(SIZE_T offset, BOO
     DebuggerILToNativeMap *mMax = mMin + GetSequenceMapCount();
 
     _ASSERTE(m_sequenceMapSorted);
-    _ASSERTE( mMin < mMax ); //otherwise we have no code
 
     if (exact)
     {
         *exact = FALSE;
     }
 
-    if (mMin)
+    if (mMin == NULL || mMin >= mMax)
     {
-        while (mMin + 1 < mMax)
-        {
-            _ASSERTE(mMin>=m_sequenceMap);
-            DebuggerILToNativeMap *mMid = mMin + ((mMax - mMin)>>1);
-            _ASSERTE(mMid>=m_sequenceMap);
-
-            if (offset == mMid->ilOffset)
-            {
-                if (exact)
-                {
-                    *exact = TRUE;
-                }
-                ADJUST_MAP_ENTRY(mMid, fWantFirst);
-                return mMid;
-            }
-            else if (offset < mMid->ilOffset && mMid->ilOffset != (ULONG) ICorDebugInfo::PROLOG)
-            {
-                mMax = mMid;
-            }
-            else
-            {
-                mMin = mMid;
-            }
-        }
-
-        if (exact && offset == mMin->ilOffset)
-        {
-            *exact = TRUE;
-        }
-        ADJUST_MAP_ENTRY(mMin, fWantFirst);
+        return NULL;
     }
+
+    while (mMin + 1 < mMax)
+    {
+        _ASSERTE(mMin>=m_sequenceMap);
+        DebuggerILToNativeMap *mMid = mMin + ((mMax - mMin)>>1);
+        _ASSERTE(mMid>=m_sequenceMap);
+
+        if (offset == mMid->ilOffset)
+        {
+            if (exact)
+            {
+                *exact = TRUE;
+            }
+            ADJUST_MAP_ENTRY(mMid, fWantFirst);
+            return mMid;
+        }
+        else if (offset < mMid->ilOffset && mMid->ilOffset != (ULONG) ICorDebugInfo::PROLOG)
+        {
+            mMax = mMid;
+        }
+        else
+        {
+            mMin = mMid;
+        }
+    }
+
+    if (exact && offset == mMin->ilOffset)
+    {
+        *exact = TRUE;
+    }
+    ADJUST_MAP_ENTRY(mMin, fWantFirst);
     return mMin;
 }
 
@@ -365,6 +366,13 @@ DebuggerJitInfo::NativeOffset DebuggerJitInfo::MapILOffsetToNative(DebuggerJitIn
     NativeOffset resultOffset;
 
     DebuggerILToNativeMap *map = MapILOffsetToMapEntry(ilOffset.m_ilOffset, &(resultOffset.m_fExact));
+
+    if (map == NULL)
+    {
+        resultOffset.m_fExact       = FALSE;
+        resultOffset.m_nativeOffset = ((SIZE_T)-1);
+        return resultOffset;
+    }
 
     // See if we want the map entry for the parent.
     if (ilOffset.m_funcletIndex <= PARENT_METHOD_INDEX)
@@ -587,6 +595,15 @@ SIZE_T DebuggerJitInfo::MapILOffsetToNativeForSetIP(SIZE_T offsetILTo, int funcl
 
     DebuggerILToNativeMap* pMap    = MapILOffsetToMapEntry(offsetILTo, pExact, TRUE);
     DebuggerILToNativeMap* pMapEnd = GetSequenceMap() + GetSequenceMapCount();
+
+    if (pMap == NULL)
+    {
+        if (pExact != NULL)
+        {
+            *pExact = FALSE;
+        }
+        return ((SIZE_T)-1);
+    }
 
     _ASSERTE(pMap == m_sequenceMap ||
              (pMap - 1)->ilOffset == (ULONG)ICorDebugInfo::NO_MAPPING ||
@@ -1272,6 +1289,11 @@ ICorDebugInfo::SourceTypes DebuggerJitInfo::GetSrcTypeFromILOffset(SIZE_T ilOffs
 
     BOOL exact = FALSE;
     DebuggerILToNativeMap *pMap = MapILOffsetToMapEntry(ilOffset, &exact);
+
+    if (pMap == NULL)
+    {
+        return ICorDebugInfo::SOURCE_TYPE_INVALID;
+    }
 
     LOG((LF_CORDB, LL_INFO100000, "DJI::GSTFILO: for il 0x%x, got entry 0x%p,"
         "(il 0x%x) nat 0x%x to 0x%x, SourceTypes 0x%x, exact:%x\n", ilOffset, pMap,

--- a/src/coreclr/debug/ee/functioninfo.cpp
+++ b/src/coreclr/debug/ee/functioninfo.cpp
@@ -299,7 +299,6 @@ DebuggerILToNativeMap *DebuggerJitInfo::MapILOffsetToMapEntry(SIZE_T offset, BOO
     //
 
     DebuggerILToNativeMap *mMin = GetSequenceMap();
-    DebuggerILToNativeMap *mMax = mMin + GetSequenceMapCount();
 
     _ASSERTE(m_sequenceMapSorted);
 
@@ -308,7 +307,14 @@ DebuggerILToNativeMap *DebuggerJitInfo::MapILOffsetToMapEntry(SIZE_T offset, BOO
         *exact = FALSE;
     }
 
-    if (mMin == NULL || mMin >= mMax)
+    if (mMin == NULL)
+    {
+        return NULL;
+    }
+
+    DebuggerILToNativeMap *mMax = mMin + GetSequenceMapCount();
+
+    if (mMin >= mMax)
     {
         return NULL;
     }
@@ -594,7 +600,6 @@ SIZE_T DebuggerJitInfo::MapILOffsetToNativeForSetIP(SIZE_T offsetILTo, int funcl
     CONTRACTL_END;
 
     DebuggerILToNativeMap* pMap    = MapILOffsetToMapEntry(offsetILTo, pExact, TRUE);
-    DebuggerILToNativeMap* pMapEnd = GetSequenceMap() + GetSequenceMapCount();
 
     if (pMap == NULL)
     {
@@ -604,6 +609,8 @@ SIZE_T DebuggerJitInfo::MapILOffsetToNativeForSetIP(SIZE_T offsetILTo, int funcl
         }
         return ((SIZE_T)-1);
     }
+
+    DebuggerILToNativeMap* pMapEnd = GetSequenceMap() + GetSequenceMapCount();
 
     _ASSERTE(pMap == m_sequenceMap ||
              (pMap - 1)->ilOffset == (ULONG)ICorDebugInfo::NO_MAPPING ||


### PR DESCRIPTION
## Description

`DebuggerJitInfo::MapILOffsetToNative` dereferences the entry returned by `MapILOffsetToMapEntry` without checking for NULL, which crashes when `m_sequenceMap` is NULL. This is the expected state for ReadyToRun-precompiled methods that ship without IL-to-native debug info. The crash reproduces on the first R2R framework method call under the CoreCLR remote debugger.

The fix is to return a `(SIZE_T)-1` sentinel from `MapILOffsetToNative`, `MapILOffsetToNativeForSetIP`, and `GetSrcTypeFromILOffset` when the map is missing, and skip sentinel funclet entries in `AddBindAndActivateILReplicaPatch`.