### PR TITLE
[cDAC] Cache resolved read-only metadata address per module in EcmaMetadata_1

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -6,15 +6,7 @@ using System.Collections.Generic;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-public readonly struct ModuleHandle
-{
-    public ModuleHandle(TargetPointer address)
-    {
-        Address = address;
-    }
-
-    public TargetPointer Address { get; }
-}
+public readonly record struct ModuleHandle(TargetPointer Address);
 
 [Flags]
 public enum ModuleFlags

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -13,15 +13,20 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
 {
-    private Dictionary<ModuleHandle, MetadataReaderProvider?> _metadata = new();
+    private readonly Dictionary<ModuleHandle, MetadataReaderProvider?> _metadata = [];
+    private readonly Dictionary<ModuleHandle, TargetSpan> _readOnlyMetadataAddress = [];
 
     public void Flush()
     {
         _metadata.Clear();
+        _readOnlyMetadataAddress.Clear();
     }
 
     public TargetSpan GetReadOnlyMetadataAddress(ModuleHandle handle)
     {
+        if (_readOnlyMetadataAddress.TryGetValue(handle, out TargetSpan cached))
+            return cached;
+
         ILoader loader = target.Contracts.Loader;
 
         if (!loader.TryGetLoadedImageContents(handle, out TargetPointer baseAddress, out uint size, out uint imageFlags))
@@ -32,12 +37,14 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
         PEStreamOptions isLoaded = isMapped ? PEStreamOptions.IsLoadedImage : PEStreamOptions.Default;
 
         TargetStream stream = new(target, baseAddress, size);
-        using PEReader peReader = new PEReader(stream, PEStreamOptions.PrefetchMetadata | isLoaded);
+        using PEReader peReader = new PEReader(stream, isLoaded);
 
         int metadataStartOffset = peReader.PEHeaders.MetadataStartOffset;
         int metadataSize = peReader.PEHeaders.MetadataSize;
 
-        return new TargetSpan(baseAddress + (ulong)metadataStartOffset, (ulong)metadataSize);
+        TargetSpan result = new TargetSpan(baseAddress + (ulong)metadataStartOffset, (ulong)metadataSize);
+        _readOnlyMetadataAddress[handle] = result;
+        return result;
     }
 
     public MetadataReader? GetMetadata(ModuleHandle handle)


### PR DESCRIPTION
Fixes part of #128717.

`GetReadOnlyMetadataAddress` walked the PE headers on every call and asked `PEReader` to also `PrefetchMetadata`, which eagerly read the entire metadata blob into memory and then discarded it (we only ever read `PEHeaders.MetadataStartOffset` / `MetadataSize` from the `PEReader` before disposing it).

On dumps where the metadata pages are not all captured, the prefetch threw `VirtualReadException` before the method could cache its result, so every subsequent call repeated the full PE walk and threw again. The exceptions were swallowed by callers' fallbacks (e.g. `SOSDacImpl.GetMethodTableName` -> `DacStreams.StringFromEEAddress`), so functionality was unaffected but performance suffered badly.

This PR:
- Drops `PrefetchMetadata` (we never use the prefetched bytes; callers read the metadata span themselves via `target.ReadBuffer`).
- Adds a small per-handle cache that `Flush()` clears alongside `_metadata`.
- Promotes `ModuleHandle` to a `record struct` so dictionary lookups use compiler-generated `IEquatable<T>`/`GetHashCode` instead of reflection-based `ValueType.Equals` (~6x faster in a microbenchmark).

### Measurements

Measured on `SOS.WebApp3.Heap.dmp` via a local benchmark harness (`GetMethodTableData` + `GetMethodTableName` + `GetMethodTableFieldData` + `GetObjectData` over the full GC heap, 3 iterations):

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Cold-iter reads | 137,522 | 61,306 | -55% |
| Warm-iter reads | 99,198 | 19,518 | -80% |
| Total reads | 385,928 | 150,351 | -61% |
| Failed reads | 1,992 | 1,992 | unchanged |
| Name resolution ok/err | 686/0 | 686/0 | unchanged |
