### PR TITLE
[cDAC] Implement IsDelegate for cDAC

### DIFF
--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -114,6 +114,8 @@ partial interface IRuntimeTypeSystem : IContract
     bool IsValueType(TypeHandle typeHandle);
     // return true if the TypeHandle represents an enum type.
     bool IsEnum(TypeHandle typeHandle);
+    // return true if the TypeHandle represents a delegate type (i.e., its parent is System.MulticastDelegate)
+    bool IsDelegate(TypeHandle typeHandle);
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.
     bool IsArray(TypeHandle typeHandle, out uint rank);
     TypeHandle GetTypeParam(TypeHandle typeHandle);
@@ -459,6 +461,7 @@ The contract depends on the following globals
 | `ContinuationMethodTable` | A pointer to the address of the base `Continuation` `MethodTable`, or null if no continuations have been created
 | `ContinuationSingletonEEClass` | A pointer to the address of the singleton `EEClass` shared by continuation subtypes that have no metadata of their own
 | `FreeObjectMethodTable` | A pointer to the address of a `MethodTable` used by the GC to indicate reclaimed memory
+| `MulticastDelegateMethodTable` | A pointer to the address of the `System.MulticastDelegate` `MethodTable` (`g_pMulticastDelegateClass`)
 | `ObjectMethodTable` | A pointer to the address of the `System.Object` `MethodTable` (`g_pObjectClass`)
 | `StaticsPointerMask` | For masking out a bit of DynamicStaticsInfo pointer fields
 | `ArrayBaseSize` | The base size of an array object; used to compute multidimensional array rank from `MethodTable::BaseSize`
@@ -916,6 +919,15 @@ Contracts used:
 
         MethodTable methodTable = _methodTables[typeHandle.Address];
         return methodTable.Flags.GetFlag(WFLAGS_HIGH.Category_Mask) == WFLAGS_HIGH.Category_Primitive;
+    }
+
+    public bool IsDelegate(TypeHandle typeHandle)
+    {
+        if (!typeHandle.IsMethodTable())
+            return false;
+
+        TargetPointer parentMT = GetParentMethodTable(typeHandle);
+        return parentMT == MulticastDelegateMethodTablePointer;
     }
 
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -1557,6 +1557,7 @@ CDAC_GLOBAL_POINTER(ContinuationMethodTable, &::g_pContinuationClassIfSubTypeCre
 CDAC_GLOBAL_POINTER(ContinuationSingletonEEClass, &::g_singletonContinuationEEClass)
 CDAC_GLOBAL_POINTER(ExceptionMethodTable, &::g_pExceptionClass)
 CDAC_GLOBAL_POINTER(FreeObjectMethodTable, &::g_pFreeObjectMethodTable)
+CDAC_GLOBAL_POINTER(MulticastDelegateMethodTable, &::g_pMulticastDelegateClass)
 CDAC_GLOBAL_POINTER(ObjectMethodTable, &::g_pObjectClass)
 CDAC_GLOBAL_POINTER(ObjectArrayMethodTable, &::g_pPredefinedArrayTypes[ELEMENT_TYPE_OBJECT])
 CDAC_GLOBAL_POINTER(StringMethodTable, &::g_pStringClass)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -188,6 +188,9 @@ public interface IRuntimeTypeSystem : IContract
     // return true if the TypeHandle represents an enum type.
     bool IsEnum(TypeHandle typeHandle) => throw new NotImplementedException();
 
+    // return true if the TypeHandle represents a delegate type (i.e., its parent is System.MulticastDelegate)
+    bool IsDelegate(TypeHandle typeHandle) => throw new NotImplementedException();
+
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.
     bool IsArray(TypeHandle typeHandle, out uint rank) => throw new NotImplementedException();
     TypeHandle GetTypeParam(TypeHandle typeHandle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Constants.cs
@@ -38,6 +38,7 @@ public static class Constants
         public const string FreeObjectMethodTable = nameof(FreeObjectMethodTable);
         public const string ObjectMethodTable = nameof(ObjectMethodTable);
         public const string ObjectArrayMethodTable = nameof(ObjectArrayMethodTable);
+        public const string MulticastDelegateMethodTable = nameof(MulticastDelegateMethodTable);
         public const string StringMethodTable = nameof(StringMethodTable);
 
         public const string MiniMetaDataBuffAddress = nameof(MiniMetaDataBuffAddress);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -21,6 +21,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     private readonly TargetPointer _objectMethodTablePointer;
     private readonly TargetPointer _continuationMethodTablePointer;
     private readonly TargetPointer _continuationSingletonEEClassPointer;
+    private readonly TargetPointer _multicastDelegateMethodTablePointer;
     private readonly ulong _methodDescAlignment;
     private readonly TypeValidation _typeValidation;
     private readonly MethodValidation _methodValidation;
@@ -423,6 +424,8 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
             target.ReadGlobalPointer(Constants.Globals.ContinuationMethodTable));
         _continuationSingletonEEClassPointer = target.ReadPointer(
             target.ReadGlobalPointer(Constants.Globals.ContinuationSingletonEEClass));
+        _multicastDelegateMethodTablePointer = target.ReadPointer(
+            target.ReadGlobalPointer(Constants.Globals.MulticastDelegateMethodTable));
         _methodDescAlignment = target.ReadGlobal<ulong>(Constants.Globals.MethodDescAlignment);
         _typeValidation = new TypeValidation(target, _continuationMethodTablePointer, _continuationSingletonEEClassPointer);
         _methodValidation = new MethodValidation(target, _methodDescAlignment);
@@ -926,6 +929,15 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
 
         MethodTable methodTable = _methodTables[typeHandle.Address];
         return methodTable.Flags.GetFlag(MethodTableFlags_1.WFLAGS_HIGH.Category_Mask) == MethodTableFlags_1.WFLAGS_HIGH.Category_Primitive;
+    }
+
+    public bool IsDelegate(TypeHandle typeHandle)
+    {
+        if (!typeHandle.IsMethodTable())
+            return false;
+
+        TargetPointer parentMT = GetParentMethodTable(typeHandle);
+        return parentMT == _multicastDelegateMethodTablePointer;
     }
 
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -3425,8 +3425,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             }
             else
             {
-                TargetPointer objectAddress = new TargetPointer(vmObject);
-                TargetPointer mt = _target.Contracts.Object.GetMethodTableAddress(objectAddress);
+                TargetPointer mt = _target.Contracts.Object.GetMethodTableAddress(vmObject);
                 IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
                 TypeHandle typeHandle = rts.GetTypeHandle(mt);
                 *pResult = rts.IsDelegate(typeHandle) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -3415,7 +3415,39 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     }
 
     public int IsDelegate(ulong vmObject, Interop.BOOL* pResult)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.IsDelegate(vmObject, pResult) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (vmObject == 0)
+            {
+                *pResult = Interop.BOOL.FALSE;
+            }
+            else
+            {
+                TargetPointer objectAddress = new TargetPointer(vmObject);
+                TargetPointer mt = _target.Contracts.Object.GetMethodTableAddress(objectAddress);
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                TypeHandle typeHandle = rts.GetTypeHandle(mt);
+                *pResult = rts.IsDelegate(typeHandle) ? Interop.BOOL.TRUE : Interop.BOOL.FALSE;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            Interop.BOOL pResultLocal;
+            int hrLocal = _legacy.IsDelegate(vmObject, &pResultLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pResult == pResultLocal, $"cDAC: {*pResult}, DAC: {pResultLocal}");
+        }
+#endif
+        return hr;
+    }
 
     public int GetDelegateType(ulong delegateObject, int* delegateType)
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetDelegateType(delegateObject, delegateType) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -37,6 +37,7 @@ public class MethodTableTests
             (nameof(Constants.Globals.ContinuationMethodTable), rtsBuilder.ContinuationMethodTableGlobalAddress),
             (nameof(Constants.Globals.ContinuationSingletonEEClass), rtsBuilder.ContinuationSingletonEEClassGlobalAddress),
             (nameof(Constants.Globals.ObjectMethodTable), rtsBuilder.ObjectMethodTableGlobalAddress),
+            (nameof(Constants.Globals.MulticastDelegateMethodTable), rtsBuilder.MulticastDelegateMethodTableGlobalAddress),
             (nameof(Constants.Globals.MethodDescAlignment), rtsBuilder.MethodDescAlignment),
             (nameof(Constants.Globals.ArrayBaseSize), rtsBuilder.ArrayBaseSize),
         ];
@@ -135,6 +136,44 @@ public class MethodTableTests
         Assert.Equal(systemStringMethodTablePtr.Value, systemStringTypeHandle.Address.Value);
         Assert.False(contract.IsFreeObjectMethodTable(systemStringTypeHandle));
         Assert.True(contract.IsString(systemStringTypeHandle));
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void ValidateIsDelegate(MockTarget.Architecture arch)
+    {
+        TargetPointer multicastDelegateMTPtr = default;
+        TargetPointer delegateMTPtr = default;
+        TargetPointer systemObjectMTPtr = default;
+        TestPlaceholderTarget target = CreateTarget(
+            arch,
+            rtsBuilder =>
+            {
+                systemObjectMTPtr = rtsBuilder.SystemObjectMethodTable.Address;
+
+                MockMethodTable AddSimpleType(string name, ulong parentMT)
+                {
+                    MockEEClass eeClass = rtsBuilder.AddEEClass(name);
+                    MockMethodTable mt = rtsBuilder.AddMethodTable(name);
+                    mt.BaseSize = rtsBuilder.Builder.TargetTestHelpers.ObjectBaseSize;
+                    mt.ParentMethodTable = parentMT;
+                    eeClass.MethodTable = mt.Address;
+                    mt.EEClassOrCanonMT = eeClass.Address;
+                    return mt;
+                }
+
+                MockMethodTable multicastDelegateMT = AddSimpleType("System.MulticastDelegate", systemObjectMTPtr);
+                multicastDelegateMTPtr = multicastDelegateMT.Address;
+                rtsBuilder.SetMulticastDelegateMethodTable(multicastDelegateMT.Address);
+
+                delegateMTPtr = AddSimpleType("MyDelegate", multicastDelegateMT.Address).Address;
+            });
+
+        IRuntimeTypeSystem contract = target.Contracts.RuntimeTypeSystem;
+
+        Assert.True(contract.IsDelegate(contract.GetTypeHandle(delegateMTPtr)));
+        Assert.False(contract.IsDelegate(contract.GetTypeHandle(multicastDelegateMTPtr)));
+        Assert.False(contract.IsDelegate(contract.GetTypeHandle(systemObjectMTPtr)));
     }
 
     [Theory]

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.RuntimeTypeSystem.cs
@@ -302,6 +302,7 @@ internal partial class MockDescriptors
         internal const ulong TestContinuationMethodTableGlobalAddress = 0x00000000_7a0000b0;
         internal const ulong TestContinuationSingletonEEClassGlobalAddress = 0x00000000_7a0000b8;
         internal const ulong TestObjectMethodTableGlobalAddress = 0x00000000_7a0000c0;
+        internal const ulong TestMulticastDelegateMethodTableGlobalAddress = 0x00000000_7a0000c8;
 
         private const ulong DefaultAllocationRangeStart = 0x00000000_4a000000;
         private const ulong DefaultAllocationRangeEnd = 0x00000000_4b000000;
@@ -330,6 +331,7 @@ internal partial class MockDescriptors
         internal ulong ContinuationMethodTableGlobalAddress => TestContinuationMethodTableGlobalAddress;
         internal ulong ContinuationSingletonEEClassGlobalAddress => TestContinuationSingletonEEClassGlobalAddress;
         internal ulong ObjectMethodTableGlobalAddress => TestObjectMethodTableGlobalAddress;
+        internal ulong MulticastDelegateMethodTableGlobalAddress => TestMulticastDelegateMethodTableGlobalAddress;
         internal ulong MethodDescAlignment => GetMethodDescAlignment(Builder.TargetTestHelpers);
         internal ulong ArrayBaseSize => Builder.TargetTestHelpers.ArrayBaseBaseSize;
         // sizeof(ContinuationObject) = sizeof(MT*) + sizeof(Next*) + sizeof(Resume*) + sizeof(Flags) + sizeof(State)
@@ -363,6 +365,7 @@ internal partial class MockDescriptors
             AddFreeObjectMethodTable();
             AddContinuationMethodTableGlobal();
             AddObjectMethodTableGlobal();
+            AddMulticastDelegateMethodTableGlobal();
         }
 
         private void AddDefaultTypes()
@@ -388,6 +391,11 @@ internal partial class MockDescriptors
         {
             // Initialized to 0; patched to point to SystemObjectMethodTable in AddSystemObjectType.
             AddPointerGlobal("Address of Object Method Table", TestObjectMethodTableGlobalAddress, 0);
+        }
+
+        private void AddMulticastDelegateMethodTableGlobal()
+        {
+            AddPointerGlobal("Address of MulticastDelegate Method Table", TestMulticastDelegateMethodTableGlobalAddress, 0);
         }
 
         private void AddSystemObjectType()
@@ -447,6 +455,12 @@ internal partial class MockDescriptors
         {
             Span<byte> globalAddrBytes = Builder.BorrowAddressRange(TestContinuationSingletonEEClassGlobalAddress, Builder.TargetTestHelpers.PointerSize);
             Builder.TargetTestHelpers.WritePointer(globalAddrBytes, continuationSingletonEEClass);
+        }
+
+        internal void SetMulticastDelegateMethodTable(ulong multicastDelegateMethodTable)
+        {
+            Span<byte> globalAddrBytes = Builder.BorrowAddressRange(TestMulticastDelegateMethodTableGlobalAddress, Builder.TargetTestHelpers.PointerSize);
+            Builder.TargetTestHelpers.WritePointer(globalAddrBytes, multicastDelegateMethodTable);
         }
 
         internal MockEEClass AddEEClass(string name)


### PR DESCRIPTION
### Summary 
Implements IRuntimeTypeSystem.IsDelegate in the cDAC, replacing the legacy DAC fallback in DacDbiImpl. A type is considered a delegate if its parent MethodTable is System.MulticastDelegate, matching existing native behavior.

### Changes
- Added MulticastDelegateMethodTable global pointer to datadescriptor.inc
- Added IsDelegate to the IRuntimeTypeSystem contract interface and RuntimeTypeSystem_1 implementation
- Implemented DacDbiImpl.IsDelegate using the new contract method
- Documented the new API and global in RuntimeTypeSystem.md
- Added unit tests validating delegate, non-delegate, and MulticastDelegate-itself cases