### PR TITLE
[cDAC] Add single-file application dump tests

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
@@ -129,6 +129,7 @@ internal sealed class ClrMdDumpHost : IDisposable
     /// </summary>
     public ulong FindContractDescriptorAddress()
     {
+        // First pass: check known runtime module names (fast path for normal deployments).
         foreach (ModuleInfo module in _dataTarget.DataReader.EnumerateModules())
         {
             string? fileName = module.FileName;
@@ -143,20 +144,37 @@ internal sealed class ClrMdDumpHost : IDisposable
             if (!IsRuntimeModule(name))
                 continue;
 
-            ulong address = module.GetExportSymbolAddress("DotNetRuntimeContractDescriptor");
+            ulong address = TryGetContractDescriptor(module);
             if (address != 0)
-            {
-                // ClrMD may return addresses with spurious upper bits on 32-bit targets
-                // (observed on ARM32 ELF). Mask to the target's pointer size.
-                // https://github.com/microsoft/clrmd/issues/1407
-                if (_dataTarget.DataReader.PointerSize == 4)
-                    address &= 0xFFFF_FFFF;
-
                 return address;
-            }
         }
 
-        throw new InvalidOperationException("Could not find DotNetRuntimeContractDescriptor export in any runtime module in the dump.");
+        // Second pass: scan all modules. In single-file bundles the runtime is
+        // embedded in the apphost, so the module name is the app exe (e.g.,
+        // "BasicThreads.exe") rather than "coreclr.dll".
+        foreach (ModuleInfo module in _dataTarget.DataReader.EnumerateModules())
+        {
+            ulong address = TryGetContractDescriptor(module);
+            if (address != 0)
+                return address;
+        }
+
+        throw new InvalidOperationException("Could not find DotNetRuntimeContractDescriptor export in any module in the dump.");
+    }
+
+    private ulong TryGetContractDescriptor(ModuleInfo module)
+    {
+        ulong address = module.GetExportSymbolAddress("DotNetRuntimeContractDescriptor");
+        if (address != 0)
+        {
+            // ClrMD may return addresses with spurious upper bits on 32-bit targets
+            // (observed on ARM32 ELF). Mask to the target's pointer size.
+            // https://github.com/microsoft/clrmd/issues/1407
+            if (_dataTarget.DataReader.PointerSize == 4)
+                address &= 0xFFFF_FFFF;
+        }
+
+        return address;
     }
 
     private string? FindFileOnDisk(string modulePath)

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/BasicThreads/BasicThreads.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/BasicThreads/BasicThreads.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <DumpTypes>Heap;Full</DumpTypes>
+    <PublishModes>Normal;SingleFile</PublishModes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.props
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.props
@@ -19,6 +19,12 @@
          Jit runs with DOTNET_ReadyToRun=0 to force JIT compilation.
          Binaries are always compiled with R2R; this controls runtime behavior only. -->
     <R2RModes Condition="'$(R2RModes)' == ''">R2R</R2RModes>
+    <!-- Default publish mode for dump generation. Override per-debuggee csproj as needed.
+         Supported values: "Normal", "SingleFile", or "Normal;SingleFile" for both.
+         Normal is a framework-dependent publish (run via testhost).
+         SingleFile is a self-contained single-file publish (bundled apphost).
+         SingleFile is cross-producted with R2RModes, e.g. singlefile-r2r, singlefile-jit. -->
+    <PublishModes Condition="'$(PublishModes)' == ''">Normal</PublishModes>
     <!-- Set to true in a debuggee csproj to exclude it from non-Windows platforms. -->
     <WindowsOnly Condition="'$(WindowsOnly)' == ''">false</WindowsOnly>
   </PropertyGroup>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.targets
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/Directory.Build.targets
@@ -24,6 +24,7 @@
       <_DumpTypeOutput Include="$(MSBuildProjectName)"
                        DumpTypes="$(DumpTypes)"
                        R2RModes="$(R2RModes)"
+                       PublishModes="$(PublishModes)"
                        EnvironmentVariables="$(EnvironmentVariables)"
                        WindowsOnly="$(WindowsOnly)"
                        MacOnly="$(MacOnly)"

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/StackWalk/StackWalk.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/StackWalk/StackWalk.csproj
@@ -2,5 +2,6 @@
   <PropertyGroup>
     <DumpTypes>Heap</DumpTypes>
     <R2RModes>R2R;Jit</R2RModes>
+    <PublishModes>Normal;SingleFile</PublishModes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/TypeHierarchy/TypeHierarchy.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/TypeHierarchy/TypeHierarchy.csproj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <PublishModes>Normal;SingleFile</PublishModes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -31,22 +31,28 @@ public abstract class DumpTestBase : IDisposable
     private static readonly string[] RuntimeVersions = ["local", "net10.0"];
 
     /// <summary>
-    /// The set of runtime versions and R2R modes to test against.
+    /// The set of runtime versions, R2R modes, and publish modes to test against.
     /// Each entry produces a separate test invocation via <c>[MemberData]</c>.
-    /// R2R modes are provided by <see cref="GetR2RModes"/>, which currently yields
-    /// both <c>"r2r"</c> and <c>"jit"</c> for each runtime version.
+    /// Missing dumps are auto-skipped via <see cref="SkipTestException"/>.
     /// </summary>
     public static IEnumerable<object[]> TestConfigurations
     {
         get
         {
             string? dumpSource = GetDumpSource();
-            foreach (string r2rMode in GetR2RModes())
+            foreach (string publishMode in GetPublishModes())
             {
-                foreach (string version in RuntimeVersions)
+                foreach (string r2rMode in GetR2RModes())
                 {
-                    if (!IsVersionSkipped(version))
-                        yield return [new TestConfiguration(version, r2rMode, dumpSource)];
+                    foreach (string version in RuntimeVersions)
+                    {
+                        // SingleFile is only supported for local builds
+                        if (publishMode == "singlefile" && version != "local")
+                            continue;
+
+                        if (!IsVersionSkipped(version))
+                            yield return [new TestConfiguration(version, r2rMode, publishMode, dumpSource)];
+                    }
                 }
             }
         }
@@ -95,12 +101,12 @@ public abstract class DumpTestBase : IDisposable
 
         EvaluateSkipAttributes(config, callerName, dumpType);
 
-        string dumpPath = Path.Combine(versionDir, dumpType, config.R2RMode, debuggeeName, $"{debuggeeName}.dmp");
+        string dumpPath = Path.Combine(versionDir, dumpType, config.CompoundDirName, debuggeeName, $"{debuggeeName}.dmp");
 
         if (!File.Exists(dumpPath))
         {
-            if (_dumpInfo is not null && _dumpInfo.IsDumpExpected(debuggeeName, dumpType, config.R2RMode))
-                Assert.Fail($"Expected {config.R2RMode}/{dumpType} dump for {debuggeeName} but not found: {dumpPath}");
+            if (_dumpInfo is not null && _dumpInfo.IsDumpExpected(debuggeeName, dumpType, config.CompoundDirName))
+                Assert.Fail($"Expected {config.CompoundDirName}/{dumpType} dump for {debuggeeName} but not found: {dumpPath}");
 
             throw new SkipTestException($"No {config.R2RMode} dump for {debuggeeName}: {dumpPath}");
         }
@@ -239,6 +245,16 @@ public abstract class DumpTestBase : IDisposable
     {
         yield return "r2r";
         yield return "jit";
+    }
+
+    /// <summary>
+    /// Returns the publish modes to test against. Both modes are always enumerated;
+    /// dumps that don't exist for a given mode are skipped via <see cref="SkipTestException"/>.
+    /// </summary>
+    private static IEnumerable<string> GetPublishModes()
+    {
+        yield return "normal";
+        yield return "singlefile";
     }
 
     /// <summary>

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -108,7 +108,7 @@ public abstract class DumpTestBase : IDisposable
             if (_dumpInfo is not null && _dumpInfo.IsDumpExpected(debuggeeName, dumpType, config.CompoundDirName))
                 Assert.Fail($"Expected {config.CompoundDirName}/{dumpType} dump for {debuggeeName} but not found: {dumpPath}");
 
-            throw new SkipTestException($"No {config.R2RMode} dump for {debuggeeName}: {dumpPath}");
+            throw new SkipTestException($"No {config.CompoundDirName} dump for {debuggeeName}: {dumpPath}");
         }
 
         _host = ClrMdDumpHost.Open(dumpPath, GetSymbolPaths(debuggeeName, versionDir));

--- a/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
@@ -150,7 +150,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GenerateDumpsForDebuggee"
-             Properties="DebuggeeName=%(_DebuggeeWithDumpTypes.Identity);_DebuggeeDumpTypes=%(_DebuggeeWithDumpTypes.DumpTypes);_DebuggeeR2RModes=%(_DebuggeeWithDumpTypes.R2RModes);_DebuggeeEnvVars=$([MSBuild]::Escape('%(_DebuggeeWithDumpTypes.EnvironmentVariables)'))" />
+             Properties="DebuggeeName=%(_DebuggeeWithDumpTypes.Identity);_DebuggeeDumpTypes=%(_DebuggeeWithDumpTypes.DumpTypes);_DebuggeeR2RModes=%(_DebuggeeWithDumpTypes.R2RModes);_DebuggeePublishModes=%(_DebuggeeWithDumpTypes.PublishModes);_DebuggeeEnvVars=$([MSBuild]::Escape('%(_DebuggeeWithDumpTypes.EnvironmentVariables)'))" />
 
     <!-- Write dump-info.json into each version directory so tests can determine
          the OS/arch the dumps were generated on. -->
@@ -172,9 +172,13 @@
       <_DumpInfoHeap Include="@(_DumpInfoDebuggeeTypes)" Condition="$([System.String]::new('%(DumpTypes)').Contains('Heap')) AND '$(DumpRuntimeVersion)' != 'net10.0'" DumpDir="heap" />
       <_DumpInfoFull Include="@(_DumpInfoDebuggeeTypes)" Condition="$([System.String]::new('%(DumpTypes)').Contains('Full'))" DumpDir="full" />
       <_DumpInfoByType Include="@(_DumpInfoHeap);@(_DumpInfoFull)" />
-      <_DumpInfoR2R Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R'))" R2RDir="r2r" />
-      <_DumpInfoJit Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit'))" R2RDir="jit" />
-      <_DumpInfoAll Include="@(_DumpInfoR2R);@(_DumpInfoJit)" />
+      <!-- Normal publish mode: r2r and jit directories -->
+      <_DumpInfoR2R Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R')) AND $([System.String]::new('%(PublishModes)').Contains('Normal'))" R2RDir="r2r" />
+      <_DumpInfoJit Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit')) AND $([System.String]::new('%(PublishModes)').Contains('Normal'))" R2RDir="jit" />
+      <!-- SingleFile publish mode: compound directory names (only for local version) -->
+      <_DumpInfoSingleFileR2R Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R')) AND $([System.String]::new('%(PublishModes)').Contains('SingleFile')) AND '$(DumpRuntimeVersion)' == 'local'" R2RDir="singlefile-r2r" />
+      <_DumpInfoSingleFileJit Include="@(_DumpInfoByType)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit')) AND $([System.String]::new('%(PublishModes)').Contains('SingleFile')) AND '$(DumpRuntimeVersion)' == 'local'" R2RDir="singlefile-jit" />
+      <_DumpInfoAll Include="@(_DumpInfoR2R);@(_DumpInfoJit);@(_DumpInfoSingleFileR2R);@(_DumpInfoSingleFileJit)" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -193,11 +197,24 @@
 
   <!-- Build all debuggees with R2R without running them (for Helix payload preparation).
        Uses dotnet publish (via Exec) with ReadyToRun enabled to produce R2R-compiled
-       framework-dependent binaries. Invoke explicitly: dotnet msbuild /t:BuildDebuggeesOnly -->
+       framework-dependent binaries. Also publishes single-file variants for debuggees
+       that opt in via PublishModes=Normal;SingleFile.
+       Invoke explicitly: dotnet msbuild /t:BuildDebuggeesOnly -->
   <Target Name="BuildDebuggeesOnly">
+    <!-- Normal (framework-dependent) publish for all debuggees -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_PublishSingleDebuggee"
              Properties="_DebuggeeCsproj=%(DebuggeeCsproj.Identity);DebuggeeName=%(DebuggeeCsproj.Filename)" />
+    <!-- Single-file publish for opted-in debuggees -->
+    <MSBuild Projects="@(DebuggeeCsproj)"
+             Targets="GetDumpTypes"
+             Properties="Configuration=$(DebuggeeConfiguration)">
+      <Output TaskParameter="TargetOutputs" ItemName="_BuildDebuggeeWithTypes" />
+    </MSBuild>
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_PublishSingleFileDebuggee"
+             Properties="_DebuggeeCsproj=%(_BuildDebuggeeWithTypes.ProjectPath);DebuggeeName=%(_BuildDebuggeeWithTypes.Identity)"
+             Condition="$([System.String]::new('%(_BuildDebuggeeWithTypes.PublishModes)').Contains('SingleFile'))" />
   </Target>
 
   <Target Name="_PublishSingleDebuggee">
@@ -205,6 +222,13 @@
       <_PublishOutDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)'))</_PublishOutDir>
     </PropertyGroup>
     <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --no-self-contained /p:PublishReadyToRun=true $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishOutDir)&quot;" />
+  </Target>
+
+  <Target Name="_PublishSingleFileDebuggee">
+    <PropertyGroup>
+      <_PublishOutDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)-singlefile'))</_PublishOutDir>
+    </PropertyGroup>
+    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --self-contained /p:PublishSingleFile=true /p:PublishReadyToRun=true $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishOutDir)&quot;" />
   </Target>
 
   <Target Name="_GenerateDumpsForDebuggee">
@@ -216,7 +240,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GenerateDumpsForDumpType"
-             Properties="DebuggeeName=$(DebuggeeName);_DumpTypeName=%(_DumpTypeItem.Identity);_DebuggeeR2RModes=$(_DebuggeeR2RModes);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))" />
+             Properties="DebuggeeName=$(DebuggeeName);_DumpTypeName=%(_DumpTypeItem.Identity);_DebuggeeR2RModes=$(_DebuggeeR2RModes);_DebuggeePublishModes=$(_DebuggeePublishModes);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))" />
   </Target>
 
   <Target Name="_GenerateDumpsForDumpType">
@@ -228,6 +252,18 @@
       <_DumpTypeDirName Condition="'$(_DumpTypeName)' == 'Full'">full</_DumpTypeDirName>
     </PropertyGroup>
 
+    <!-- Expand PublishModes (e.g. "Normal;SingleFile") into individual _PublishModeItem entries -->
+    <ItemGroup>
+      <_PublishModeItem Remove="@(_PublishModeItem)" />
+      <_PublishModeItem Include="$(_DebuggeePublishModes)" />
+    </ItemGroup>
+
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_GenerateDumpsForPublishMode"
+             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DumpTypeDirName=$(_DumpTypeDirName);_DumpTypeName=$(_DumpTypeName);_DebuggeeR2RModes=$(_DebuggeeR2RModes);_PublishModeName=%(_PublishModeItem.Identity);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))" />
+  </Target>
+
+  <Target Name="_GenerateDumpsForPublishMode">
     <!-- Expand R2RModes (e.g. "R2R;Jit") into individual _R2RModeItem entries -->
     <ItemGroup>
       <_R2RModeItem Remove="@(_R2RModeItem)" />
@@ -236,7 +272,7 @@
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GenerateDumpsForR2RMode"
-             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DumpTypeDirName=$(_DumpTypeDirName);_DumpTypeName=$(_DumpTypeName);_R2RModeName=%(_R2RModeItem.Identity);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))" />
+             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DumpTypeDirName=$(_DumpTypeDirName);_DumpTypeName=$(_DumpTypeName);_PublishModeName=$(_PublishModeName);_R2RModeName=%(_R2RModeItem.Identity);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))" />
   </Target>
 
   <Target Name="_GenerateDumpsForR2RMode">
@@ -246,13 +282,18 @@
       <_R2RValue Condition="'$(_R2RModeName)' == 'Jit'">0</_R2RValue>
       <_R2RDirName Condition="'$(_R2RModeName)' == 'R2R'">r2r</_R2RDirName>
       <_R2RDirName Condition="'$(_R2RModeName)' == 'Jit'">jit</_R2RDirName>
+      <!-- For SingleFile publish mode, prefix the R2R dir name (e.g., singlefile-r2r) -->
+      <_CompoundDirName Condition="'$(_PublishModeName)' == 'Normal'">$(_R2RDirName)</_CompoundDirName>
+      <_CompoundDirName Condition="'$(_PublishModeName)' == 'SingleFile'">singlefile-$(_R2RDirName)</_CompoundDirName>
     </PropertyGroup>
 
     <Error Condition="'$(_R2RValue)' == '' Or '$(_R2RDirName)' == ''"
            Text="Invalid R2R mode '$(_R2RModeName)' specified for debuggee '$(DebuggeeName)'. Supported values: 'R2R', 'Jit'." />
+    <Error Condition="'$(_CompoundDirName)' == ''"
+           Text="Invalid publish mode '$(_PublishModeName)' specified for debuggee '$(DebuggeeName)'. Supported values: 'Normal', 'SingleFile'." />
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GenerateSingleDump"
-             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DumpTypeDirName=$(_DumpTypeDirName);_DumpTypeName=$(_DumpTypeName);_R2RValue=$(_R2RValue);_R2RDirName=$(_R2RDirName);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'));DumpRuntimeVersion=%(DumpRuntimeVersion.Identity)" />
+             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DumpTypeDirName=$(_DumpTypeDirName);_DumpTypeName=$(_DumpTypeName);_R2RValue=$(_R2RValue);_R2RDirName=$(_CompoundDirName);_PublishModeName=$(_PublishModeName);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'));DumpRuntimeVersion=%(DumpRuntimeVersion.Identity)" />
   </Target>
 
   <Target Name="_GenerateSingleDump">
@@ -268,16 +309,26 @@
     <!-- Skip heap dumps for net10.0 — cDAC is not supported in heap dumps for that version. -->
     <Message Text="[$(_DumpTypeName)] Skipping heap dump for $(DumpRuntimeVersion) (not supported)." Condition="'$(_DumpTypeName)' == 'Heap' AND '$(DumpRuntimeVersion)' == 'net10.0'" Importance="high" />
 
-    <!-- Determine build/run strategy based on runtime version -->
+    <!-- Skip single-file for non-local versions (single-file requires local runtime packs) -->
+    <Message Text="[$(_DumpTypeName)] Skipping single-file dump for $(DumpRuntimeVersion) (only supported for local)." Condition="'$(_PublishModeName)' == 'SingleFile' AND '$(DumpRuntimeVersion)' != 'local'" Importance="high" />
+
+    <!-- Normal publish mode: framework-dependent, run via testhost -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GenerateLocalDump"
              Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DebuggeeDir=$(_DebuggeeDir);_DumpDir=$(_DumpDir);_DumpFile=$(_DumpFile);_R2RValue=$(_R2RValue);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))"
-             Condition="!Exists('$(_DumpFile)') AND '$(DumpRuntimeVersion)' == 'local'" />
+             Condition="!Exists('$(_DumpFile)') AND '$(DumpRuntimeVersion)' == 'local' AND '$(_PublishModeName)' != 'SingleFile'" />
 
+    <!-- SingleFile publish mode: self-contained single-file, run exe directly -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="_GenerateSingleFileDump"
+             Properties="DebuggeeName=$(DebuggeeName);_MiniDumpType=$(_MiniDumpType);_DebuggeeDir=$(_DebuggeeDir);_DumpDir=$(_DumpDir);_DumpFile=$(_DumpFile);_R2RValue=$(_R2RValue);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))"
+             Condition="!Exists('$(_DumpFile)') AND '$(DumpRuntimeVersion)' == 'local' AND '$(_PublishModeName)' == 'SingleFile'" />
+
+    <!-- Released runtime (net10.0): self-contained publish, run exe directly -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="_GeneratePublishedDump"
              Properties="DebuggeeName=$(DebuggeeName);DumpRuntimeVersion=$(DumpRuntimeVersion);_MiniDumpType=$(_MiniDumpType);_DebuggeeDir=$(_DebuggeeDir);_DumpDir=$(_DumpDir);_DumpFile=$(_DumpFile);_R2RValue=$(_R2RValue);_DebuggeeEnvVars=$([MSBuild]::Escape('$(_DebuggeeEnvVars)'))"
-             Condition="!Exists('$(_DumpFile)') AND '$(DumpRuntimeVersion)' == 'net10.0' AND '$(_DumpTypeName)' != 'Heap'" />
+             Condition="!Exists('$(_DumpFile)') AND '$(DumpRuntimeVersion)' == 'net10.0' AND '$(_DumpTypeName)' != 'Heap' AND '$(_PublishModeName)' != 'SingleFile'" />
 
     <Message Text="Dump created: $(_DumpFile)" Importance="high" Condition="Exists('$(_DumpFile)')" />
   </Target>
@@ -313,6 +364,29 @@
     </PropertyGroup>
 
     <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(DumpRuntimeVersion) -r $(PortableTargetRid) --self-contained /p:PublishReadyToRun=true --nologo -o &quot;$(_PublishDir)&quot;"
+          WorkingDirectory="$(_DebuggeeDir)" />
+
+    <MakeDir Directories="$(_DumpDir)" />
+
+    <Exec Command="&quot;$(_PublishedExe)&quot;"
+          WorkingDirectory="$(_DumpDir)"
+          IgnoreExitCode="true"
+          EnvironmentVariables="DOTNET_DbgEnableMiniDump=1;DOTNET_DbgMiniDumpType=$(_MiniDumpType);DOTNET_DbgMiniDumpName=$(_DumpFile);DOTNET_ReadyToRun=$(_R2RValue);$([MSBuild]::Unescape('$(_DebuggeeEnvVars)'))" />
+
+    <Error Text="Dump file could not be created: $(_DumpFile)" Condition="!Exists('$(_DumpFile)')" />
+  </Target>
+
+  <!-- Local build, single-file: self-contained single-file publish, run the bundled exe directly -->
+  <Target Name="_GenerateSingleFileDump">
+    <PropertyGroup>
+      <_PublishDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)-singlefile'))</_PublishDir>
+      <_DebuggeeCsproj>$([MSBuild]::NormalizePath('$(_DebuggeeDir)', '$(DebuggeeName).csproj'))</_DebuggeeCsproj>
+      <_PublishedExe>$([MSBuild]::NormalizePath('$(_PublishDir)', '$(DebuggeeName)$(ExeSuffix)'))</_PublishedExe>
+      <_R2RPublishFlag Condition="'$(_R2RValue)' == '1'">/p:PublishReadyToRun=true</_R2RPublishFlag>
+      <_R2RPublishFlag Condition="'$(_R2RValue)' != '1'"></_R2RPublishFlag>
+    </PropertyGroup>
+
+    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --self-contained /p:PublishSingleFile=true $(_R2RPublishFlag) $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishDir)&quot;"
           WorkingDirectory="$(_DebuggeeDir)" />
 
     <MakeDir Directories="$(_DumpDir)" />

--- a/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTests.targets
@@ -376,17 +376,17 @@
     <Error Text="Dump file could not be created: $(_DumpFile)" Condition="!Exists('$(_DumpFile)')" />
   </Target>
 
-  <!-- Local build, single-file: self-contained single-file publish, run the bundled exe directly -->
+  <!-- Local build, single-file: self-contained single-file publish, run the bundled exe directly.
+       Always published with ReadyToRun — the jit variant controls R2R at runtime via
+       DOTNET_ReadyToRun=0, matching the existing normal-mode approach in _GenerateLocalDump. -->
   <Target Name="_GenerateSingleFileDump">
     <PropertyGroup>
       <_PublishDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)-singlefile'))</_PublishDir>
       <_DebuggeeCsproj>$([MSBuild]::NormalizePath('$(_DebuggeeDir)', '$(DebuggeeName).csproj'))</_DebuggeeCsproj>
       <_PublishedExe>$([MSBuild]::NormalizePath('$(_PublishDir)', '$(DebuggeeName)$(ExeSuffix)'))</_PublishedExe>
-      <_R2RPublishFlag Condition="'$(_R2RValue)' == '1'">/p:PublishReadyToRun=true</_R2RPublishFlag>
-      <_R2RPublishFlag Condition="'$(_R2RValue)' != '1'"></_R2RPublishFlag>
     </PropertyGroup>
 
-    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --self-contained /p:PublishSingleFile=true $(_R2RPublishFlag) $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishDir)&quot;"
+    <Exec Command="&quot;$(_DotNetExe)&quot; publish &quot;$(_DebuggeeCsproj)&quot; -c $(DebuggeeConfiguration) -f $(NetCoreAppCurrent) -r $(PortableTargetRid) --self-contained /p:PublishSingleFile=true /p:PublishReadyToRun=true $(_DebuggeePublishProps) --nologo -o &quot;$(_PublishDir)&quot;"
           WorkingDirectory="$(_DebuggeeDir)" />
 
     <MakeDir Directories="$(_DumpDir)" />

--- a/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
@@ -95,16 +95,20 @@
       <_HeapDebuggee Include="@(_DebuggeeWithTypes)" Condition="$([System.String]::new('%(DumpTypes)').Contains('Heap'))" DumpDir="heap" MiniDumpType="2" />
       <_FullDebuggee Include="@(_DebuggeeWithTypes)" Condition="$([System.String]::new('%(DumpTypes)').Contains('Full'))" DumpDir="full" MiniDumpType="4" />
       <_DumpTypeDebuggee Include="@(_HeapDebuggee);@(_FullDebuggee)" />
-      <!-- Cross-product DumpType × R2RMode -->
-      <_R2RDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R'))" R2RDir="r2r" R2RValue="1" />
-      <_JitDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit'))" R2RDir="jit" R2RValue="0" />
-      <_AllDebuggeeMetadata Include="@(_R2RDebuggee);@(_JitDebuggee)" />
+      <!-- Cross-product DumpType × PublishMode × R2RMode -->
+      <!-- Normal publish mode -->
+      <_R2RDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R')) AND $([System.String]::new('%(PublishModes)').Contains('Normal'))" R2RDir="r2r" R2RValue="1" IsSingleFile="false" />
+      <_JitDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit')) AND $([System.String]::new('%(PublishModes)').Contains('Normal'))" R2RDir="jit" R2RValue="0" IsSingleFile="false" />
+      <!-- SingleFile publish mode (compound directory names) -->
+      <_SingleFileR2RDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('R2R')) AND $([System.String]::new('%(PublishModes)').Contains('SingleFile'))" R2RDir="singlefile-r2r" R2RValue="1" IsSingleFile="true" />
+      <_SingleFileJitDebuggee Include="@(_DumpTypeDebuggee)" Condition="$([System.String]::new('%(R2RModes)').Contains('Jit')) AND $([System.String]::new('%(PublishModes)').Contains('SingleFile'))" R2RDir="singlefile-jit" R2RValue="0" IsSingleFile="true" />
+      <_AllDebuggeeMetadata Include="@(_R2RDebuggee);@(_JitDebuggee);@(_SingleFileR2RDebuggee);@(_SingleFileJitDebuggee)" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(SkipDebuggeeCopy)' != 'true'">
       <_MetadataLines Include="&lt;Project&gt;" />
       <_MetadataLines Include="  &lt;ItemGroup&gt;" />
-      <_MetadataLines Include="@(_AllDebuggeeMetadata->'    &lt;_Debuggee Include=&quot;%(Identity)&quot; DumpDir=&quot;%(DumpDir)&quot; MiniDumpType=&quot;%(MiniDumpType)&quot; R2RDir=&quot;%(R2RDir)&quot; R2RValue=&quot;%(R2RValue)&quot; EnvironmentVariables=&quot;%(EnvironmentVariables)&quot; /&gt;')" />
+      <_MetadataLines Include="@(_AllDebuggeeMetadata->'    &lt;_Debuggee Include=&quot;%(Identity)&quot; DumpDir=&quot;%(DumpDir)&quot; MiniDumpType=&quot;%(MiniDumpType)&quot; R2RDir=&quot;%(R2RDir)&quot; R2RValue=&quot;%(R2RValue)&quot; IsSingleFile=&quot;%(IsSingleFile)&quot; EnvironmentVariables=&quot;%(EnvironmentVariables)&quot; /&gt;')" />
       <_MetadataLines Include="  &lt;/ItemGroup&gt;" />
       <_MetadataLines Include="&lt;/Project&gt;" />
     </ItemGroup>
@@ -119,11 +123,21 @@
     <PropertyGroup>
       <_DebuggeeBinDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)'))</_DebuggeeBinDir>
       <_HelixDebuggeeDir>$([MSBuild]::NormalizeDirectory('$(_HelixDebuggeesDir)', '$(DebuggeeName)'))</_HelixDebuggeeDir>
+      <_SingleFileBinDir>$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'DumpTests', '$(DebuggeeName)', '$(DebuggeeConfiguration)', '$(NetCoreAppCurrent)-singlefile'))</_SingleFileBinDir>
+      <_HelixSingleFileDir>$([MSBuild]::NormalizeDirectory('$(_HelixDebuggeesDir)', '$(DebuggeeName)-singlefile'))</_HelixSingleFileDir>
     </PropertyGroup>
 
+    <!-- Copy normal (framework-dependent) build output -->
     <ItemGroup>
       <_DebuggeeOutput Include="$(_DebuggeeBinDir)**\*" />
     </ItemGroup>
     <Copy SourceFiles="@(_DebuggeeOutput)" DestinationFolder="$(_HelixDebuggeeDir)%(RecursiveDir)" />
+
+    <!-- Copy single-file build output if it exists -->
+    <ItemGroup>
+      <_SingleFileOutput Include="$(_SingleFileBinDir)**\*" Condition="Exists('$(_SingleFileBinDir)')" />
+    </ItemGroup>
+    <Copy SourceFiles="@(_SingleFileOutput)" DestinationFolder="$(_HelixSingleFileDir)%(RecursiveDir)"
+          Condition="'@(_SingleFileOutput)' != ''" />
   </Target>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
+++ b/src/native/managed/cdac/tests/DumpTests/TestConfiguration.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
 using Xunit.Abstractions;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
@@ -27,6 +28,14 @@ public sealed class TestConfiguration : IXunitSerializable
     public string R2RMode { get; set; } = "r2r";
 
     /// <summary>
+    /// The publish mode for the dump (e.g., "normal", "singlefile").
+    /// "normal" is a framework-dependent publish; "singlefile" is a self-contained
+    /// single-file bundle. Combined with R2RMode to form the directory name
+    /// (e.g., "r2r", "singlefile-r2r").
+    /// </summary>
+    public string PublishMode { get; set; } = "normal";
+
+    /// <summary>
     /// The platform that produced the dump (e.g., "windows_x64", "linux_arm64").
     /// Null for local runs where the host and dump source are the same.
     /// </summary>
@@ -34,20 +43,35 @@ public sealed class TestConfiguration : IXunitSerializable
 
     public TestConfiguration() { }
 
-    public TestConfiguration(string runtimeVersion, string r2rMode, string? dumpSource = null)
+    public TestConfiguration(string runtimeVersion, string r2rMode, string publishMode = "normal", string? dumpSource = null)
     {
         RuntimeVersion = runtimeVersion;
         R2RMode = r2rMode;
+        PublishMode = publishMode;
         DumpSource = dumpSource;
     }
 
-    public override string ToString() =>
-        DumpSource is not null ? $"{RuntimeVersion}/{R2RMode} ({DumpSource})" : $"{RuntimeVersion}/{R2RMode}";
+    /// <summary>
+    /// Returns the compound directory name used in the dump path layout.
+    /// Normal publish mode uses the R2R mode directly (e.g., "r2r", "jit").
+    /// SingleFile publish mode prefixes with "singlefile-" (e.g., "singlefile-r2r").
+    /// </summary>
+    public string CompoundDirName =>
+        PublishMode.Equals("singlefile", StringComparison.OrdinalIgnoreCase)
+            ? $"singlefile-{R2RMode}"
+            : R2RMode;
+
+    public override string ToString()
+    {
+        string mode = PublishMode.Equals("normal", StringComparison.OrdinalIgnoreCase) ? R2RMode : CompoundDirName;
+        return DumpSource is not null ? $"{RuntimeVersion}/{mode} ({DumpSource})" : $"{RuntimeVersion}/{mode}";
+    }
 
     public void Serialize(IXunitSerializationInfo info)
     {
         info.AddValue(nameof(RuntimeVersion), RuntimeVersion);
         info.AddValue(nameof(R2RMode), R2RMode);
+        info.AddValue(nameof(PublishMode), PublishMode);
         info.AddValue(nameof(DumpSource), DumpSource, typeof(string));
     }
 
@@ -55,6 +79,7 @@ public sealed class TestConfiguration : IXunitSerializable
     {
         RuntimeVersion = info.GetValue<string>(nameof(RuntimeVersion));
         R2RMode = info.GetValue<string>(nameof(R2RMode));
+        PublishMode = info.GetValue<string>(nameof(PublishMode));
         DumpSource = info.GetValue<string>(nameof(DumpSource));
     }
 }

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -110,8 +110,12 @@
           Include="set &quot;DOTNET_ReadyToRun=%(_Debuggee.R2RValue)&quot;" />
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows' AND '%(_Debuggee.EnvironmentVariables)' != ''"
           Include="set &quot;$([System.String]::new('%(_Debuggee.EnvironmentVariables)').Replace(';', '&quot; %26 set &quot;'))&quot;" />
-      <_HelixCommandLines Condition="'$(TargetOS)' == 'windows'"
+      <!-- Normal publish: run via dotnet exec -->
+      <_HelixCommandLines Condition="'$(TargetOS)' == 'windows' AND '%(_Debuggee.IsSingleFile)' != 'true'"
           Include="%25HELIX_CORRELATION_PAYLOAD%25\dotnet.exe exec %25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(_Debuggee.Identity)\%(_Debuggee.Identity).dll" />
+      <!-- SingleFile publish: run the bundled exe directly -->
+      <_HelixCommandLines Condition="'$(TargetOS)' == 'windows' AND '%(_Debuggee.IsSingleFile)' == 'true'"
+          Include="%25HELIX_WORKITEM_PAYLOAD%25\debuggees\%(_Debuggee.Identity)-singlefile\%(_Debuggee.Identity).exe" />
       <_HelixCommandLines Condition="'$(TargetOS)' == 'windows' AND '%(_Debuggee.EnvironmentVariables)' != ''"
           Include="endlocal" />
       <!-- Unix: create dir, run debuggee with inline env vars -->
@@ -119,8 +123,12 @@
           Include="mkdir -p $HELIX_WORKITEM_PAYLOAD/dumps/local/%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir)/%(_Debuggee.Identity)" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
           Include="echo &quot;  Generating dump for %(_Debuggee.Identity) (%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir))...&quot;" />
-      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows'"
+      <!-- Normal publish: run via dotnet exec -->
+      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows' AND '%(_Debuggee.IsSingleFile)' != 'true'"
           Include="$([System.String]::new('%(_Debuggee.EnvironmentVariables)').Replace(';', ' ')) DOTNET_DbgMiniDumpType=%(_Debuggee.MiniDumpType) DOTNET_DbgMiniDumpName=$HELIX_WORKITEM_PAYLOAD/dumps/local/%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir)/%(_Debuggee.Identity)/%(_Debuggee.Identity).dmp DOTNET_ReadyToRun=%(_Debuggee.R2RValue) $HELIX_CORRELATION_PAYLOAD/dotnet exec $HELIX_WORKITEM_PAYLOAD/debuggees/%(_Debuggee.Identity)/%(_Debuggee.Identity).dll || true" />
+      <!-- SingleFile publish: run the bundled exe directly -->
+      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows' AND '%(_Debuggee.IsSingleFile)' == 'true'"
+          Include="$([System.String]::new('%(_Debuggee.EnvironmentVariables)').Replace(';', ' ')) DOTNET_DbgMiniDumpType=%(_Debuggee.MiniDumpType) DOTNET_DbgMiniDumpName=$HELIX_WORKITEM_PAYLOAD/dumps/local/%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir)/%(_Debuggee.Identity)/%(_Debuggee.Identity).dmp DOTNET_ReadyToRun=%(_Debuggee.R2RValue) $HELIX_WORKITEM_PAYLOAD/debuggees/%(_Debuggee.Identity)-singlefile/%(_Debuggee.Identity) || true" />
     </ItemGroup>
   </Target>
 

--- a/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
+++ b/src/native/managed/cdac/tests/DumpTests/cdac-dump-helix.proj
@@ -126,7 +126,9 @@
       <!-- Normal publish: run via dotnet exec -->
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows' AND '%(_Debuggee.IsSingleFile)' != 'true'"
           Include="$([System.String]::new('%(_Debuggee.EnvironmentVariables)').Replace(';', ' ')) DOTNET_DbgMiniDumpType=%(_Debuggee.MiniDumpType) DOTNET_DbgMiniDumpName=$HELIX_WORKITEM_PAYLOAD/dumps/local/%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir)/%(_Debuggee.Identity)/%(_Debuggee.Identity).dmp DOTNET_ReadyToRun=%(_Debuggee.R2RValue) $HELIX_CORRELATION_PAYLOAD/dotnet exec $HELIX_WORKITEM_PAYLOAD/debuggees/%(_Debuggee.Identity)/%(_Debuggee.Identity).dll || true" />
-      <!-- SingleFile publish: run the bundled exe directly -->
+      <!-- SingleFile publish: chmod +x and run the bundled exe directly -->
+      <_HelixCommandLines Condition="'$(TargetOS)' != 'windows' AND '%(_Debuggee.IsSingleFile)' == 'true'"
+          Include="chmod +x $HELIX_WORKITEM_PAYLOAD/debuggees/%(_Debuggee.Identity)-singlefile/%(_Debuggee.Identity)" />
       <_HelixCommandLines Condition="'$(TargetOS)' != 'windows' AND '%(_Debuggee.IsSingleFile)' == 'true'"
           Include="$([System.String]::new('%(_Debuggee.EnvironmentVariables)').Replace(';', ' ')) DOTNET_DbgMiniDumpType=%(_Debuggee.MiniDumpType) DOTNET_DbgMiniDumpName=$HELIX_WORKITEM_PAYLOAD/dumps/local/%(_Debuggee.DumpDir)/%(_Debuggee.R2RDir)/%(_Debuggee.Identity)/%(_Debuggee.Identity).dmp DOTNET_ReadyToRun=%(_Debuggee.R2RValue) $HELIX_WORKITEM_PAYLOAD/debuggees/%(_Debuggee.Identity)-singlefile/%(_Debuggee.Identity) || true" />
     </ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> This PR was created with assistance from GitHub Copilot.

## Summary

Adds single-file application dump tests to the cDAC dump test framework. Single-file apps bundle the runtime into one executable, which changes how modules appear in crash dumps -- this was previously untested.

## Changes

### New `PublishModes` dimension

`PublishModes` is a new per-debuggee property (default: `Normal`), orthogonal to the existing `R2RModes` (R2R/Jit). Debuggees opt in with:

```xml
<PublishModes>Normal;SingleFile</PublishModes>
```

This produces compound dump directory names: `singlefile-r2r`, `singlefile-jit`.

### Module discovery fix

`ClrMdDumpHost.FindContractDescriptorAddress()` now has a two-pass scan: first checks known runtime module names (fast path), then falls back to scanning all modules for the `DotNetRuntimeContractDescriptor` export. This handles single-file bundles where coreclr is embedded in the apphost.

### Initial debuggees

Three debuggees opt in as initial coverage:
- **BasicThreads** (Thread contract)
- **StackWalk** (StackWalk contract)
- **TypeHierarchy** (RuntimeTypeSystem contract)

### CI integration

No pipeline YAML changes needed -- the existing `BuildDebuggeesOnly` and `PrepareHelixPayload` MSBuild targets automatically pick up single-file variants for opted-in debuggees. The build stage already includes `host+packs` which builds `singlefilehost`.

### Validation

- Locally validated: single-file dump generated and `ThreadCounts_AreNonNegative(config: local/singlefile-r2r)` passed
- Uses locally-built `singlefilehost` via `targetingpacks.targets` (same mechanism as R2R tests)