### PR TITLE
JIT: Use STL iterator tags instead of custom ones

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5066,12 +5066,6 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
         Statement*  m_stmt;
     };
 
-    // Test
-    jitstd::vector<PredInfo> v(getAllocator(CMK_ArrayStack));
-    std::partition(v.begin(), v.end(), [](PredInfo a) {
-        return true;
-    });
-
     ArrayStack<PredInfo>    predInfo(getAllocator(CMK_ArrayStack));
     ArrayStack<PredInfo>    matchedPredInfo(getAllocator(CMK_ArrayStack));
     ArrayStack<BasicBlock*> retryBlocks(getAllocator(CMK_ArrayStack));

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -5066,6 +5066,12 @@ PhaseStatus Compiler::fgHeadTailMerge(bool early)
         Statement*  m_stmt;
     };
 
+    // Test
+    jitstd::vector<PredInfo> v(getAllocator(CMK_ArrayStack));
+    std::partition(v.begin(), v.end(), [](PredInfo a) {
+        return true;
+    });
+
     ArrayStack<PredInfo>    predInfo(getAllocator(CMK_ArrayStack));
     ArrayStack<PredInfo>    matchedPredInfo(getAllocator(CMK_ArrayStack));
     ArrayStack<BasicBlock*> retryBlocks(getAllocator(CMK_ArrayStack));

--- a/src/coreclr/jit/jitstd/iterator.h
+++ b/src/coreclr/jit/jitstd/iterator.h
@@ -18,22 +18,6 @@ struct iterator
     typedef Category iterator_category;
 };
 
-struct input_iterator_tag
-{
-};
-
-struct forward_iterator_tag : public input_iterator_tag
-{
-};
-
-struct bidirectional_iterator_tag : public forward_iterator_tag
-{
-};
-
-struct random_access_iterator_tag : public bidirectional_iterator_tag
-{
-};
-
 struct int_not_an_iterator_tag
 {
 };
@@ -55,7 +39,7 @@ struct iterator_traits<T*>
     typedef T value_type;
     typedef T* pointer;
     typedef T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    typedef std::random_access_iterator_tag iterator_category;
 };
 
 template <typename T>
@@ -65,7 +49,7 @@ struct iterator_traits<const T*>
     typedef T value_type;
     typedef const T* pointer;
     typedef const T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    typedef std::random_access_iterator_tag iterator_category;
 };
 
 template<>

--- a/src/coreclr/jit/jitstd/list.h
+++ b/src/coreclr/jit/jitstd/list.h
@@ -40,7 +40,7 @@ private:
 public:
     // nested classes
     class iterator;
-    class const_iterator : public jitstd::iterator<bidirectional_iterator_tag, T>
+    class const_iterator : public jitstd::iterator<std::bidirectional_iterator_tag, T>
     {
     private:
         const_iterator(Node* ptr);
@@ -67,7 +67,7 @@ public:
         Node* m_pNode;
     };
 
-    class iterator : public jitstd::iterator<bidirectional_iterator_tag, T>
+    class iterator : public jitstd::iterator<std::bidirectional_iterator_tag, T>
     {
         iterator(Node* ptr);
     public:
@@ -94,7 +94,7 @@ public:
     };
 
     class reverse_iterator;
-    class const_reverse_iterator : public jitstd::iterator<bidirectional_iterator_tag, T>
+    class const_reverse_iterator : public jitstd::iterator<std::bidirectional_iterator_tag, T>
     {
     private:
         const_reverse_iterator(Node* ptr);
@@ -121,7 +121,7 @@ public:
         Node* m_pNode;
     };
 
-    class reverse_iterator : public jitstd::iterator<bidirectional_iterator_tag, T>
+    class reverse_iterator : public jitstd::iterator<std::bidirectional_iterator_tag, T>
     {
     private:
         reverse_iterator(Node* ptr);
@@ -268,15 +268,15 @@ private:
 
     void construct_helper(size_type n, const T& value, int_not_an_iterator_tag);
     template <typename InputIterator>
-    void construct_helper(InputIterator first, InputIterator last, forward_iterator_tag);
+    void construct_helper(InputIterator first, InputIterator last, std::forward_iterator_tag);
 
     void assign_helper(size_type n, const T& value, int_not_an_iterator_tag);
     template <typename InputIterator>
-    void assign_helper(InputIterator first, InputIterator last, forward_iterator_tag);
+    void assign_helper(InputIterator first, InputIterator last, std::forward_iterator_tag);
 
     void insert_helper(iterator position, size_type n, const T& value, int_not_an_iterator_tag);
     template <typename InputIterator>
-    void insert_helper(iterator position, InputIterator first, InputIterator last, forward_iterator_tag);
+    void insert_helper(iterator position, InputIterator first, InputIterator last, std::forward_iterator_tag);
 
     void insert_new_node_helper(Node* pInsert, Node* pNewNode);
 
@@ -332,7 +332,7 @@ list<T, Allocator>::list(const list<T, Allocator>& other)
     , m_allocator(other.m_allocator)
     , m_nodeAllocator(other.m_nodeAllocator)
 {
-    construct_helper(other.begin(), other.end(), forward_iterator_tag());
+    construct_helper(other.begin(), other.end(), std::forward_iterator_tag());
 }
 
 template <typename T, typename Allocator>
@@ -551,7 +551,7 @@ template <typename T, typename Allocator>
 list<T, Allocator>& list<T, Allocator>::operator=(const list<T, Allocator>& lst)
 {
     destroy_helper();
-    construct_helper(lst.begin(), lst.end(), forward_iterator_tag());
+    construct_helper(lst.begin(), lst.end(), std::forward_iterator_tag());
     return *this;
 }
 
@@ -803,7 +803,7 @@ void list<T, Allocator>::construct_helper(size_type n, const T& value, int_not_a
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void list<T, Allocator>::construct_helper(InputIterator first, InputIterator last, forward_iterator_tag)
+void list<T, Allocator>::construct_helper(InputIterator first, InputIterator last, std::forward_iterator_tag)
 {
     while (first != last)
     {
@@ -824,7 +824,7 @@ void list<T, Allocator>::assign_helper(size_type n, const T& value, int_not_an_i
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void list<T, Allocator>::assign_helper(InputIterator first, InputIterator last, forward_iterator_tag)
+void list<T, Allocator>::assign_helper(InputIterator first, InputIterator last, std::forward_iterator_tag)
 {
     destroy_helper();
     while (first != last)
@@ -845,7 +845,10 @@ void list<T, Allocator>::insert_helper(iterator position, size_type n, const T& 
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void list<T, Allocator>::insert_helper(iterator position, InputIterator first, InputIterator last, forward_iterator_tag)
+void list<T, Allocator>::insert_helper(iterator      position,
+                                       InputIterator first,
+                                       InputIterator last,
+                                       std::forward_iterator_tag)
 {
     while (first != last)
     {

--- a/src/coreclr/jit/jitstd/vector.h
+++ b/src/coreclr/jit/jitstd/vector.h
@@ -33,7 +33,7 @@ public:
     typedef T value_type;
 
     // nested classes
-    class iterator : public jitstd::iterator<random_access_iterator_tag, T>
+    class iterator : public jitstd::iterator<std::random_access_iterator_tag, T>
     {
         iterator(T* ptr);
     public:
@@ -58,7 +58,7 @@ public:
         pointer m_pElem;
     };
 
-    class const_iterator : public jitstd::iterator<random_access_iterator_tag, T>
+    class const_iterator : public jitstd::iterator<std::random_access_iterator_tag, T>
     {
     private:
         const_iterator(T* ptr);
@@ -84,7 +84,7 @@ public:
         pointer m_pElem;
     };
 
-    class reverse_iterator : public jitstd::iterator<random_access_iterator_tag, T>
+    class reverse_iterator : public jitstd::iterator<std::random_access_iterator_tag, T>
     {
     private:
         reverse_iterator(T* ptr);
@@ -110,7 +110,7 @@ public:
         pointer m_pElem;
     };
 
-    class const_reverse_iterator : public jitstd::iterator<random_access_iterator_tag, T>
+    class const_reverse_iterator : public jitstd::iterator<std::random_access_iterator_tag, T>
     {
     private:
         const_reverse_iterator(T* ptr);
@@ -233,19 +233,19 @@ private:
     bool ensure_capacity(size_type capacity);
 
     template <typename InputIterator>
-    void construct_helper(InputIterator first, InputIterator last, forward_iterator_tag);
+    void construct_helper(InputIterator first, InputIterator last, std::forward_iterator_tag);
     template <typename InputIterator>
     void construct_helper(InputIterator first, InputIterator last, int_not_an_iterator_tag);
     void construct_helper(size_type size, const T& value);
 
     template <typename InputIterator>
-    void insert_helper(iterator iter, InputIterator first, InputIterator last, forward_iterator_tag);
+    void insert_helper(iterator iter, InputIterator first, InputIterator last, std::forward_iterator_tag);
     template <typename InputIterator>
     void insert_helper(iterator iter, InputIterator first, InputIterator last, int_not_an_iterator_tag);
     void insert_elements_helper(iterator iter, size_type size, const T& value);
 
     template <typename InputIterator>
-    void assign_helper(InputIterator first, InputIterator last, forward_iterator_tag);
+    void assign_helper(InputIterator first, InputIterator last, std::forward_iterator_tag);
     template <typename InputIterator>
     void assign_helper(InputIterator first, InputIterator last, int_not_an_iterator_tag);
 
@@ -728,7 +728,7 @@ void vector<T, Allocator>::construct_helper(InputIterator first, InputIterator l
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void vector<T, Allocator>::construct_helper(InputIterator first, InputIterator last, forward_iterator_tag)
+void vector<T, Allocator>::construct_helper(InputIterator first, InputIterator last, std::forward_iterator_tag)
 {
     size_type size = iterator_difference(first, last);
 
@@ -779,7 +779,10 @@ void vector<T, Allocator>::insert_helper(iterator iter, InputIterator first, Inp
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void vector<T, Allocator>::insert_helper(iterator iter, InputIterator first, InputIterator last, forward_iterator_tag)
+void vector<T, Allocator>::insert_helper(iterator      iter,
+                                         InputIterator first,
+                                         InputIterator last,
+                                         std::forward_iterator_tag)
 {
     // m_pElem could be NULL then m_pArray would be NULL too.
     size_type pos = iter.m_pElem - m_pArray;
@@ -809,7 +812,7 @@ void vector<T, Allocator>::insert_helper(iterator iter, InputIterator first, Inp
 
 template <typename T, typename Allocator>
 template <typename InputIterator>
-void vector<T, Allocator>::assign_helper(InputIterator first, InputIterator last, forward_iterator_tag)
+void vector<T, Allocator>::assign_helper(InputIterator first, InputIterator last, std::forward_iterator_tag)
 {
     size_type size = iterator_difference(first, last);
 


### PR DESCRIPTION
Allows us to call into STL functions that operate on iterators like `std::partition`.
I would like to have this for #128515. The alternative could be to implement that function ourselves.
But even then, having iterators be STL compatible is still helpful for quick prototyping. And I don't see any downsides.