### PR TITLE
JIT: replace R2R EH-inlining workaround for PInvoke stubs

### DIFF
--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4411,6 +4411,7 @@ enum GenTreeCallFlags : unsigned int
     GTF_CALL_M_CAST_OBJ_NONNULL        = 0x04000000, // if we expand this specific cast we don't need to check the input object for null
                                                      // NOTE: if needed, this flag can be removed, and we can introduce new _NONNUL cast helpers
     GTF_CALL_M_STACK_ARRAY             = 0x08000000, // this call is a new array helper for a stack allocated array.
+    GTF_CALL_M_PINVOKE_STUB_NO_INLINE  = 0x10000000, // PInvoke call where the IL stub should not be inlined
 };
 
 inline constexpr GenTreeCallFlags operator ~(GenTreeCallFlags a)
@@ -5506,6 +5507,12 @@ struct GenTreeCall final : public GenTree
     bool IsPInvoke() const
     {
         return (gtCallMoreFlags & GTF_CALL_M_PINVOKE) != 0;
+    }
+
+    // Returns true if this PInvoke call's IL stub should not be inlined.
+    bool IsPInvokeStubNoInline() const
+    {
+        return (gtCallMoreFlags & GTF_CALL_M_PINVOKE_STUB_NO_INLINE) != 0;
     }
 
     // Note that the distinction of whether tail prefixed or an implicit tail call

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6930,6 +6930,8 @@ void Compiler::impCheckForPInvokeCall(
         {
             if (!impCanPInvokeInline())
             {
+                // Mark this so we won't decide to inline the stub.
+                call->gtCallMoreFlags |= GTF_CALL_M_PINVOKE_STUB_NO_INLINE;
                 return;
             }
 
@@ -6942,6 +6944,8 @@ void Compiler::impCheckForPInvokeCall(
             if ((!compIsForInlining() && block->isRunRarely()) ||
                 (compIsForInlining() && impInlineInfo->iciBlock->isRunRarely()))
             {
+                // Mark this so we won't decide to inline the stub.
+                call->gtCallMoreFlags |= GTF_CALL_M_PINVOKE_STUB_NO_INLINE;
                 return;
             }
         }
@@ -8376,12 +8380,11 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         }
     }
 
-    // The inliner gets confused when the unmanaged convention reverses arg order (like x86).
-    // Just suppress for all targets for now.
-    //
-    if (call->GetUnmanagedCallConv() != CorInfoCallConvExtension::Managed)
+    if (call->IsUnmanaged())
     {
-        inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_UNMANAGED_CALLCONV);
+        // We must have IL to inline.
+        //
+        inlineResult->NoteFatal(InlineObservation::CALLEE_IS_UNMANAGED);
         return;
     }
 
@@ -8480,15 +8483,13 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         return;
     }
 
-    /* Check legality of PInvoke callsite (for inlining of marshalling code) */
-
-    if (methAttr & CORINFO_FLG_PINVOKE)
+    // Don't inline the IL stub for PInvoke calls where impCheckForPInvokeCall set this flag.
+    if (call->IsPInvokeStubNoInline())
     {
-        if (!impCanPInvokeInlineCallSite(compCurBB))
-        {
-            inlineResult->NoteFatal(InlineObservation::CALLSITE_PINVOKE_EH);
-            return;
-        }
+        assert(!call->IsUnmanaged());
+        assert(methAttr & CORINFO_FLG_PINVOKE);
+        inlineResult->NoteFatal(InlineObservation::CALLSITE_PINVOKE_STUB_NO_INLINE);
+        return;
     }
 
     InlineCandidateInfo* inlineCandidateInfo = nullptr;
@@ -8507,14 +8508,6 @@ void Compiler::impMarkInlineCandidateHelper(GenTreeCall*           call,
         if (bbInFilterBBRange(compCurBB))
         {
             inlineResult->NoteFatal(InlineObservation::CALLSITE_IS_WITHIN_FILTER);
-            return;
-        }
-
-        // Do not inline pinvoke stubs with EH.
-        //
-        if ((methAttr & CORINFO_FLG_PINVOKE) != 0)
-        {
-            inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_EH);
             return;
         }
     }

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -37,11 +37,11 @@ INLINE_OBSERVATION(HAS_MANAGED_VARARGS,       bool,   "managed varargs",        
 INLINE_OBSERVATION(HAS_NATIVE_VARARGS,        bool,   "native varargs",                       FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_NO_BODY,               bool,   "has no body",                          FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_NULL_FOR_LDELEM,       bool,   "has null pointer for ldelem",          FATAL,       CALLEE)
-INLINE_OBSERVATION(HAS_UNMANAGED_CALLCONV,    bool,   "has unmanaged calling convention",     FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_ARRAY_METHOD,           bool,   "is array method",                      FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoinline",             FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_NOINLINE,               bool,   "noinline per IL/cached result",        FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_SYNCHRONIZED,           bool,   "is synchronized",                      FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_UNMANAGED,              bool,   "is unmanaged code",                    FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_VM_NOINLINE,            bool,   "noinline per VM",                      FATAL,       CALLEE)
 INLINE_OBSERVATION(LACKS_RETURN,              bool,   "no return opcode",                     FATAL,       CALLEE)
 INLINE_OBSERVATION(LDFLD_NEEDS_HELPER,        bool,   "ldfld needs helper",                   FATAL,       CALLEE)
@@ -163,7 +163,7 @@ INLINE_OBSERVATION(RANDOM_REJECT,             bool,   "random reject",          
 INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",                 FATAL,       CALLSITE)
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",                   FATAL,       CALLSITE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",                      FATAL,       CALLSITE)
-INLINE_OBSERVATION(PINVOKE_EH,                bool,   "PInvoke call site with EH",            FATAL,       CALLSITE)
+INLINE_OBSERVATION(PINVOKE_STUB_NO_INLINE,    bool,   "PInvoke stub not to be inlined",       FATAL,       CALLSITE)
 
 // ------ Call Site Performance -------
 


### PR DESCRIPTION
PR #112998 added a workaround blocking inline of PInvoke callees with EH, standing in for a missing crossgen2 version-resilience check. Jan fixed that in PR #115277, so the workaround is no longer needed.

Replace it with:

* Early bail in impMarkInlineCandidateHelper when call->IsUnmanaged(). Rename CALLEE_HAS_UNMANAGED_CALLCONV to CALLEE_IS_UNMANAGED.
* New GTF_CALL_M_PINVOKE_STUB_NO_INLINE, set by impCheckForPInvokeCall at the two cost-based bails (rarely-run, !impCanPInvokeInline) and honored by the inliner. Closes the cold-pinvoke case where the inliner would still inline the (larger) stub IL.

No SPMI asmdiffs. R2R version-resilience tests pass.

Fixes #113742.