### PR TITLE
[release/10.0] Fix crash on calling COM interface method on a class where a derived class overriding it was created first

### DIFF
--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -3587,6 +3587,20 @@ BOOL ComMethodTable::LayOutInterfaceMethodTable(MethodTable* pClsMT)
         if (pClassMD != NULL)
         {
             pNewMD->InitMethod(pClassMD, pIntfMD);
+
+            // Restore the vtable slot on parent MethodTables that may share this ComMethodTable.
+            // This ensures that we do not end up with a NULL slot during COM dispatch due to lazy
+            // entry point allocation.
+            if (pClassMD->IsVirtual())
+            {
+                DWORD slot = pClassMD->GetSlot();
+                MethodTable *pParentWalk = pClsMT->GetParentMethodTable();
+                while (pParentWalk != NULL && slot < pParentWalk->GetNumVirtuals())
+                {
+                    pParentWalk->GetRestoredSlot(slot);
+                    pParentWalk = pParentWalk->GetParentMethodTable();
+                }
+            }
         }
         else
         {

--- a/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
+++ b/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000001")]
+public interface IFoo
+{
+    void DoWork();
+}
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000002")]
+[ComDefaultInterface(typeof(IFoo))]
+public class Foo : IFoo
+{
+    public virtual void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(Foo);
+}
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000003")]
+[ComDefaultInterface(typeof(IFoo))]
+public class FooDerived : Foo
+{
+    public override void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(FooDerived);
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000001")]
+public interface IBar
+{
+    void DoWork();
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000002")]
+[ComDefaultInterface(typeof(IBar))]
+public class Bar : IBar
+{
+    public virtual void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(Bar);
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000003")]
+[ComDefaultInterface(typeof(IBar))]
+public class BarDerived : Bar
+{
+    public override void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(BarDerived);
+}
+
+/// <summary>
+/// Tests that COM-to-CLR dispatch correctly resolves virtual method overrides
+/// regardless of whether the base or derived class is accessed via COM first.
+/// </summary>
+public class VirtualMethodOverrideTest
+{
+    internal static string? LastCalledType;
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    delegate int DoWorkDelegate(IntPtr pThis);
+
+    private static int CallDoWork(IntPtr pInterface, int slot)
+    {
+        IntPtr vtbl = Marshal.ReadIntPtr(pInterface);
+        IntPtr fnPtr = Marshal.ReadIntPtr(vtbl, slot * IntPtr.Size);
+        Assert.NotEqual(IntPtr.Zero, fnPtr);
+
+        var fn = Marshal.GetDelegateForFunctionPointer<DoWorkDelegate>(fnPtr);
+        return fn(pInterface);
+    }
+
+    [Fact]
+    public static void DerivedFirst()
+    {
+        int doWorkSlot = Marshal.GetStartComSlot(typeof(IFoo));
+        IntPtr pDerived = Marshal.GetComInterfaceForObject(new FooDerived(), typeof(IFoo));
+        IntPtr pBase = Marshal.GetComInterfaceForObject(new Foo(), typeof(IFoo));
+        try
+        {
+            LastCalledType = null;
+            Assert.True(CallDoWork(pDerived, doWorkSlot) >= 0);
+            Assert.Equal(nameof(FooDerived), LastCalledType);
+
+            LastCalledType = null;
+            Assert.True(CallDoWork(pBase, doWorkSlot) >= 0);
+            Assert.Equal(nameof(Foo), LastCalledType);
+        }
+        finally
+        {
+            Marshal.Release(pDerived);
+            Marshal.Release(pBase);
+        }
+    }
+
+    [Fact]
+    public static void BaseFirst()
+    {
+        int doWorkSlot = Marshal.GetStartComSlot(typeof(IBar));
+        IntPtr pBase = Marshal.GetComInterfaceForObject(new Bar(), typeof(IBar));
+        IntPtr pDerived = Marshal.GetComInterfaceForObject(new BarDerived(), typeof(IBar));
+        try
+        {
+            LastCalledType = null;
+            Assert.True(CallDoWork(pBase, doWorkSlot) >= 0);
+            Assert.Equal(nameof(Bar), LastCalledType);
+
+            LastCalledType = null;
+            Assert.True(CallDoWork(pDerived, doWorkSlot) >= 0);
+            Assert.Equal(nameof(BarDerived), LastCalledType);
+        }
+        finally
+        {
+            Marshal.Release(pBase);
+            Marshal.Release(pDerived);
+        }
+    }
+}

--- a/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.csproj
+++ b/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="VirtualMethodOverrideTest.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes #127512

When a COM interface is implemented by a class with a virtual method and a derived class overrides it, they share a `ComMethodTable`. We then use `GetSlotForVirtual` to resolve to the correct target for a method. With #101580, the slot for the base class is lazily populated. If the derived class is used first it creates a `ComMethodTable` and lays it out, which makes sure the slots for that class' method table are restored. When base class is then used, it shares the same `ComMethodTable` which is already laid out, so it does not explicitly restore its slots, leaving the slot for the base class method null.

This change makes laying out a `ComMethodTable` also restore parent vtable slots. I did this directly against release/10.0, as how we do this dispatch is quite different in .NET 11. It doesn't crash anymore, but we do still have a correctness issue there.

cc @dotnet/appmodel @AaronRobinsonMSFT 

Example setup:
```c#
[ComVisible(true)]
public interface IFoo
{
    void DoWork();
}
 
[ComVisible(true), ComDefaultInterface(typeof(IFoo))]
public class Base : IFoo
{
    public virtual void DoWork() { }
}
 
[ComVisible(true), ComDefaultInterface(typeof(IFoo))]
public class Derived : Base
{
    public override void DoWork() { }
}
```
If `Derived` is created first, calling `Base.DoWork` crashes.

## Regression

- [x] Yes
- [ ] No

Regressed in .NET 9 from #101580

## Testing

Automated tests added. Ran customer-provided minimal repro.

## Risk

Low.