### PR TITLE
[experiment] x64: custom calling convention for WB helpers

### DIFF
--- a/src/coreclr/jit/targetamd64.h
+++ b/src/coreclr/jit/targetamd64.h
@@ -182,23 +182,28 @@
 
 // AMD64 write barrier ABI (see vm\amd64\JitHelpers_Fast.asm, vm\amd64\JitHelpers_Fast.S):
 // CORINFO_HELP_ASSIGN_REF (JIT_WriteBarrier), CORINFO_HELP_CHECKED_ASSIGN_REF (JIT_CheckedWriteBarrier):
-//     The usual amd64 calling convention is observed.
-//     TODO-CQ: could this be optimized?
+//     Custom calling convention: dst is passed in R11 (NOT REG_ARG_0). The "this"-equivalent
+//     register on each ABI (RCX on Win-x64, RDI on SysV) is preserved by the helpers, so the
+//     JIT can keep its contents live across the call.
 //
 
-#define REG_WRITE_BARRIER_DST          REG_ARG_0
-#define RBM_WRITE_BARRIER_DST          RBM_ARG_0
+#define REG_WRITE_BARRIER_DST          REG_R11
+#define RBM_WRITE_BARRIER_DST          RBM_R11
 
 #define REG_WRITE_BARRIER_SRC          REG_ARG_1
 #define RBM_WRITE_BARRIER_SRC          RBM_ARG_1
 
 #define RBM_CALLEE_TRASH_NOGC        RBM_CALLEE_TRASH
 
-// Registers killed by CORINFO_HELP_ASSIGN_REF and CORINFO_HELP_CHECKED_ASSIGN_REF.
-#define RBM_CALLEE_TRASH_WRITEBARRIER         RBM_CALLEE_TRASH_NOGC
-
-// Registers no longer containing GC pointers after CORINFO_HELP_ASSIGN_REF and CORINFO_HELP_CHECKED_ASSIGN_REF.
-#define RBM_CALLEE_GCTRASH_WRITEBARRIER       RBM_CALLEE_TRASH_NOGC
+#ifdef UNIX_AMD64_ABI
+// RDI (REG_ARG_0 on SysV) is preserved by the helper so it stays out of the kill set.
+#define RBM_CALLEE_TRASH_WRITEBARRIER         (RBM_CALLEE_TRASH_NOGC & ~RBM_RDI)
+#define RBM_CALLEE_GCTRASH_WRITEBARRIER       (RBM_CALLEE_TRASH_NOGC & ~RBM_RDI)
+#else // !UNIX_AMD64_ABI
+// RCX (REG_ARG_0 on Win-x64) is preserved by the helper so it stays out of the kill set.
+#define RBM_CALLEE_TRASH_WRITEBARRIER         (RBM_CALLEE_TRASH_NOGC & ~RBM_RCX)
+#define RBM_CALLEE_GCTRASH_WRITEBARRIER       (RBM_CALLEE_TRASH_NOGC & ~RBM_RCX)
+#endif // !UNIX_AMD64_ABI
 
 // We have two register classifications
 // * callee trash: aka     volatile or caller saved

--- a/src/coreclr/runtime/amd64/WriteBarriers.S
+++ b/src/coreclr/runtime/amd64/WriteBarriers.S
@@ -83,23 +83,28 @@ LOCAL_LABEL(\BASENAME\()_UpdateShadowHeap_Done_\REFREG):
 #endif // WRITE_BARRIER_CHECK
 
 // There are several different helpers used depending on which register holds the object reference. Since all
-// the helpers have identical structure we use a macro to define this structure. Two arguments are taken, the
-// name of the register that points to the location to be updated and the name of the register that holds the
-// object reference (this should be in upper case as it's used in the definition of the name of the helper).
-.macro DEFINE_UNCHECKED_WRITE_BARRIER_CORE BASENAME, REFREG
+// the helpers have identical structure we use a macro to define this structure. Three arguments are taken:
+// the basename of the generated labels, the register that holds the object reference (this should be in upper
+// case as it's used in the definition of the name of the helper), and the register that holds the destination
+// address. The destination defaults to RDI (the legacy AOT contract used by the interlocked helpers); the
+// CORINFO_HELP_ASSIGN_REF helpers pass R11 to match the JIT's custom write-barrier calling convention which
+// preserves RDI (the 'this' register on SysV-x64).
+.macro DEFINE_UNCHECKED_WRITE_BARRIER_CORE BASENAME, REFREG, DESTREG
 
     // Update the shadow copy of the heap with the same value just written to the same heap. (A no-op unless
     // we're in a debug build and write barrier checking has been enabled).
-    UPDATE_GC_SHADOW \BASENAME, \REFREG, rdi
+    UPDATE_GC_SHADOW \BASENAME, \REFREG, \DESTREG
 
 #ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    mov     r11, [C_VAR(g_write_watch_table)]
-    cmp     r11, 0x0
+    // Use R9 (callee-trash, unused by every helper that expands this macro) for the WWT pointer,
+    // because R11 may be live as DESTREG under the JIT WB calling convention for RhpAssignRef.
+    mov     r9, [C_VAR(g_write_watch_table)]
+    cmp     r9, 0x0
     je      LOCAL_LABEL(\BASENAME\()_CheckCardTable_\REFREG)
 
-    mov     r10, rdi
+    mov     r10, \DESTREG
     shr     r10, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
-    add     r10, r11
+    add     r10, r9
     cmp     byte ptr [r10], 0x0
     jne     LOCAL_LABEL(\BASENAME\()_CheckCardTable_\REFREG)
     mov     byte ptr [r10], 0xFF
@@ -118,22 +123,22 @@ LOCAL_LABEL(\BASENAME\()_CheckCardTable_\REFREG):
     // track this write. The location address is translated into an offset in the card table bitmap. We set
     // an entire byte in the card table since it's quicker than messing around with bitmasks and we only write
     // the byte if it hasn't already been done since writes are expensive and impact scaling.
-    shr     rdi, 0x0B
+    shr     \DESTREG, 0x0B
     mov     r10, [C_VAR(g_card_table)]
-    cmp     byte ptr [rdi + r10], 0x0FF
+    cmp     byte ptr [\DESTREG + r10], 0x0FF
     je      LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG)
 
 // We get here if it's necessary to update the card table.
-    mov     byte ptr [rdi + r10], 0xFF
+    mov     byte ptr [\DESTREG + r10], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-    // Shift rdi by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
-    shr     rdi, 0x0A
-    add     rdi, [C_VAR(g_card_bundle_table)]
-    cmp     byte ptr [rdi], 0xFF
+    // Shift DESTREG by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
+    shr     \DESTREG, 0x0A
+    add     \DESTREG, [C_VAR(g_card_bundle_table)]
+    cmp     byte ptr [\DESTREG], 0xFF
     je      LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG)
 
-    mov     byte ptr [rdi], 0xFF
+    mov     byte ptr [\DESTREG], 0xFF
 #endif
 
 LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
@@ -141,11 +146,9 @@ LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG):
 
 .endm
 
-// There are several different helpers used depending on which register holds the object reference. Since all
-// the helpers have identical structure we use a macro to define this structure. One argument is taken, the
-// name of the register that will hold the object reference (this should be in upper case as it's used in the
-// definition of the name of the helper).
-.macro DEFINE_UNCHECKED_WRITE_BARRIER REFREG, EXPORT_REG_NAME
+// Generates a helper of the form RhpAssignRef<EXPORT_REG_NAME>. REFREG holds the object reference; DESTREG
+// holds the destination address.
+.macro DEFINE_UNCHECKED_WRITE_BARRIER REFREG, EXPORT_REG_NAME, DESTREG
 
 // Define a helper with a name of the form RhpAssignRefEAX etc. (along with suitable calling standard
 // decoration). The location to be updated is in DESTREG. The object reference that will be assigned into that
@@ -164,16 +167,17 @@ LEAF_ENTRY RhpAssignRef\EXPORT_REG_NAME, _TEXT
 
     // Write the reference into the location. Note that we rely on the fact that no GC can occur between here
     // and the card table update we may perform below.
-    mov     qword ptr [rdi], \REFREG
+    mov     qword ptr [\DESTREG], \REFREG
 
-    DEFINE_UNCHECKED_WRITE_BARRIER_CORE RhpAssignRef, \REFREG
+    DEFINE_UNCHECKED_WRITE_BARRIER_CORE RhpAssignRef, \REFREG, \DESTREG
 
 LEAF_END RhpAssignRef\EXPORT_REG_NAME, _TEXT
 .endm
 
 // One day we might have write barriers for all the possible argument registers but for now we have
-// just one write barrier that assumes the input register is RSI.
-DEFINE_UNCHECKED_WRITE_BARRIER RSI, ESI
+// just one write barrier that assumes the input register is RSI. The CORINFO_HELP_ASSIGN_REF JIT calling
+// convention passes the destination in R11.
+DEFINE_UNCHECKED_WRITE_BARRIER RSI, ESI, r11
 
 //
 // Define the helpers used to implement the write barrier required when writing an object reference into a
@@ -182,16 +186,16 @@ DEFINE_UNCHECKED_WRITE_BARRIER RSI, ESI
 // collection.
 //
 
-.macro DEFINE_CHECKED_WRITE_BARRIER_CORE BASENAME, REFREG
+.macro DEFINE_CHECKED_WRITE_BARRIER_CORE BASENAME, REFREG, DESTREG
 
     // The location being updated might not even lie in the GC heap (a handle or stack location for instance),
     // in which case no write barrier is required.
-    cmp     rdi, [C_VAR(g_lowest_address)]
+    cmp     \DESTREG, [C_VAR(g_lowest_address)]
     jb      LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG)
-    cmp     rdi, [C_VAR(g_highest_address)]
+    cmp     \DESTREG, [C_VAR(g_highest_address)]
     jae     LOCAL_LABEL(\BASENAME\()_NoBarrierRequired_\REFREG)
 
-    DEFINE_UNCHECKED_WRITE_BARRIER_CORE \BASENAME, \REFREG
+    DEFINE_UNCHECKED_WRITE_BARRIER_CORE \BASENAME, \REFREG, \DESTREG
 
 .endm
 
@@ -199,7 +203,7 @@ DEFINE_UNCHECKED_WRITE_BARRIER RSI, ESI
 // the helpers have identical structure we use a macro to define this structure. One argument is taken, the
 // name of the register that will hold the object reference (this should be in upper case as it's used in the
 // definition of the name of the helper).
-.macro DEFINE_CHECKED_WRITE_BARRIER REFREG, EXPORT_REG_NAME
+.macro DEFINE_CHECKED_WRITE_BARRIER REFREG, EXPORT_REG_NAME, DESTREG
 
 // Define a helper with a name of the form RhpCheckedAssignRefEAX etc. (along with suitable calling standard
 // decoration). The location to be updated is always in RDI. The object reference that will be assigned into
@@ -218,23 +222,24 @@ LEAF_ENTRY RhpCheckedAssignRef\EXPORT_REG_NAME, _TEXT
 
     // Write the reference into the location. Note that we rely on the fact that no GC can occur between here
     // and the card table update we may perform below.
-    mov     qword ptr [rdi], \REFREG
+    mov     qword ptr [\DESTREG], \REFREG
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedAssignRef, \REFREG
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedAssignRef, \REFREG, \DESTREG
 
 LEAF_END RhpCheckedAssignRef\EXPORT_REG_NAME, _TEXT
 .endm
 
 // One day we might have write barriers for all the possible argument registers but for now we have
-// just one write barrier that assumes the input register is RSI.
-DEFINE_CHECKED_WRITE_BARRIER RSI, ESI
+// just one write barrier that assumes the input register is RSI. The CORINFO_HELP_CHECKED_ASSIGN_REF JIT
+// calling convention passes the destination in R11.
+DEFINE_CHECKED_WRITE_BARRIER RSI, ESI, r11
 
 LEAF_ENTRY RhpCheckedLockCmpXchg, _TEXT
     mov             rax, rdx
     lock cmpxchg    [rdi], rsi
     jne             LOCAL_LABEL(RhpCheckedLockCmpXchg_NoBarrierRequired_RSI)
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedLockCmpXchg, RSI
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedLockCmpXchg, RSI, rdi
 
 LEAF_END RhpCheckedLockCmpXchg, _TEXT
 
@@ -245,7 +250,7 @@ LEAF_ENTRY RhpCheckedXchg, _TEXT
     mov             rax, rsi
     xchg            [rdi], rax
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedXchg, RSI
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedXchg, RSI, rdi
 
 LEAF_END RhpCheckedXchg, _TEXT
 

--- a/src/coreclr/runtime/amd64/WriteBarriers.asm
+++ b/src/coreclr/runtime/amd64/WriteBarriers.asm
@@ -91,23 +91,28 @@ endm
 endif ; WRITE_BARRIER_CHECK
 
 ;; There are several different helpers used depending on which register holds the object reference. Since all
-;; the helpers have identical structure we use a macro to define this structure. Two arguments are taken, the
-;; name of the register that points to the location to be updated and the name of the register that holds the
-;; object reference (this should be in upper case as it's used in the definition of the name of the helper).
-DEFINE_UNCHECKED_WRITE_BARRIER_CORE macro BASENAME, REFREG
+;; the helpers have identical structure we use a macro to define this structure. Three arguments are taken: the
+;; basename of the generated labels, the register that holds the object reference (this should be in upper
+;; case as it's used in the definition of the name of the helper), and the register that holds the destination
+;; address. The destination defaults to RCX (the legacy AOT contract used by the interlocked helpers); the
+;; CORINFO_HELP_ASSIGN_REF helpers pass R11 to match the JIT's custom write-barrier calling convention which
+;; preserves RCX (the 'this' register on Win-x64).
+DEFINE_UNCHECKED_WRITE_BARRIER_CORE macro BASENAME, REFREG, DESTREG
 
     ;; Update the shadow copy of the heap with the same value just written to the same heap. (A no-op unless
     ;; we're in a debug build and write barrier checking has been enabled).
-    UPDATE_GC_SHADOW BASENAME, REFREG, rcx
+    UPDATE_GC_SHADOW BASENAME, REFREG, DESTREG
 
 ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
-    mov     r11, [g_write_watch_table]
-    cmp     r11, 0
+    ;; Use R9 (callee-trash, unused by every helper that expands this macro) for the WWT pointer,
+    ;; because R11 may be live as DESTREG under the JIT WB calling convention for RhpAssignRef.
+    mov     r9, [g_write_watch_table]
+    cmp     r9, 0
     je      &BASENAME&_CheckCardTable_&REFREG&
 
-    mov     r10, rcx
+    mov     r10, DESTREG
     shr     r10, 0Ch ;; SoftwareWriteWatch::AddressToTableByteIndexShift
-    add     r10, r11
+    add     r10, r9
     cmp     byte ptr [r10], 0
     jne     &BASENAME&_CheckCardTable_&REFREG&
     mov     byte ptr [r10], 0FFh
@@ -126,22 +131,22 @@ endif
     ;; track this write. The location address is translated into an offset in the card table bitmap. We set
     ;; an entire byte in the card table since it's quicker than messing around with bitmasks and we only write
     ;; the byte if it hasn't already been done since writes are expensive and impact scaling.
-    shr     rcx, 0Bh
+    shr     DESTREG, 0Bh
     mov     r10, [g_card_table]
-    cmp     byte ptr [rcx + r10], 0FFh
+    cmp     byte ptr [DESTREG + r10], 0FFh
     je      &BASENAME&_NoBarrierRequired_&REFREG&
 
     ;; We get here if it's necessary to update the card table.
-    mov     byte ptr [rcx + r10], 0FFh
+    mov     byte ptr [DESTREG + r10], 0FFh
 
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-    ;; Shift rcx by 0Ah more to get the card bundle byte (we shifted by 0x0B already)
-    shr     rcx, 0Ah
-    add     rcx, [g_card_bundle_table]
-    cmp     byte ptr [rcx], 0FFh
+    ;; Shift DESTREG by 0Ah more to get the card bundle byte (we shifted by 0x0B already)
+    shr     DESTREG, 0Ah
+    add     DESTREG, [g_card_bundle_table]
+    cmp     byte ptr [DESTREG], 0FFh
     je      &BASENAME&_NoBarrierRequired_&REFREG&
 
-    mov     byte ptr [rcx], 0FFh
+    mov     byte ptr [DESTREG], 0FFh
 endif
 
 &BASENAME&_NoBarrierRequired_&REFREG&:
@@ -149,15 +154,9 @@ endif
 
 endm
 
-;; There are several different helpers used depending on which register holds the object reference. Since all
-;; the helpers have identical structure we use a macro to define this structure. One argument is taken, the
-;; name of the register that will hold the object reference (this should be in upper case as it's used in the
-;; definition of the name of the helper).
-DEFINE_UNCHECKED_WRITE_BARRIER macro REFREG, EXPORT_REG_NAME
-
-;; Define a helper with a name of the form RhpAssignRefEAX etc. (along with suitable calling standard
-;; decoration). The location to be updated is in DESTREG. The object reference that will be assigned into that
-;; location is in one of the other general registers determined by the value of REFREG.
+;; Generates a helper of the form RhpAssignRef<EXPORT_REG_NAME>. REFREG holds the object reference; DESTREG
+;; holds the destination address.
+DEFINE_UNCHECKED_WRITE_BARRIER macro REFREG, EXPORT_REG_NAME, DESTREG
 
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 ;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen on the first instruction
@@ -172,16 +171,17 @@ LEAF_ENTRY RhpAssignRef&EXPORT_REG_NAME&, _TEXT
 
     ;; Write the reference into the location. Note that we rely on the fact that no GC can occur between here
     ;; and the card table update we may perform below.
-    mov     qword ptr [rcx], REFREG
+    mov     qword ptr [DESTREG], REFREG
 
-    DEFINE_UNCHECKED_WRITE_BARRIER_CORE RhpAssignRef, REFREG
+    DEFINE_UNCHECKED_WRITE_BARRIER_CORE RhpAssignRef, REFREG, DESTREG
 
 LEAF_END RhpAssignRef&EXPORT_REG_NAME&, _TEXT
 endm
 
 ;; One day we might have write barriers for all the possible argument registers but for now we have
-;; just one write barrier that assumes the input register is RDX.
-DEFINE_UNCHECKED_WRITE_BARRIER RDX, EDX
+;; just one write barrier that assumes the input register is RDX. The destination register is R11 to match
+;; the JIT's custom write-barrier calling convention.
+DEFINE_UNCHECKED_WRITE_BARRIER RDX, EDX, r11
 
 ;;
 ;; Define the helpers used to implement the write barrier required when writing an object reference into a
@@ -190,28 +190,22 @@ DEFINE_UNCHECKED_WRITE_BARRIER RDX, EDX
 ;; collection.
 ;;
 
-DEFINE_CHECKED_WRITE_BARRIER_CORE macro BASENAME, REFREG
+DEFINE_CHECKED_WRITE_BARRIER_CORE macro BASENAME, REFREG, DESTREG
 
     ;; The location being updated might not even lie in the GC heap (a handle or stack location for instance),
     ;; in which case no write barrier is required.
-    cmp     rcx, [g_lowest_address]
+    cmp     DESTREG, [g_lowest_address]
     jb      &BASENAME&_NoBarrierRequired_&REFREG&
-    cmp     rcx, [g_highest_address]
+    cmp     DESTREG, [g_highest_address]
     jae     &BASENAME&_NoBarrierRequired_&REFREG&
 
-    DEFINE_UNCHECKED_WRITE_BARRIER_CORE BASENAME, REFREG
+    DEFINE_UNCHECKED_WRITE_BARRIER_CORE BASENAME, REFREG, DESTREG
 
 endm
 
-;; There are several different helpers used depending on which register holds the object reference. Since all
-;; the helpers have identical structure we use a macro to define this structure. One argument is taken, the
-;; name of the register that will hold the object reference (this should be in upper case as it's used in the
-;; definition of the name of the helper).
-DEFINE_CHECKED_WRITE_BARRIER macro REFREG, EXPORT_REG_NAME
-
-;; Define a helper with a name of the form RhpCheckedAssignRefEAX etc. (along with suitable calling standard
-;; decoration). The location to be updated is always in RCX. The object reference that will be assigned into
-;; that location is in one of the other general registers determined by the value of REFREG.
+;; Generates a helper of the form RhpCheckedAssignRef<EXPORT_REG_NAME>. REFREG holds the object reference;
+;; DESTREG holds the destination address.
+DEFINE_CHECKED_WRITE_BARRIER macro REFREG, EXPORT_REG_NAME, DESTREG
 
 ;; WARNING: Code in EHHelpers.cpp makes assumptions about write barrier code, in particular:
 ;; - Function "InWriteBarrierHelper" assumes an AV due to passed in null pointer will happen on the first instruction
@@ -226,23 +220,24 @@ LEAF_ENTRY RhpCheckedAssignRef&EXPORT_REG_NAME&, _TEXT
 
     ;; Write the reference into the location. Note that we rely on the fact that no GC can occur between here
     ;; and the card table update we may perform below.
-    mov     qword ptr [rcx], REFREG
+    mov     qword ptr [DESTREG], REFREG
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedAssignRef, REFREG
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedAssignRef, REFREG, DESTREG
 
 LEAF_END RhpCheckedAssignRef&EXPORT_REG_NAME&, _TEXT
 endm
 
 ;; One day we might have write barriers for all the possible argument registers but for now we have
-;; just one write barrier that assumes the input register is RDX.
-DEFINE_CHECKED_WRITE_BARRIER RDX, EDX
+;; just one write barrier that assumes the input register is RDX. The destination register is R11 to match
+;; the JIT's custom write-barrier calling convention.
+DEFINE_CHECKED_WRITE_BARRIER RDX, EDX, r11
 
 LEAF_ENTRY RhpCheckedLockCmpXchg, _TEXT
     mov             rax, r8
     lock cmpxchg    [rcx], rdx
     jne             RhpCheckedLockCmpXchg_NoBarrierRequired_RDX
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedLockCmpXchg, RDX
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedLockCmpXchg, RDX, rcx
 
 LEAF_END RhpCheckedLockCmpXchg, _TEXT
 
@@ -253,7 +248,7 @@ LEAF_ENTRY RhpCheckedXchg, _TEXT
     mov             rax, rdx
     xchg            [rcx], rax
 
-    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedXchg, RDX
+    DEFINE_CHECKED_WRITE_BARRIER_CORE RhpCheckedXchg, RDX, rcx
 
 LEAF_END RhpCheckedXchg, _TEXT
 

--- a/src/coreclr/vm/amd64/JitHelpers_Fast.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Fast.asm
@@ -69,22 +69,23 @@ JIT_WriteBarrier_Loc:
 ; it needs to have it's card updated
 ;
 ; void JIT_CheckedWriteBarrier(Object** dst, Object* src)
+; Custom calling convention: dst is in R11 (NOT RCX). RCX is preserved.
 LEAF_ENTRY JIT_CheckedWriteBarrier, _TEXT
 
         ; When WRITE_BARRIER_CHECK is defined _NotInHeap will write the reference
         ; but if it isn't then it will just return.
         ;
         ; See if this is in GCHeap
-        cmp     rcx, [g_lowest_address]
+        cmp     r11, [g_lowest_address]
         jb      NotInHeap
-        cmp     rcx, [g_highest_address]
+        cmp     r11, [g_highest_address]
         jnb     NotInHeap
 
         jmp     QWORD PTR [JIT_WriteBarrier_Loc]
 
     NotInHeap:
         ; See comment above about possible AV
-        mov     [rcx], rdx
+        mov     [r11], rdx
         ret
 LEAF_END_MARKED JIT_CheckedWriteBarrier, _TEXT
 

--- a/src/coreclr/vm/amd64/JitHelpers_FastWriteBarriers.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_FastWriteBarriers.asm
@@ -40,7 +40,7 @@ LEAF_ENTRY JIT_WriteBarrier_PreGrow64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         NOP_3_BYTE ; padding for alignment of constant
 
@@ -59,24 +59,29 @@ PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        shr     rcx, 0Ah
+        shr     r11, 0Ah
+        ; Extra 6-byte pad: the r11-based byte ops above grew vs the original
+        ; rcx-based ones (REX.B prefix). Restore 8-byte alignment of the next
+        ; movabs immediate.
+        NOP_3_BYTE
+        NOP_3_BYTE
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
@@ -93,7 +98,7 @@ LEAF_ENTRY JIT_WriteBarrier_PostGrow64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         NOP_3_BYTE ; padding for alignment of constant
 
@@ -123,24 +128,28 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        shr     rcx, 0Ah
+        shr     r11, 0Ah
+        ; Extra 6-byte pad to keep the next movabs immediate 8-byte aligned
+        ; after r11-based byte ops grew vs the original rcx-based ones.
+        NOP_3_BYTE
+        NOP_3_BYTE
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
@@ -165,32 +174,36 @@ LEAF_ENTRY JIT_WriteBarrier_SVR64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         NOP_3_BYTE ; padding for alignment of constant
 
 PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
-        shr     rcx, 0Bh
+        shr     r11, 0Bh
 
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        shr     rcx, 0Ah
+        shr     r11, 0Ah
+        ; Extra 6-byte pad to keep the next movabs immediate 8-byte aligned
+        ; after r11-based byte ops grew vs the original rcx-based ones.
+        NOP_3_BYTE
+        NOP_3_BYTE
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 LEAF_END_MARKED JIT_WriteBarrier_SVR64, _TEXT
@@ -202,24 +215,29 @@ LEAF_ENTRY JIT_WriteBarrier_Byte_Region64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
-        mov     r8, rcx
+        mov     r8, r11
 
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionToGeneration
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionShrDest
-        shr     rcx, 16h ; compute region index
+        shr     r11, 16h ; compute region index
 
         ; Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rcx + rax], 0
+        cmp     byte ptr [r11 + rax], 0
         jne     NotGen0
         REPRET
 
         NOP_2_BYTE ; padding for alignment of constant
 
     NotGen0:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_Lower
         mov     r9, 0F0F0F0F0F0F0F0F0h
         cmp     rdx, r9
@@ -235,12 +253,17 @@ PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_Upper
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionShrSrc
         shr     rdx, 16h ; compute region index
         mov     dl, [rdx + rax]
-        cmp     dl, [rcx + rax]
+        cmp     dl, [r11 + rax]
         jb      isOldToYoung
         REPRET
         nop
 
     IsOldToYoung:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
@@ -272,24 +295,29 @@ LEAF_ENTRY JIT_WriteBarrier_Bit_Region64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
-        mov     r8, rcx
+        mov     r8, r11
 
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionToGeneration
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionShrDest
-        shr     rcx, 16h ; compute region index
+        shr     r11, 16h ; compute region index
 
         ; Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rcx + rax], 0
+        cmp     byte ptr [r11 + rax], 0
         jne     NotGen0
         REPRET
 
         NOP_2_BYTE ; padding for alignment of constant
 
     NotGen0:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_Lower
         mov     r9, 0F0F0F0F0F0F0F0F0h
         cmp     rdx, r9
@@ -305,21 +333,28 @@ PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_Upper
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionShrSrc
         shr     rdx, 16h ; compute region index
         mov     dl, [rdx + rax]
-        cmp     dl, [rcx + rax]
+        cmp     dl, [r11 + rax]
         jb      isOldToYoung
         REPRET
         nop
 
     IsOldToYoung:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
-        mov     ecx, r8d
+        ; Compute the bit mask `1 << ((r8 >> 8) & 7)` without touching CL/RCX
+        ; (RCX is preserved under the custom write-barrier convention).
+        mov     r10d, r8d
         shr     r8, 0Bh
-        shr     ecx, 8
-        and     ecx, 7
-        mov     dl, 1
-        shl     dl, cl
+        shr     r10d, 8
+        and     r10d, 7
+        xor     edx, edx
+        bts     edx, r10d
         test    byte ptr [r8 + rax], dl
         je      UpdateCardTable
         REPRET
@@ -328,6 +363,11 @@ PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardTable
         lock or byte ptr [r8 + rax], dl
 
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        ; Extra 4-byte pad to restore 8-byte alignment of the next movabs imm
+        ; after the BTS replacement above grew the section by 4 bytes vs the
+        ; original `mov dl,1; shl dl,cl` sequence.
+        NOP_2_BYTE
+        NOP_2_BYTE
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
         shr     r8, 0Ah
@@ -360,10 +400,10 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PreGrow64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_WriteWatchTable
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
@@ -381,27 +421,31 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_Lower
         jb      Exit
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
+        shr     r11, 0Bh
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        ; Extra 6-byte pad to keep the next movabs immediate 8-byte aligned
+        ; after r11-based byte ops grew vs the original rcx-based ones.
+        NOP_3_BYTE
+        NOP_3_BYTE
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        shr     rcx, 0Ah
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Ah
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
@@ -425,10 +469,10 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PostGrow64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_WriteWatchTable
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
@@ -461,24 +505,28 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        shr     rcx, 0Ah
+        shr     r11, 0Ah
+        ; Extra 6-byte pad to keep the next movabs immediate 8-byte aligned
+        ; after r11-based byte ops grew vs the original rcx-based ones.
+        NOP_3_BYTE
+        NOP_3_BYTE
         NOP_2_BYTE ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        cmp     byte ptr [rcx + rax], 0FFh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
@@ -511,10 +559,10 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_SVR64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_WriteWatchTable
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
@@ -527,24 +575,24 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardTable
         mov     byte ptr [rax], 0FFh
 
     CheckCardTable:
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + r9], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + r9], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + r9], 0FFh
+        mov     byte ptr [r11 + r9], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         nop ; padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        shr     rcx, 0Ah
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Ah
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 LEAF_END_MARKED JIT_WriteBarrier_WriteWatch_SVR64, _TEXT
@@ -558,17 +606,17 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_Byte_Region64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_WriteWatchTable
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
         add     rax, r8
-        mov     r8, rcx
+        mov     r8, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionShrDest
-        shr     rcx, 16h ; compute region index
+        shr     r11, 16h ; compute region index
         cmp     byte ptr [rax], 0h
         jne     JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionToGeneration
         mov     byte ptr [rax], 0FFh
@@ -577,7 +625,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionToGenera
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rcx + rax], 0
+        cmp     byte ptr [r11 + rax], 0
         jne     NotGen0
         REPRET
 
@@ -586,6 +634,11 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionToGenera
         NOP_2_BYTE ; padding for alignment of constant
 
     NotGen0:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_Lower
         mov     r9, 0F0F0F0F0F0F0F0F0h
         cmp     rdx, r9
@@ -601,12 +654,17 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_Upper
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionShrSrc
         shr     rdx, 16h ; compute region index
         mov     dl, [rdx + rax]
-        cmp     dl, [rcx + rax]
+        cmp     dl, [r11 + rax]
         jb      isOldToYoung
         REPRET
         nop
 
     IsOldToYoung:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
@@ -638,17 +696,17 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_Bit_Region64, _TEXT
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_WriteWatchTable
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
         add     rax, r8
-        mov     r8, rcx
+        mov     r8, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionShrDest
-        shr     rcx, 16h ; compute region index
+        shr     r11, 16h ; compute region index
         cmp     byte ptr [rax], 0h
         jne     JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionToGeneration
         mov     byte ptr [rax], 0FFh
@@ -657,7 +715,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionToGenerat
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rcx + rax], 0
+        cmp     byte ptr [r11 + rax], 0
         jne     NotGen0
         REPRET
 
@@ -666,6 +724,11 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionToGenerat
         NOP_2_BYTE ; padding for alignment of constant
 
     NotGen0:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_Lower
         mov     r9, 0F0F0F0F0F0F0F0F0h
         cmp     rdx, r9
@@ -681,21 +744,28 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_Upper
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionShrSrc
         shr     rdx, 16h ; compute region index
         mov     dl, [rdx + rax]
-        cmp     dl, [rcx + rax]
+        cmp     dl, [r11 + rax]
         jb      isOldToYoung
         REPRET
         nop
 
     IsOldToYoung:
+        ; Extra 7-byte pad: r11-based byte op above grew vs the original rcx
+        ; one (REX.B prefix). Restore 8-byte alignment of the next movabs imm.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
-        mov     ecx, r8d
+        ; Compute the bit mask `1 << ((r8 >> 8) & 7)` without touching CL/RCX
+        ; (RCX is preserved under the custom write-barrier convention).
+        mov     r10d, r8d
         shr     r8, 0Bh
-        shr     ecx, 8
-        and     ecx, 7
-        mov     dl, 1
-        shl     dl, cl
+        shr     r10d, 8
+        and     r10d, 7
+        xor     edx, edx
+        bts     edx, r10d
         test    byte ptr [r8 + rax], dl
         je      UpdateCardTable
         REPRET
@@ -703,6 +773,11 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardTable
     UpdateCardTable:
         lock or byte ptr [r8 + rax], dl
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        ; Extra 4-byte pad to restore 8-byte alignment of the next movabs imm
+        ; after the BTS replacement above grew the section by 4 bytes vs the
+        ; original `mov dl,1; shl dl,cl` sequence.
+        NOP_2_BYTE
+        NOP_2_BYTE
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardBundleTable
         mov     rax, 0F0F0F0F0F0F0F0F0h
         shr     r8, 0Ah

--- a/src/coreclr/vm/amd64/JitHelpers_Slow.asm
+++ b/src/coreclr/vm/amd64/JitHelpers_Slow.asm
@@ -46,6 +46,7 @@ ifdef _DEBUG
 ; needs to be updated
 ;
 ; void JIT_WriteBarrier_Debug(Object** dst, Object* src)
+; Custom calling convention: dst is in R11 (NOT RCX). RCX is preserved.
 LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
 
 ifdef WRITE_BARRIER_CHECK
@@ -55,7 +56,7 @@ ifdef WRITE_BARRIER_CHECK
         je      NoShadow
 
         ; If we end up outside of the heap don't corrupt random memory
-        mov     r10, rcx
+        mov     r10, r11
         sub     r10, [g_lowest_address]
         jb      NoShadow
 
@@ -65,7 +66,7 @@ ifdef WRITE_BARRIER_CHECK
         jnb     NoShadow
 
         ; Write ref into real GC; see comment below about possibility of AV
-        mov     [rcx], rdx
+        mov     [r11], rdx
         ; Write ref into shadow GC
         mov     [r10], rdx
 
@@ -74,12 +75,12 @@ ifdef WRITE_BARRIER_CHECK
         mfence
 
         ; Check that GC/ShadowGC values match
-        mov     r11, [rcx]
+        mov     r8, [r11]
         mov     rax, [r10]
-        cmp     rax, r11
+        cmp     rax, r8
         je      DoneShadow
-        mov     r11, INVALIDGCVALUE
-        mov     [r10], r11
+        mov     r8, INVALIDGCVALUE
+        mov     [r10], r8
 
         jmp     DoneShadow
 
@@ -93,7 +94,7 @@ endif
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rax
+        mov     [r11], rax
 
 ifdef WRITE_BARRIER_CHECK
     ; If we had a shadow GC then we already wrote to the real GC at the same time
@@ -105,7 +106,7 @@ ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         ; Update the write watch table if necessary
         cmp     byte ptr [g_sw_ww_enabled_for_gc_heap], 0h
         je      CheckCardTable
-        mov     r10, rcx
+        mov     r10, r11
         shr     r10, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
         add     r10, qword ptr [g_write_watch_table]
         cmp     byte ptr [r10], 0h
@@ -122,26 +123,26 @@ endif
 
         ; Check if we need to update the card table
         ; Calc pCardByte
-        shr     rcx, 0Bh
-        add     rcx, [g_card_table]
+        shr     r11, 0Bh
+        add     r11, [g_card_table]
 
         ; Check if this card is dirty
-        cmp     byte ptr [rcx], 0FFh
+        cmp     byte ptr [r11], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx], 0FFh
+        mov     byte ptr [r11], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        sub     rcx, [g_card_table]
-        shr     rcx, 0Ah
-        add     rcx, [g_card_bundle_table]
-        cmp     byte ptr [rcx], 0FFh
+        sub     r11, [g_card_table]
+        shr     r11, 0Ah
+        add     r11, [g_card_bundle_table]
+        cmp     byte ptr [r11], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx], 0FFh
+        mov     byte ptr [r11], 0FFh
 endif
         ret
 

--- a/src/coreclr/vm/amd64/jithelpers_fastwritebarriers.S
+++ b/src/coreclr/vm/amd64/jithelpers_fastwritebarriers.S
@@ -11,7 +11,7 @@ LEAF_ENTRY JIT_WriteBarrier_PreGrow64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -23,12 +23,7 @@ PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_Lower
         // Check the lower ephemeral region bound.
         cmp     rsi, rax
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x72, 0x4B
-#else
-        .byte 0x72, 0x2b
-#endif
-        // jb      Exit_PreGrow64
+        .byte 0x72, Exit_PreGrow64 - . - 1
 
         nop // padding for alignment of constant
 
@@ -36,32 +31,34 @@ PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_PreGrow64)
+        shr     r11, 0x0B
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_PreGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_PreGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
 
+        // Extra 6-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
 PATCH_LABEL JIT_WriteBarrier_PreGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card bundle, if not already dirty.
-        // rdi is already shifted by 0xB, so shift by 0xA more
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0xFF
+        // r11 is already shifted by 0xB, so shift by 0xA more
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_PreGrow64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_PreGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_PreGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -79,7 +76,7 @@ LEAF_ENTRY JIT_WriteBarrier_PostGrow64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -94,12 +91,7 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_Lower
         // Check the lower and upper ephemeral region bounds
         cmp     rsi, rax
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x72, 0x5b
-#else
-        .byte 0x72, 0x3b
-#endif
-        // jb      Exit_PostGrow64
+        .byte 0x72, Exit_PostGrow64 - . - 1
 
         nop // padding for alignment of constant
 
@@ -108,12 +100,7 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_Upper
 
         cmp     rsi, r8
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x73, 0x4b
-#else
-        .byte 0x73, 0x2b
-#endif
-        // jae     Exit_PostGrow64
+        .byte 0x73, Exit_PostGrow64 - . - 1
 
         nop // padding for alignment of constant
 
@@ -121,32 +108,34 @@ PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_PostGrow64)
+        shr     r11, 0x0B
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_PostGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_PostGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
 
+        // Extra 6-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
 PATCH_LABEL JIT_WriteBarrier_PostGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card bundle, if not already dirty.
-        // rdi is already shifted by 0xB, so shift by 0xA more
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0xFF
+        // r11 is already shifted by 0xB, so shift by 0xA more
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_PostGrow64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_PostGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_PostGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -172,39 +161,41 @@ LEAF_ENTRY JIT_WriteBarrier_SVR64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         NOP_3_BYTE // padding for alignment of constant
 
 PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
-        shr     rdi, 0x0B
+        shr     r11, 0x0B
 
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_SVR64)
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_SVR64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_SVR64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
 
+        // Extra 6-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
 PATCH_LABEL JIT_WriteBarrier_SVR64_PatchLabel_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Shift the address by 0xA more since already shifted by 0xB
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0xFF
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_SVR64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_SVR64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_SVR64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -220,56 +211,61 @@ LEAF_ENTRY JIT_WriteBarrier_Byte_Region64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
-        mov     r8, rdi
+        mov     r8, r11
 
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionToGeneration
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionShrDest
-        shr     rdi, 0x16 // compute region index
+        shr     r11, 0x16 // compute region index
 
         // Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rdi + rax], 0
-        .byte 0x75, 0x04
-        //jne     LOCAL_LABEL(NotGen0_Byte_Region64)
+        cmp     byte ptr [r11 + rax], 0
+        .byte 0x75, LOCAL_LABEL(NotGen0_Byte_Region64) - . - 1
         REPRET
 
         NOP_2_BYTE // padding for alignment of constant
 
     LOCAL_LABEL(NotGen0_Byte_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_Lower
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x73, 0x01
-        // jae     LOCAL_LABEL(NotLow_Byte_Region64)
+        .byte 0x73, LOCAL_LABEL(NotLow_Byte_Region64) - . - 1
         ret
     LOCAL_LABEL(NotLow_Byte_Region64):
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_Upper
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x72, 0x02
-        // jb      LOCAL_LABEL(NotHigh_Byte_Region64)
+        .byte 0x72, LOCAL_LABEL(NotHigh_Byte_Region64) - . - 1
         REPRET
     LOCAL_LABEL(NotHigh_Byte_Region64):
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_RegionShrSrc
         shr     rsi, 0x16 // compute region index
         mov     dl, [rsi + rax]
-        cmp     dl, [rdi + rax]
-        .byte 0x72, 0x03
-        // jb      LOCAL_LABEL(IsOldToYoung_Byte_Region64)
+        cmp     dl, [r11 + rax]
+        .byte 0x72, LOCAL_LABEL(IsOldToYoung_Byte_Region64) - . - 1
         REPRET
         nop
 
     LOCAL_LABEL(IsOldToYoung_Byte_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         shr     r8, 0xB
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne      LOCAL_LABEL(UpdateCardTable_Byte_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_Byte_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_Byte_Region64):
@@ -279,8 +275,7 @@ PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_CardTable
 PATCH_LABEL JIT_WriteBarrier_Byte_Region64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundleTable_Byte_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundleTable_Byte_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundleTable_Byte_Region64):
@@ -295,49 +290,55 @@ LEAF_ENTRY JIT_WriteBarrier_Bit_Region64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
-        mov     r8, rdi
+        mov     r8, r11
 
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionToGeneration
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionShrDest
-        shr     rdi, 0x16 // compute region index
+        shr     r11, 0x16 // compute region index
 
         // Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rdi + rax], 0
-        .byte 0x75, 0x04
-        //jne     LOCAL_LABEL(NotGen0_Bit_Region64)
+        cmp     byte ptr [r11 + rax], 0
+        .byte 0x75, LOCAL_LABEL(NotGen0_Bit_Region64) - . - 1
         REPRET
 
         NOP_2_BYTE // padding for alignment of constant
 
     LOCAL_LABEL(NotGen0_Bit_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_Lower
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x73, 0x01
-        // jae     LOCAL_LABEL(NotLow_Bit_Region64)
+        .byte 0x73, LOCAL_LABEL(NotLow_Bit_Region64) - . - 1
         ret
     LOCAL_LABEL(NotLow_Bit_Region64):
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_Upper
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x72, 0x02
-        // jb      LOCAL_LABEL(NotHigh_Bit_Region64)
+        .byte 0x72, LOCAL_LABEL(NotHigh_Bit_Region64) - . - 1
         REPRET
     LOCAL_LABEL(NotHigh_Bit_Region64):
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_RegionShrSrc
         shr     rsi, 0x16 // compute region index
         mov     dl, [rsi + rax]
-        cmp     dl, [rdi + rax]
-        .byte 0x72, 0x03
-        // jb      LOCAL_LABEL(IsOldToYoung_Bit_Region64)
+        cmp     dl, [r11 + rax]
+        .byte 0x72, LOCAL_LABEL(IsOldToYoung_Bit_Region64) - . - 1
         REPRET
         nop
 
     LOCAL_LABEL(IsOldToYoung_Bit_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
@@ -348,8 +349,7 @@ PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardTable
         mov     dl, 1
         shl     dl, cl
         test    byte ptr [r8 + rax], dl
-        .byte 0x74, 0x02
-        // je      LOCAL_LABEL(UpdateCardTable_Bit_Region64)
+        .byte 0x74, LOCAL_LABEL(UpdateCardTable_Bit_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_Bit_Region64):
@@ -359,8 +359,7 @@ PATCH_LABEL JIT_WriteBarrier_Bit_Region64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
         shr     r8, 0x0A
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundleTable_Bit_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundleTable_Bit_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundleTable_Bit_Region64):
@@ -384,61 +383,56 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PreGrow64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_Lower
-        movabs  r11, 0xF0F0F0F0F0F0F0F0
+        movabs  r9, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x03
-        // jne     LOCAL_LABEL(CheckCardTable_WriteWatch_PreGrow64)
+        .byte 0x75, LOCAL_LABEL(CheckCardTable_WriteWatch_PreGrow64) - . - 1
         mov     byte ptr [rax], 0xFF
 
     LOCAL_LABEL(CheckCardTable_WriteWatch_PreGrow64):
         // Check the lower ephemeral region bound.
-        cmp     rsi, r11
+        cmp     rsi, r9
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x72, 0x40
-#else
-        .byte 0x72, 0x20
-#endif
-
-        // jb      Exit_WriteWatch_PreGrow64
+        .byte 0x72, Exit_WriteWatch_PreGrow64 - . - 1
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0x0B
+        shr     r11, 0x0B
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_WriteWatch_PreGrow64)
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_WriteWatch_PreGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_WriteWatch_PreGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
+        // Extra 6-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PreGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0xFF
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PreGrow64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_WriteWatch_PreGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PreGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -462,34 +456,28 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_PostGrow64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_Lower
-        movabs  r11, 0xF0F0F0F0F0F0F0F0
+        movabs  r9, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x06
-        // jne     LOCAL_LABEL(CheckCardTable_WriteWatch_PostGrow64)
+        .byte 0x75, LOCAL_LABEL(CheckCardTable_WriteWatch_PostGrow64) - . - 1
         mov     byte ptr [rax], 0xFF
 
         NOP_3_BYTE // padding for alignment of constant
 
         // Check the lower and upper ephemeral region bounds
     LOCAL_LABEL(CheckCardTable_WriteWatch_PostGrow64):
-        cmp     rsi, r11
+        cmp     rsi, r9
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x72, 0x4d
-#else
-        .byte 0x72, 0x3d
-#endif
-        // jb      Exit_WriteWatch_PostGrow64
+        .byte 0x72, Exit_WriteWatch_PostGrow64 - . - 1
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -498,12 +486,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_Upper
 
         cmp     rsi, r10
 
-#ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        .byte 0x73, 0x3b
-#else
-        .byte 0x73, 0x2b
-#endif
-        // jae     Exit_WriteWatch_PostGrow64
+        .byte 0x73, Exit_WriteWatch_PostGrow64 - . - 1
 
         nop // padding for alignment of constant
 
@@ -511,29 +494,31 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_WriteWatch_PostGrow64)
+        shr     r11, 0x0B
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_WriteWatch_PostGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_WriteWatch_PostGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
-        shr     rdi, 0x0A
+        shr     r11, 0x0A
 
+        // Extra 6-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_PostGrow64_Patch_Label_CardBundleTable
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0xFF
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -565,46 +550,43 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_SVR64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_WriteWatchTable
         movabs  r10, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardTable
-        movabs  r11, 0xF0F0F0F0F0F0F0F0
+        movabs  r9, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x03
-        // jne     LOCAL_LABEL(CheckCardTable_WriteWatch_SVR64)
+        .byte 0x75, LOCAL_LABEL(CheckCardTable_WriteWatch_SVR64) - . - 1
         mov     byte ptr [rax], 0xFF
 
     LOCAL_LABEL(CheckCardTable_WriteWatch_SVR64):
-        shr     rdi, 0x0B
-        cmp     byte ptr [rdi + r11], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable_WriteWatch_SVR64)
+        shr     r11, 0x0B
+        cmp     byte ptr [r11 + r9], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_WriteWatch_SVR64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_WriteWatch_SVR64):
-        mov     byte ptr [rdi + r11], 0xFF
+        mov     byte ptr [r11 + r9], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP // padding for alignment of constant
 
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_SVR64_PatchLabel_CardBundleTable
-        movabs  r11, 0xF0F0F0F0F0F0F0F0
+        movabs  r9, 0xF0F0F0F0F0F0F0F0
 
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + r11], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_WriteWatch_SVR64)
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + r9], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_WriteWatch_SVR64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_WriteWatch_SVR64):
-        mov     byte ptr [rdi + r11], 0xFF
+        mov     byte ptr [r11 + r9], 0xFF
 #endif
 
         ret
@@ -619,29 +601,27 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_Byte_Region64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_WriteWatchTable
         movabs  r8, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         add     rax, r8
-        mov     r8, rdi
+        mov     r8, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionShrDest
-        shr     rdi, 0x16 // compute region index
+        shr     r11, 0x16 // compute region index
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x03
-        // jne     LOCAL_LABEL(CheckGen0_WriteWatch_Byte_Region64)
+        .byte 0x75, LOCAL_LABEL(CheckGen0_WriteWatch_Byte_Region64) - . - 1
         mov     byte ptr [rax], 0xFF
     LOCAL_LABEL(CheckGen0_WriteWatch_Byte_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionToGeneration
         mov     rax, 0xF0F0F0F0F0F0F0F0
 
         // Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rdi + rax], 0
-        .byte 0x75, 0x08
-        // jne     LOCAL_LABEL(NotGen0_WriteWatch_Byte_Region64)
+        cmp     byte ptr [r11 + rax], 0
+        .byte 0x75, LOCAL_LABEL(NotGen0_WriteWatch_Byte_Region64) - . - 1
         REPRET
 
         NOP_2_BYTE // padding for alignment of constant
@@ -649,37 +629,43 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionToGenera
         NOP_2_BYTE // padding for alignment of constant
 
     LOCAL_LABEL(NotGen0_WriteWatch_Byte_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_Lower
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x73, 0x01
-        // jae     LOCAL_LABEL(NotLow_WriteWatch_Byte_Region64)
+        .byte 0x73, LOCAL_LABEL(NotLow_WriteWatch_Byte_Region64) - . - 1
         ret
     LOCAL_LABEL(NotLow_WriteWatch_Byte_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_Upper
         mov     r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x72, 0x02
-        // jb      LOCAL_LABEL(NotHigh_WriteWatch_Byte_Region64)
+        .byte 0x72, LOCAL_LABEL(NotHigh_WriteWatch_Byte_Region64) - . - 1
         REPRET
     LOCAL_LABEL(NotHigh_WriteWatch_Byte_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_RegionShrSrc
         shr     rsi, 0x16 // compute region index
         mov     dl, [rsi + rax]
-        cmp     dl, [rdi + rax]
-        .byte 0x72, 0x03
-        // jb      LOCAL_LABEL(IsOldToYoung_WriteWatch_Byte_Region64)
+        cmp     dl, [r11 + rax]
+        .byte 0x72, LOCAL_LABEL(IsOldToYoung_WriteWatch_Byte_Region64) - . - 1
         REPRET
         nop
 
     LOCAL_LABEL(IsOldToYoung_WriteWatch_Byte_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_CardTable
         mov     rax, 0xF0F0F0F0F0F0F0F0
 
         shr     r8, 0xB
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne      LOCAL_LABEL(UpdateCardTable_WriteWatch_Byte_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable_WriteWatch_Byte_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_WriteWatch_Byte_Region64):
@@ -689,8 +675,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_CardTable
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Byte_Region64_Patch_Label_CardBundleTable
         mov     rax, 0xF0F0F0F0F0F0F0F0
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Byte_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Byte_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Byte_Region64):
@@ -705,29 +690,27 @@ LEAF_ENTRY JIT_WriteBarrier_WriteWatch_Bit_Region64, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_WriteWatchTable
         movabs  r8, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0x0C // SoftwareWriteWatch::AddressToTableByteIndexShift
         add     rax, r8
-        mov     r8, rdi
+        mov     r8, r11
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionShrDest
-        shr     rdi, 0x16 // compute region index
+        shr     r11, 0x16 // compute region index
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x03
-        // jne     LOCAL_LABEL(CheckGen0_WriteWatch_Bit_Region64)
+        .byte 0x75, LOCAL_LABEL(CheckGen0_WriteWatch_Bit_Region64) - . - 1
         mov     byte ptr [rax], 0xFF
     LOCAL_LABEL(CheckGen0_WriteWatch_Bit_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionToGeneration
         mov     rax, 0xF0F0F0F0F0F0F0F0
 
         // Check whether the region we're storing into is gen 0 - nothing to do in this case
-        cmp     byte ptr [rdi + rax], 0
-        .byte 0x75, 0x08
-        // jne     LOCAL_LABEL(NotGen0_WriteWatch_Bit_Region64)
+        cmp     byte ptr [r11 + rax], 0
+        .byte 0x75, LOCAL_LABEL(NotGen0_WriteWatch_Bit_Region64) - . - 1
         REPRET
 
         NOP_2_BYTE // padding for alignment of constant
@@ -735,30 +718,37 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionToGenerat
         NOP_2_BYTE // padding for alignment of constant
 
     LOCAL_LABEL(NotGen0_WriteWatch_Bit_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_Lower
         movabs  r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x73, 0x01
-        // jae     LOCAL_LABEL(NotLow_WriteWatch_Bit_Region64)
+        .byte 0x73, LOCAL_LABEL(NotLow_WriteWatch_Bit_Region64) - . - 1
         ret
     LOCAL_LABEL(NotLow_WriteWatch_Bit_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_Upper
         mov     r9, 0xF0F0F0F0F0F0F0F0
         cmp     rsi, r9
-        .byte 0x72, 0x02
-        // jb      LOCAL_LABEL(NotHigh_WriteWatch_Bit_Region64)
+        .byte 0x72, LOCAL_LABEL(NotHigh_WriteWatch_Bit_Region64) - . - 1
         REPRET
     LOCAL_LABEL(NotHigh_WriteWatch_Bit_Region64):
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_RegionShrSrc
         shr     rsi, 0x16 // compute region index
         mov     dl, [rsi + rax]
-        cmp     dl, [rdi + rax]
-        .byte 0x72, 0x03
-        // jb      LOCAL_LABEL(IsOldToYoung_WriteWatch_Bit_Region64)
+        cmp     dl, [r11 + rax]
+        .byte 0x72, LOCAL_LABEL(IsOldToYoung_WriteWatch_Bit_Region64) - . - 1
         REPRET
         nop
 
     LOCAL_LABEL(IsOldToYoung_WriteWatch_Bit_Region64):
+        // Extra 7-byte pad: r11 REX growth on prior byte ops shifted
+        // this patchable movabs immediate; restore 8-byte alignment.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        nop
 PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardTable
         mov     rax, 0xF0F0F0F0F0F0F0F0
 
@@ -769,8 +759,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardTable
         mov     dl, 1
         shl     dl, cl
         test    byte ptr [r8 + rax], dl
-        .byte 0x74, 0x02
-        // je      LOCAL_LABEL(UpdateCardTable_WriteWatch_Bit_Region64)
+        .byte 0x74, LOCAL_LABEL(UpdateCardTable_WriteWatch_Bit_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable_WriteWatch_Bit_Region64):
@@ -780,8 +769,7 @@ PATCH_LABEL JIT_WriteBarrier_WriteWatch_Bit_Region64_Patch_Label_CardBundleTable
         mov     rax, 0xF0F0F0F0F0F0F0F0
         shr     r8, 0x0A
         cmp     byte ptr [r8 + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Bit_Region64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Bit_Region64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundleTable_WriteWatch_Bit_Region64):

--- a/src/coreclr/vm/amd64/jithelpers_slow.S
+++ b/src/coreclr/vm/amd64/jithelpers_slow.S
@@ -19,19 +19,19 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         je      NoShadow
 
         // If we end up outside of the heap don't corrupt random memory
-        mov     r10, rdi
-        PREPARE_EXTERNAL_VAR g_lowest_address, r11
-        sub     r10, [r11]
+        mov     r10, r11
+        PREPARE_EXTERNAL_VAR g_lowest_address, r9
+        sub     r10, [r9]
         jb      NoShadow
 
         // Check that our adjusted destination is somewhere in the shadow gc
         add     r10, [rax]
-        PREPARE_EXTERNAL_VAR g_GCShadowEnd, r11
-        cmp     r10, [r11]
+        PREPARE_EXTERNAL_VAR g_GCShadowEnd, r9
+        cmp     r10, [r9]
         jnb     NoShadow
 
         // Write ref into real GC// see comment below about possibility of AV
-        mov     [rdi], rsi
+        mov     [r11], rsi
         // Write ref into shadow GC
         mov     [r10], rsi
 
@@ -40,12 +40,12 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         mfence
 
         // Check that GC/ShadowGC values match
-        mov     r11, [rdi]
+        mov     r9, [r11]
         mov     rax, [r10]
-        cmp     rax, r11
+        cmp     rax, r9
         je      DoneShadow
-        movabs  r11, INVALIDGCVALUE
-        mov     [r10], r11
+        movabs  r9, INVALIDGCVALUE
+        mov     [r10], r9
 
         jmp     DoneShadow
 
@@ -59,7 +59,7 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rax
+        mov     [r11], rax
 
 #ifdef WRITE_BARRIER_CHECK
     // If we had a shadow GC then we already wrote to the real GC at the same time
@@ -72,10 +72,10 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         PREPARE_EXTERNAL_VAR g_sw_ww_enabled_for_gc_heap, r10
         cmp     byte ptr [r10], 0x0
         je      CheckCardTable_Debug
-        mov     r10, rdi
+        mov     r10, r11
         shr     r10, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
-        PREPARE_EXTERNAL_VAR g_write_watch_table, r11
-        add     r10, qword ptr [r11]
+        PREPARE_EXTERNAL_VAR g_write_watch_table, r9
+        add     r10, qword ptr [r9]
         cmp     byte ptr [r10], 0x0
         jne     CheckCardTable_Debug
         mov     byte ptr [r10], 0xFF
@@ -92,35 +92,35 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
 
         // Check if we need to update the card table
         // Calc pCardByte
-        shr     rdi, 0x0B
+        shr     r11, 0x0B
 
         PREPARE_EXTERNAL_VAR g_card_table, r10
         mov     r10, [r10]
 
         // Check if this card is dirty
-        cmp     byte ptr [rdi + r10], 0xFF
+        cmp     byte ptr [r11 + r10], 0xFF
 
         jne     UpdateCardTable_Debug
         REPRET
 
     UpdateCardTable_Debug:
-        mov     byte ptr [rdi + r10], 0xFF
+        mov     byte ptr [r11 + r10], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
-        // Shift rdi by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
-        shr     rdi, 0x0A
+        // Shift r11 by 0x0A more to get the card bundle byte (we shifted by 0x0B already)
+        shr     r11, 0x0A
 
         PREPARE_EXTERNAL_VAR g_card_bundle_table, r10
-        add     rdi, [r10]
+        add     r11, [r10]
 
         // Check if this bundle byte is dirty
-        cmp     byte ptr [rdi], 0xFF
+        cmp     byte ptr [r11], 0xFF
 
         jne     UpdateCardBundle_Debug
         REPRET
 
     UpdateCardBundle_Debug:
-        mov     byte ptr [rdi], 0xFF
+        mov     byte ptr [r11], 0xFF
 #endif
 
         ret

--- a/src/coreclr/vm/amd64/patchedcode.S
+++ b/src/coreclr/vm/amd64/patchedcode.S
@@ -84,19 +84,17 @@ WRITE_BARRIER_ENTRY JIT_CheckedWriteBarrier
         //
         // See if this is in GCHeap
         PREPARE_EXTERNAL_VAR g_lowest_address, rax
-        cmp     rdi, [rax]
-        // jb      LOCAL_LABEL(NotInHeap)
-        .byte 0x72, 0x12
+        cmp     r11, [rax]
+        .byte 0x72, LOCAL_LABEL(NotInHeap) - . - 1
         PREPARE_EXTERNAL_VAR g_highest_address, rax
-        cmp     rdi, [rax]
+        cmp     r11, [rax]
 
-        // jnb     LOCAL_LABEL(NotInHeap)
-        .byte 0x73, 0x06
+        .byte 0x73, LOCAL_LABEL(NotInHeap) - . - 1
         jmp     [rip + C_FUNC(JIT_WriteBarrier_Loc)]
 
     LOCAL_LABEL(NotInHeap):
         // See comment above about possible AV
-        mov     [rdi], rsi
+        mov     [r11], rsi
         ret
 WRITE_BARRIER_END JIT_CheckedWriteBarrier
 
@@ -127,63 +125,58 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         // Update the write watch table if necessary
-        mov     rax, rdi
+        mov     rax, r11
         movabs  r10, 0xF0F0F0F0F0F0F0F0
         shr     rax, 0xC // SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE // padding for alignment of constant
-        movabs  r11, 0xF0F0F0F0F0F0F0F0
+        movabs  r9, 0xF0F0F0F0F0F0F0F0
         add     rax, r10
         cmp     byte ptr [rax], 0x0
-        .byte 0x75, 0x06
-        // jne     LOCAL_LABEL(CheckCardTable)
+        .byte 0x75, LOCAL_LABEL(CheckCardTable) - . - 1
         mov     byte ptr [rax], 0xFF
 
         NOP_3_BYTE // padding for alignment of constant
 
         // Check the lower and upper ephemeral region bounds
     LOCAL_LABEL(CheckCardTable):
-        cmp     rsi, r11
-        .byte 0x72,0x3D
-        // jb      LOCAL_LABEL(Exit)
+        cmp     rsi, r9
+        .byte 0x72, LOCAL_LABEL(Exit) - . - 1
 
         NOP_3_BYTE // padding for alignment of constant
 
         movabs  r10, 0xF0F0F0F0F0F0F0F0
 
         cmp     rsi, r10
-        .byte 0x73,0x2B
-        // jae     LOCAL_LABEL(Exit)
+        .byte 0x73, LOCAL_LABEL(Exit) - . - 1
 
         nop // padding for alignment of constant
 
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0x0B
-        cmp     byte ptr [rdi + rax], 0xFF
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable)
+        shr     r11, 0x0B
+        cmp     byte ptr [r11 + rax], 0xFF
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_2_BYTE // padding for alignment of constant
-        shr     rdi, 0x0A
+        shr     r11, 0x0A
 
         movabs  rax, 0xF0F0F0F0F0F0F0F0
-        cmp     byte ptr [rdi + rax], 0xFF
+        cmp     byte ptr [r11 + rax], 0xFF
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle_WriteWatch_PostGrow64):
-        mov     byte ptr [rdi + rax], 0xFF
+        mov     byte ptr [r11 + rax], 0xFF
 #endif
 
         ret
@@ -223,7 +216,7 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
         // figures out that this came from a WriteBarrier and correctly maps it back
         // to the managed method which called the WriteBarrier (see setup in
         // InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rdi], rsi
+        mov     [r11], rsi
 
         NOP_3_BYTE // padding for alignment of constant
 
@@ -237,30 +230,27 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
 
         // Check the lower and upper ephemeral region bounds
         cmp     rsi, rax
-        // jb      LOCAL_LABEL(Exit)
-        .byte 0x72, 0x36
+        .byte 0x72, LOCAL_LABEL(Exit) - . - 1
 
         nop // padding for alignment of constant
 
         movabs  r8, 0xF0F0F0F0F0F0F0F0
 
         cmp     rsi, r8
-        // jae     LOCAL_LABEL(Exit)
-        .byte 0x73, 0x26
+        .byte 0x73, LOCAL_LABEL(Exit) - . - 1
 
         nop // padding for alignment of constant
 
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card table entry, if not already dirty.
-        shr     rdi, 0Bh
-        cmp     byte ptr [rdi + rax], 0FFh
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardTable)
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
+        .byte 0x75, LOCAL_LABEL(UpdateCardTable) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardTable):
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         NOP_6_BYTE // padding for alignment of constant
@@ -268,16 +258,15 @@ WRITE_BARRIER_ENTRY JIT_WriteBarrier
         movabs  rax, 0xF0F0F0F0F0F0F0F0
 
         // Touch the card bundle, if not already dirty.
-        // rdi is already shifted by 0xB, so shift by 0xA more
-        shr     rdi, 0x0A
-        cmp     byte ptr [rdi + rax], 0FFh
+        // r11 is already shifted by 0xB, so shift by 0xA more
+        shr     r11, 0x0A
+        cmp     byte ptr [r11 + rax], 0FFh
 
-        .byte 0x75, 0x02
-        // jne     LOCAL_LABEL(UpdateCardBundle)
+        .byte 0x75, LOCAL_LABEL(UpdateCardBundle) - . - 1
         REPRET
 
     LOCAL_LABEL(UpdateCardBundle):
-        mov     byte ptr [rdi + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 #endif
 
         ret

--- a/src/coreclr/vm/amd64/patchedcode.asm
+++ b/src/coreclr/vm/amd64/patchedcode.asm
@@ -51,10 +51,10 @@ ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         ; Update the write watch table if necessary
-        mov     rax, rcx
+        mov     rax, r11
         mov     r8, 0F0F0F0F0F0F0F0F0h
         shr     rax, 0Ch ; SoftwareWriteWatch::AddressToTableByteIndexShift
         NOP_2_BYTE ; padding for alignment of constant
@@ -83,22 +83,22 @@ ifdef FEATURE_USE_SOFTWARE_WRITE_WATCH_FOR_GC_HEAP
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        shr     rcx, 0Ah
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Ah
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
@@ -130,6 +130,19 @@ endif
         NOP_3_BYTE
         NOP_3_BYTE
 
+        ; Extra padding so the JIT_WriteBarrier buffer is at least as large as
+        ; WriteWatch_Bit_Region64 after the r11 convention grew that template
+        ; more than the WriteWatch_PostGrow64 body used here (BTS rewrite plus
+        ; three alignment pads).
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+
 else
         ; JIT_WriteBarrier_PostGrow64
 
@@ -137,7 +150,7 @@ else
         ; figures out that this came from a WriteBarrier and correctly maps it back
         ; to the managed method which called the WriteBarrier (see setup in
         ; InitializeExceptionHandling, vm\exceptionhandling.cpp).
-        mov     [rcx], rdx
+        mov     [r11], rdx
 
         NOP_3_BYTE ; padding for alignment of constant
 
@@ -165,28 +178,55 @@ else
         mov     rax, 0F0F0F0F0F0F0F0F0h
 
         ; Touch the card table entry, if not already dirty.
-        shr     rcx, 0Bh
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Bh
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardTable
         REPRET
 
     UpdateCardTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
+        ; Extra 6-byte pad to keep the next movabs immediate 8-byte aligned
+        ; after r11-based byte ops grew vs the original rcx-based ones.
+        NOP_3_BYTE
+        NOP_3_BYTE
         mov     rax, 0F0F0F0F0F0F0F0F0h
-        shr     rcx, 0Ah
-        cmp     byte ptr [rcx + rax], 0FFh
+        shr     r11, 0Ah
+        cmp     byte ptr [r11 + rax], 0FFh
         jne     UpdateCardBundleTable
         REPRET
 
     UpdateCardBundleTable:
-        mov     byte ptr [rcx + rax], 0FFh
+        mov     byte ptr [r11 + rax], 0FFh
 endif
         ret
 
     align 16
     Exit:
         REPRET
+
+        ; Padding so the JIT_WriteBarrier buffer is at least as large as the
+        ; largest fast template after the r11 convention growth.
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
+        NOP_3_BYTE
 endif
 
     ; make sure this is bigger than any of the others


### PR DESCRIPTION
Custom calling convention for `CORINFO_HELP_ASSIGN_REF` / `CORINFO_HELP_CHECKED_ASSIGN_REF` on x64: dst is passed in R11 instead of REG_ARG_0, and the helpers preserve REG_ARG_0 (RCX on Win-x64, RDI on SysV) so the JIT can keep `this`-style values alive across the call.

[Big diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1442495&view=ms.vss-build-web.run-extensions-tab)