### PR TITLE
JIT: Fix debug `igDataSize` assignment to use code size (so exclude gc vars)

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1054,7 +1054,7 @@ insGroup* emitter::emitSavIG(bool emitAdd)
 
     assert((ig->igFlags & IGF_PLACEHOLDER) == 0);
     ig->igData = id;
-    INDEBUG(ig->igDataSize = gs;)
+    INDEBUG(ig->igDataSize = sz;)
 
     memcpy(id, emitCurIGfreeBase, sz);
 


### PR DESCRIPTION
This random method (and other) tells us at that `igData` points to after the gc vars.
https://github.com/dotnet/runtime/blob/f2d5042ceaea5642bac6bde8a1a5765afcbf2ef4/src/coreclr/jit/emit.h#L352-L360

More specifically it points to "addr of instruction descriptors". However the corresponding debug-only `igDataSize` was being assigned `gs` which is the size of the entire IG (including gc vars). It should use code size (`sz`) instead.

Fixes this assert I was hitting in https://github.com/dotnet/runtime/pull/128536:
https://github.com/dotnet/runtime/blob/f2d5042ceaea5642bac6bde8a1a5765afcbf2ef4/src/coreclr/jit/emit.cpp#L10081
