### PR TITLE
Avoid redundant boxing in ValueTuple<T1,...,T7,TRest>

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/ValueTuple.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ValueTuple.cs
@@ -2009,7 +2009,7 @@ namespace System
         public override int GetHashCode()
         {
             // We want to have a limited hash in this case. We'll use the first 7 elements of the tuple
-            if (Rest is not IValueTupleInternal)
+            if (Rest is not IValueTupleInternal rest)
             {
                 return HashCode.Combine(Item1?.GetHashCode() ?? 0,
                                         Item2?.GetHashCode() ?? 0,
@@ -2020,7 +2020,7 @@ namespace System
                                         Item7?.GetHashCode() ?? 0);
             }
 
-            int size = ((IValueTupleInternal)Rest).Length;
+            int size = rest.Length;
             int restHashCode = Rest.GetHashCode();
             if (size >= 8)
             {
@@ -2170,9 +2170,9 @@ namespace System
         /// </remarks>
         public override string ToString()
         {
-            if (Rest is IValueTupleInternal)
+            if (Rest is IValueTupleInternal rest)
             {
-                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + ((IValueTupleInternal)Rest).ToStringEnd();
+                return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
             }
 
             return "(" + Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2180,9 +2180,9 @@ namespace System
 
         string IValueTupleInternal.ToStringEnd()
         {
-            if (Rest is IValueTupleInternal)
+            if (Rest is IValueTupleInternal rest)
             {
-                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + ((IValueTupleInternal)Rest).ToStringEnd();
+                return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + rest.ToStringEnd();
             }
 
             return Item1?.ToString() + ", " + Item2?.ToString() + ", " + Item3?.ToString() + ", " + Item4?.ToString() + ", " + Item5?.ToString() + ", " + Item6?.ToString() + ", " + Item7?.ToString() + ", " + Rest.ToString() + ")";
@@ -2191,7 +2191,7 @@ namespace System
         /// <summary>
         /// The number of positions in this data structure.
         /// </summary>
-        int ITuple.Length => Rest is IValueTupleInternal ? 7 + ((IValueTupleInternal)Rest).Length : 8;
+        int ITuple.Length => Rest is IValueTupleInternal rest ? 7 + rest.Length : 8;
 
         /// <summary>
         /// Get the element at position <param name="index"/>.
@@ -2218,9 +2218,9 @@ namespace System
                         return Item7;
                 }
 
-                if (Rest is IValueTupleInternal)
+                if (Rest is IValueTupleInternal rest)
                 {
-                    return ((IValueTupleInternal)Rest)[index - 7];
+                    return rest[index - 7];
                 }
 
 


### PR DESCRIPTION
This PR use pattern variable capture (`is IValueTupleInternal rest`) instead of a separate type-check followed by a cast to `IValueTupleInternal`. This avoids a redundant boxing of `TRest` when it is a `ValueTuple<TRest>` containing reference-type fields, reducing heap allocations in `GetHashCode`, `ToString`, `ITuple.Length`, and the `ITuple` indexer.

## Benchmark

| Method           | Job        | Toolchain         | Mean      | Error     | StdDev    | Median    | Min       | Max       | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|----------------- |----------- |------------------ |----------:|----------:|----------:|----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| GetHashCode_Int8 | Job-QIDXWP | \main\corerun.exe |  5.260 ns | 0.1494 ns | 0.1720 ns |  5.318 ns |  4.939 ns |  5.557 ns |  1.00 |    0.00 |      - |         - |          NA |
| GetHashCode_Int8 | Job-TLPBEL | \pr\corerun.exe   |  4.964 ns | 0.1389 ns | 0.1599 ns |  4.911 ns |  4.764 ns |  5.344 ns |  0.94 |    0.04 |      - |         - |          NA |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| GetHashCode_Str8 | Job-QIDXWP | \main\corerun.exe | 13.155 ns | 0.5284 ns | 0.5873 ns | 13.028 ns | 12.442 ns | 14.690 ns |  1.00 |    0.00 | 0.0028 |      24 B |        1.00 |
| GetHashCode_Str8 | Job-TLPBEL | \pr\corerun.exe   |  8.563 ns | 0.1916 ns | 0.2206 ns |  8.447 ns |  8.311 ns |  8.969 ns |  0.65 |    0.03 |      - |         - |        0.00 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| ToString_Int8    | Job-QIDXWP | \main\corerun.exe | 72.434 ns | 2.1456 ns | 2.4709 ns | 71.774 ns | 69.573 ns | 76.946 ns |  1.00 |    0.00 | 0.0304 |     256 B |        1.00 |
| ToString_Int8    | Job-TLPBEL | \pr\corerun.exe   | 70.706 ns | 1.8968 ns | 2.1844 ns | 70.259 ns | 67.266 ns | 75.064 ns |  0.98 |    0.04 | 0.0305 |     256 B |        1.00 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| ToString_Str8    | Job-QIDXWP | \main\corerun.exe | 76.118 ns | 2.1219 ns | 2.4436 ns | 76.160 ns | 71.786 ns | 81.114 ns |  1.00 |    0.00 | 0.0334 |     280 B |        1.00 |
| ToString_Str8    | Job-TLPBEL | \pr\corerun.exe   | 71.267 ns | 1.5937 ns | 1.8353 ns | 70.953 ns | 68.286 ns | 74.699 ns |  0.94 |    0.04 | 0.0305 |     256 B |        0.91 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| Length_Int8      | Job-QIDXWP | \main\corerun.exe |  4.052 ns | 0.1157 ns | 0.1287 ns |  4.069 ns |  3.882 ns |  4.256 ns |  1.00 |    0.00 | 0.0057 |      48 B |        1.00 |
| Length_Int8      | Job-TLPBEL | \pr\corerun.exe   |  4.284 ns | 0.1248 ns | 0.1438 ns |  4.287 ns |  4.080 ns |  4.595 ns |  1.06 |    0.05 | 0.0057 |      48 B |        1.00 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| Length_Str8      | Job-QIDXWP | \main\corerun.exe | 10.711 ns | 0.2865 ns | 0.3184 ns | 10.782 ns | 10.178 ns | 11.242 ns |  1.00 |    0.00 | 0.0095 |      80 B |        1.00 |
| Length_Str8      | Job-TLPBEL | \pr\corerun.exe   |  6.129 ns | 0.1166 ns | 0.1248 ns |  6.155 ns |  5.816 ns |  6.290 ns |  0.57 |    0.02 | 0.0067 |      56 B |        0.70 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| Indexer_Int8     | Job-QIDXWP | \main\corerun.exe |  6.039 ns | 0.2171 ns | 0.2500 ns |  6.036 ns |  5.719 ns |  6.515 ns |  1.00 |    0.00 | 0.0086 |      72 B |        1.00 |
| Indexer_Int8     | Job-TLPBEL | \pr\corerun.exe   |  6.479 ns | 0.2155 ns | 0.2395 ns |  6.487 ns |  6.112 ns |  7.022 ns |  1.07 |    0.06 | 0.0086 |      72 B |        1.00 |
|                  |            |                   |           |           |           |           |           |           |       |         |        |           |             |
| Indexer_Str8     | Job-QIDXWP | \main\corerun.exe | 11.339 ns | 0.2880 ns | 0.3201 ns | 11.413 ns | 10.752 ns | 11.848 ns |  1.00 |    0.00 | 0.0095 |      80 B |        1.00 |
| Indexer_Str8     | Job-TLPBEL | \pr\corerun.exe   |  6.356 ns | 0.1778 ns | 0.1976 ns |  6.367 ns |  6.058 ns |  6.811 ns |  0.56 |    0.02 | 0.0067 |      56 B |        0.70 |


```csharp
    public class Perf_ValueTuple
    {
        private ValueTuple<int, int, int, int, int, int, int, ValueTuple<int>> _tupleInt8;
        private ValueTuple<int, int, int, int, int, int, int, ValueTuple<string>> _tupleStr8;

        [GlobalSetup]
        public void Setup()
        {
            _tupleInt8 = new(1, 2, 3, 4, 5, 6, 7, new ValueTuple<int>(8));
            _tupleStr8 = new(1, 2, 3, 4, 5, 6, 7, new ValueTuple<string>("8"));
        }

        [Benchmark]
        public int GetHashCode_Int8() => _tupleInt8.GetHashCode();

        [Benchmark]
        public int GetHashCode_Str8() => _tupleStr8.GetHashCode();

        [Benchmark]
        public string ToString_Int8() => _tupleInt8.ToString();

        [Benchmark]
        public string ToString_Str8() => _tupleStr8.ToString();

        [Benchmark]
        public int Length_Int8() => ((ITuple)_tupleInt8).Length;

        [Benchmark]
        public int Length_Str8() => ((ITuple)_tupleStr8).Length;

        [Benchmark]
        public object Indexer_Int8() => ((ITuple)_tupleInt8)[7];

        [Benchmark]
        public object Indexer_Str8() => ((ITuple)_tupleStr8)[7];
    }
```