### PR TITLE
Fix minor typo/formatting in the memory model spec

### DIFF
--- a/docs/design/specs/Memory-model.md
+++ b/docs/design/specs/Memory-model.md
@@ -105,7 +105,7 @@ It may be possible for an optimizing compiler to prove that some data is accessi
      - `System.Threading.Interlocked` methods
 
 ## C# `volatile` feature
-One common way to introduce volatile memory accesses is by using C# `volatile` language feature. Declaring a field as `volatile` does not have any effect on how .NET runtime treats the field. The decoration works as a hint to the C# compiler itself (and compilers for other .Net languages) to emit reads and writes of such field as  reads and writes with `volatile.` prefix.
+One common way to introduce volatile memory accesses is by using C# `volatile` language feature. Declaring a field as `volatile` does not have any effect on how .NET runtime treats the field. The decoration works as a hint to the C# compiler itself (and compilers for other .NET languages) to emit reads and writes of such field as  reads and writes with `volatile.` prefix.
 
 ## Process-wide barrier
 Process-wide barrier has full-fence semantics with an additional guarantee that each thread in the program effectively performs a full fence at arbitrary point synchronized with the process-wide barrier in such a way that effects of writes that precede both barriers are observable by memory operations that follow the barriers.


### PR DESCRIPTION
.Net → .NET