### PR TITLE
[ci-scan] Allow feedback workflow to edit shared KBE instructions

### DIFF
--- a/.github/workflows/ci-failure-scan-feedback.lock.yml
+++ b/.github/workflows/ci-failure-scan-feedback.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2e1c800f18e97303502871201083b668124fa7908f8eb8291f65226193f7283a","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1929f083ec00920b8f3cdcefbb74f23e8099c86521ebee20211153ff97215805","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot","agent_model":"claude-opus-4.6"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","COPILOT_PAT_0","COPILOT_PAT_1","COPILOT_PAT_2","COPILOT_PAT_3","COPILOT_PAT_4","COPILOT_PAT_5","COPILOT_PAT_6","COPILOT_PAT_7","COPILOT_PAT_8","COPILOT_PAT_9","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR.
+# Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md or shared/create-kbe.instructions.md as a single draft PR.
 #
 # Resolved workflow manifest:
 #   Imports:
@@ -208,24 +208,24 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_187c5a26e23653eb_EOF'
           <system>
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_187c5a26e23653eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_187c5a26e23653eb_EOF'
           <safe-output-tools>
           Tools: create_issue, update_issue, create_pull_request, update_pull_request, push_to_pull_request_branch, missing_tool, missing_data, noop
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_187c5a26e23653eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_push_to_pr_branch.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_187c5a26e23653eb_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_187c5a26e23653eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_187c5a26e23653eb_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -257,12 +257,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_187c5a26e23653eb_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF'
+          cat << 'GH_AW_PROMPT_187c5a26e23653eb_EOF'
           </system>
           {{#runtime-import .github/workflows/ci-failure-scan-feedback.md}}
-          GH_AW_PROMPT_b84e5ae3b6ca0cd1_EOF
+          GH_AW_PROMPT_187c5a26e23653eb_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF'
-          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_4c60e9f8dfc33010_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_b6855cdc8ae621a8_EOF'
+          {"create_issue":{"allowed_labels":["agentic-workflows"],"labels":["agentic-workflows"],"max":1},"create_pull_request":{"allowed_files":[".github/workflows/ci-failure-scan.md",".github/workflows/shared/create-kbe.instructions.md"],"draft":true,"labels":["agentic-workflows"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked","title_prefix":"[ci-scan-feedback] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"false"},"push_to_pull_request_branch":{"allowed_files":[".github/workflows/ci-failure-scan.md",".github/workflows/shared/create-kbe.instructions.md"],"if_no_changes":"warn","max":1,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_dot_folder_excludes":[".github/"],"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"protected_files_policy":"blocked"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1,"target":"*"},"update_pull_request":{"allow_body":true,"allow_title":true,"max":1,"update_branch":false}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_b6855cdc8ae621a8_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -812,7 +812,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f2860c2b4223cd4e_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -856,7 +856,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_b45f93710d9b2073_EOF
+          GH_AW_MCP_CONFIG_f2860c2b4223cd4e_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1274,26 +1274,22 @@ jobs:
             await main();
 
   detection:
-    # ###############################################################
-    # MANUAL PATCH: `detection` needs `pat_pool`
-    # ---------------------------------------------------------------
-    # `gh aw compile` only infers PAT-pool dependency for the `agent`
-    # job. Without `pat_pool` listed here, every secret/case() lookup
-    # in this job that consults `needs.pat_pool.outputs.pat_number`
-    # collapses to '', the `COPILOT_GITHUB_TOKEN` case() expression
-    # falls through to an empty/stale token, the api-proxy returns
-    # HTTP 400, the threat-detection parser fails, and gh-aw stamps a
-    # "Security scanning requires review" CAUTION banner on every
-    # issue/PR the agent produces.
-    #
-    # Re-add `- pat_pool` (and this comment) after every recompile.
-    # Tracked upstream by gh-aw issue #30232 — engine.env-based needs
-    # inference was fixed for the `agent` job in v0.71.5 but the fix
-    # has not been generalised to `detection`.
-    # ###############################################################
     needs:
       - activation
       - agent
+    # MANUAL PATCH: `detection` needs `pat_pool`
+    #
+    # Why: the generated workflow's expression evaluator can fail open if the
+    # pat_pool job is omitted from `needs` while case(needs.pat_pool...) is used
+    # in env resolution. In practice this manifests as:
+    #   "Error when evaluating 'env'. ... Object has no member 'pat_pool'"
+    # before the detector even starts, which means no detection log artifact,
+    # HTTP 400, the threat-detection parser fails, and gh-aw stamps a
+    # misleading detection failure on unrelated prompt edits.
+    #
+    # Re-add `- pat_pool` (and this comment) after every recompile.
+    # The same patch exists in ci-failure-scan.lock.yml and ci-scan.lock.yml but
+    # has not been generalised to `detection`.
       - pat_pool
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')
@@ -1381,7 +1377,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "CI Outer-Loop Failure Scanner — Feedback"
-          WORKFLOW_DESCRIPTION: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR."
+          WORKFLOW_DESCRIPTION: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md or shared/create-kbe.instructions.md as a single draft PR."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1691,7 +1687,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"allowed_labels\":[\"agentic-workflows\"],\"labels\":[\"agentic-workflows\"],\"max\":1},\"create_pull_request\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\",\".github/workflows/shared/create-kbe.instructions.md\"],\"draft\":true,\"labels\":[\"agentic-workflows\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\",\"title_prefix\":\"[ci-scan-feedback] \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"false\"},\"push_to_pull_request_branch\":{\"allowed_files\":[\".github/workflows/ci-failure-scan.md\",\".github/workflows/shared/create-kbe.instructions.md\"],\"if_no_changes\":\"warn\",\"max\":1,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_dot_folder_excludes\":[\".github/\"],\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"protected_files_policy\":\"blocked\"},\"report_incomplete\":{},\"update_issue\":{\"allow_body\":true,\"max\":1,\"target\":\"*\"},\"update_pull_request\":{\"allow_body\":true,\"allow_title\":true,\"max\":1,\"update_branch\":false}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -1709,4 +1705,3 @@ jobs:
             /tmp/gh-aw/safe-output-items.jsonl
             /tmp/gh-aw/temporary-id-map.json
           if-no-files-found: ignore
-

--- a/.github/workflows/ci-failure-scan-feedback.lock.yml
+++ b/.github/workflows/ci-failure-scan-feedback.lock.yml
@@ -1274,22 +1274,26 @@ jobs:
             await main();
 
   detection:
+    # ###############################################################
+    # MANUAL PATCH: `detection` needs `pat_pool`
+    # ---------------------------------------------------------------
+    # `gh aw compile` only infers PAT-pool dependency for the `agent`
+    # job. Without `pat_pool` listed here, every secret/case() lookup
+    # in this job that consults `needs.pat_pool.outputs.pat_number`
+    # collapses to '', the `COPILOT_GITHUB_TOKEN` case() expression
+    # falls through to an empty/stale token, the api-proxy returns
+    # HTTP 400, the threat-detection parser fails, and gh-aw stamps a
+    # "Security scanning requires review" CAUTION banner on every
+    # issue/PR the agent produces.
+    #
+    # Re-add `- pat_pool` (and this comment) after every recompile.
+    # Tracked upstream by gh-aw issue #30232 — engine.env-based needs
+    # inference was fixed for the `agent` job in v0.71.5 but the fix
+    # has not been generalised to `detection`.
+    # ###############################################################
     needs:
       - activation
       - agent
-    # MANUAL PATCH: `detection` needs `pat_pool`
-    #
-    # Why: the generated workflow's expression evaluator can fail open if the
-    # pat_pool job is omitted from `needs` while case(needs.pat_pool...) is used
-    # in env resolution. In practice this manifests as:
-    #   "Error when evaluating 'env'. ... Object has no member 'pat_pool'"
-    # before the detector even starts, which means no detection log artifact,
-    # HTTP 400, the threat-detection parser fails, and gh-aw stamps a
-    # misleading detection failure on unrelated prompt edits.
-    #
-    # Re-add `- pat_pool` (and this comment) after every recompile.
-    # The same patch exists in ci-failure-scan.lock.yml and ci-scan.lock.yml but
-    # has not been generalised to `detection`.
       - pat_pool
     if: >
       always() && needs.agent.result != 'skipped' && (needs.agent.outputs.output_types != '' || needs.agent.outputs.has_patch == 'true')

--- a/.github/workflows/ci-failure-scan-feedback.md
+++ b/.github/workflows/ci-failure-scan-feedback.md
@@ -1,6 +1,6 @@
 ---
 name: "CI Outer-Loop Failure Scanner — Feedback"
-description: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md as a single draft PR."
+description: "Periodic tick that reads the latest ci-failure-scan runs and maintainer feedback on the issues/PRs it produced, scores them against a quality rubric, and proposes targeted edits to ci-failure-scan.md or shared/create-kbe.instructions.md as a single draft PR."
 
 permissions:
   contents: read
@@ -52,6 +52,7 @@ safe-outputs:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+      - ".github/workflows/shared/create-kbe.instructions.md"
     protected-files:
       policy: blocked
       exclude:
@@ -62,6 +63,7 @@ safe-outputs:
     max: 1
     allowed-files:
       - ".github/workflows/ci-failure-scan.md"
+      - ".github/workflows/shared/create-kbe.instructions.md"
     protected-files:
       policy: blocked
       exclude:
@@ -88,9 +90,9 @@ network:
 
 # CI Failure Scanner — Feedback
 
-You evaluate the [`CI Outer-Loop Failure Scanner`](ci-failure-scan.md), maintain a single KPI tracker issue with a running window of metrics, and propose targeted edits to its prompt so the next run produces tighter, more actionable artifacts. You run read-only; the only write paths are against `.github/workflows/ci-failure-scan.md` and the tracker issue body.
+You evaluate the [`CI Outer-Loop Failure Scanner`](ci-failure-scan.md), maintain a single KPI tracker issue with a running window of metrics, and propose targeted edits to its prompt/instructions so the next run produces tighter, more actionable artifacts. You run read-only; the only write paths are against `.github/workflows/ci-failure-scan.md`, `.github/workflows/shared/create-kbe.instructions.md`, and the tracker issue body.
 
-Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-failure-scan.md`, max 1 PR + 1 tracker issue open at a time. Reading issue/PR bodies and comments (the user-supplied content the integrity gate exists to filter) MUST go through the `github` MCP tool with `min-integrity: approved`; `[Filtered]` results are skipped (record the count, do not chase them). `gh` calls are allowed for workflow-run metadata (`gh api .../actions/...`, `gh run view --log`) and for enumerating this workflow's own artifacts (finding the `[ci-scan-feedback]` PR/tracker by title or repository-owned label), but NOT for reading maintainer-supplied content — do not use `gh issue view`, `gh pr view`, or `gh api /repos/.../comments` to substitute for the integrity-gated reads.
+Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-failure-scan.md` and `.github/workflows/shared/create-kbe.instructions.md`, max 1 PR + 1 tracker issue open at a time. Reading issue/PR bodies and comments (the user-supplied content the integrity gate exists to filter) MUST go through the `github` MCP tool with `min-integrity: approved`; `[Filtered]` results are skipped (record the count, do not chase them). `gh` calls are allowed for workflow-run metadata (`gh api .../actions/...`, `gh run view --log`) and for enumerating this workflow's own artifacts (finding the `[ci-scan-feedback]` PR/tracker by title or repository-owned label), but NOT for reading maintainer-supplied content — do not use `gh issue view`, `gh pr view`, or `gh api /repos/.../comments` to substitute for the integrity-gated reads.
 
 ## Steps
 
@@ -129,7 +131,7 @@ Hard rules: no comments on issues/PRs, no edits outside `.github/workflows/ci-fa
    - For a sample of in-scope KBEs, cross-check the signature against the cited failing log (`gh run view <id> --log-failed | head -300` or the AzDO/Helix URL in the body) and flag PASS-line collisions or paraphrased signatures.
    - Skip-reason vocabulary stability: any tally row using a `skipped:` reason NOT in the Step 6 'Recognized values' list in `ci-failure-scan.md` is flagged as `unknown-skip-reason: <verbatim string>`. The recognized values list is the source of truth; the feedback PR should propose adding new reasons there before they start appearing in tallies.
 
-5. Translate each failure mode into a targeted edit to `.github/workflows/ci-failure-scan.md`. Prefer rule-shaped edits (tighten Step 4.2, extend Step 4.7's phrase list, add a Bad/Good row, narrow KBE check 7) over wholesale rewrites. Read the file first; reuse the existing voice and section structure.
+5. Translate each failure mode into a targeted edit to whichever file owns the rule: `.github/workflows/ci-failure-scan.md` for scanner behavior or `.github/workflows/shared/create-kbe.instructions.md` for KBE authoring guidance. Prefer rule-shaped edits (tighten Step 4.2, extend Step 4.7's phrase list, add a Bad/Good row, narrow KBE check 7) over wholesale rewrites. Read the target file first; reuse the existing voice and section structure.
 
 6. Emit changes. Check for an existing open `[ci-scan-feedback]` PR first:
 


### PR DESCRIPTION
> [!NOTE]
> This pull request description was generated with Copilot assistance.

## Summary
- allow ci-failure-scan-feedback to update .github/workflows/shared/create-kbe.instructions.md
- keep the workflow prompt text in sync with the expanded allowed file set
- regenerate the compiled lock workflow so the safe-outputs allow-list matches the source workflow

## Validation
- gh aw compile .github/workflows/ci-failure-scan-feedback.md
- git diff --check -- .github/workflows/ci-failure-scan-feedback.md .github/workflows/ci-failure-scan-feedback.lock.yml