### PR TITLE
JIT: Remove a TODO comment

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1975,10 +1975,12 @@ bool AsyncTransformation::IsReusableSuspension(const AsyncState*          state,
         }
     }
 
+    // There can still be disagreement on saving a local here if it has its
+    // default value on one path and was assigned a non-default value on the
+    // other path. Do a final layout check to catch that and all other possible
+    // cases.
     if (!ContinuationLayoutBuilder::Equals(*layoutBuilder, *state->Layout))
     {
-        // TODO: We would expect liveness to match in tail positions here. But
-        // sometimes that isn't the case -- why not?
         return false;
     }
 


### PR DESCRIPTION
This case is legitimate. A reduced repro looks like:
```csharp
public class Program
{
    public static async Task Main(string[] args)
    {
        Program p = GetP();
        int x = 0;
        await Aaa();
        if (args.Length > 1)
        {
            x = 456;
            await p.Foo(ref x);
        }
        else
        {
            await p.Bar();
        }
        Console.WriteLine(x);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static Program GetP() => new Program();

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static async Task Aaa()
    {
    }

    public virtual Task Foo(ref int x)
    {
        return Task.CompletedTask;
    }

    public virtual Task Bar()
    {
        return Task.CompletedTask;
    }
}
```
In this case we need to save `x` only in the first path even though `x` is live in both cases. The layout check is needed to catch this case.
Note that `ref x` is necessary to the `Foo` call, but only because otherwise the previous save-set check filters the case. 