### PR TITLE
[release/10.0] Configurable EventPipe CPU sampling rate

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -600,6 +600,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeCircularMB, W("EventPipeCircularMB"),
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeProcNumbers, W("EventPipeProcNumbers"), 0, "Enable/disable capturing processor numbers in EventPipe event headers")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeOutputStreaming, W("EventPipeOutputStreaming"), 1, "Enable/disable streaming for trace file set in DOTNET_EventPipeOutputPath.  Non-zero values enable streaming.")
 RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeEnableStackwalk, W("EventPipeEnableStackwalk"), 1, "Set to 0 to disable collecting stacks for EventPipe events.")
+RETAIL_CONFIG_DWORD_INFO(INTERNAL_EventPipeThreadSamplingRate, W("EventPipeThreadSamplingRate"), 0, "Desired sample interval in milliseconds for EventPipe thread time sampling profiler. 0 means use the default.")
 
 //
 // UserEvents

--- a/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
+++ b/src/coreclr/nativeaot/Runtime/eventpipe/ep-rt-aot.h
@@ -507,6 +507,23 @@ ep_rt_config_value_get_enable_stackwalk (void)
     return false;
 }
 
+static
+inline
+uint32_t
+ep_rt_config_value_get_sampling_rate (void)
+{
+    STATIC_CONTRACT_NOTHROW;
+
+    uint64_t value;
+    if (RhConfig::Environment::TryGetIntegerValue("EventPipeThreadSamplingRate", &value, true))
+    {
+        EP_ASSERT(value <= UINT32_MAX);
+        return static_cast<uint32_t>(value);
+    }
+
+    return 0;
+}
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.h
@@ -432,9 +432,9 @@ ep_rt_provider_config_init (EventPipeProviderConfiguration *provider_config)
 // This function is auto-generated from /src/scripts/genEventPipe.py
 #ifdef TARGET_UNIX
 extern "C" void InitProvidersAndEvents ();
-#else
+#else // TARGET_UNIX
 extern void InitProvidersAndEvents ();
-#endif
+#endif // TARGET_UNIX
 
 static
 void
@@ -560,6 +560,15 @@ ep_rt_config_value_get_enable_stackwalk (void)
 	return CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeEnableStackwalk) != 0;
 }
 
+static
+inline
+uint32_t
+ep_rt_config_value_get_sampling_rate (void)
+{
+	STATIC_CONTRACT_NOTHROW;
+	return CLRConfig::GetConfigValue(CLRConfig::INTERNAL_EventPipeThreadSamplingRate);
+}
+
 /*
  * EventPipeSampleProfiler.
  */
@@ -610,13 +619,12 @@ void
 ep_rt_notify_profiler_provider_created (EventPipeProvider *provider)
 {
 	STATIC_CONTRACT_NOTHROW;
-
-#ifndef DACCESS_COMPILE
+#if !defined(DACCESS_COMPILE) && defined(PROFILING_SUPPORTED)
 		// Let the profiler know the provider has been created so it can register if it wants to
 		BEGIN_PROFILER_CALLBACK (CORProfilerTrackEventPipe ());
 		(&g_profControlBlock)->EventPipeProviderCreated (provider);
 		END_PROFILER_CALLBACK ();
-#endif // DACCESS_COMPILE
+#endif // !DACCESS_COMPILE && PROFILING_SUPPORTED
 }
 
 /*

--- a/src/mono/mono/eventpipe/ep-rt-mono.h
+++ b/src/mono/mono/eventpipe/ep-rt-mono.h
@@ -637,6 +637,25 @@ ep_rt_config_value_get_enable_stackwalk (void)
 	return value_uint32_t != 0;
 }
 
+static
+inline
+uint32_t
+ep_rt_config_value_get_sampling_rate (void)
+{
+	uint32_t value_uint32_t = 0;
+	gchar *value = g_getenv ("DOTNET_EventPipeThreadSamplingRate");
+	if (!value)
+		value = g_getenv ("COMPlus_EventPipeThreadSamplingRate");
+	if (value) {
+		gchar *endptr = NULL;
+		guint64 parsed = strtoull (value, &endptr, 10);
+		if (endptr != value && *endptr == '\0' && value [0] != '-' && parsed <= G_MAXUINT32)
+			value_uint32_t = (uint32_t)parsed;
+	}
+	g_free (value);
+	return value_uint32_t;
+}
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/native/eventpipe/ep-rt.h
+++ b/src/native/eventpipe/ep-rt.h
@@ -200,6 +200,11 @@ inline
 bool
 ep_rt_config_value_get_enable_stackwalk (void);
 
+static
+inline
+uint32_t
+ep_rt_config_value_get_sampling_rate (void);
+
 /*
  * EventPipeSampleProfiler.
  */

--- a/src/native/eventpipe/ep.c
+++ b/src/native/eventpipe/ep.c
@@ -1488,7 +1488,13 @@ ep_init (void)
 #else // PERFTRACING_DISABLE_THREADS
 	const uint32_t default_profiler_sample_rate_in_nanoseconds = 5000000; // 5 msec.
 #endif // PERFTRACING_DISABLE_THREADS
-	ep_sample_profiler_set_sampling_rate (default_profiler_sample_rate_in_nanoseconds);
+
+	// Allow overriding the sampling rate via DOTNET_EventPipeThreadSamplingRate (in milliseconds).
+	uint32_t configured_rate_ms = ep_rt_config_value_get_sampling_rate ();
+	if (configured_rate_ms > 0)
+		ep_sample_profiler_set_sampling_rate ((uint64_t)configured_rate_ms * 1000000);
+	else
+		ep_sample_profiler_set_sampling_rate (default_profiler_sample_rate_in_nanoseconds);
 
 	_ep_deferred_enable_session_ids = dn_vector_alloc_t (EventPipeSessionID);
 	_ep_deferred_disable_session_ids = dn_vector_alloc_t (EventPipeSessionID);

--- a/src/tests/tracing/eventpipe/samplingrate/samplingrate.cs
+++ b/src/tests/tracing/eventpipe/samplingrate/samplingrate.cs
@@ -24,13 +24,17 @@ namespace Tracing.Tests.SamplingRate
         // so the observed rate is unambiguously different.
         private const int ConfiguredSampleIntervalMs = 50;
 
-        // Length of the CPU-burn workload in the child.
-        private const int WorkloadDurationMs = 3000;
+        // Length of the CPU-burn workload in the child. Longer than strictly necessary so that
+        // contested/slow CI machines still accumulate enough samples for the interval analysis below.
+        private const int WorkloadDurationMs = 5000;
 
-        // Lower bound on samples for the busiest thread. With 50ms interval over ~3s we expect ~60.
-        private const int MinExpectedSamples = 30;
+        // Lower bound on samples for the busiest thread. With 50ms interval over ~5s we'd expect ~100,
+        // but contested macOS Helix runners have been observed producing only ~5-6 samples/sec. 10 is a
+        // generous floor: still well above background noise, and large enough to make the median
+        // inter-sample interval check below statistically meaningful (>= 9 intervals).
+        private const int MinExpectedSamples = 10;
 
-        // Upper bound on samples for the busiest thread. With default 1ms over ~3s we'd expect ~3000;
+        // Upper bound on samples for the busiest thread. With default 1ms over ~5s we'd expect ~5000;
         // 600 leaves >5x headroom above the 50ms expectation while still excluding default-rate behavior.
         private const int MaxAllowedSamples = 600;
 

--- a/src/tests/tracing/eventpipe/samplingrate/samplingrate.cs
+++ b/src/tests/tracing/eventpipe/samplingrate/samplingrate.cs
@@ -1,0 +1,240 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Tracing.Tests.Common;
+
+namespace Tracing.Tests.SamplingRate
+{
+    public class SamplingRate
+    {
+        private const string ChildArg = "child";
+        private const string SampleProviderName = "Microsoft-DotNETCore-SampleProfiler";
+
+        // Configured sample interval (ms) passed to the child via DOTNET_EventPipeThreadSamplingRate.
+        // Picked well above the per-platform default (1ms on CoreCLR, 5ms with PERFTRACING_DISABLE_THREADS)
+        // so the observed rate is unambiguously different.
+        private const int ConfiguredSampleIntervalMs = 50;
+
+        // Length of the CPU-burn workload in the child.
+        private const int WorkloadDurationMs = 3000;
+
+        // Lower bound on samples for the busiest thread. With 50ms interval over ~3s we expect ~60.
+        private const int MinExpectedSamples = 30;
+
+        // Upper bound on samples for the busiest thread. With default 1ms over ~3s we'd expect ~3000;
+        // 600 leaves >5x headroom above the 50ms expectation while still excluding default-rate behavior.
+        private const int MaxAllowedSamples = 600;
+
+        // Lower bound on median inter-sample interval. With 50ms configured we expect ~50ms; the default
+        // 1ms would produce ~1ms. 20ms cleanly separates the two while tolerating scheduling jitter.
+        private const double MinMedianIntervalMs = 20.0;
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0] == ChildArg)
+            {
+                return RunChild();
+            }
+
+            return RunParent();
+        }
+
+        private static int RunParent()
+        {
+            Process process;
+            try
+            {
+                process = new Process();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                Console.WriteLine("Child process launch not supported on this platform; skipping.");
+                return 100;
+            }
+
+            string coreRoot = Environment.GetEnvironmentVariable("CORE_ROOT");
+            string hostPath = Process.GetCurrentProcess().MainModule.FileName;
+            string assemblyPath = typeof(SamplingRate).Assembly.Location;
+
+            process.StartInfo.FileName = hostPath;
+            process.StartInfo.Arguments = TestLibrary.Utilities.IsNativeAot
+                ? ChildArg
+                : $"{assemblyPath} {ChildArg}";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+
+            process.StartInfo.Environment["DOTNET_EventPipeThreadSamplingRate"] = ConfiguredSampleIntervalMs.ToString();
+            if (!string.IsNullOrEmpty(coreRoot))
+            {
+                process.StartInfo.Environment["CORE_ROOT"] = coreRoot;
+            }
+
+            // Drain child stdio asynchronously so the child cannot deadlock on a full pipe (IpcTraceTest
+            // is chatty).
+            process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    Console.WriteLine($"[child stdout] {e.Data}");
+                }
+            };
+            process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                {
+                    Console.Error.WriteLine($"[child stderr] {e.Data}");
+                }
+            };
+
+            Console.WriteLine($"Starting child '{process.StartInfo.FileName}' '{process.StartInfo.Arguments}' " +
+                              $"with DOTNET_EventPipeThreadSamplingRate={ConfiguredSampleIntervalMs}");
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+
+            process.WaitForExit();
+            int exitCode = process.ExitCode;
+            Console.WriteLine($"Child exited with code {exitCode}");
+            return exitCode;
+        }
+
+        private static int RunChild()
+        {
+            Logger.logger.Log($"Child started with DOTNET_EventPipeThreadSamplingRate=" +
+                              $"{Environment.GetEnvironmentVariable("DOTNET_EventPipeThreadSamplingRate") ?? "<unset>"}");
+
+            var providers = new List<EventPipeProvider>
+            {
+                new EventPipeProvider(SampleProviderName, EventLevel.Verbose),
+            };
+
+            var expectedEventCounts = new Dictionary<string, ExpectedEventCount>
+            {
+                { SampleProviderName, -1 },
+                { "Microsoft-Windows-DotNETRuntimeRundown", -1 },
+            };
+
+            // Per-thread (ThreadID -> TimeStampRelativeMSec list) collected from the trace.
+            var samplesByThread = new Dictionary<int, List<double>>();
+            object samplesLock = new();
+
+            Action eventGeneratingAction = () =>
+            {
+                Logger.logger.Log($"Burning CPU for {WorkloadDurationMs} ms");
+                long deadline = Environment.TickCount64 + WorkloadDurationMs;
+                long counter = 0;
+                while (Environment.TickCount64 < deadline)
+                {
+                    for (int i = 0; i < 100_000; i++)
+                    {
+                        counter++;
+                    }
+                }
+                Logger.logger.Log($"Workload done (counter={counter})");
+            };
+
+            Func<EventPipeEventSource, Func<int>> validator = (source) =>
+            {
+                source.Dynamic.All += (eventData) =>
+                {
+                    // Filter primarily by provider name and the well-known sample event id (0).
+                    // Matching by event name alone is brittle when metadata is unavailable.
+                    if (eventData.ProviderName != SampleProviderName)
+                        return;
+                    if ((int)eventData.ID != 0)
+                        return;
+
+                    int tid = eventData.ThreadID;
+                    double ts = eventData.TimeStampRelativeMSec;
+                    lock (samplesLock)
+                    {
+                        if (!samplesByThread.TryGetValue(tid, out var list))
+                        {
+                            list = new List<double>();
+                            samplesByThread[tid] = list;
+                        }
+                        list.Add(ts);
+                    }
+                };
+
+                return () =>
+                {
+                    lock (samplesLock)
+                    {
+                        if (samplesByThread.Count == 0)
+                        {
+                            Logger.logger.Log("FAIL: No ThreadSample events observed at all.");
+                            return -1;
+                        }
+
+                        Logger.logger.Log($"Observed sample events from {samplesByThread.Count} thread(s):");
+                        foreach (var (tid, samples) in samplesByThread.OrderByDescending(kv => kv.Value.Count))
+                        {
+                            Logger.logger.Log($"  thread {tid}: {samples.Count} samples");
+                        }
+
+                        // Pick the busiest thread — it's the one the CPU-burn loop ran on, and the most
+                        // reliable signal. Background threads (finalizer, GC, etc.) sample sparsely.
+                        var busiest = samplesByThread.OrderByDescending(kv => kv.Value.Count).First();
+                        int busiestTid = busiest.Key;
+                        List<double> sortedTimes = busiest.Value.OrderBy(t => t).ToList();
+                        int count = sortedTimes.Count;
+
+                        Logger.logger.Log($"Busiest thread: {busiestTid} with {count} samples");
+
+                        if (count < MinExpectedSamples)
+                        {
+                            Logger.logger.Log($"FAIL: busiest thread has {count} samples, expected >= {MinExpectedSamples}.");
+                            return -1;
+                        }
+
+                        if (count > MaxAllowedSamples)
+                        {
+                            Logger.logger.Log($"FAIL: busiest thread has {count} samples, expected <= {MaxAllowedSamples}. " +
+                                              $"This suggests DOTNET_EventPipeThreadSamplingRate was ignored " +
+                                              $"and the default (~1ms) rate was used.");
+                            return -1;
+                        }
+
+                        var intervals = new List<double>(count - 1);
+                        for (int i = 1; i < count; i++)
+                        {
+                            intervals.Add(sortedTimes[i] - sortedTimes[i - 1]);
+                        }
+                        intervals.Sort();
+                        double median = intervals[intervals.Count / 2];
+                        double mean = intervals.Average();
+                        Logger.logger.Log($"Busiest thread inter-sample interval (ms): " +
+                                          $"min={intervals.First():F2} median={median:F2} mean={mean:F2} max={intervals.Last():F2}");
+
+                        if (median < MinMedianIntervalMs)
+                        {
+                            Logger.logger.Log($"FAIL: median inter-sample interval is {median:F2}ms, expected >= {MinMedianIntervalMs}ms.");
+                            return -1;
+                        }
+
+                        Logger.logger.Log("PASS: sample interval is consistent with the configured rate.");
+                        return 100;
+                    }
+                };
+            };
+
+            return IpcTraceTest.RunAndValidateEventCounts(
+                expectedEventCounts,
+                eventGeneratingAction,
+                providers,
+                circularBufferMB: 1024,
+                optionalTraceValidator: validator);
+        }
+    }
+}

--- a/src/tests/tracing/eventpipe/samplingrate/samplingrate.csproj
+++ b/src/tests/tracing/eventpipe/samplingrate/samplingrate.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/eventpipe_common.csproj" />
+    <ProjectReference Include="../common/Microsoft.Diagnostics.NETCore.Client/Microsoft.Diagnostics.NETCore.Client.csproj" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
> [!NOTE]
> This pull request was prepared with assistance from GitHub Copilot.

Backport of the **CoreCLR / NativeAOT** portion of #127292 to `release/10.0`.

## Customer Impact

- [] Customer reported
- [x] Found internally

Cosmic has reported dramatic overhead when trying to enable the sample profiler due to our default sampling rate being too high. They saw this change land in main and requested we backport to 10 so that they can override to a lower sampling rate.

## Regression

- [ ] Yes
- [x] No

## Testing
Added a functional test to change the default sampling rate and make sure it lines up with what was expected.

## Risk

Low - this only activates with the `DOTNET_EventPipeThreadSamplingRate` environment variable.