### PR TITLE
[cdac] Introduce FlushScope and add TargetState scope

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/ContractRegistry.cs
@@ -166,8 +166,9 @@ public abstract class ContractRegistry
         where TContract : IContract;
 
     /// <summary>
-    /// Flush all cached data held by contracts in this registry.
-    /// Called when the target process state may have changed (e.g. on resume).
+    /// Flush all cached data held by contracts in this registry for the given
+    /// <paramref name="scope"/>. Called when the target process state may have changed
+    /// (e.g. on resume) or as part of a stress-harness re-read of live target state.
     /// </summary>
-    public abstract void Flush();
+    public abstract void Flush(FlushScope scope);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
@@ -10,8 +10,15 @@ public interface IContract
     static virtual string Name => throw new NotImplementedException();
 
     /// <summary>
-    /// Clear any cached data held by this contract.
-    /// Called when the target process state may have changed (e.g. on resume).
+    /// Clear cached data held by this contract for the given <paramref name="scope"/>.
+    /// Called when the target process state may have changed (e.g. on resume) or as
+    /// part of a stress-harness re-read of live target state.
+    /// <para>
+    /// Default implementation is a no-op. Contracts that maintain caches or capture
+    /// target-memory snapshots at construction must override this method and handle
+    /// each <see cref="FlushScope"/> value appropriately. See the remarks on
+    /// <see cref="FlushScope.TargetState"/>.
+    /// </para>
     /// </summary>
-    void Flush() { }
+    void Flush(FlushScope scope) { }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IContract.cs
@@ -16,8 +16,7 @@ public interface IContract
     /// <para>
     /// Default implementation is a no-op. Contracts that maintain caches or capture
     /// target-memory snapshots at construction must override this method and handle
-    /// each <see cref="FlushScope"/> value appropriately. See the remarks on
-    /// <see cref="FlushScope.TargetState"/>.
+    /// each <see cref="FlushScope"/> value appropriately.
     /// </para>
     /// </summary>
     void Flush(FlushScope scope) { }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/FlushScope.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/FlushScope.cs
@@ -16,15 +16,25 @@ public enum FlushScope
     All,
 
     /// <summary>
-    /// Clear only target-state caches (<see cref="Target.ProcessedData"/>). Contract
-    /// instances and any metadata caches they own are retained.
+    /// Flush only caches that may have become stale because the target process
+    /// has executed forward in time since the last flush (e.g. a debugger
+    /// resume/continue/step). Caches of immutable state that the runtime loads
+    /// once and never unloads (modules, types, code metadata, ECMA metadata,
+    /// execution-manager ranges, etc.) may be retained.
+    /// <para>
+    /// This corresponds to ICorDebug's <c>CorDebugStateChange.PROCESS_RUNNING</c>:
+    /// see <see href="https://learn.microsoft.com/dotnet/core/unmanaged-api/debugging/icordebug/cordebugstatechange-enumeration"/>.
+    /// Use <see cref="All"/> instead for arbitrary state snapshots where no
+    /// continuity with the previous target state can be assumed.
+    /// </para>
     /// <para>
     /// Each contract is responsible for its own correctness under this scope: a
-    /// contract that captures a target-memory snapshot at construction MUST re-read
-    /// that snapshot in its <see cref="Contracts.IContract.Flush(FlushScope)"/>
-    /// implementation when called with <see cref="TargetState"/>, otherwise the
-    /// snapshot becomes stale across the flush.
+    /// contract that captures a target-memory snapshot at construction MUST
+    /// re-read that snapshot in its
+    /// <see cref="Contracts.IContract.Flush(FlushScope)"/> implementation when
+    /// called with <see cref="ForwardExecution"/>, otherwise the snapshot
+    /// becomes stale across the flush.
     /// </para>
     /// </summary>
-    TargetState,
+    ForwardExecution,
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/FlushScope.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/FlushScope.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Diagnostics.DataContractReader;
+
+/// <summary>
+/// Scope of a <see cref="Target.Flush(FlushScope)"/> operation.
+/// </summary>
+public enum FlushScope
+{
+    /// <summary>
+    /// Clear every cache held by the target, including immutable metadata caches
+    /// (type layouts, contract instances, ECMA metadata, execution-manager ranges).
+    /// This is the safe default and matches the historical no-argument Flush behavior.
+    /// </summary>
+    All,
+
+    /// <summary>
+    /// Clear only target-state caches (<see cref="Target.ProcessedData"/>). Contract
+    /// instances and any metadata caches they own are retained.
+    /// <para>
+    /// Each contract is responsible for its own correctness under this scope: a
+    /// contract that captures a target-memory snapshot at construction MUST re-read
+    /// that snapshot in its <see cref="Contracts.IContract.Flush(FlushScope)"/>
+    /// implementation when called with <see cref="TargetState"/>, otherwise the
+    /// snapshot becomes stale across the flush.
+    /// </para>
+    /// </summary>
+    TargetState,
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -324,12 +324,12 @@ public abstract class Target
     public abstract ContractRegistry Contracts { get; }
 
     /// <summary>
-    /// Clear all cached data held by this target, including processed data and contract caches.
+    /// Clear cached data held by this target for the given <paramref name="scope"/>.
     /// Called when the target process state may have changed (e.g. on resume).
     /// </summary>
-    public virtual void Flush()
+    public virtual void Flush(FlushScope scope)
     {
         ProcessedData.Clear();
-        Contracts.Flush();
+        Contracts.Flush(scope);
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -16,7 +16,7 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
     private readonly Dictionary<ModuleHandle, MetadataReaderProvider?> _metadata = [];
     private readonly Dictionary<ModuleHandle, TargetSpan> _readOnlyMetadataAddress = [];
 
-    public void Flush()
+    public void Flush(FlushScope scope)
     {
         _metadata.Clear();
         _readOnlyMetadataAddress.Clear();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManagerCore.cs
@@ -17,16 +17,19 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
 
     // maps CodeBlockHandle.Address (which is the CodeHeaderAddress) to the CodeBlock
     private readonly Dictionary<TargetPointer, CodeBlock> _codeInfos = new();
-    private readonly Data.RangeSectionMap _topRangeSectionMap;
+    private readonly TargetPointer _topRangeSectionMapAddress;
     private readonly ExecutionManagerHelpers.RangeSectionMap _rangeSectionMapLookup;
     private readonly EEJitManager _eeJitManager;
     private readonly ReadyToRunJitManager _r2rJitManager;
     private readonly InterpreterJitManager _interpreterJitManager;
 
-    public ExecutionManagerCore(Target target, Data.RangeSectionMap topRangeSectionMap)
+    private Data.RangeSectionMap _topRangeSectionMap
+        => _target.ProcessedData.GetOrAdd<Data.RangeSectionMap>(_topRangeSectionMapAddress);
+
+    public ExecutionManagerCore(Target target, TargetPointer topRangeSectionMapAddress)
     {
         _target = target;
-        _topRangeSectionMap = topRangeSectionMap;
+        _topRangeSectionMapAddress = topRangeSectionMapAddress;
         _rangeSectionMapLookup = ExecutionManagerHelpers.RangeSectionMap.Create(_target);
         INibbleMap nibbleMap = T.Create(_target);
         _eeJitManager = new EEJitManager(_target, nibbleMap);
@@ -34,7 +37,7 @@ internal sealed partial class ExecutionManagerCore<T> : IExecutionManager
         _interpreterJitManager = new InterpreterJitManager(_target, nibbleMap);
     }
 
-    public void Flush()
+    public void Flush(FlushScope scope)
     {
         _codeInfos.Clear();
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_1.cs
@@ -13,8 +13,7 @@ public sealed class ExecutionManager_1 : IExecutionManager
     internal ExecutionManager_1(Target target)
     {
         TargetPointer addr = target.ReadGlobalPointer(Constants.Globals.ExecutionManagerCodeRangeMapAddress);
-        Data.RangeSectionMap map = target.ProcessedData.GetOrAdd<Data.RangeSectionMap>(addr);
-        _executionManagerCore = new ExecutionManagerCore<NibbleMapLinearLookup>(target, map);
+        _executionManagerCore = new ExecutionManagerCore<NibbleMapLinearLookup>(target, addr);
     }
 
     public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
@@ -36,5 +35,5 @@ public sealed class ExecutionManager_1 : IExecutionManager
     public IEnumerable<ICodeHeapInfo> GetCodeHeapInfos() => _executionManagerCore.GetCodeHeapInfos();
     public CodeKind GetCodeKind(TargetCodePointer codeAddress) => _executionManagerCore.GetCodeKind(codeAddress);
     public TargetPointer FindReadyToRunModule(TargetPointer address) => _executionManagerCore.FindReadyToRunModule(address);
-    public void Flush() => _executionManagerCore.Flush();
+    public void Flush(FlushScope scope) => _executionManagerCore.Flush(scope);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ExecutionManager/ExecutionManager_2.cs
@@ -13,8 +13,7 @@ public sealed class ExecutionManager_2 : IExecutionManager
     internal ExecutionManager_2(Target target)
     {
         TargetPointer addr = target.ReadGlobalPointer(Constants.Globals.ExecutionManagerCodeRangeMapAddress);
-        Data.RangeSectionMap map = target.ProcessedData.GetOrAdd<Data.RangeSectionMap>(addr);
-        _executionManagerCore = new ExecutionManagerCore<NibbleMapConstantLookup>(target, map);
+        _executionManagerCore = new ExecutionManagerCore<NibbleMapConstantLookup>(target, addr);
     }
 
     public CodeBlockHandle? GetCodeBlockHandle(TargetCodePointer ip) => _executionManagerCore.GetCodeBlockHandle(ip);
@@ -36,5 +35,5 @@ public sealed class ExecutionManager_2 : IExecutionManager
     public IEnumerable<ICodeHeapInfo> GetCodeHeapInfos() => _executionManagerCore.GetCodeHeapInfos();
     public CodeKind GetCodeKind(TargetCodePointer codeAddress) => _executionManagerCore.GetCodeKind(codeAddress);
     public TargetPointer FindReadyToRunModule(TargetPointer address) => _executionManagerCore.FindReadyToRunModule(address);
-    public void Flush() => _executionManagerCore.Flush();
+    public void Flush(FlushScope scope) => _executionManagerCore.Flush(scope);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
@@ -23,8 +23,15 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
         _target = target;
     }
 
-    public void Flush()
+    public void Flush(FlushScope scope)
     {
+        // They are safe to retain across FlushScope.TargetState because
+        // ManagedTypeSource_1 only resolves names in System.Private.CoreLib, which
+        // is loaded into the non-collectible default AssemblyLoadContext at runtime
+        // startup and whose ECMA metadata never changes for the process lifetime.
+        if (scope != FlushScope.All)
+            return;
+
         _typeInfoCache.Clear();
         _typeHandleCache.Clear();
         _fieldDescCache.Clear();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ManagedTypeSource_1.cs
@@ -25,7 +25,7 @@ internal sealed class ManagedTypeSource_1 : IManagedTypeSource
 
     public void Flush(FlushScope scope)
     {
-        // They are safe to retain across FlushScope.TargetState because
+        // They are safe to retain across FlushScope.ForwardExecution because
         // ManagedTypeSource_1 only resolves names in System.Private.CoreLib, which
         // is loaded into the non-collectible default AssemblyLoadContext at runtime
         // startup and whose ECMA metadata never changes for the process lifetime.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PlatformMetadata_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/PlatformMetadata_1.cs
@@ -5,16 +5,17 @@ using System;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal readonly partial struct PlatformMetadata_1 : IPlatformMetadata
+internal readonly struct PlatformMetadata_1 : IPlatformMetadata
 {
     internal readonly Target _target;
-    private readonly Data.PlatformMetadata _cdacMetadata;
+    private readonly TargetPointer _cdacMetadataAddress;
+    private Data.PlatformMetadata _cdacMetadata
+        => _target.ProcessedData.GetOrAdd<Data.PlatformMetadata>(_cdacMetadataAddress);
 
     public PlatformMetadata_1(Target target)
     {
         _target = target;
-        TargetPointer cdacMetadataAddress = target.ReadGlobalPointer(Constants.Globals.PlatformMetadata);
-        _cdacMetadata = target.ProcessedData.GetOrAdd<Data.PlatformMetadata>(cdacMetadataAddress);
+        _cdacMetadataAddress = target.ReadGlobalPointer(Constants.Globals.PlatformMetadata);
     }
 
     TargetPointer IPlatformMetadata.GetPrecodeMachineDescriptor()

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJIT_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJIT_1.cs
@@ -7,10 +7,12 @@ using Microsoft.Diagnostics.DataContractReader.Data;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
-internal readonly partial struct ReJIT_1 : IReJIT
+internal readonly struct ReJIT_1 : IReJIT
 {
     internal readonly Target _target;
-    private readonly Data.ProfControlBlock _profControlBlock;
+    private readonly TargetPointer _profControlBlockAddress;
+    private Data.ProfControlBlock _profControlBlock
+        => _target.ProcessedData.GetOrAdd<Data.ProfControlBlock>(_profControlBlockAddress);
 
     // see src/coreclr/inc/corprof.idl
     [Flags]
@@ -33,8 +35,7 @@ internal readonly partial struct ReJIT_1 : IReJIT
     public ReJIT_1(Target target)
     {
         _target = target;
-        TargetPointer profControlBlockAddress = target.ReadGlobalPointer(Constants.Globals.ProfilerControlBlock);
-        _profControlBlock = target.ProcessedData.GetOrAdd<Data.ProfControlBlock>(profControlBlockAddress);
+        _profControlBlockAddress = target.ReadGlobalPointer(Constants.Globals.ProfilerControlBlock);
     }
 
     bool IReJIT.IsEnabled()

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -32,7 +32,7 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
     private readonly Dictionary<TargetPointer, MethodDesc> _methodDescs = new();
     private readonly Dictionary<TypeKey, TypeHandle> _typeHandles = new();
 
-    public void Flush()
+    public void Flush(FlushScope scope)
     {
         _methodTables.Clear();
         _methodDescs.Clear();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/Signature_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Signature/Signature_1.cs
@@ -25,7 +25,7 @@ internal sealed class Signature_1 : ISignature
         _target = target;
     }
 
-    public void Flush()
+    public void Flush(FlushScope scope)
     {
         _thProviders.Clear();
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -67,7 +67,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
 
     public int FlushCache()
     {
-        _target.Flush();
+        _target.Flush(FlushScope.All);
         return _legacy is not null ? _legacy.FlushCache() : HResults.S_OK;
     }
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -21,7 +21,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
 {
     int IXCLRDataProcess.Flush()
     {
-        _target.Flush();
+        _target.Flush(FlushScope.All);
 
         // Flush is always propagated — it's cache management, not data retrieval.
         if (_legacyProcess is not null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -6712,7 +6712,7 @@ public sealed unsafe partial class SOSDacImpl
     }
     int ISOSDacInterface13.LockedFlush()
     {
-        _target.Flush();
+        _target.Flush(FlushScope.All);
 
         // As long as any part of cDAC falls back to the legacy DAC, we need to propagate the Flush call
         if (_legacyImpl13 is not null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/CachingContractRegistry.cs
@@ -70,11 +70,11 @@ internal sealed class CachingContractRegistry : ContractRegistry
         return true;
     }
 
-    public override void Flush()
+    public override void Flush(FlushScope scope)
     {
         foreach (IContract contract in _contracts.Values)
         {
-            contract.Flush();
+            contract.Flush(scope);
         }
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -143,9 +143,9 @@ public sealed unsafe class ContractDescriptorTarget : Target
         BuildDescriptors(forceBuild: true);
     }
 
-    public override void Flush()
+    public override void Flush(FlushScope scope)
     {
-        base.Flush();
+        base.Flush(scope);
 
         BuildDescriptors();
     }

--- a/src/native/managed/cdac/tests/DataGenerator/TestTarget.cs
+++ b/src/native/managed/cdac/tests/DataGenerator/TestTarget.cs
@@ -283,7 +283,7 @@ internal sealed class TestTarget : Target
         public override void Register<TContract>(string version, Func<Target, TContract> creator)
             => throw new NotImplementedException();
 
-        public override void Flush() { }
+        public override void Flush(FlushScope scope) { }
     }
 
     // --- Trivial IDataCache for ReadDataField support ----------------

--- a/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
+++ b/src/native/managed/cdac/tests/TestPlaceholderTarget.cs
@@ -625,7 +625,7 @@ internal class TestPlaceholderTarget : Target
             return true;
         }
 
-        public override void Flush() { }
+        public override void Flush(FlushScope scope) { }
     }
 
 }


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with the help of GitHub Copilot.

## Summary

Replaces `IContract.Flush()` and `Target.Flush()` with a `Flush(FlushScope)` overload and introduces a `FlushScope` enum:

- **`All`** -- clears every cache the target holds, including immutable metadata caches (type layouts, contract instances, ECMA metadata, execution-manager ranges). Matches the historical no-argument `Flush` behavior.
- **`TargetState`** -- clears only target-state caches (`Target.ProcessedData`). Contract instances and any metadata caches they own are retained. Each contract is responsible for its own correctness under this scope: contracts that capture a target-memory snapshot at construction must re-read that snapshot in their `Flush(FlushScope.TargetState)` override.

## Motivation

This is the foundation for a follow-up cDAC **stress harness** change that re-verifies live target state between snapshots (e.g. after every GC allocation under `DOTNET_CdacStress=0x1`). Today, every such flush re-walks System.Private.CoreLib's ECMA metadata even though that metadata is immutable for the process lifetime (CoreLib is loaded into the non-collectible default ALC). The new `FlushScope.TargetState` lets `ManagedTypeSource_1` retain its CoreLib-only caches across these stress flushes.

Measured impact on a `BasicAlloc` cDAC-stress run (Release cDAC):

| Scope behavior in stress | Median (s) |
|---|---|
| `FlushScope.TargetState` keeps CoreLib caches (this PR's win) | 5.81 |
| All flushes clear everything (today's behavior) | 11.83 |

A 2x speedup on the most allocation-heavy stress test before any further optimization.

## Contract updates in this PR

| Contract | Change |
|---|---|
| `ManagedTypeSource_1` | Retains type/typehandle/fielddesc caches across `FlushScope.TargetState`; clears on `FlushScope.All` as before. Safe because the contract only resolves names in CoreLib. |
| `ReJIT_1`, `PlatformMetadata_1` | Lazy-snapshot pattern -- no longer captures target state in the constructor; re-snapshots on the next read after any flush. |
| `ExecutionManager_1`/`_2`/`ExecutionManagerCore` | The top `RangeSectionMap` is resolved lazily and re-resolved after any flush so that `FlushScope.TargetState` correctly invalidates execution-range data that may have changed across a runtime resume. |

`EcmaMetadata_1`, `Signature_1`, and `RuntimeTypeSystem_1` currently treat both scopes the same and clear on every call -- they can be tuned in follow-up changes if profiling motivates it.

## Compatibility

All public `Flush()` entry points now require a `FlushScope` argument. Every caller in `dotnet/runtime` is updated in this PR:
- `SOSDacImpl.FlushCache`, `ISOSDacInterface13.LockedFlush`, `IXCLRDataProcess.Flush` -> pass `FlushScope.All` (no behavior change)
- `DacDbiImpl.FlushCache` -> `FlushScope.All`
- Test harnesses (`TestPlaceholderTarget`, `TestTarget`) updated to the new signature

The default no-op override on `IContract.Flush(FlushScope)` preserves source compatibility for any contract that does not maintain caches.

## Validation

- `cdac.slnx` builds with 0 warnings, 0 errors.
- `Microsoft.Diagnostics.DataContractReader.Tests`: 2417 passed / 0 failed / 16 platform-skipped.

## Out of scope (planned follow-ups)

- The actual cDAC stress harness (`cdacstress.{cpp,h}`, the `DACSTRESSPRIV_REQUEST_FLUSH_TARGET_STATE` opcode in `IXCLRDataProcess.Request`, and the helix pipeline).
- DataCache two-level dictionary refactor in `ContractDescriptorTarget`.
- `EcmaMetadata_1._readOnlyMetadataAddress` cache.
- `LayoutPair` N-source lazy resolution.

/cc @dotnet/runtime-diagnostics-cdac
