### PR TITLE
Move PlatformDocAnalyzer to Analyzers.targets and gate behind EnablePlatformDocAnalyzer

### DIFF
--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -32,7 +32,7 @@
 
   <!-- PlatformDocAnalyzer: Enforce documentation conventions for platform-specific libraries.
        Opt-in via EnablePlatformDocAnalyzer; src/libraries enables this by default for src projects. -->
-  <ItemGroup Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
+  <ItemGroup Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunAnalyzers)' != 'false'">
     <ProjectReference Include="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.csproj"
                       ReferenceOutputAssembly="false"
                       OutputItemType="Analyzer"
@@ -40,5 +40,5 @@
   </ItemGroup>
 
   <Import Project="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.props"
-          Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'" />
+          Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj' and '$(RunAnalyzers)' != 'false'" />
 </Project>

--- a/eng/Analyzers.targets
+++ b/eng/Analyzers.targets
@@ -29,4 +29,16 @@
     <EditorConfigFiles Remove="$(RepositoryEngineeringDir)CodeAnalysis.src.globalconfig" />
     <EditorConfigFiles Include="$(RepositoryEngineeringDir)CodeAnalysis.test.globalconfig" />
   </ItemGroup>
+
+  <!-- PlatformDocAnalyzer: Enforce documentation conventions for platform-specific libraries.
+       Opt-in via EnablePlatformDocAnalyzer; src/libraries enables this by default for src projects. -->
+  <ItemGroup Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
+    <ProjectReference Include="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.csproj"
+                      ReferenceOutputAssembly="false"
+                      OutputItemType="Analyzer"
+                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
+  </ItemGroup>
+
+  <Import Project="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.props"
+          Condition="'$(EnablePlatformDocAnalyzer)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'" />
 </Project>

--- a/eng/generators.targets
+++ b/eng/generators.targets
@@ -93,15 +93,4 @@
 
   <Import Project="$(LibrariesProjectRoot)System.Runtime.InteropServices\gen\LibraryImportGenerator\Microsoft.Interop.LibraryImportGenerator.props" />
 
-  <!-- PlatformDocAnalyzer: Enforce documentation conventions for platform-specific libraries -->
-  <ItemGroup Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' == '.csproj'">
-    <ProjectReference Include="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.csproj"
-                      ReferenceOutputAssembly="false"
-                      OutputItemType="Analyzer"
-                      SetConfiguration="Configuration=$(LibrariesConfiguration)" />
-  </ItemGroup>
-
-  <Import Project="$(RepositoryEngineeringDir)analyzers\PlatformDocAnalyzer\PlatformDocAnalyzer.props"
-          Condition="'$(IsSourceProject)' == 'true'" />
-
 </Project>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -44,8 +44,6 @@
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
     <!-- Disable analyzers for tests and unsupported projects -->
     <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>
-    <!-- Enable the PlatformDocAnalyzer by default for src projects under src/libraries. -->
-    <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
     <!-- Enable documentation file generation by the compiler for all libraries except for vbproj. -->
     <GenerateDocumentationFile Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.vbproj'">true</GenerateDocumentationFile>
     <CLSCompliant Condition="'$(CLSCompliant)' == '' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">true</CLSCompliant>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -44,6 +44,8 @@
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
     <!-- Disable analyzers for tests and unsupported projects -->
     <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>
+    <!-- Enable the PlatformDocAnalyzer by default for src projects under src/libraries. -->
+    <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
     <!-- Enable documentation file generation by the compiler for all libraries except for vbproj. -->
     <GenerateDocumentationFile Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.vbproj'">true</GenerateDocumentationFile>
     <CLSCompliant Condition="'$(CLSCompliant)' == '' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">true</CLSCompliant>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -43,7 +43,9 @@
   <PropertyGroup>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
     <!-- Disable analyzers for tests and unsupported projects -->
-    <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>
+    <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>    
+    <!-- Enable the PlatformDocAnalyzer by default for src projects. -->
+    <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
     <!-- Enable documentation file generation by the compiler for all libraries except for vbproj. -->
     <GenerateDocumentationFile Condition="'$(IsSourceProject)' == 'true' and '$(MSBuildProjectExtension)' != '.vbproj'">true</GenerateDocumentationFile>
     <CLSCompliant Condition="'$(CLSCompliant)' == '' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">true</CLSCompliant>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -43,7 +43,7 @@
   <PropertyGroup>
     <GenFacadesIgnoreBuildAndRevisionMismatch>true</GenFacadesIgnoreBuildAndRevisionMismatch>
     <!-- Disable analyzers for tests and unsupported projects -->
-    <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>    
+    <RunAnalyzers Condition="'$(IsTestProject)' != 'true' and '$(IsSourceProject)' != 'true' and '$(IsGeneratorProject)' != 'true'">false</RunAnalyzers>
     <!-- Enable the PlatformDocAnalyzer by default for src projects. -->
     <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
     <!-- Enable documentation file generation by the compiler for all libraries except for vbproj. -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -5,9 +5,6 @@
     <TestStrongNameKeyId Condition="'$(TestStrongNameKeyId)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">MicrosoftAspNetCore</TestStrongNameKeyId>
     <TestStrongNameKeyId Condition="'$(TestStrongNameKeyId)' == ''">Open</TestStrongNameKeyId>
     <StrongNameKeyId Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">$(TestStrongNameKeyId)</StrongNameKeyId>
-    
-    <!-- Enable the PlatformDocAnalyzer by default for src projects. -->
-    <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
   </PropertyGroup>
 
   <!-- Enable native ARM64 execution for .NET Framework test projects on ARM64 devices -->

--- a/src/libraries/Directory.Build.targets
+++ b/src/libraries/Directory.Build.targets
@@ -5,6 +5,9 @@
     <TestStrongNameKeyId Condition="'$(TestStrongNameKeyId)' == '' and $(MSBuildProjectName.StartsWith('Microsoft.Extensions.'))">MicrosoftAspNetCore</TestStrongNameKeyId>
     <TestStrongNameKeyId Condition="'$(TestStrongNameKeyId)' == ''">Open</TestStrongNameKeyId>
     <StrongNameKeyId Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">$(TestStrongNameKeyId)</StrongNameKeyId>
+    
+    <!-- Enable the PlatformDocAnalyzer by default for src projects. -->
+    <EnablePlatformDocAnalyzer Condition="'$(EnablePlatformDocAnalyzer)' == '' and '$(IsSourceProject)' == 'true' and '$(RunAnalyzers)' != 'false'">true</EnablePlatformDocAnalyzer>
   </PropertyGroup>
 
   <!-- Enable native ARM64 execution for .NET Framework test projects on ARM64 devices -->

--- a/src/libraries/Microsoft.Bcl.AsyncInterfaces/Microsoft.Bcl.AsyncInterfaces.slnx
+++ b/src/libraries/Microsoft.Bcl.AsyncInterfaces/Microsoft.Bcl.AsyncInterfaces.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Bcl.Cryptography/Microsoft.Bcl.Cryptography.slnx
+++ b/src/libraries/Microsoft.Bcl.Cryptography/Microsoft.Bcl.Cryptography.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Bcl.Memory/Microsoft.Bcl.Memory.slnx
+++ b/src/libraries/Microsoft.Bcl.Memory/Microsoft.Bcl.Memory.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Bcl.Numerics/Microsoft.Bcl.Numerics.slnx
+++ b/src/libraries/Microsoft.Bcl.Numerics/Microsoft.Bcl.Numerics.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Bcl.TimeProvider/Microsoft.Bcl.TimeProvider.slnx
+++ b/src/libraries/Microsoft.Bcl.TimeProvider/Microsoft.Bcl.TimeProvider.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.CSharp/Microsoft.CSharp.slnx
+++ b/src/libraries/Microsoft.CSharp/Microsoft.CSharp.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/Microsoft.Extensions.Caching.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/Microsoft.Extensions.Caching.Abstractions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/Microsoft.Extensions.Caching.Memory.slnx
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/Microsoft.Extensions.Caching.Memory.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Abstractions/Microsoft.Extensions.Configuration.Abstractions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/Microsoft.Extensions.Configuration.Binder.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/Microsoft.Extensions.Configuration.Binder.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Configuration.CommandLine/Microsoft.Extensions.Configuration.CommandLine.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.CommandLine/Microsoft.Extensions.Configuration.CommandLine.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />

--- a/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/Microsoft.Extensions.Configuration.EnvironmentVariables.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.EnvironmentVariables/Microsoft.Extensions.Configuration.EnvironmentVariables.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/Microsoft.Extensions.Configuration.FileExtensions.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/Microsoft.Extensions.Configuration.FileExtensions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.Configuration.Ini/Microsoft.Extensions.Configuration.Ini.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Ini/Microsoft.Extensions.Configuration.Ini.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Json/Microsoft.Extensions.Configuration.Json.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Json/Microsoft.Extensions.Configuration.Json.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/Microsoft.Extensions.Configuration.UserSecrets.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.UserSecrets/Microsoft.Extensions.Configuration.UserSecrets.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Configuration.Xml/Microsoft.Extensions.Configuration.Xml.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration.Xml/Microsoft.Extensions.Configuration.Xml.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Configuration/Microsoft.Extensions.Configuration.slnx
+++ b/src/libraries/Microsoft.Extensions.Configuration/Microsoft.Extensions.Configuration.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/Microsoft.Extensions.DependencyInjection.Abstractions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.slnx
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection/Microsoft.Extensions.DependencyInjection.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.slnx
+++ b/src/libraries/Microsoft.Extensions.DependencyModel/Microsoft.Extensions.DependencyModel.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/Microsoft.Extensions.Diagnostics.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.Diagnostics.Abstractions/Microsoft.Extensions.Diagnostics.Abstractions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Diagnostics/Microsoft.Extensions.Diagnostics.slnx
+++ b/src/libraries/Microsoft.Extensions.Diagnostics/Microsoft.Extensions.Diagnostics.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/Microsoft.Extensions.FileProviders.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Abstractions/Microsoft.Extensions.FileProviders.Abstractions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Composite/Microsoft.Extensions.FileProviders.Composite.slnx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Composite/Microsoft.Extensions.FileProviders.Composite.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.FileProviders.Physical/Microsoft.Extensions.FileProviders.Physical.slnx
+++ b/src/libraries/Microsoft.Extensions.FileProviders.Physical/Microsoft.Extensions.FileProviders.Physical.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/Microsoft.Extensions.FileSystemGlobbing.slnx
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/Microsoft.Extensions.FileSystemGlobbing.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Extensions.HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.slnx
+++ b/src/libraries/Microsoft.Extensions.HostFactoryResolver/Microsoft.Extensions.HostFactoryResolver.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/Microsoft.Extensions.Hosting.Abstractions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Hosting.Systemd/Microsoft.Extensions.Hosting.Systemd.slnx
+++ b/src/libraries/Microsoft.Extensions.Hosting.Systemd/Microsoft.Extensions.Hosting.Systemd.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/Microsoft.Extensions.Hosting.WindowsServices.slnx
+++ b/src/libraries/Microsoft.Extensions.Hosting.WindowsServices/Microsoft.Extensions.Hosting.WindowsServices.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Hosting/Microsoft.Extensions.Hosting.slnx
+++ b/src/libraries/Microsoft.Extensions.Hosting/Microsoft.Extensions.Hosting.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Http/Microsoft.Extensions.Http.slnx
+++ b/src/libraries/Microsoft.Extensions.Http/Microsoft.Extensions.Http.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.Abstractions.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/Microsoft.Extensions.Logging.Abstractions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.Configuration/Microsoft.Extensions.Logging.Configuration.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.Configuration/Microsoft.Extensions.Logging.Configuration.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.Console/Microsoft.Extensions.Logging.Console.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/Microsoft.Extensions.Logging.Console.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.Debug/Microsoft.Extensions.Logging.Debug.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.Debug/Microsoft.Extensions.Logging.Debug.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.EventLog/Microsoft.Extensions.Logging.EventLog.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.EventLog/Microsoft.Extensions.Logging.EventLog.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.EventSource/Microsoft.Extensions.Logging.EventSource.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.EventSource/Microsoft.Extensions.Logging.EventSource.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging.TraceSource/Microsoft.Extensions.Logging.TraceSource.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging.TraceSource/Microsoft.Extensions.Logging.TraceSource.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Logging.Abstractions/gen/Microsoft.Extensions.Logging.Generators.Roslyn3.11.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Logging/Microsoft.Extensions.Logging.slnx
+++ b/src/libraries/Microsoft.Extensions.Logging/Microsoft.Extensions.Logging.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/Microsoft.Extensions.Options.ConfigurationExtensions.slnx
+++ b/src/libraries/Microsoft.Extensions.Options.ConfigurationExtensions/Microsoft.Extensions.Options.ConfigurationExtensions.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj" />
     <Project Path="../Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />

--- a/src/libraries/Microsoft.Extensions.Options.DataAnnotations/Microsoft.Extensions.Options.DataAnnotations.slnx
+++ b/src/libraries/Microsoft.Extensions.Options.DataAnnotations/Microsoft.Extensions.Options.DataAnnotations.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../Microsoft.Extensions.Options/gen/Microsoft.Extensions.Options.SourceGeneration.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />

--- a/src/libraries/Microsoft.Extensions.Options/Microsoft.Extensions.Options.slnx
+++ b/src/libraries/Microsoft.Extensions.Options/Microsoft.Extensions.Options.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../Microsoft.Extensions.Configuration.Binder/gen/Microsoft.Extensions.Configuration.Binder.SourceGeneration.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.slnx
+++ b/src/libraries/Microsoft.Extensions.Primitives/Microsoft.Extensions.Primitives.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.slnx
+++ b/src/libraries/Microsoft.NETCore.Platforms/Microsoft.NETCore.Platforms.slnx
@@ -1,4 +1,7 @@
 <Solution>
+  <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
+  </Folder>
   <Folder Name="/src/">
     <Project Path="src/Microsoft.NETCore.Platforms.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.VisualBasic.Core/Microsoft.VisualBasic.Core.slnx
+++ b/src/libraries/Microsoft.VisualBasic.Core/Microsoft.VisualBasic.Core.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Win32.Primitives/Microsoft.Win32.Primitives.slnx
+++ b/src/libraries/Microsoft.Win32.Primitives/Microsoft.Win32.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.slnx
+++ b/src/libraries/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.Win32.Registry/Microsoft.Win32.Registry.slnx
+++ b/src/libraries/Microsoft.Win32.Registry/Microsoft.Win32.Registry.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/Microsoft.Win32.SystemEvents/Microsoft.Win32.SystemEvents.slnx
+++ b/src/libraries/Microsoft.Win32.SystemEvents/Microsoft.Win32.SystemEvents.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/Microsoft.XmlSerializer.Generator/Microsoft.XmlSerializer.Generator.slnx
+++ b/src/libraries/Microsoft.XmlSerializer.Generator/Microsoft.XmlSerializer.Generator.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.CodeDom/System.CodeDom.slnx
+++ b/src/libraries/System.CodeDom/System.CodeDom.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Collections.Concurrent/System.Collections.Concurrent.slnx
+++ b/src/libraries/System.Collections.Concurrent/System.Collections.Concurrent.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Collections.Immutable/System.Collections.Immutable.slnx
+++ b/src/libraries/System.Collections.Immutable/System.Collections.Immutable.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Collections.NonGeneric/System.Collections.NonGeneric.slnx
+++ b/src/libraries/System.Collections.NonGeneric/System.Collections.NonGeneric.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Collections.Specialized/System.Collections.Specialized.slnx
+++ b/src/libraries/System.Collections.Specialized/System.Collections.Specialized.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Collections/System.Collections.slnx
+++ b/src/libraries/System.Collections/System.Collections.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ComponentModel.Annotations/System.ComponentModel.Annotations.slnx
+++ b/src/libraries/System.ComponentModel.Annotations/System.ComponentModel.Annotations.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ComponentModel.Composition.Registration/System.ComponentModel.Composition.Registration.slnx
+++ b/src/libraries/System.ComponentModel.Composition.Registration/System.ComponentModel.Composition.Registration.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.ComponentModel.Composition/System.ComponentModel.Composition.slnx
+++ b/src/libraries/System.ComponentModel.Composition/System.ComponentModel.Composition.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.ComponentModel.EventBasedAsync/System.ComponentModel.EventBasedAsync.slnx
+++ b/src/libraries/System.ComponentModel.EventBasedAsync/System.ComponentModel.EventBasedAsync.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ComponentModel.Primitives/System.ComponentModel.Primitives.slnx
+++ b/src/libraries/System.ComponentModel.Primitives/System.ComponentModel.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ComponentModel.TypeConverter/System.ComponentModel.TypeConverter.slnx
+++ b/src/libraries/System.ComponentModel.TypeConverter/System.ComponentModel.TypeConverter.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ComponentModel/System.ComponentModel.slnx
+++ b/src/libraries/System.ComponentModel/System.ComponentModel.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Composition.AttributedModel/System.Composition.AttributedModel.slnx
+++ b/src/libraries/System.Composition.AttributedModel/System.Composition.AttributedModel.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Composition.Convention/System.Composition.Convention.slnx
+++ b/src/libraries/System.Composition.Convention/System.Composition.Convention.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Composition.Hosting/System.Composition.Hosting.slnx
+++ b/src/libraries/System.Composition.Hosting/System.Composition.Hosting.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Composition.Runtime/System.Composition.Runtime.slnx
+++ b/src/libraries/System.Composition.Runtime/System.Composition.Runtime.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Composition.TypedParts/System.Composition.TypedParts.slnx
+++ b/src/libraries/System.Composition.TypedParts/System.Composition.TypedParts.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Composition/System.Composition.slnx
+++ b/src/libraries/System.Composition/System.Composition.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Configuration.ConfigurationManager/System.Configuration.ConfigurationManager.slnx
+++ b/src/libraries/System.Configuration.ConfigurationManager/System.Configuration.ConfigurationManager.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Console/System.Console.slnx
+++ b/src/libraries/System.Console/System.Console.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Data.Common/System.Data.Common.slnx
+++ b/src/libraries/System.Data.Common/System.Data.Common.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Data.Odbc/System.Data.Odbc.slnx
+++ b/src/libraries/System.Data.Odbc/System.Data.Odbc.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Data.OleDb/System.Data.Oledb.slnx
+++ b/src/libraries/System.Data.OleDb/System.Data.Oledb.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.Contracts/System.Diagnostics.Contracts.slnx
+++ b/src/libraries/System.Diagnostics.Contracts/System.Diagnostics.Contracts.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.slnx
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/System.Diagnostics.DiagnosticSource.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.EventLog/System.Diagnostics.EventLog.slnx
+++ b/src/libraries/System.Diagnostics.EventLog/System.Diagnostics.EventLog.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.FileVersionInfo/System.Diagnostics.FileVersionInfo.slnx
+++ b/src/libraries/System.Diagnostics.FileVersionInfo/System.Diagnostics.FileVersionInfo.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.PerformanceCounter/System.Diagnostics.PerformanceCounter.slnx
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/System.Diagnostics.PerformanceCounter.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.Process/System.Diagnostics.Process.slnx
+++ b/src/libraries/System.Diagnostics.Process/System.Diagnostics.Process.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.StackTrace/System.Diagnostics.StackTrace.slnx
+++ b/src/libraries/System.Diagnostics.StackTrace/System.Diagnostics.StackTrace.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.TextWriterTraceListener/System.Diagnostics.TextWriterTraceListener.slnx
+++ b/src/libraries/System.Diagnostics.TextWriterTraceListener/System.Diagnostics.TextWriterTraceListener.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.TraceSource/System.Diagnostics.TraceSource.slnx
+++ b/src/libraries/System.Diagnostics.TraceSource/System.Diagnostics.TraceSource.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Diagnostics.Tracing/System.Diagnostics.Tracing.slnx
+++ b/src/libraries/System.Diagnostics.Tracing/System.Diagnostics.Tracing.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.slnx
+++ b/src/libraries/System.DirectoryServices.AccountManagement/System.DirectoryServices.AccountManagement.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.slnx
+++ b/src/libraries/System.DirectoryServices.Protocols/System.DirectoryServices.Protocols.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.DirectoryServices/System.DirectoryServices.slnx
+++ b/src/libraries/System.DirectoryServices/System.DirectoryServices.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Drawing.Primitives/System.Drawing.Primitives.slnx
+++ b/src/libraries/System.Drawing.Primitives/System.Drawing.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Formats.Asn1/System.Formats.Asn1.slnx
+++ b/src/libraries/System.Formats.Asn1/System.Formats.Asn1.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Formats.Cbor/System.Formats.Cbor.slnx
+++ b/src/libraries/System.Formats.Cbor/System.Formats.Cbor.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Formats.Nrbf/System.Formats.Nrbf.slnx
+++ b/src/libraries/System.Formats.Nrbf/System.Formats.Nrbf.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Formats.Tar/System.Formats.Tar.slnx
+++ b/src/libraries/System.Formats.Tar/System.Formats.Tar.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Compression.Brotli/System.IO.Compression.Brotli.slnx
+++ b/src/libraries/System.IO.Compression.Brotli/System.IO.Compression.Brotli.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.slnx
+++ b/src/libraries/System.IO.Compression.ZipFile/System.IO.Compression.ZipFile.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Compression/System.IO.Compression.slnx
+++ b/src/libraries/System.IO.Compression/System.IO.Compression.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.slnx
+++ b/src/libraries/System.IO.FileSystem.AccessControl/System.IO.FileSystem.AccessControl.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.slnx
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/System.IO.FileSystem.DriveInfo.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.slnx
+++ b/src/libraries/System.IO.FileSystem.Watcher/System.IO.FileSystem.Watcher.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Hashing/System.IO.Hashing.slnx
+++ b/src/libraries/System.IO.Hashing/System.IO.Hashing.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.IO.IsolatedStorage/System.IO.IsolatedStorage.slnx
+++ b/src/libraries/System.IO.IsolatedStorage/System.IO.IsolatedStorage.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.MemoryMappedFiles/System.IO.MemoryMappedFiles.slnx
+++ b/src/libraries/System.IO.MemoryMappedFiles/System.IO.MemoryMappedFiles.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Packaging/System.IO.Packaging.slnx
+++ b/src/libraries/System.IO.Packaging/System.IO.Packaging.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.IO.Pipelines/System.IO.Pipelines.slnx
+++ b/src/libraries/System.IO.Pipelines/System.IO.Pipelines.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.slnx
+++ b/src/libraries/System.IO.Pipes.AccessControl/System.IO.Pipes.AccessControl.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Pipes/System.IO.Pipes.slnx
+++ b/src/libraries/System.IO.Pipes/System.IO.Pipes.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.IO.Ports/System.IO.Ports.slnx
+++ b/src/libraries/System.IO.Ports/System.IO.Ports.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Linq.AsyncEnumerable/System.Linq.AsyncEnumerable.slnx
+++ b/src/libraries/System.Linq.AsyncEnumerable/System.Linq.AsyncEnumerable.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Linq.Expressions/System.Linq.Expressions.slnx
+++ b/src/libraries/System.Linq.Expressions/System.Linq.Expressions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Linq.Parallel/System.Linq.Parallel.slnx
+++ b/src/libraries/System.Linq.Parallel/System.Linq.Parallel.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Linq.Queryable/System.Linq.Queryable.slnx
+++ b/src/libraries/System.Linq.Queryable/System.Linq.Queryable.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Linq/System.Linq.slnx
+++ b/src/libraries/System.Linq/System.Linq.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Management/System.Management.slnx
+++ b/src/libraries/System.Management/System.Management.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Memory.Data/System.Memory.Data.slnx
+++ b/src/libraries/System.Memory.Data/System.Memory.Data.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Memory/System.Memory.slnx
+++ b/src/libraries/System.Memory/System.Memory.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Http.Json/System.Net.Http.Json.slnx
+++ b/src/libraries/System.Net.Http.Json/System.Net.Http.Json.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.slnx
+++ b/src/libraries/System.Net.Http.WinHttpHandler/System.Net.Http.WinHttpHandler.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Http/System.Net.Http.slnx
+++ b/src/libraries/System.Net.Http/System.Net.Http.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.HttpListener/System.Net.HttpListener.slnx
+++ b/src/libraries/System.Net.HttpListener/System.Net.HttpListener.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Mail/System.Net.Mail.slnx
+++ b/src/libraries/System.Net.Mail/System.Net.Mail.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.NameResolution/System.Net.NameResolution.slnx
+++ b/src/libraries/System.Net.NameResolution/System.Net.NameResolution.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.NetworkInformation/System.Net.NetworkInformation.slnx
+++ b/src/libraries/System.Net.NetworkInformation/System.Net.NetworkInformation.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Ping/System.Net.Ping.slnx
+++ b/src/libraries/System.Net.Ping/System.Net.Ping.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Primitives/System.Net.Primitives.slnx
+++ b/src/libraries/System.Net.Primitives/System.Net.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Quic/System.Net.Quic.slnx
+++ b/src/libraries/System.Net.Quic/System.Net.Quic.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Requests/System.Net.Requests.slnx
+++ b/src/libraries/System.Net.Requests/System.Net.Requests.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Security/System.Net.Security.slnx
+++ b/src/libraries/System.Net.Security/System.Net.Security.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.ServerSentEvents/System.Net.ServerSentEvents.slnx
+++ b/src/libraries/System.Net.ServerSentEvents/System.Net.ServerSentEvents.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.Sockets/System.Net.Sockets.slnx
+++ b/src/libraries/System.Net.Sockets/System.Net.Sockets.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.WebClient/System.Net.WebClient.slnx
+++ b/src/libraries/System.Net.WebClient/System.Net.WebClient.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.WebHeaderCollection/System.Net.WebHeaderCollection.slnx
+++ b/src/libraries/System.Net.WebHeaderCollection/System.Net.WebHeaderCollection.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.WebProxy/System.Net.WebProxy.slnx
+++ b/src/libraries/System.Net.WebProxy/System.Net.WebProxy.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.WebSockets.Client/System.Net.WebSockets.Client.slnx
+++ b/src/libraries/System.Net.WebSockets.Client/System.Net.WebSockets.Client.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Net.WebSockets/System.Net.WebSockets.slnx
+++ b/src/libraries/System.Net.WebSockets/System.Net.WebSockets.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Numerics.Tensors/System.Numerics.Tensors.slnx
+++ b/src/libraries/System.Numerics.Tensors/System.Numerics.Tensors.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Numerics.Vectors/System.Numerics.Vectors.slnx
+++ b/src/libraries/System.Numerics.Vectors/System.Numerics.Vectors.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ObjectModel/System.ObjectModel.slnx
+++ b/src/libraries/System.ObjectModel/System.ObjectModel.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Private.DataContractSerialization/System.Private.DataContractSerialization.slnx
+++ b/src/libraries/System.Private.DataContractSerialization/System.Private.DataContractSerialization.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Private.Uri/System.Private.Uri.slnx
+++ b/src/libraries/System.Private.Uri/System.Private.Uri.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Private.Xml.Linq/System.Private.Xml.Linq.slnx
+++ b/src/libraries/System.Private.Xml.Linq/System.Private.Xml.Linq.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Private.Xml/System.Private.Xml.slnx
+++ b/src/libraries/System.Private.Xml/System.Private.Xml.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Context/System.Reflection.Context.slnx
+++ b/src/libraries/System.Reflection.Context/System.Reflection.Context.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.slnx
+++ b/src/libraries/System.Reflection.DispatchProxy/System.Reflection.DispatchProxy.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Emit.ILGeneration/System.Reflection.Emit.ILGeneration.slnx
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/System.Reflection.Emit.ILGeneration.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Emit.Lightweight/System.Reflection.Emit.Lightweight.slnx
+++ b/src/libraries/System.Reflection.Emit.Lightweight/System.Reflection.Emit.Lightweight.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Emit/System.Reflection.Emit.slnx
+++ b/src/libraries/System.Reflection.Emit/System.Reflection.Emit.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Metadata/System.Reflection.Metadata.slnx
+++ b/src/libraries/System.Reflection.Metadata/System.Reflection.Metadata.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.MetadataLoadContext/System.Reflection.MetadataLoadContext.slnx
+++ b/src/libraries/System.Reflection.MetadataLoadContext/System.Reflection.MetadataLoadContext.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.Primitives/System.Reflection.Primitives.slnx
+++ b/src/libraries/System.Reflection.Primitives/System.Reflection.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.slnx
+++ b/src/libraries/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Resources.Extensions/System.Resources.Extensions.slnx
+++ b/src/libraries/System.Resources.Extensions/System.Resources.Extensions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Resources.Writer/System.Resources.Writer.slnx
+++ b/src/libraries/System.Resources.Writer/System.Resources.Writer.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Caching/System.Runtime.Caching.slnx
+++ b/src/libraries/System.Runtime.Caching/System.Runtime.Caching.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.CompilerServices.VisualC/System.Runtime.CompilerServices.VisualC.slnx
+++ b/src/libraries/System.Runtime.CompilerServices.VisualC/System.Runtime.CompilerServices.VisualC.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.InteropServices.JavaScript/System.Runtime.InteropServices.JavaScript.slnx
+++ b/src/libraries/System.Runtime.InteropServices.JavaScript/System.Runtime.InteropServices.JavaScript.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.InteropServices/System.Runtime.InteropServices.slnx
+++ b/src/libraries/System.Runtime.InteropServices/System.Runtime.InteropServices.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Intrinsics/System.Runtime.Intrinsics.slnx
+++ b/src/libraries/System.Runtime.Intrinsics/System.Runtime.Intrinsics.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Loader/System.Runtime.Loader.slnx
+++ b/src/libraries/System.Runtime.Loader/System.Runtime.Loader.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Numerics/System.Runtime.Numerics.slnx
+++ b/src/libraries/System.Runtime.Numerics/System.Runtime.Numerics.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.slnx
+++ b/src/libraries/System.Runtime.Serialization.Formatters/System.Runtime.Serialization.Formatters.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Serialization.Json/System.Runtime.Serialization.Json.slnx
+++ b/src/libraries/System.Runtime.Serialization.Json/System.Runtime.Serialization.Json.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.slnx
+++ b/src/libraries/System.Runtime.Serialization.Primitives/System.Runtime.Serialization.Primitives.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime.Serialization.Schema/System.Runtime.Serialization.Schema.slnx
+++ b/src/libraries/System.Runtime.Serialization.Schema/System.Runtime.Serialization.Schema.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.slnx
+++ b/src/libraries/System.Runtime.Serialization.Xml/System.Runtime.Serialization.Xml.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Runtime/System.Runtime.slnx
+++ b/src/libraries/System.Runtime/System.Runtime.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.AccessControl/System.Security.AccessControl.slnx
+++ b/src/libraries/System.Security.AccessControl/System.Security.AccessControl.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Claims/System.Security.Claims.slnx
+++ b/src/libraries/System.Security.Claims/System.Security.Claims.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Cryptography.Cose/System.Security.Cryptography.Cose.slnx
+++ b/src/libraries/System.Security.Cryptography.Cose/System.Security.Cryptography.Cose.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Cryptography.Pkcs/System.Security.Cryptography.Pkcs.slnx
+++ b/src/libraries/System.Security.Cryptography.Pkcs/System.Security.Cryptography.Pkcs.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Cryptography.ProtectedData/System.Security.Cryptography.ProtectedData.slnx
+++ b/src/libraries/System.Security.Cryptography.ProtectedData/System.Security.Cryptography.ProtectedData.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Security.Cryptography.Xml/System.Security.Cryptography.Xml.slnx
+++ b/src/libraries/System.Security.Cryptography.Xml/System.Security.Cryptography.Xml.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Cryptography/System.Security.Cryptography.slnx
+++ b/src/libraries/System.Security.Cryptography/System.Security.Cryptography.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Permissions/System.Security.Permissions.slnx
+++ b/src/libraries/System.Security.Permissions/System.Security.Permissions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Security.Principal.Windows/System.Security.Principal.Windows.slnx
+++ b/src/libraries/System.Security.Principal.Windows/System.Security.Principal.Windows.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.ServiceModel.Syndication/System.ServiceModel.Syndication.slnx
+++ b/src/libraries/System.ServiceModel.Syndication/System.ServiceModel.Syndication.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.ServiceProcess.ServiceController/System.ServiceProcess.ServiceController.slnx
+++ b/src/libraries/System.ServiceProcess.ServiceController/System.ServiceProcess.ServiceController.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Speech/System.Speech.slnx
+++ b/src/libraries/System.Speech/System.Speech.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Text.Encoding.CodePages/System.Text.Encoding.CodePages.slnx
+++ b/src/libraries/System.Text.Encoding.CodePages/System.Text.Encoding.CodePages.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Text.Encoding.Extensions/System.Text.Encoding.Extensions.slnx
+++ b/src/libraries/System.Text.Encoding.Extensions/System.Text.Encoding.Extensions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Text.Encodings.Web/System.Text.Encodings.Web.slnx
+++ b/src/libraries/System.Text.Encodings.Web/System.Text.Encodings.Web.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Text.Json/System.Text.Json.slnx
+++ b/src/libraries/System.Text.Json/System.Text.Json.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Text.RegularExpressions/System.Text.RegularExpressions.slnx
+++ b/src/libraries/System.Text.RegularExpressions/System.Text.RegularExpressions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.AccessControl/System.Threading.AccessControl.slnx
+++ b/src/libraries/System.Threading.AccessControl/System.Threading.AccessControl.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.Channels/System.Threading.Channels.slnx
+++ b/src/libraries/System.Threading.Channels/System.Threading.Channels.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.Overlapped/System.Threading.Overlapped.slnx
+++ b/src/libraries/System.Threading.Overlapped/System.Threading.Overlapped.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.RateLimiting/System.Threading.RateLimiting.slnx
+++ b/src/libraries/System.Threading.RateLimiting/System.Threading.RateLimiting.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/DownlevelLibraryImportGenerator/DownlevelLibraryImportGenerator.csproj" />
     <Project Path="../System.Runtime.InteropServices/gen/Microsoft.Interop.SourceGeneration/Microsoft.Interop.SourceGeneration.csproj" />
   </Folder>

--- a/src/libraries/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.slnx
+++ b/src/libraries/System.Threading.Tasks.Dataflow/System.Threading.Tasks.Dataflow.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.Tasks.Parallel/System.Threading.Tasks.Parallel.slnx
+++ b/src/libraries/System.Threading.Tasks.Parallel/System.Threading.Tasks.Parallel.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.Thread/System.Threading.Thread.slnx
+++ b/src/libraries/System.Threading.Thread/System.Threading.Thread.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading.ThreadPool/System.Threading.ThreadPool.slnx
+++ b/src/libraries/System.Threading.ThreadPool/System.Threading.ThreadPool.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Threading/System.Threading.slnx
+++ b/src/libraries/System.Threading/System.Threading.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Transactions.Local/System.Transactions.Local.slnx
+++ b/src/libraries/System.Transactions.Local/System.Transactions.Local.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Web.HttpUtility/System.Web.HttpUtility.slnx
+++ b/src/libraries/System.Web.HttpUtility/System.Web.HttpUtility.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Windows.Extensions/System.Windows.Extensions.slnx
+++ b/src/libraries/System.Windows.Extensions/System.Windows.Extensions.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Xml.ReaderWriter/System.Xml.ReaderWriter.slnx
+++ b/src/libraries/System.Xml.ReaderWriter/System.Xml.ReaderWriter.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Xml.XDocument/System.Xml.XDocument.slnx
+++ b/src/libraries/System.Xml.XDocument/System.Xml.XDocument.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.slnx
+++ b/src/libraries/System.Xml.XPath.XDocument/System.Xml.XPath.XDocument.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Xml.XPath/System.Xml.XPath.slnx
+++ b/src/libraries/System.Xml.XPath/System.Xml.XPath.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />

--- a/src/libraries/System.Xml.XmlSerializer/System.Xml.XmlSerializer.slnx
+++ b/src/libraries/System.Xml.XmlSerializer/System.Xml.XmlSerializer.slnx
@@ -10,6 +10,14 @@
     <Platform Name="x86" />
   </Configurations>
   <Folder Name="/gen/">
+    <Project Path="../../../eng/analyzers/PlatformDocAnalyzer/PlatformDocAnalyzer.csproj">
+      <BuildType Solution="Checked|*" Project="Debug" />
+      <Build Solution="*|arm" Project="false" />
+      <Build Solution="*|arm64" Project="false" />
+      <Build Solution="Checked|Any CPU" Project="false" />
+      <Build Solution="Checked|x64" Project="false" />
+      <Build Solution="Checked|x86" Project="false" />
+    </Project>
     <Project Path="../System.Private.CoreLib/gen/EventSourceGenerator.csproj">
       <BuildType Solution="Checked|*" Project="Debug" />
       <Build Solution="*|arm" Project="false" />


### PR DESCRIPTION
Move the PlatformDocAnalyzer ProjectReference and props import from generators.targets to Analyzers.targets, gated behind a new EnablePlatformDocAnalyzer property that defaults to true for src/libraries source projects. This scopes the analyzer to libraries src projects unless explicitly opted in. Regenerate the affected library slnx files to include the analyzer project.