### PR TITLE
[cDAC] Implement GetManagedStoppedContext for cDAC

### DIFF
--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -68,6 +68,10 @@ DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress);
 // This is the primary API for GC reference enumeration, used by SOSDacImpl.GetStackReferences.
 IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData);
 
+// Returns a context for the thread, trying (in order): the debugger filter context,
+// the OS thread context, or a context derived from the explicit Frame chain.
+byte[] GetContext(ThreadData threadData, ThreadContextSource contextSource, uint contextFlags);
+
 // Walks the thread's explicit (capital-F) Frame chain and looks for a thread context.
 byte[] GetContextFromFrames(ThreadData threadData);
 
@@ -582,6 +586,8 @@ IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData)
 ```
 
 The implementation uses the same stack walk algorithm as `CreateStackWalk`, but integrates the GC-aware `Filter` directly (rather than consuming pre-generated frames) and performs GC reference enumeration at each frame. See [GC Stack Reference Scanning](#gc-stack-reference-scanning) for details.
+
+`GetContext` returns a thread context by trying three sources in order: (1) the debugger filter context from `ThreadData.DebuggerFilterContext` (when `ThreadContextSource.Debugger` is requested), (2) the OS thread context via `TryGetThreadContext`, or (3) a context derived from the explicit Frame chain via `GetContextFromFrames`.
 
 The `GetContextFromFrames` implementation walks the Frame chain (`Thread::Frame` linked list) and returns the first frame that yields a usable context:
 * If the current Frame is an `InterpreterFrame`, clear the context and update it from the Frame. Return the resulting bytes.

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -67,6 +67,12 @@ DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress);
 // Walks the stack and returns all GC references found on each frame.
 // This is the primary API for GC reference enumeration, used by SOSDacImpl.GetStackReferences.
 IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData);
+
+// Walks the thread's explicit (capital-F) Frame chain and looks for a thread context.
+byte[] GetContextFromFrames(ThreadData threadData);
+
+// Returns the saved TargetContext pointer carried by the head Frame, if applicable.
+TargetPointer GetRedirectedContextPointer(ThreadData threadData);
 ```
 
 ## Version 1
@@ -576,6 +582,14 @@ IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData)
 ```
 
 The implementation uses the same stack walk algorithm as `CreateStackWalk`, but integrates the GC-aware `Filter` directly (rather than consuming pre-generated frames) and performs GC reference enumeration at each frame. See [GC Stack Reference Scanning](#gc-stack-reference-scanning) for details.
+
+The `GetContextFromFrames`implementation walks the Frame chain (`Thread::Frame` linked list) and returns the first frame that yields a usable context:
+* If the current Frame is an `InterpreterFrame`, clear the context and update it from the Frame. Return the resulting bytes.
+* Otherwise, clear the context and update it from the current Frame; accept the context when both the stack pointer and instruction pointer are non-zero (e.g. `RedirectedThreadFrame`, `InlinedCallFrame`, `DynamicHelperFrame`). Mark `RawContextFlags = FullContextFlags` so callers know SP/PC/FP are valid.
+
+If no Frame in the chain produces a usable context (thread is not running managed code), a zeroed context of the target architecture's size is returned.
+
+`GetRedirectedContextPointer` returns the saved `TargetContext` pointer carried by the head Frame when that Frame is a `RedirectedThreadFrame` (a `ResumableFrame`). Otherwise it returns `TargetPointer.Null`.
 
 ### GC Stack Reference Scanning
 

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -72,9 +72,6 @@ IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData);
 // the OS thread context, or a context derived from the explicit Frame chain.
 byte[] GetContext(ThreadData threadData, ThreadContextSource contextSource, uint contextFlags);
 
-// Walks the thread's explicit (capital-F) Frame chain and looks for a thread context.
-byte[] GetContextFromFrames(ThreadData threadData);
-
 // Returns the saved TargetContext pointer carried by the head Frame, if applicable.
 TargetPointer GetRedirectedContextPointer(ThreadData threadData);
 ```
@@ -587,9 +584,7 @@ IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData)
 
 The implementation uses the same stack walk algorithm as `CreateStackWalk`, but integrates the GC-aware `Filter` directly (rather than consuming pre-generated frames) and performs GC reference enumeration at each frame. See [GC Stack Reference Scanning](#gc-stack-reference-scanning) for details.
 
-`GetContext` returns a thread context by trying three sources in order: (1) the debugger filter context from `ThreadData.DebuggerFilterContext` (when `ThreadContextSource.Debugger` is requested), (2) the OS thread context via `TryGetThreadContext`, or (3) a context derived from the explicit Frame chain via `GetContextFromFrames`.
-
-The `GetContextFromFrames` implementation walks the Frame chain (`Thread::Frame` linked list) and returns the first frame that yields a usable context:
+`GetContext` returns a thread context by trying three sources in order: (1) the debugger filter context from `ThreadData.DebuggerFilterContext` (when `ThreadContextSource.Debugger` is requested), (2) the OS thread context via `TryGetThreadContext`, or (3) a context derived from walking the explicit Frame chain (`Thread::Frame` linked list), returning the first frame that yields a usable context:
 * If the current Frame is an `InterpreterFrame`, clear the context and update it from the Frame. Return the resulting bytes.
 * Otherwise, clear the context and update it from the current Frame; accept the context when both the stack pointer and instruction pointer are non-zero (e.g. `RedirectedThreadFrame`, `InlinedCallFrame`, `DynamicHelperFrame`). Mark `RawContextFlags = FullContextFlags` so callers know SP/PC/FP are valid.
 

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -583,7 +583,7 @@ IReadOnlyList<StackReferenceData> WalkStackReferences(ThreadData threadData)
 
 The implementation uses the same stack walk algorithm as `CreateStackWalk`, but integrates the GC-aware `Filter` directly (rather than consuming pre-generated frames) and performs GC reference enumeration at each frame. See [GC Stack Reference Scanning](#gc-stack-reference-scanning) for details.
 
-The `GetContextFromFrames`implementation walks the Frame chain (`Thread::Frame` linked list) and returns the first frame that yields a usable context:
+The `GetContextFromFrames` implementation walks the Frame chain (`Thread::Frame` linked list) and returns the first frame that yields a usable context:
 * If the current Frame is an `InterpreterFrame`, clear the context and update it from the Frame. Return the resulting bytes.
 * Otherwise, clear the context and update it from the current Frame; accept the context when both the stack pointer and instruction pointer are non-zero (e.g. `RedirectedThreadFrame`, `InlinedCallFrame`, `DynamicHelperFrame`). Mark `RawContextFlags = FullContextFlags` so callers know SP/PC/FP are valid.
 

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -77,7 +77,6 @@ TargetPointer GetThreadLocalStaticBase(TargetPointer threadPointer, TargetPointe
 byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags);
 bool IsInteropDebuggingHijacked(TargetPointer threadPointer);
 TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer);
-TargetPointer GetRedirectedContext(TargetPointer threadPointer);
 ```
 
 ## Version 1
@@ -413,16 +412,10 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
     if (target.TryGetThreadContext(osId, contextFlags, bytes))
         return bytes;
 
-    // Derive a context from the explicit Frame chain stored in the Thread (sufficient for managed
-    // debugging stack walks). Walk the Frame chain and pick the first
-    // frame that yields a usable context:
-    //   * If it is an InterpreterFrame, fill the context from the top
-    //     InterpMethodContextFrame.
-    //   * Otherwise, update the context from the frame and accept it when both
-    //     StackPointer and InstructionPointer are non-zero. Mark the resulting
-    //     context flags as full so callers know SP/PC/FP are valid.
-    // If no frame supplies a usable context (thread is not running managed code),
-    // return a zeroed context.
+    // Fall back to deriving a context from the explicit Frame chain stored in the Thread
+    // object (sufficient for managed debugging stack walks).
+    ThreadData threadData = GetThreadData(threadPointer);
+    return target.Contracts.StackWalk.GetContextFromFrames(threadData);
 }
 
 bool IsInteropDebuggingHijacked(TargetPointer threadPointer)
@@ -434,19 +427,4 @@ TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer)
 {
     return target.ReadPointer(threadPointer + /* Thread::DebuggerFilterContext offset */);
 }
-
-TargetPointer GetRedirectedContext(TargetPointer threadPointer)
-{
-    // Frame handling and ResumableFrame descriptors are defined in the StackWalk contract.
-    TargetPointer framePointer = target.ReadPointer(threadPointer + /* Thread::Frame offset */);
-    // If the frame is valid and its type is RedirectedThreadFrame, read the ResumableFrame and return the context pointer.
-    if (IsFrameValid(framePointer) && GetFrameType(framePointer) == FrameType.RedirectedThreadFrame)
-    {
-        TargetPointer contextPtr = target.ReadPointer(framePointer + /* ResumableFrame::TargetContextPtr offset */);
-        return contextPtr;
-    }
-    return TargetPointer.Null;
-}
-
 ```
-

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -131,6 +131,7 @@ The contract additionally depends on these data descriptors
 | `Thread` | `LinkNext` | Pointer to get next thread |
 | `Thread` | `ExceptionTracker` | Pointer to exception tracking information |
 | `Thread` | `DebuggerFilterContext` | Pointer to the debugger filter context for the thread |
+| `Thread` | `InteropDebuggingHijacked` | Whether the thread has been hijacked for interop debugging |
 | `Thread` | `RuntimeThreadLocals` | Pointer to some thread-local storage |
 | `Thread` | `ThreadLocalDataPtr` | Pointer to thread local data structure |
 | `Thread` | `ThreadHandle` | OS thread handle (optional, Windows only; readers should expect `TargetPointer.Null` on non-Windows targets) |
@@ -421,3 +422,4 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
 }
 
 ```
+

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -155,7 +155,6 @@ The contract depends on the following other contracts
 | Contract |
 | --- |
 | Object |
-| StackWalk |
 
 ``` csharp
 enum TLSIndexType

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -75,6 +75,9 @@ void GetStackLimitData(TargetPointer threadPointer, out TargetPointer stackBase,
 TargetPointer IdToThread(uint id);
 TargetPointer GetThreadLocalStaticBase(TargetPointer threadPointer, TargetPointer tlsIndexPtr);
 byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags);
+bool IsInteropDebuggingHijacked(TargetPointer threadPointer);
+TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer);
+TargetPointer GetRedirectedContext(TargetPointer threadPointer);
 ```
 
 ## Version 1
@@ -153,6 +156,7 @@ The contract depends on the following other contracts
 | Contract |
 | --- |
 | Object |
+| StackWalk |
 
 ``` csharp
 enum TLSIndexType
@@ -421,23 +425,25 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
     // return a zeroed context.
 }
 
-bool IsInteropDebuggingHijacked(TargetPointer thread)
+bool IsInteropDebuggingHijacked(TargetPointer threadPointer)
 {
-    return target.Read<uint>(thread + /* Thread::InteropDebuggingHijacked offset */) != 0;
+    return target.Read<uint>(threadPointer + /* Thread::InteropDebuggingHijacked offset */) != 0;
 }
 
-TargetPointer GetDebuggerFilterContext(TargetPointer thread)
+TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer)
 {
-    return target.ReadPointer(thread + /* Thread::DebuggerFilterContext offset */);
+    return target.ReadPointer(threadPointer + /* Thread::DebuggerFilterContext offset */);
 }
 
-TargetPointer GetRedirectedContext(TargetPointer thread)
+TargetPointer GetRedirectedContext(TargetPointer threadPointer)
 {
-    FrameIterator iterator = new FrameIterator(thread);
-    if (iterator.IsValid() && iterator.GetCurrentFrameType() == FrameType.RedirectedThreadFrame)
+    // Frame handling and ResumableFrame descriptors are defined in the StackWalk contract.
+    TargetPointer framePointer = target.ReadPointer(threadPointer + /* Thread::Frame offset */);
+    // If the frame is valid and its type is RedirectedThreadFrame, read the ResumableFrame and return the context pointer.
+    if (IsFrameValid(framePointer) && GetFrameType(framePointer) == FrameType.RedirectedThreadFrame)
     {
-        ResumableFrame rf = ReadResumableFrame(iterator.CurrentFrameAddress);
-        return rf.TargetContextPtr;
+        TargetPointer contextPtr = target.ReadPointer(framePointer + /* ResumableFrame::TargetContextPtr offset */);
+        return contextPtr;
     }
     return TargetPointer.Null;
 }

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -421,5 +421,26 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
     // return a zeroed context.
 }
 
+bool GetInteropDebuggingHijacked(TargetPointer thread)
+{
+    return thread.InteropDebuggingHijacked != 0;
+}
+
+TargetPointer GetDebuggerFilterContext(TargetPointer thread)
+{
+    return thread.DebuggerFilterContext;
+}
+
+TargetPointer GetRedirectedContext(TargetPointer thread)
+{
+    FrameIterator iterator = new FrameIterator(thread);
+    if (iterator.IsValid() && iterator.GetCurrentFrameType() == FrameType.RedirectedThreadFrame)
+    {
+        ResumableFrame rf = ReadResumableFrame(iterator.CurrentFrameAddress);
+        return rf.TargetContextPtr;
+    }
+    return TargetPointer.Null;
+}
+
 ```
 

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -421,14 +421,14 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
     // return a zeroed context.
 }
 
-bool GetInteropDebuggingHijacked(TargetPointer thread)
+bool IsInteropDebuggingHijacked(TargetPointer thread)
 {
-    return thread.InteropDebuggingHijacked != 0;
+    return target.Read<byte>(thread + /* Thread::InteropDebuggingHijacked offset */) != 0;
 }
 
 TargetPointer GetDebuggerFilterContext(TargetPointer thread)
 {
-    return thread.DebuggerFilterContext;
+    return target.ReadPointer(thread + /* Thread::DebuggerFilterContext offset */);
 }
 
 TargetPointer GetRedirectedContext(TargetPointer thread)

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -423,7 +423,7 @@ byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource conte
 
 bool IsInteropDebuggingHijacked(TargetPointer thread)
 {
-    return target.Read<byte>(thread + /* Thread::InteropDebuggingHijacked offset */) != 0;
+    return target.Read<uint>(thread + /* Thread::InteropDebuggingHijacked offset */) != 0;
 }
 
 TargetPointer GetDebuggerFilterContext(TargetPointer thread)

--- a/docs/design/datacontracts/Thread.md
+++ b/docs/design/datacontracts/Thread.md
@@ -53,6 +53,8 @@ record struct ThreadData (
     bool HasUnhandledException;
     TargetPointer NextThread;
     TargetPointer ThreadHandle;
+    bool IsInteropDebuggingHijacked;
+    TargetPointer DebuggerFilterContext;
 );
 ```
 
@@ -74,9 +76,6 @@ void ResetDebuggerControlledThreadState(TargetPointer thread, DebuggerControlled
 void GetStackLimitData(TargetPointer threadPointer, out TargetPointer stackBase, out TargetPointer stackLimit, out TargetPointer frameAddress);
 TargetPointer IdToThread(uint id);
 TargetPointer GetThreadLocalStaticBase(TargetPointer threadPointer, TargetPointer tlsIndexPtr);
-byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags);
-bool IsInteropDebuggingHijacked(TargetPointer threadPointer);
-TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer);
 ```
 
 ## Version 1
@@ -388,42 +387,4 @@ byte[] IThread.GetWatsonBuckets(TargetPointer threadPointer)
     return span.ToArray();
 }
 
-byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags)
-{
-    // Allocate a context buffer for the target platform
-    IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(target);
-    byte[] bytes = new byte[context.Size];
-
-    TargetPointer filterContext = TargetPointer.Null;
-
-    if (contextSource.HasFlag(ThreadContextSource.Debugger))
-        filterContext = target.ReadPointer(threadPointer + /* Thread::DebuggerFilterContext offset */);
-
-    if (filterContext != TargetPointer.Null)
-    {
-        // Use the filter context directly
-        target.ReadBuffer(filterContext, bytes);
-        return bytes;
-    }
-
-    // Try to read the OS thread context from the data target
-    ulong osId = target.ReadNUInt(threadPointer + /* Thread::OSId offset */);
-    if (target.TryGetThreadContext(osId, contextFlags, bytes))
-        return bytes;
-
-    // Fall back to deriving a context from the explicit Frame chain stored in the Thread
-    // object (sufficient for managed debugging stack walks).
-    ThreadData threadData = GetThreadData(threadPointer);
-    return target.Contracts.StackWalk.GetContextFromFrames(threadData);
-}
-
-bool IsInteropDebuggingHijacked(TargetPointer threadPointer)
-{
-    return target.Read<uint>(threadPointer + /* Thread::InteropDebuggingHijacked offset */) != 0;
-}
-
-TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer)
-{
-    return target.ReadPointer(threadPointer + /* Thread::DebuggerFilterContext offset */);
-}
 ```

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -46,6 +46,7 @@ CDAC_TYPE_FIELD(Thread, T_POINTER, CachedStackLimit, cdac_data<Thread>::CachedSt
 CDAC_TYPE_FIELD(Thread, T_POINTER, ExceptionTracker, cdac_data<Thread>::ExceptionTracker)
 CDAC_TYPE_FIELD(Thread, T_UINT32, DebuggerControlledThreadState, cdac_data<Thread>::DebuggerControlledThreadState)
 CDAC_TYPE_FIELD(Thread, T_POINTER, DebuggerFilterContext, cdac_data<Thread>::DebuggerFilterContext)
+CDAC_TYPE_FIELD(Thread, T_UINT32, InteropDebuggingHijacked, cdac_data<Thread>::InteropDebuggingHijacked)
 #ifdef TARGET_WINDOWS
 CDAC_TYPE_FIELD(Thread, T_POINTER, ThreadHandle, cdac_data<Thread>::ThreadHandle)
 #endif // TARGET_WINDOWS

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -3779,6 +3779,7 @@ struct cdac_data<Thread>
         "Thread::m_ExceptionState is of type ThreadExceptionState");
     static constexpr size_t ExceptionTracker = offsetof(Thread, m_ExceptionState) + offsetof(ThreadExceptionState, m_pCurrentTracker);
     static constexpr size_t DebuggerFilterContext = offsetof(Thread, m_debuggerFilterContext);
+    static constexpr size_t InteropDebuggingHijacked = offsetof(Thread, m_fInteropDebuggingHijacked);
 #ifdef TARGET_WINDOWS
     static constexpr size_t ThreadHandle = offsetof(Thread, m_ThreadHandle);
 #endif

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -85,6 +85,7 @@ public interface IStackWalk : IContract
     DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress) => throw new NotImplementedException();
     byte[] GetContextFromFrames(ThreadData threadData) => throw new NotImplementedException();
     TargetPointer GetRedirectedContextPointer(ThreadData threadData) => throw new NotImplementedException();
+    byte[] GetContext(ThreadData threadData, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
 }
 
 public struct StackWalk : IStackWalk

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -83,7 +83,6 @@ public interface IStackWalk : IContract
     IEnumerable<StackFrameData> GetFrames(TargetPointer threadPointer) => throw new NotImplementedException();
     bool IsExceptionHandlingHelperInlinedCallFrame(TargetPointer frameAddress) => throw new NotImplementedException();
     DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress) => throw new NotImplementedException();
-    byte[] GetContextFromFrames(ThreadData threadData) => throw new NotImplementedException();
     TargetPointer GetRedirectedContextPointer(ThreadData threadData) => throw new NotImplementedException();
     byte[] GetContext(ThreadData threadData, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -83,6 +83,8 @@ public interface IStackWalk : IContract
     IEnumerable<StackFrameData> GetFrames(TargetPointer threadPointer) => throw new NotImplementedException();
     bool IsExceptionHandlingHelperInlinedCallFrame(TargetPointer frameAddress) => throw new NotImplementedException();
     DebuggerEvalData GetDebuggerEvalData(TargetPointer funcEvalFrameAddress) => throw new NotImplementedException();
+    byte[] GetContextFromFrames(ThreadData threadData) => throw new NotImplementedException();
+    TargetPointer GetRedirectedContextPointer(ThreadData threadData) => throw new NotImplementedException();
 }
 
 public struct StackWalk : IStackWalk

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -79,6 +79,9 @@ public interface IThread : IContract
     TargetPointer GetCurrentExceptionHandle(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetWatsonBuckets(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
+    bool GetInteropDebuggingHijacked(TargetPointer thread) => throw new NotImplementedException();
+    TargetPointer GetDebuggerFilterContext(TargetPointer thread) => throw new NotImplementedException();
+    TargetPointer GetRedirectedContext(TargetPointer thread) => throw new NotImplementedException();
 }
 
 public readonly struct Thread : IThread

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -79,7 +79,7 @@ public interface IThread : IContract
     TargetPointer GetCurrentExceptionHandle(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetWatsonBuckets(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
-    bool GetInteropDebuggingHijacked(TargetPointer thread) => throw new NotImplementedException();
+    bool IsInteropDebuggingHijacked(TargetPointer thread) => throw new NotImplementedException();
     TargetPointer GetDebuggerFilterContext(TargetPointer thread) => throw new NotImplementedException();
     TargetPointer GetRedirectedContext(TargetPointer thread) => throw new NotImplementedException();
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -60,7 +60,9 @@ public record struct ThreadData(
     bool LastThrownObjectIsUnhandled,
     bool HasUnhandledException,
     TargetPointer NextThread,
-    TargetPointer ThreadHandle);
+    TargetPointer ThreadHandle,
+    bool IsInteropDebuggingHijacked,
+    TargetPointer DebuggerFilterContext);
 
 public interface IThread : IContract
 {
@@ -78,9 +80,6 @@ public interface IThread : IContract
     TargetPointer GetThreadLocalStaticBase(TargetPointer threadPointer, TargetPointer tlsIndexPtr) => throw new NotImplementedException();
     TargetPointer GetCurrentExceptionHandle(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetWatsonBuckets(TargetPointer threadPointer) => throw new NotImplementedException();
-    byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
-    bool IsInteropDebuggingHijacked(TargetPointer threadPointer) => throw new NotImplementedException();
-    TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer) => throw new NotImplementedException();
 }
 
 public readonly struct Thread : IThread

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -81,7 +81,6 @@ public interface IThread : IContract
     byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
     bool IsInteropDebuggingHijacked(TargetPointer threadPointer) => throw new NotImplementedException();
     TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer) => throw new NotImplementedException();
-    TargetPointer GetRedirectedContext(TargetPointer threadPointer) => throw new NotImplementedException();
 }
 
 public readonly struct Thread : IThread

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IThread.cs
@@ -79,9 +79,9 @@ public interface IThread : IContract
     TargetPointer GetCurrentExceptionHandle(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetWatsonBuckets(TargetPointer threadPointer) => throw new NotImplementedException();
     byte[] GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags) => throw new NotImplementedException();
-    bool IsInteropDebuggingHijacked(TargetPointer thread) => throw new NotImplementedException();
-    TargetPointer GetDebuggerFilterContext(TargetPointer thread) => throw new NotImplementedException();
-    TargetPointer GetRedirectedContext(TargetPointer thread) => throw new NotImplementedException();
+    bool IsInteropDebuggingHijacked(TargetPointer threadPointer) => throw new NotImplementedException();
+    TargetPointer GetDebuggerFilterContext(TargetPointer threadPointer) => throw new NotImplementedException();
+    TargetPointer GetRedirectedContext(TargetPointer threadPointer) => throw new NotImplementedException();
 }
 
 public readonly struct Thread : IThread

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -918,6 +918,32 @@ internal partial class StackWalk_1 : IStackWalk
         return new DebuggerEvalData(debuggerEval.MethodToken, debuggerEval.AssemblyPtr);
     }
 
+    byte[] IStackWalk.GetContext(ThreadData threadData, ThreadContextSource contextSource, uint contextFlags)
+    {
+        IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
+        byte[] bytes = new byte[context.Size];
+        Span<byte> buffer = new Span<byte>(bytes);
+
+        TargetPointer filterContext = TargetPointer.Null;
+
+        if (contextSource.HasFlag(ThreadContextSource.Debugger))
+            filterContext = threadData.DebuggerFilterContext;
+
+        if (filterContext != TargetPointer.Null)
+        {
+            _target.ReadBuffer(filterContext.Value, buffer);
+            return bytes;
+        }
+
+        if (_target.TryGetThreadContext(threadData.OSId.Value, contextFlags, buffer))
+        {
+            return bytes;
+        }
+
+        // Fall back to deriving a context from the explicit Frame chain stored in the Thread object.
+        return ((IStackWalk)this).GetContextFromFrames(threadData);
+    }
+
     byte[] IStackWalk.GetContextFromFrames(ThreadData threadData)
     {
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
@@ -979,8 +1005,8 @@ internal partial class StackWalk_1 : IStackWalk
 
     private void FillContextFromThread(IPlatformAgnosticContext context, ThreadData threadData, uint flags)
     {
-        byte[] bytes = _target.Contracts.Thread.GetContext(
-            threadData.ThreadAddress,
+        byte[] bytes = ((IStackWalk)this).GetContext(
+            threadData,
             ThreadContextSource.Debugger,
             flags);
         context.FillFromBuffer(bytes);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -941,10 +941,10 @@ internal partial class StackWalk_1 : IStackWalk
         }
 
         // Fall back to deriving a context from the explicit Frame chain stored in the Thread object.
-        return ((IStackWalk)this).GetContextFromFrames(threadData);
+        return GetContextFromFrames(threadData);
     }
 
-    byte[] IStackWalk.GetContextFromFrames(ThreadData threadData)
+    private byte[] GetContextFromFrames(ThreadData threadData)
     {
         IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -918,6 +918,53 @@ internal partial class StackWalk_1 : IStackWalk
         return new DebuggerEvalData(debuggerEval.MethodToken, debuggerEval.AssemblyPtr);
     }
 
+    byte[] IStackWalk.GetContextFromFrames(ThreadData threadData)
+    {
+        IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
+
+        FrameIterator iterator = new FrameIterator(_target, threadData);
+        while (iterator.IsValid())
+        {
+            // For InterpreterFrame, fill the context from the top InterpMethodContextFrame
+            // (matches native InterpreterFrame::SetContextToInterpMethodContextFrame).
+            if (iterator.GetCurrentFrameType() == FrameType.InterpreterFrame)
+            {
+                context.Clear();
+                _frameHelpers.UpdateContextFromFrame(iterator.CurrentFrame, context);
+                return context.GetBytes();
+            }
+
+            // For other frames, look for the first (deepest) frame that yields a context
+            // with both SP and PC set (e.g. RedirectedThreadFrame, InlinedCallFrame,
+            // DynamicHelperFrame).
+            context.Clear();
+            _frameHelpers.UpdateContextFromFrame(iterator.CurrentFrame, context);
+            if (context.StackPointer.Value != 0 && context.InstructionPointer.Value != 0)
+            {
+                context.RawContextFlags = context.FullContextFlags;
+                return context.GetBytes();
+            }
+
+            iterator.Next();
+        }
+
+        // The thread is not running managed code: return a zeroed context.
+        context.Clear();
+        return context.GetBytes();
+    }
+
+    TargetPointer IStackWalk.GetRedirectedContextPointer(ThreadData threadData)
+    {
+        FrameIterator iterator = new FrameIterator(_target, threadData);
+        if (iterator.IsValid() && iterator.GetCurrentFrameType() == FrameType.RedirectedThreadFrame)
+        {
+            Data.ResumableFrame rf = _target.ProcessedData.GetOrAdd<Data.ResumableFrame>(iterator.CurrentFrameAddress);
+            return rf.TargetContextPtr;
+        }
+
+        return TargetPointer.Null;
+    }
+
     private bool IsManaged(TargetPointer ip, [NotNullWhen(true)] out CodeBlockHandle? codeBlockHandle)
     {
         TargetCodePointer codePointer = CodePointerUtils.CodePointerFromAddress(ip, _target);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -371,7 +371,7 @@ internal readonly struct Thread_1 : IThread
         return context.GetBytes();
     }
 
-    bool IThread.GetInteropDebuggingHijacked(TargetPointer threadPointer)
+    bool IThread.IsInteropDebuggingHijacked(TargetPointer threadPointer)
     {
         Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
         return thread.InteropDebuggingHijacked != 0;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -332,43 +332,8 @@ internal readonly struct Thread_1 : IThread
         }
 
         // Fall back to deriving a context from the explicit Frame chain stored in the Thread object.
-        return GetContextFromFrames(threadPointer);
-    }
-
-    private byte[] GetContextFromFrames(TargetPointer threadPointer)
-    {
-        IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
-
         ThreadData threadData = ((IThread)this).GetThreadData(threadPointer);
-        FrameIterator iterator = new FrameIterator(_target, threadData);
-        while (iterator.IsValid())
-        {
-            // For InterpreterFrame, fill the context from the top InterpMethodContextFrame
-            // (matches native InterpreterFrame::SetContextToInterpMethodContextFrame).
-            if (iterator.GetCurrentFrameType() == FrameType.InterpreterFrame)
-            {
-                context.Clear();
-                iterator.UpdateContextFromCurrentFrame(context);
-                return context.GetBytes();
-            }
-
-            // For other frames, look for the first (deepest) frame that yields a context
-            // with both SP and PC set (e.g. RedirectedThreadFrame, InlinedCallFrame,
-            // DynamicHelperFrame).
-            context.Clear();
-            iterator.UpdateContextFromCurrentFrame(context);
-            if (context.StackPointer.Value != 0 && context.InstructionPointer.Value != 0)
-            {
-                context.RawContextFlags = context.FullContextFlags;
-                return context.GetBytes();
-            }
-
-            iterator.Next();
-        }
-
-        // The thread is not running managed code: return a zeroed context.
-        context.Clear();
-        return context.GetBytes();
+        return _target.Contracts.StackWalk.GetContextFromFrames(threadData);
     }
 
     bool IThread.IsInteropDebuggingHijacked(TargetPointer threadPointer)
@@ -381,18 +346,5 @@ internal readonly struct Thread_1 : IThread
     {
         Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
         return thread.DebuggerFilterContext;
-    }
-
-    TargetPointer IThread.GetRedirectedContext(TargetPointer threadPointer)
-    {
-        ThreadData threadData = ((IThread)this).GetThreadData(threadPointer);
-        FrameIterator iterator = new FrameIterator(_target, threadData);
-        if (iterator.IsValid() && iterator.GetCurrentFrameType() == FrameType.RedirectedThreadFrame)
-        {
-            Data.ResumableFrame rf = _target.ProcessedData.GetOrAdd<Data.ResumableFrame>(iterator.CurrentFrameAddress);
-            return rf.TargetContextPtr;
-        }
-
-        return TargetPointer.Null;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -370,4 +370,29 @@ internal readonly struct Thread_1 : IThread
         context.Clear();
         return context.GetBytes();
     }
+
+    bool IThread.GetInteropDebuggingHijacked(TargetPointer threadPointer)
+    {
+        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
+        return thread.InteropDebuggingHijacked != 0;
+    }
+
+    TargetPointer IThread.GetDebuggerFilterContext(TargetPointer threadPointer)
+    {
+        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
+        return thread.DebuggerFilterContext;
+    }
+
+    TargetPointer IThread.GetRedirectedContext(TargetPointer threadPointer)
+    {
+        ThreadData threadData = ((IThread)this).GetThreadData(threadPointer);
+        FrameIterator iterator = new FrameIterator(_target, threadData);
+        if (iterator.IsValid() && iterator.GetCurrentFrameType() == FrameType.RedirectedThreadFrame)
+        {
+            Data.ResumableFrame rf = _target.ProcessedData.GetOrAdd<Data.ResumableFrame>(iterator.CurrentFrameAddress);
+            return rf.TargetContextPtr;
+        }
+
+        return TargetPointer.Null;
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Thread_1.cs
@@ -148,7 +148,9 @@ internal readonly struct Thread_1 : IThread
             thread.LastThrownObjectIsUnhandled != 0,
             hasUnhandledException,
             thread.LinkNext,
-            thread.ThreadHandle);
+            thread.ThreadHandle,
+            thread.InteropDebuggingHijacked != 0,
+            thread.DebuggerFilterContext);
     }
 
     void IThread.GetThreadAllocContext(TargetPointer threadPointer, out long allocBytes, out long allocBytesLoh)
@@ -305,46 +307,5 @@ internal readonly struct Thread_1 : IThread
         byte[] rval = new byte[_target.ReadGlobal<uint>(Constants.Globals.SizeOfGenericModeBlock)];
         _target.ReadBuffer(readFrom, rval);
         return rval;
-    }
-
-    byte[] IThread.GetContext(TargetPointer threadPointer, ThreadContextSource contextSource, uint contextFlags)
-    {
-        IPlatformAgnosticContext context = IPlatformAgnosticContext.GetContextForPlatform(_target);
-        byte[] bytes = new byte[context.Size];
-        Span<byte> buffer = new Span<byte>(bytes);
-
-        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
-
-        TargetPointer filterContext = TargetPointer.Null;
-
-        if (contextSource.HasFlag(ThreadContextSource.Debugger))
-            filterContext = thread.DebuggerFilterContext;
-
-        if (filterContext != TargetPointer.Null)
-        {
-            _target.ReadBuffer(filterContext.Value, buffer);
-            return bytes;
-        }
-
-        if (_target.TryGetThreadContext(thread.OSId.Value, contextFlags, buffer))
-        {
-            return bytes;
-        }
-
-        // Fall back to deriving a context from the explicit Frame chain stored in the Thread object.
-        ThreadData threadData = ((IThread)this).GetThreadData(threadPointer);
-        return _target.Contracts.StackWalk.GetContextFromFrames(threadData);
-    }
-
-    bool IThread.IsInteropDebuggingHijacked(TargetPointer threadPointer)
-    {
-        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
-        return thread.InteropDebuggingHijacked != 0;
-    }
-
-    TargetPointer IThread.GetDebuggerFilterContext(TargetPointer threadPointer)
-    {
-        Data.Thread thread = _target.ProcessedData.GetOrAdd<Data.Thread>(threadPointer);
-        return thread.DebuggerFilterContext;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Thread.cs
@@ -26,6 +26,7 @@ internal sealed partial class Thread : IData<Thread>
     [Field] public TargetPointer? UEWatsonBucketTrackerBuckets { get; }
     [Field] public TargetPointer ThreadLocalDataPtr { get; }
     [Field] public TargetPointer DebuggerFilterContext { get; }
+    [Field] public uint InteropDebuggingHijacked { get; }
     [Field] public ObjectHandle CurrentCustomDebuggerNotification { get; }
 
     public RuntimeThreadLocals? RuntimeThreadLocals { get; private set; }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1198,14 +1198,15 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
     public int GetManagedStoppedContext(ulong vmThread, ulong* pRetVal)
     {
         int hr = HResults.S_OK;
-        *pRetVal = 0;
         try
         {
+            *pRetVal = 0;
             Contracts.IThread threadContract = _target.Contracts.Thread;
+            Contracts.ThreadData threadData = threadContract.GetThreadData(vmThread);
 
-            if (!threadContract.IsInteropDebuggingHijacked(vmThread))
+            if (!threadData.IsInteropDebuggingHijacked)
             {
-                TargetPointer filterContext = threadContract.GetDebuggerFilterContext(vmThread);
+                TargetPointer filterContext = threadData.DebuggerFilterContext;
                 if (filterContext != TargetPointer.Null)
                 {
                     *pRetVal = filterContext.Value;
@@ -1213,7 +1214,6 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                 else
                 {
                     IStackWalk sw = _target.Contracts.StackWalk;
-                    Contracts.ThreadData threadData = threadContract.GetThreadData(vmThread);
                     TargetPointer redirectedContext = sw.GetRedirectedContextPointer(threadData);
                     if (redirectedContext != TargetPointer.Null)
                     {
@@ -1233,7 +1233,7 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
             int hrLocal = _legacy.GetManagedStoppedContext(vmThread, &pRetValLocal);
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
-                Debug.Assert(*pRetVal == pRetValLocal, $"cDAC: {*pRetVal}, DAC: {pRetValLocal}");
+                Debug.Assert(*pRetVal == pRetValLocal, $"cDAC: {*pRetVal:x}, DAC: {pRetValLocal:x}");
         }
 #endif
         return hr;
@@ -1505,7 +1505,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         {
             IPlatformAgnosticContext leafCtx = IPlatformAgnosticContext.GetContextForPlatform(_target);
             uint allFlags = leafCtx.AllContextFlags;
-            byte[] leafContext = _target.Contracts.Thread.GetContext(new TargetPointer(vmThread), ThreadContextSource.None, allFlags);
+            ThreadData threadData = _target.Contracts.Thread.GetThreadData(new TargetPointer(vmThread));
+            byte[] leafContext = _target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.None, allFlags);
             leafCtx.FillFromBuffer(leafContext);
 
             // Read the given context from the native buffer.
@@ -1539,7 +1540,8 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         try
         {
             uint allFlags = IPlatformAgnosticContext.GetContextForPlatform(_target).AllContextFlags;
-            byte[] context = _target.Contracts.Thread.GetContext(new TargetPointer(vmThread), ThreadContextSource.Debugger, allFlags);
+            ThreadData threadData = _target.Contracts.Thread.GetThreadData(new TargetPointer(vmThread));
+            byte[] context = _target.Contracts.StackWalk.GetContext(threadData, ThreadContextSource.Debugger, allFlags);
 
             context.AsSpan().CopyTo(new Span<byte>(pContextBuffer, context.Length));
         }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1202,34 +1202,21 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         try
         {
             TargetPointer threadPointer = new TargetPointer(vmThread);
-            Target.TypeInfo threadType = _target.GetTypeInfo(DataType.Thread);
-            uint hijacked = _target.ReadField<uint>(threadPointer, threadType, "InteropDebuggingHijacked");
+            Contracts.IThread threadContract = _target.Contracts.Thread;
 
-            if (hijacked == 0)
+            if (!threadContract.GetInteropDebuggingHijacked(threadPointer))
             {
-                TargetPointer filterContext = _target.ReadPointerField(threadPointer, threadType, "DebuggerFilterContext");
+                TargetPointer filterContext = threadContract.GetDebuggerFilterContext(threadPointer);
                 if (filterContext != TargetPointer.Null)
                 {
                     *pRetVal = filterContext.Value;
                 }
                 else
                 {
-                    ThreadData threadData = _target.Contracts.Thread.GetThreadData(threadPointer);
-                    TargetPointer topFrame = threadData.Frame;
-                    ulong frameTop = _target.PointerSize == 8 ? ulong.MaxValue : uint.MaxValue;
-                    if (topFrame.Value != frameTop)
+                    TargetPointer redirectedContext = threadContract.GetRedirectedContext(threadPointer);
+                    if (redirectedContext != TargetPointer.Null)
                     {
-                        TargetPointer frameIdentifier = _target.ReadPointer(topFrame);
-                        _target.TryReadGlobalPointer("RedirectedThreadFrameIdentifier", out TargetPointer? redirectedId);
-                        if (redirectedId is not null && frameIdentifier == redirectedId)
-                        {
-                            Target.TypeInfo rfType = _target.GetTypeInfo(DataType.ResumableFrame);
-                            TargetPointer contextPtr = _target.ReadPointerField(topFrame, rfType, "TargetContextPtr");
-                            if (contextPtr != TargetPointer.Null)
-                            {
-                                *pRetVal = contextPtr.Value;
-                            }
-                        }
+                        *pRetVal = redirectedContext.Value;
                     }
                 }
             }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1201,19 +1201,18 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         *pRetVal = 0;
         try
         {
-            TargetPointer threadPointer = new TargetPointer(vmThread);
             Contracts.IThread threadContract = _target.Contracts.Thread;
 
-            if (!threadContract.GetInteropDebuggingHijacked(threadPointer))
+            if (!threadContract.IsInteropDebuggingHijacked(vmThread))
             {
-                TargetPointer filterContext = threadContract.GetDebuggerFilterContext(threadPointer);
+                TargetPointer filterContext = threadContract.GetDebuggerFilterContext(vmThread);
                 if (filterContext != TargetPointer.Null)
                 {
                     *pRetVal = filterContext.Value;
                 }
                 else
                 {
-                    TargetPointer redirectedContext = threadContract.GetRedirectedContext(threadPointer);
+                    TargetPointer redirectedContext = threadContract.GetRedirectedContext(vmThread);
                     if (redirectedContext != TargetPointer.Null)
                     {
                         *pRetVal = redirectedContext.Value;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1196,7 +1196,60 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetNativeCodeSequencePointsAndVarInfo(vmMethodDesc, startAddress, fCodeAvailable, pNativeVarData, pSequencePoints) : HResults.E_NOTIMPL;
 
     public int GetManagedStoppedContext(ulong vmThread, ulong* pRetVal)
-        => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.GetManagedStoppedContext(vmThread, pRetVal) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+        *pRetVal = 0;
+        try
+        {
+            TargetPointer threadPointer = new TargetPointer(vmThread);
+            Target.TypeInfo threadType = _target.GetTypeInfo(DataType.Thread);
+            uint hijacked = _target.ReadField<uint>(threadPointer, threadType, "InteropDebuggingHijacked");
+
+            if (hijacked == 0)
+            {
+                TargetPointer filterContext = _target.ReadPointerField(threadPointer, threadType, "DebuggerFilterContext");
+                if (filterContext != TargetPointer.Null)
+                {
+                    *pRetVal = filterContext.Value;
+                }
+                else
+                {
+                    ThreadData threadData = _target.Contracts.Thread.GetThreadData(threadPointer);
+                    TargetPointer topFrame = threadData.Frame;
+                    ulong frameTop = _target.PointerSize == 8 ? ulong.MaxValue : uint.MaxValue;
+                    if (topFrame.Value != frameTop)
+                    {
+                        TargetPointer frameIdentifier = _target.ReadPointer(topFrame);
+                        _target.TryReadGlobalPointer("RedirectedThreadFrameIdentifier", out TargetPointer? redirectedId);
+                        if (redirectedId is not null && frameIdentifier == redirectedId)
+                        {
+                            Target.TypeInfo rfType = _target.GetTypeInfo(DataType.ResumableFrame);
+                            TargetPointer contextPtr = _target.ReadPointerField(topFrame, rfType, "TargetContextPtr");
+                            if (contextPtr != TargetPointer.Null)
+                            {
+                                *pRetVal = contextPtr.Value;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacy is not null)
+        {
+            ulong pRetValLocal;
+            int hrLocal = _legacy.GetManagedStoppedContext(vmThread, &pRetValLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr == HResults.S_OK)
+                Debug.Assert(*pRetVal == pRetValLocal, $"cDAC: {*pRetVal}, DAC: {pRetValLocal}");
+        }
+#endif
+        return hr;
+    }
 
     public int CreateStackWalk(ulong vmThread, nint pInternalContextBuffer, nuint* ppSFIHandle)
         => LegacyFallbackHelper.CanFallback() && _legacy is not null ? _legacy.CreateStackWalk(vmThread, pInternalContextBuffer, ppSFIHandle) : HResults.E_NOTIMPL;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/DacDbiImpl.cs
@@ -1212,7 +1212,9 @@ public sealed unsafe partial class DacDbiImpl : IDacDbiInterface
                 }
                 else
                 {
-                    TargetPointer redirectedContext = threadContract.GetRedirectedContext(vmThread);
+                    IStackWalk sw = _target.Contracts.StackWalk;
+                    Contracts.ThreadData threadData = threadContract.GetThreadData(vmThread);
+                    TargetPointer redirectedContext = sw.GetRedirectedContextPointer(threadData);
                     if (redirectedContext != TargetPointer.Null)
                     {
                         *pRetVal = redirectedContext.Value;

--- a/src/native/managed/cdac/tests/ClrDataExceptionStateTests.cs
+++ b/src/native/managed/cdac/tests/ClrDataExceptionStateTests.cs
@@ -90,7 +90,9 @@ public unsafe class ExceptionStateTests
             LastThrownObjectIsUnhandled: false,
             HasUnhandledException: false,
             NextThread: TargetPointer.Null,
-            ThreadHandle: TargetPointer.Null));
+            ThreadHandle: TargetPointer.Null,
+            IsInteropDebuggingHijacked: false,
+            DebuggerFilterContext: TargetPointer.Null));
 
         var target = new TestPlaceholderTarget.Builder(arch)
             .UseReader((ulong _, Span<byte> _) => -1)
@@ -472,7 +474,9 @@ public unsafe class ExceptionStateTests
             LastThrownObjectIsUnhandled: false,
             HasUnhandledException: false,
             NextThread: TargetPointer.Null,
-            ThreadHandle: TargetPointer.Null));
+            ThreadHandle: TargetPointer.Null,
+            IsInteropDebuggingHijacked: false,
+            DebuggerFilterContext: TargetPointer.Null));
 
         var mockException = new Mock<IException>();
         mockException.Setup(e => e.GetExceptionData(exceptionObjectAddr)).Returns(new ExceptionData(

--- a/src/native/managed/cdac/tests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/DacDbiImplTests.cs
@@ -734,4 +734,100 @@ public unsafe class DacDbiImplTests
         Assert.Equal(System.HResults.S_OK, hr);
         Assert.Equal(Interop.BOOL.FALSE, result);
     }
+
+    private static (DacDbiImpl DacDbi, MockThread Thread, MockFrameBuilder FrameBuilder) CreateManagedStoppedContextDacDbi(
+        MockTarget.Architecture arch,
+        Action<MockFrameBuilder>? configureFrames = null)
+    {
+        TestPlaceholderTarget.Builder targetBuilder = new(arch);
+        MockThreadBuilder threadBuilder = new(targetBuilder.MemoryBuilder);
+        MockFrameBuilder frameBuilder = new(targetBuilder.MemoryBuilder);
+
+        MockThread thread = threadBuilder.AddThread(1, 1234);
+        ulong terminator = arch.Is64Bit ? ulong.MaxValue : uint.MaxValue;
+        thread.Frame = terminator;
+
+        configureFrames?.Invoke(frameBuilder);
+
+        targetBuilder
+            .AddTypes(new Dictionary<DataType, Target.TypeInfo>
+            {
+                [DataType.ExceptionInfo] = TargetTestHelpers.CreateTypeInfo(threadBuilder.ExceptionInfoLayout),
+                [DataType.Thread] = TargetTestHelpers.CreateTypeInfo(threadBuilder.ThreadLayout),
+                [DataType.ThreadStore] = TargetTestHelpers.CreateTypeInfo(threadBuilder.ThreadStoreLayout),
+                [DataType.GCAllocContext] = TargetTestHelpers.CreateTypeInfo(threadBuilder.GCAllocContextLayout),
+                [DataType.EEAllocContext] = TargetTestHelpers.CreateTypeInfo(threadBuilder.EEAllocContextLayout),
+                [DataType.RuntimeThreadLocals] = TargetTestHelpers.CreateTypeInfo(threadBuilder.RuntimeThreadLocalsLayout),
+                [DataType.Frame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.FrameLayout),
+                [DataType.ResumableFrame] = TargetTestHelpers.CreateTypeInfo(frameBuilder.ResumableFrameLayout),
+            })
+            .AddGlobals(
+                (nameof(Constants.Globals.ThreadStore), threadBuilder.ThreadStoreGlobalAddress),
+                (nameof(Constants.Globals.FinalizerThread), threadBuilder.FinalizerThreadGlobalAddress),
+                (nameof(Constants.Globals.GCThread), threadBuilder.GCThreadGlobalAddress),
+                ("RedirectedThreadFrameIdentifier", MockFrameBuilder.RedirectedThreadFrameIdentifierValue))
+            .AddContract<IThread>(version: "c1");
+
+        TestPlaceholderTarget target = targetBuilder.Build();
+        DacDbiImpl dacDbi = new(target, legacyObj: null);
+        return (dacDbi, thread, frameBuilder);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetManagedStoppedContext_InteropDebuggingHijacked(MockTarget.Architecture arch)
+    {
+        var (dacDbi, thread, _) = CreateManagedStoppedContextDacDbi(arch);
+        thread.InteropDebuggingHijacked = 1;
+
+        ulong retVal;
+        int hr = dacDbi.GetManagedStoppedContext(thread.Address, &retVal);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(0UL, retVal);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetManagedStoppedContext_FilterContextSet(MockTarget.Architecture arch)
+    {
+        const ulong filterContextAddr = 0x0009_0000;
+        var (dacDbi, thread, _) = CreateManagedStoppedContextDacDbi(arch);
+        thread.DebuggerFilterContext = filterContextAddr;
+
+        ulong retVal;
+        int hr = dacDbi.GetManagedStoppedContext(thread.Address, &retVal);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(filterContextAddr, retVal);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetManagedStoppedContext_RedirectedThread(MockTarget.Architecture arch)
+    {
+        const ulong contextAddr = 0x000A_0000;
+        MockResumableFrame? redirectedFrame = null;
+        var (dacDbi, thread, _) = CreateManagedStoppedContextDacDbi(arch, frameBuilder =>
+        {
+            redirectedFrame = frameBuilder.AddRedirectedThreadFrame(contextAddr);
+        });
+
+        thread.Frame = redirectedFrame!.Address;
+
+        ulong retVal;
+        int hr = dacDbi.GetManagedStoppedContext(thread.Address, &retVal);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(contextAddr, retVal);
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public void GetManagedStoppedContext_NoContextAvailable(MockTarget.Architecture arch)
+    {
+        var (dacDbi, thread, _) = CreateManagedStoppedContextDacDbi(arch);
+
+        ulong retVal;
+        int hr = dacDbi.GetManagedStoppedContext(thread.Address, &retVal);
+        Assert.Equal(System.HResults.S_OK, hr);
+        Assert.Equal(0UL, retVal);
+    }
 }

--- a/src/native/managed/cdac/tests/DacDbiImplTests.cs
+++ b/src/native/managed/cdac/tests/DacDbiImplTests.cs
@@ -766,8 +766,10 @@ public unsafe class DacDbiImplTests
                 (nameof(Constants.Globals.FinalizerThread), threadBuilder.FinalizerThreadGlobalAddress),
                 (nameof(Constants.Globals.GCThread), threadBuilder.GCThreadGlobalAddress),
                 ("RedirectedThreadFrameIdentifier", MockFrameBuilder.RedirectedThreadFrameIdentifierValue))
-            .AddContract<IThread>(version: "c1");
-
+            .AddMockContract(new Mock<IExecutionManager>())
+            .AddMockContract(new Mock<IGCInfo>())
+            .AddContract<IThread>(version: "c1")
+            .AddContract<IStackWalk>(version: "c1");
         TestPlaceholderTarget target = targetBuilder.Build();
         DacDbiImpl dacDbi = new(target, legacyObj: null);
         return (dacDbi, thread, frameBuilder);

--- a/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiStackWalkDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DacDbi/DacDbiStackWalkDumpTests.cs
@@ -62,7 +62,7 @@ public class DacDbiStackWalkDumpTests : DumpTestBase
         }
 
         uint allFlags = IPlatformAgnosticContext.GetContextForPlatform(Target).AllContextFlags;
-        byte[] contractContext = Target.Contracts.Thread.GetContext(crashingThread.ThreadAddress, ThreadContextSource.Debugger, allFlags);
+        byte[] contractContext = Target.Contracts.StackWalk.GetContext(crashingThread, ThreadContextSource.Debugger, allFlags);
 
         IPlatformAgnosticContext dbiCtx = IPlatformAgnosticContext.GetContextForPlatform(Target);
         IPlatformAgnosticContext contractCtx = IPlatformAgnosticContext.GetContextForPlatform(Target);
@@ -84,7 +84,7 @@ public class DacDbiStackWalkDumpTests : DumpTestBase
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
         uint allFlags = IPlatformAgnosticContext.GetContextForPlatform(Target).AllContextFlags;
-        byte[] leafContext = Target.Contracts.Thread.GetContext(crashingThread.ThreadAddress, ThreadContextSource.None, allFlags);
+        byte[] leafContext = Target.Contracts.StackWalk.GetContext(crashingThread, ThreadContextSource.None, allFlags);
 
         Interop.BOOL result;
         fixed (byte* pContext = leafContext)
@@ -107,7 +107,7 @@ public class DacDbiStackWalkDumpTests : DumpTestBase
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
         uint allFlags = IPlatformAgnosticContext.GetContextForPlatform(Target).AllContextFlags;
-        byte[] leafContext = Target.Contracts.Thread.GetContext(crashingThread.ThreadAddress, ThreadContextSource.None, allFlags);
+        byte[] leafContext = Target.Contracts.StackWalk.GetContext(crashingThread, ThreadContextSource.None, allFlags);
         IPlatformAgnosticContext leafCtx = IPlatformAgnosticContext.GetContextForPlatform(Target);
         leafCtx.FillFromBuffer(leafContext);
 

--- a/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
@@ -343,7 +343,7 @@ public class StackWalkDumpTests : DumpTestBase
 
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
         uint allFlags = Contracts.StackWalkHelpers.IPlatformAgnosticContext.GetContextForPlatform(Target).AllContextFlags;
-        byte[] context = Target.Contracts.Thread.GetContext(crashingThread.ThreadAddress, ThreadContextSource.None, allFlags);
+        byte[] context = Target.Contracts.StackWalk.GetContext(crashingThread, ThreadContextSource.None, allFlags);
 
         Assert.NotNull(context);
         Assert.True(context.Length > 0, "Expected non-empty context");

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Frame.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Frame.cs
@@ -125,6 +125,22 @@ internal sealed class MockDebuggerEval : TypedView
     }
 }
 
+internal sealed class MockResumableFrame : MockFrame
+{
+    private const string TargetContextPtrFieldName = "TargetContextPtr";
+
+    public static Layout<MockResumableFrame> CreateLayout(Layout<MockFrame> baseLayout)
+        => new SequentialLayoutBuilder("ResumableFrame", baseLayout.Architecture, baseLayout)
+            .AddPointerField(TargetContextPtrFieldName)
+            .Build<MockResumableFrame>();
+
+    public ulong TargetContextPtr
+    {
+        get => ReadPointerField(TargetContextPtrFieldName);
+        set => WritePointerField(TargetContextPtrFieldName, value);
+    }
+}
+
 /// <summary>
 /// Helper for building a Frame chain in the mock target memory. The Frame chain is
 /// terminated with the FRAME_TOP sentinel (~0 sized to the target pointer width).
@@ -150,6 +166,7 @@ internal sealed class MockFrameBuilder
     public const ulong DebuggerU2MCatchHandlerFrameIdentifierValue = 0x0001_F008;
     public const ulong InterpreterFrameIdentifierValue = 0x0001_F009;
     public const ulong HijackFrameIdentifierValue = 0x0001_F00A;
+    public const ulong RedirectedThreadFrameIdentifierValue = 0x0001_F00B;
 
     private readonly MockMemorySpace.Builder _builder;
     private readonly MockMemorySpace.BumpAllocator _allocator;
@@ -161,6 +178,7 @@ internal sealed class MockFrameBuilder
     public Layout<MockFramedMethodFrame> FramedMethodFrameLayout { get; }
     public Layout<MockFuncEvalFrame> FuncEvalFrameLayout { get; }
     public Layout<MockDebuggerEval> DebuggerEvalLayout { get; }
+    public Layout<MockResumableFrame> ResumableFrameLayout { get; }
 
     public MockFrameBuilder(MockMemorySpace.Builder builder)
         : this(builder, (DefaultAllocationRangeStart, DefaultAllocationRangeEnd))
@@ -179,6 +197,7 @@ internal sealed class MockFrameBuilder
         FramedMethodFrameLayout = MockFramedMethodFrame.CreateLayout(FrameLayout);
         FuncEvalFrameLayout = MockFuncEvalFrame.CreateLayout(FrameLayout);
         DebuggerEvalLayout = MockDebuggerEval.CreateLayout(_helpers.Arch);
+        ResumableFrameLayout = MockResumableFrame.CreateLayout(FrameLayout);
     }
 
     public ulong FrameTopTerminator => _terminator;
@@ -216,6 +235,15 @@ internal sealed class MockFrameBuilder
         frame.Identifier = FramedMethodFrameIdentifierValue;
         frame.Next = _terminator;
         frame.MethodDescPtr = methodDescPtr;
+        return frame;
+    }
+
+    public MockResumableFrame AddRedirectedThreadFrame(ulong targetContextPtr)
+    {
+        MockResumableFrame frame = ResumableFrameLayout.Create(_allocator.Allocate((ulong)ResumableFrameLayout.Size, "RedirectedThreadFrame"));
+        frame.Identifier = RedirectedThreadFrameIdentifierValue;
+        frame.Next = _terminator;
+        frame.TargetContextPtr = targetContextPtr;
         return frame;
     }
 

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.Thread.cs
@@ -193,6 +193,7 @@ internal sealed class MockThread : TypedView
     private const string ThreadHandleFieldName = "ThreadHandle";
     private const string UEWatsonBucketTrackerBucketsFieldName = "UEWatsonBucketTrackerBuckets";
     private const string DebuggerFilterContextFieldName = "DebuggerFilterContext";
+    private const string InteropDebuggingHijackedFieldName = "InteropDebuggingHijacked";
 
     public static Layout<MockThread> CreateLayout(MockTarget.Architecture architecture)
     {
@@ -215,7 +216,8 @@ internal sealed class MockThread : TypedView
             .AddPointerField(ThreadLocalDataPtrFieldName)
             .AddPointerField(ThreadHandleFieldName)
             .AddPointerField(UEWatsonBucketTrackerBucketsFieldName)
-            .AddPointerField(DebuggerFilterContextFieldName);
+            .AddPointerField(DebuggerFilterContextFieldName)
+            .AddUInt32Field(InteropDebuggingHijackedFieldName);
 
         return layoutBuilder.Build<MockThread>();
     }
@@ -314,6 +316,18 @@ internal sealed class MockThread : TypedView
     {
         get => ReadPointerField(ThreadHandleFieldName);
         set => WritePointerField(ThreadHandleFieldName, value);
+    }
+
+    public ulong DebuggerFilterContext
+    {
+        get => ReadPointerField(DebuggerFilterContextFieldName);
+        set => WritePointerField(DebuggerFilterContextFieldName, value);
+    }
+
+    public uint InteropDebuggingHijacked
+    {
+        get => ReadUInt32Field(InteropDebuggingHijackedFieldName);
+        set => WriteUInt32Field(InteropDebuggingHijackedFieldName, value);
     }
 }
 


### PR DESCRIPTION
### Summary
Implement GetManagedStoppedContext in the cDAC DBI layer, porting the logic from the native DAC. Add the InteropDebuggingHijacked field to the Thread data descriptor.

### Changes
- Port GetManagedStoppedContext to managed cDAC with #if DEBUG legacy validation
- Add InteropDebuggingHijacked to Thread data descriptor (native, managed, docs)
- Add mock infrastructure for ResumableFrame and redirected thread frames
- Add tests covering all code paths