### PR TITLE
Revert "Guard unused llvm-libunwind symbols to avoid duplicates on Android"

### DIFF
--- a/src/coreclr/nativeaot/Runtime/CMakeLists.txt
+++ b/src/coreclr/nativeaot/Runtime/CMakeLists.txt
@@ -149,12 +149,8 @@ else()
     include_directories($ENV{EMSCRIPTEN/system/lib/libcxxabi/include})
   endif()
 
-  # Guard out the public unw_* C API, C++ exception dispatch entry points,
-  # and the LocalAddressSpace singleton from llvm-libunwind. NativeAOT does
-  # not use these - it uses the internal C++ classes directly. Omitting them
-  # avoids exporting symbols that conflict with platform libunwind (e.g.
-  # Android NDK r29).
-  add_definitions(-D_LIBUNWIND_NATIVEAOT=1)
+  # Disable building _Unwind_XXX style APIs of libunwind, since we don't use them.
+  add_definitions(-D_LIBUNWIND_DISABLE_ZERO_COST_APIS=1)
 
   # Compile unwinding only for the current compilation target architecture
   add_definitions(-D_LIBUNWIND_IS_NATIVE_ONLY)

--- a/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnixNativeCodeManager.cpp
@@ -56,7 +56,7 @@ UnixNativeCodeManager::UnixNativeCodeManager(TADDR moduleBase,
       m_pClasslibFunctions(pClasslibFunctions), m_nClasslibFunctions(nClasslibFunctions)
 {
     // Cache the location of unwind sections
-    UnwindHelpers::FindUnwindSections(
+    libunwind::LocalAddressSpace::sThisAddressSpace.findUnwindSections(
         (uintptr_t)pvManagedCodeStartRange, m_UnwindInfoSections);
 }
 

--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.cpp
@@ -1396,11 +1396,6 @@ bool UnwindHelpers::GetUnwindProcInfo(PCODE pc, UnwindInfoSections &uwInfoSectio
     return true;
 }
 
-bool UnwindHelpers::FindUnwindSections(uintptr_t pc, UnwindInfoSections &sections)
-{
-    return _addressSpace.findUnwindSections(pc, sections);
-}
-
 #if defined(TARGET_APPLE)
 // Apple considers _dyld_find_unwind_sections to be private API that cannot be used
 // by apps submitted to App Store and TestFlight, both for iOS-like and macOS platforms.

--- a/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
+++ b/src/coreclr/nativeaot/Runtime/unix/UnwindHelpers.h
@@ -15,5 +15,4 @@ class UnwindHelpers
 public:
     static bool StepFrame(REGDISPLAY *regs, unw_word_t start_ip, uint32_t format, unw_word_t unwind_info);
     static bool GetUnwindProcInfo(PCODE ip, libunwind::UnwindInfoSections &uwInfoSections, unw_proc_info_t *procInfo);
-    static bool FindUnwindSections(uintptr_t pc, libunwind::UnwindInfoSections &sections);
 };

--- a/src/native/external/llvm-libunwind-version.txt
+++ b/src/native/external/llvm-libunwind-version.txt
@@ -3,4 +3,3 @@ https://github.com/llvm/llvm-project/releases/tag/llvmorg-22.1.1
 
 Apply https://github.com/dotnet/runtime/commit/35b7d59fa1075ab0fefb921393409806a821d8ed
 Apply https://github.com/dotnet/runtime/commit/be5f98fb6702704afbaf705dce0b54d55479c6f1
-Apply https://github.com/dotnet/runtime/commit/fde4a5bd965b128318e17a3b8ba1dc0fcf8df4a0

--- a/src/native/external/llvm-libunwind/src/Unwind-EHABI.cpp
+++ b/src/native/external/llvm-libunwind/src/Unwind-EHABI.cpp
@@ -443,12 +443,6 @@ _Unwind_VRS_Interpret(_Unwind_Context *context, const uint32_t *data,
   return _URC_CONTINUE_UNWIND;
 }
 
-// The C++ exception dispatch functions below depend on __unw_step and other
-// public API functions from libunwind.cpp which are guarded out when
-// _LIBUNWIND_NATIVEAOT is defined. NativeAOT does not use these - it only
-// uses _Unwind_VRS_Interpret above.
-#if !defined(_LIBUNWIND_NATIVEAOT)
-
 extern "C" _LIBUNWIND_EXPORT _Unwind_Reason_Code
 __aeabi_unwind_cpp_pr0(_Unwind_State state, _Unwind_Control_Block *ucbp,
                        _Unwind_Context *context) {
@@ -1215,7 +1209,5 @@ __gnu_unwind_frame(_Unwind_Exception *exception_object,
     return _URC_FAILURE;
   }
 }
-
-#endif // !defined(_LIBUNWIND_NATIVEAOT)
 
 #endif  // defined(_LIBUNWIND_ARM_EHABI)

--- a/src/native/external/llvm-libunwind/src/libunwind.cpp
+++ b/src/native/external/llvm-libunwind/src/libunwind.cpp
@@ -26,8 +26,6 @@
 #include <sanitizer/asan_interface.h>
 #endif
 
-#if !defined(_LIBUNWIND_NATIVEAOT)
-
 #if !defined(__USING_SJLJ_EXCEPTIONS__) && !defined(__wasm__)
 #include "AddressSpace.hpp"
 #include "UnwindCursor.hpp"
@@ -548,8 +546,6 @@ int __unw_remove_find_dynamic_unwind_sections(
 }
 
 #endif // __APPLE__
-
-#endif // !defined(_LIBUNWIND_NATIVEAOT)
 
 // Add logging hooks in Debug builds only
 #ifndef NDEBUG


### PR DESCRIPTION
Resolves #128866.

Reverts dotnet/runtime#128667