### PR TITLE
Ensure fields cannot mangle into same things as methods

### DIFF
--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -657,7 +657,7 @@ namespace ILCompiler
                         Utf8StringBuilder sb = new Utf8StringBuilder();
                         foreach (var f in field.OwningType.GetFields())
                         {
-                            sb.Clear().Append(prependTypeName).Append("__"u8);
+                            sb.Clear().Append(prependTypeName).Append("__field__"u8);
                             Utf8String name = SanitizeName(f.Name);
 
                             name = DisambiguateName(name, deduplicator);
@@ -674,7 +674,7 @@ namespace ILCompiler
 
 
             Utf8String mangledName = SanitizeName(field.Name);
-            Utf8String utf8MangledName = new Utf8StringBuilder().Append(prependTypeName).Append("__"u8).Append(mangledName).ToUtf8String();
+            Utf8String utf8MangledName = new Utf8StringBuilder().Append(prependTypeName).Append("__field__"u8).Append(mangledName).ToUtf8String();
 
             lock (this)
             {

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -657,7 +657,7 @@ namespace ILCompiler
                         Utf8StringBuilder sb = new Utf8StringBuilder();
                         foreach (var f in field.OwningType.GetFields())
                         {
-                            sb.Clear().Append(prependTypeName).Append("__field__"u8);
+                            sb.Clear().Append(prependTypeName).Append("__f_"u8);
                             Utf8String name = SanitizeName(f.Name);
 
                             name = DisambiguateName(name, deduplicator);
@@ -674,7 +674,7 @@ namespace ILCompiler
 
 
             Utf8String mangledName = SanitizeName(field.Name);
-            Utf8String utf8MangledName = new Utf8StringBuilder().Append(prependTypeName).Append("__field__"u8).Append(mangledName).ToUtf8String();
+            Utf8String utf8MangledName = new Utf8StringBuilder().Append(prependTypeName).Append("__f_"u8).Append(mangledName).ToUtf8String();
 
             lock (this)
             {


### PR DESCRIPTION
Fixes #127646.

The problem was that this is an obfuscated assembly, so most things are named as `"\u0003\u000e"` that we sanitize to `"__"`. We're ready to deal with it and we append numbers if sanitization makes the names no longer unique. However the disambiguation doesn't work across symbol classes (method names vs field names). So we could still end up with a method and field mangling the same.