### PR TITLE
Fix iossimulator build with XCode 26.4

### DIFF
--- a/src/native/libs/System.Globalization.Native/pal_calendarData.m
+++ b/src/native/libs/System.Globalization.Native/pal_calendarData.m
@@ -227,7 +227,7 @@ int32_t GlobalizationNative_GetJapaneseEraStartDateNative(int32_t era, int32_t* 
                         startDateComponents.day = startDateComponents.day + 1;
                         date = [japaneseCalendar dateFromComponents:startDateComponents];
                         NSCalendar *gregorianCalendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-                        NSDateComponents *components = [gregorianCalendar components:NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear fromDate:date];
+                        NSDateComponents *components = [gregorianCalendar components:(NSCalendarUnit)(NSCalendarUnitDay | NSCalendarUnitMonth | NSCalendarUnitYear) fromDate:date];
                         *startYear = (int32_t)[components year];
                         *startMonth = (int32_t)[components month];
                         *startDay = (int32_t)[components day];

--- a/src/native/libs/System.Globalization.Native/pal_collation.m
+++ b/src/native/libs/System.Globalization.Native/pal_collation.m
@@ -57,7 +57,7 @@ static NSStringCompareOptions ConvertFromCompareOptionsToNSStringCompareOptions(
 {
     // To achieve an equivalent search behavior to the default in ICU,
     // NSLiteralSearch is employed as the default search option.
-    NSStringCompareOptions options = isLiteralSearchSupported ? NSLiteralSearch : 0;
+    NSStringCompareOptions options = isLiteralSearchSupported ? NSLiteralSearch : (NSStringCompareOptions)0;
 
     if (comparisonOptions & IgnoreCase)
         options |= NSCaseInsensitiveSearch;
@@ -87,7 +87,7 @@ int32_t GlobalizationNative_CompareStringNative(const uint16_t* localeName, int3
 {
     @autoreleasepool
     {
-        if (!IsComparisonOptionSupported(comparisonOptions))
+        if (!IsComparisonOptionSupported((CompareOptions)comparisonOptions))
             return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
         NSLocale *currentLocale = GetCurrentLocale(localeName, lNameLength);
         NSString *sourceString = [NSString stringWithCharacters: lpSource length: (NSUInteger)cwSourceLength];
@@ -103,12 +103,12 @@ int32_t GlobalizationNative_CompareStringNative(const uint16_t* localeName, int3
 
         if (comparisonOptions != 0 && comparisonOptions != StringSort)
         {
-            NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, false);
+            NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, false);
             sourceStrPrecomposed = [sourceStrPrecomposed stringByFoldingWithOptions:options locale:currentLocale];
             targetStrPrecomposed = [targetStrPrecomposed stringByFoldingWithOptions:options locale:currentLocale];
         }
 
-        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, true);
+        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, true);
         NSRange comparisonRange = NSMakeRange(0, sourceStrPrecomposed.length);
         return (int32_t)[sourceStrPrecomposed compare:targetStrPrecomposed
                                      options:options
@@ -130,7 +130,7 @@ static NSString* RemoveWeightlessCharacters(NSString* source)
     if (error != nil)
         return source;
 
-    NSString *modifiedString = [regex stringByReplacingMatchesInString:source options:0 range:NSMakeRange(0, [source length]) withTemplate:@""];
+    NSString *modifiedString = [regex stringByReplacingMatchesInString:source options:(NSMatchingOptions)0 range:NSMakeRange(0, [source length]) withTemplate:@""];
 
     return modifiedString;
 }
@@ -156,12 +156,12 @@ Range GlobalizationNative_IndexOfNative(const uint16_t* localeName, int32_t lNam
     {
         assert(cwTargetLength >= 0);
         Range result = {ERROR_INDEX_NOT_FOUND, 0};
-        if (!IsComparisonOptionSupported(comparisonOptions))
+        if (!IsComparisonOptionSupported((CompareOptions)comparisonOptions))
         {
             result.location = ERROR_COMPARISON_OPTIONS_NOT_FOUND;
             return result;
         }
-        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, true);
+        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, true);
         if (!fromBeginning) // LastIndexOf
             options |= NSBackwardsSearch;
 
@@ -270,9 +270,9 @@ int32_t GlobalizationNative_StartsWithNative(const uint16_t* localeName, int32_t
 {
     @autoreleasepool
     {
-        if (!IsComparisonOptionSupported(comparisonOptions))
+        if (!IsComparisonOptionSupported((CompareOptions)comparisonOptions))
             return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
-        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, true);
+        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, true);
         NSLocale *currentLocale = GetCurrentLocale(localeName, lNameLength);
         NSString *prefixString = [NSString stringWithCharacters: lpPrefix length: (NSUInteger)cwPrefixLength];
         NSString *prefixStrComposed = RemoveWeightlessCharacters(prefixString.precomposedStringWithCanonicalMapping);
@@ -302,9 +302,9 @@ int32_t GlobalizationNative_EndsWithNative(const uint16_t* localeName, int32_t l
 {
     @autoreleasepool
     {
-        if (!IsComparisonOptionSupported(comparisonOptions))
+        if (!IsComparisonOptionSupported((CompareOptions)comparisonOptions))
             return ERROR_COMPARISON_OPTIONS_NOT_FOUND;
-        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions(comparisonOptions, true);
+        NSStringCompareOptions options = ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)comparisonOptions, true);
         NSLocale *currentLocale = GetCurrentLocale(localeName, lNameLength);
         NSString *suffixString = [NSString stringWithCharacters: lpSuffix length: (NSUInteger)cwSuffixLength];
         NSString *suffixStrComposed = RemoveWeightlessCharacters(suffixString.precomposedStringWithCanonicalMapping);
@@ -336,7 +336,7 @@ int32_t GlobalizationNative_GetSortKeyNative(const uint16_t* localeName, int32_t
                 sortKey[0] = '\0';
             return 1;
         }
-        if (!IsComparisonOptionSupported(options))
+        if (!IsComparisonOptionSupported((CompareOptions)options))
             return 0;
         NSString *sourceString = [NSString stringWithCharacters: lpStr length: (NSUInteger)cwStrLength];
         if (options & IgnoreKanaType)
@@ -353,7 +353,7 @@ int32_t GlobalizationNative_GetSortKeyNative(const uint16_t* localeName, int32_t
         }
 
         NSLocale *locale = GetCurrentLocale(localeName, lNameLength);
-        NSStringCompareOptions comparisonOptions = options == 0 ? 0 : ConvertFromCompareOptionsToNSStringCompareOptions(options, false);
+        NSStringCompareOptions comparisonOptions = options == 0 ? (NSStringCompareOptions)0 : ConvertFromCompareOptionsToNSStringCompareOptions((CompareOptions)options, false);
 
         // Generate a sort key for the original string based on the locale
         NSString *transformedString = [sourceStringCleaned stringByFoldingWithOptions:comparisonOptions locale:locale];
@@ -368,7 +368,7 @@ int32_t GlobalizationNative_GetSortKeyNative(const uint16_t* localeName, int32_t
             return (int32_t)transformedStringBytes;
         NSRange range = NSMakeRange(0, [transformedString length]);
         NSUInteger usedLength = 0;
-        BOOL result = [transformedString getBytes:sortKey maxLength:transformedStringBytes usedLength:&usedLength encoding:NSUTF16StringEncoding options:0 range:range remainingRange:NULL];
+        BOOL result = [transformedString getBytes:sortKey maxLength:transformedStringBytes usedLength:&usedLength encoding:NSUTF16StringEncoding options:(NSStringEncodingConversionOptions)0 range:range remainingRange:NULL];
         if (result)
             return (int32_t)usedLength;
         return 0;

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_ios.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509_ios.c
@@ -69,7 +69,7 @@ int32_t AppleCryptoNative_X509ImportCertificate(uint8_t* pbData,
         {
             if (CFArrayGetCount(p12Items) > 0)
             {
-                CFDictionaryRef item_dict = CFArrayGetValueAtIndex(p12Items, 0);
+                CFDictionaryRef item_dict = (CFDictionaryRef)CFArrayGetValueAtIndex(p12Items, 0);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-qual"
                 *pIdentityOut = (SecIdentityRef)CFRetain(CFDictionaryGetValue(item_dict, kSecImportItemIdentity));
@@ -169,7 +169,7 @@ int32_t AppleCryptoNative_X509ImportCollection(uint8_t* pbData,
 
             for (int i = 0; i < CFArrayGetCount(p12Items); i++)
             {
-                CFDictionaryRef item_dict = CFArrayGetValueAtIndex(p12Items, i);
+                CFDictionaryRef item_dict = (CFDictionaryRef)CFArrayGetValueAtIndex(p12Items, i);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcast-qual"
                 SecIdentityRef identity =


### PR DESCRIPTION
It seems that our CI jobs are using XCode 16.4 and the latest version of XCode, 26.4, bumped clang to version 21 which adds some new warnings (`-Wimplicit-int-enum-cast` and `-Wimplicit-void-ptr-cast`). These warnings are picked locally as build errors. This fixes the local build by adding some explicit casting.

Build command used locally:
```
./build.sh -arch arm64 -os iossimulator  -s clr+clr.runtime+libs+packs+libs.tests -c Release /p:UseMonoRuntime=false /p:UseNativeAOTRuntime=false /p:EnableAdditionalTimezoneChecks=true /p:EnableAggressiveTrimming=true
```