### PR TITLE
Fix COM interface method calling wrong method for base/derived classes

### DIFF
--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -4251,8 +4251,7 @@ static bool CanShareComMethodTableWithParent(MethodTable* pClassMT, MethodTable*
     for (unsigned i = 0; i < pItfMT->GetNumVirtuals(); i++)
     {
         MethodDesc *pItfMD = pItfMT->GetMethodDescForSlot_NoThrow(i);
-        if (pItfMD == NULL)
-            return false;
+        _ASSERTE(pItfMD != NULL);
 
         if (pItfMD->IsAsyncMethod())
             continue;

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -4212,7 +4212,7 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForBasic(MethodTable
 // re-implemented pItfMT in its dispatch map, and that the interface methods
 // resolve to the same MethodDescs on both pClassMT and pParentMT.
 //--------------------------------------------------------------------------
-static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable *pParentMT, MethodTable *pItfMT)
+static bool CanShareComMethodTableWithParent(MethodTable* pClassMT, MethodTable* pParentMT, MethodTable* pItfMT)
 {
     CONTRACTL
     {
@@ -4226,7 +4226,7 @@ static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable 
     CONTRACTL_END;
 
     // Check for explicit interface re-implementations in the dispatch map.
-    MethodTable *pMT = pClassMT;
+    MethodTable* pMT = pClassMT;
     do
     {
         DispatchMap::EncodedMapIterator mapIt(pMT);
@@ -4235,7 +4235,7 @@ static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable 
             DispatchMapEntry *pEntry = mapIt.Entry();
             if (pMT->DispatchMapTypeMatchesMethodTable(pEntry->GetTypeID(), pItfMT))
             {
-                return FALSE;
+                return false;
             }
         }
 
@@ -4252,7 +4252,7 @@ static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable 
     {
         MethodDesc *pItfMD = pItfMT->GetMethodDescForSlot_NoThrow(i);
         if (pItfMD == NULL)
-            return FALSE;
+            return false;
 
         if (pItfMD->IsAsyncMethod())
             continue;
@@ -4261,13 +4261,13 @@ static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable 
         DispatchSlot parentSlot(pParentMT->FindDispatchSlotForInterfaceMD(pItfMD, FALSE /* throwOnConflict */));
 
         if (childSlot.IsNull() || parentSlot.IsNull())
-            return FALSE;
+            return false;
 
         if (childSlot.GetMethodDesc() != parentSlot.GetMethodDesc())
-            return FALSE;
+            return false;
     }
 
-    return TRUE;
+    return true;
 }
 
 //--------------------------------------------------------------------------
@@ -4287,7 +4287,7 @@ ComMethodTable *ComCallWrapperTemplate::InitializeForInterface(MethodTable *pPar
     if (m_pParent != NULL)
     {
         // Check if we can reuse the parent's ComMethodTable for this interface.
-        ComMethodTable *pParentComMT = m_pParent->GetComMTForItf(pItfMT);
+        ComMethodTable* pParentComMT = m_pParent->GetComMTForItf(pItfMT);
         if (pParentComMT != NULL && CanShareComMethodTableWithParent(m_thClass.GetMethodTable(), pParentMT, pItfMT))
         {
             pItfComMT = pParentComMT;

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -4207,6 +4207,67 @@ ComMethodTable* ComCallWrapperTemplate::CreateComMethodTableForBasic(MethodTable
 }
 
 //--------------------------------------------------------------------------
+// Returns TRUE if the parent's ComMethodTable for pItfMT can be reused for
+// pClassMT. This requires that no class between pClassMT and pParentMT has
+// re-implemented pItfMT in its dispatch map, and that the interface methods
+// resolve to the same MethodDescs on both pClassMT and pParentMT.
+//--------------------------------------------------------------------------
+static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable *pParentMT, MethodTable *pItfMT)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_TRIGGERS;
+        MODE_ANY;
+        PRECONDITION(pClassMT != NULL && !pClassMT->IsInterface());
+        PRECONDITION(pParentMT != NULL && !pParentMT->IsInterface());
+        PRECONDITION(pItfMT != NULL && pItfMT->IsInterface());
+    }
+    CONTRACTL_END;
+
+    // Check for explicit interface re-implementations in the dispatch map.
+    MethodTable *pMT = pClassMT;
+    do
+    {
+        DispatchMap::EncodedMapIterator mapIt(pMT);
+        for (; mapIt.IsValid(); mapIt.Next())
+        {
+            DispatchMapEntry *pEntry = mapIt.Entry();
+            if (pMT->DispatchMapTypeMatchesMethodTable(pEntry->GetTypeID(), pItfMT))
+            {
+                return FALSE;
+            }
+        }
+
+        pMT = pMT->GetParentMethodTable();
+        _ASSERTE(pMT != NULL);
+    }
+    while (pMT != pParentMT);
+
+    // Check that interface methods resolve to the same MethodDescs on both
+    // this class and pParentMT. With the baked-in dispatch target model, the
+    // ComMethodTable stores the resolved MethodDesc at layout time, so the
+    // table can only be shared if the targets are identical.
+    for (unsigned i = 0; i < pItfMT->GetNumVirtuals(); i++)
+    {
+        MethodDesc *pItfMD = pItfMT->GetMethodDescForSlot_NoThrow(i);
+        if (pItfMD == NULL || pItfMD->IsAsyncMethod())
+            continue;
+
+        DispatchSlot childSlot(pClassMT->FindDispatchSlotForInterfaceMD(pItfMD, FALSE /* throwOnConflict */));
+        DispatchSlot parentSlot(pParentMT->FindDispatchSlotForInterfaceMD(pItfMD, FALSE /* throwOnConflict */));
+
+        if (childSlot.IsNull() || parentSlot.IsNull())
+            return FALSE;
+
+        if (childSlot.GetMethodDesc() != parentSlot.GetMethodDesc())
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+//--------------------------------------------------------------------------
 // Creates a ComMethodTable for an interface and stores it in the m_rgpIPtr array.
 //--------------------------------------------------------------------------
 ComMethodTable *ComCallWrapperTemplate::InitializeForInterface(MethodTable *pParentMT, MethodTable *pItfMT, DWORD dwIndex)
@@ -4222,22 +4283,16 @@ ComMethodTable *ComCallWrapperTemplate::InitializeForInterface(MethodTable *pPar
     ComMethodTable *pItfComMT = NULL;
     if (m_pParent != NULL)
     {
-        pItfComMT = m_pParent->GetComMTForItf(pItfMT);
-        if (pItfComMT != NULL)
+        // Check if we can reuse the parent's ComMethodTable for this interface.
+        ComMethodTable *pParentComMT = m_pParent->GetComMTForItf(pItfMT);
+        if (pParentComMT != NULL && CanShareComMethodTableWithParent(m_thClass.GetMethodTable(), pParentMT, pItfMT))
         {
-            // if the parent COM MT is not a trivial aggregate, simple MethodTable slot check is enough
-            if (!m_thClass.GetMethodTable()->ImplementsInterfaceWithSameSlotsAsParent(pItfMT, pParentMT))
-            {
-                // the interface is implemented by parent but this class reimplemented
-                // its method(s) so we will need to build a new COM vtable for it
-                pItfComMT = NULL;
-            }
+            pItfComMT = pParentComMT;
         }
     }
 
     if (pItfComMT == NULL)
     {
-        // we couldn't use parent's vtable so we create a new one
         pItfComMT = CreateComMethodTableForInterface(pItfMT);
     }
 

--- a/src/coreclr/vm/comcallablewrapper.cpp
+++ b/src/coreclr/vm/comcallablewrapper.cpp
@@ -4251,7 +4251,10 @@ static BOOL CanShareComMethodTableWithParent(MethodTable *pClassMT, MethodTable 
     for (unsigned i = 0; i < pItfMT->GetNumVirtuals(); i++)
     {
         MethodDesc *pItfMD = pItfMT->GetMethodDescForSlot_NoThrow(i);
-        if (pItfMD == NULL || pItfMD->IsAsyncMethod())
+        if (pItfMD == NULL)
+            return FALSE;
+
+        if (pItfMD->IsAsyncMethod())
             continue;
 
         DispatchSlot childSlot(pClassMT->FindDispatchSlotForInterfaceMD(pItfMD, FALSE /* throwOnConflict */));

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -5977,39 +5977,6 @@ UINT32 MethodTable::LookupTypeID()
     return AppDomain::GetCurrentDomain()->LookupTypeID(pMT);
 }
 
-//==========================================================================================
-BOOL MethodTable::ImplementsInterfaceWithSameSlotsAsParent(MethodTable *pItfMT, MethodTable *pParentMT)
-{
-    CONTRACTL
-    {
-        THROWS;
-        GC_TRIGGERS;
-        PRECONDITION(!IsInterface() && !pParentMT->IsInterface());
-        PRECONDITION(pItfMT->IsInterface());
-    } CONTRACTL_END;
-
-    MethodTable *pMT = this;
-    do
-    {
-        DispatchMap::EncodedMapIterator it(pMT);
-        for (; it.IsValid(); it.Next())
-        {
-            DispatchMapEntry *pCurEntry = it.Entry();
-            if (DispatchMapTypeMatchesMethodTable(pCurEntry->GetTypeID(), pItfMT))
-            {
-                // this class and its parents up to pParentMT must have no mappings for the interface
-                return FALSE;
-            }
-        }
-
-        pMT = pMT->GetParentMethodTable();
-        _ASSERTE(pMT != NULL);
-    }
-    while (pMT != pParentMT);
-
-    return TRUE;
-}
-
 #endif // !DACCESS_COMPILE
 
 //==========================================================================================

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -2572,11 +2572,6 @@ public:
     MethodTable *LookupDispatchMapType(DispatchMapTypeID typeID);
     bool DispatchMapTypeMatchesMethodTable(DispatchMapTypeID typeID, MethodTable* pMT);
 
-    // Determines whether all methods in the given interface have their final implementing
-    // slot in a parent class. I.e. if this returns TRUE, it is trivial (no VSD lookup) to
-    // dispatch pItfMT methods on this class if one knows how to dispatch them on pParentMT.
-    BOOL ImplementsInterfaceWithSameSlotsAsParent(MethodTable *pItfMT, MethodTable *pParentMT);
-
     // Try to resolve a given static virtual method override on this type. Return nullptr
     // when not found.
     MethodDesc *TryResolveVirtualStaticMethodOnThisType(MethodTable* pInterfaceType, MethodDesc* pInterfaceMD, ResolveVirtualStaticMethodFlags resolveVirtualStaticMethodFlags, ClassLoadLevel level);

--- a/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
+++ b/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
@@ -76,10 +76,13 @@ public class VirtualMethodOverrideTest
     public static void DerivedFirst()
     {
         int doWorkSlot = Marshal.GetStartComSlot(typeof(IFoo));
-        IntPtr pDerived = Marshal.GetComInterfaceForObject(new FooDerived(), typeof(IFoo));
-        IntPtr pBase = Marshal.GetComInterfaceForObject(new Foo(), typeof(IFoo));
+        IntPtr pDerived = IntPtr.Zero;
+        IntPtr pBase = IntPtr.Zero;
         try
         {
+            pDerived = Marshal.GetComInterfaceForObject(new FooDerived(), typeof(IFoo));
+            pBase = Marshal.GetComInterfaceForObject(new Foo(), typeof(IFoo));
+
             LastCalledType = null;
             Assert.True(CallDoWork(pDerived, doWorkSlot) >= 0);
             Assert.Equal(nameof(FooDerived), LastCalledType);
@@ -90,8 +93,11 @@ public class VirtualMethodOverrideTest
         }
         finally
         {
-            Marshal.Release(pDerived);
-            Marshal.Release(pBase);
+            if (pDerived != IntPtr.Zero)
+                Marshal.Release(pDerived);
+
+            if (pBase != IntPtr.Zero)
+                Marshal.Release(pBase);
         }
     }
 
@@ -99,10 +105,13 @@ public class VirtualMethodOverrideTest
     public static void BaseFirst()
     {
         int doWorkSlot = Marshal.GetStartComSlot(typeof(IBar));
-        IntPtr pBase = Marshal.GetComInterfaceForObject(new Bar(), typeof(IBar));
-        IntPtr pDerived = Marshal.GetComInterfaceForObject(new BarDerived(), typeof(IBar));
+        IntPtr pBase = IntPtr.Zero;
+        IntPtr pDerived = IntPtr.Zero;
         try
         {
+            pBase = Marshal.GetComInterfaceForObject(new Bar(), typeof(IBar));
+            pDerived = Marshal.GetComInterfaceForObject(new BarDerived(), typeof(IBar));
+
             LastCalledType = null;
             Assert.True(CallDoWork(pBase, doWorkSlot) >= 0);
             Assert.Equal(nameof(Bar), LastCalledType);
@@ -113,8 +122,8 @@ public class VirtualMethodOverrideTest
         }
         finally
         {
-            Marshal.Release(pBase);
-            Marshal.Release(pDerived);
+            if (pBase != IntPtr.Zero) Marshal.Release(pBase);
+            if (pDerived != IntPtr.Zero) Marshal.Release(pDerived);
         }
     }
 }

--- a/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
+++ b/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.cs
@@ -1,0 +1,120 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000001")]
+public interface IFoo
+{
+    void DoWork();
+}
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000002")]
+[ComDefaultInterface(typeof(IFoo))]
+public class Foo : IFoo
+{
+    public virtual void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(Foo);
+}
+
+[ComVisible(true)]
+[Guid("A1111111-0000-0000-0000-000000000003")]
+[ComDefaultInterface(typeof(IFoo))]
+public class FooDerived : Foo
+{
+    public override void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(FooDerived);
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000001")]
+public interface IBar
+{
+    void DoWork();
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000002")]
+[ComDefaultInterface(typeof(IBar))]
+public class Bar : IBar
+{
+    public virtual void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(Bar);
+}
+
+[ComVisible(true)]
+[Guid("B2222222-0000-0000-0000-000000000003")]
+[ComDefaultInterface(typeof(IBar))]
+public class BarDerived : Bar
+{
+    public override void DoWork() => VirtualMethodOverrideTest.LastCalledType = nameof(BarDerived);
+}
+
+/// <summary>
+/// Tests that COM-to-CLR dispatch correctly resolves virtual method overrides
+/// regardless of whether the base or derived class is accessed via COM first.
+/// </summary>
+public class VirtualMethodOverrideTest
+{
+    internal static string? LastCalledType;
+
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    delegate int DoWorkDelegate(IntPtr pThis);
+
+    private static int CallDoWork(IntPtr pInterface, int slot)
+    {
+        IntPtr vtbl = Marshal.ReadIntPtr(pInterface);
+        IntPtr fnPtr = Marshal.ReadIntPtr(vtbl, slot * IntPtr.Size);
+        Assert.NotEqual(IntPtr.Zero, fnPtr);
+
+        var fn = Marshal.GetDelegateForFunctionPointer<DoWorkDelegate>(fnPtr);
+        return fn(pInterface);
+    }
+
+    [Fact]
+    public static void DerivedFirst()
+    {
+        int doWorkSlot = Marshal.GetStartComSlot(typeof(IFoo));
+        IntPtr pDerived = Marshal.GetComInterfaceForObject(new FooDerived(), typeof(IFoo));
+        IntPtr pBase = Marshal.GetComInterfaceForObject(new Foo(), typeof(IFoo));
+        try
+        {
+            LastCalledType = null;
+            Assert.True(CallDoWork(pDerived, doWorkSlot) >= 0);
+            Assert.Equal(nameof(FooDerived), LastCalledType);
+
+            LastCalledType = null;
+            Assert.True(CallDoWork(pBase, doWorkSlot) >= 0);
+            Assert.Equal(nameof(Foo), LastCalledType);
+        }
+        finally
+        {
+            Marshal.Release(pDerived);
+            Marshal.Release(pBase);
+        }
+    }
+
+    [Fact]
+    public static void BaseFirst()
+    {
+        int doWorkSlot = Marshal.GetStartComSlot(typeof(IBar));
+        IntPtr pBase = Marshal.GetComInterfaceForObject(new Bar(), typeof(IBar));
+        IntPtr pDerived = Marshal.GetComInterfaceForObject(new BarDerived(), typeof(IBar));
+        try
+        {
+            LastCalledType = null;
+            Assert.True(CallDoWork(pBase, doWorkSlot) >= 0);
+            Assert.Equal(nameof(Bar), LastCalledType);
+
+            LastCalledType = null;
+            Assert.True(CallDoWork(pDerived, doWorkSlot) >= 0);
+            Assert.Equal(nameof(BarDerived), LastCalledType);
+        }
+        finally
+        {
+            Marshal.Release(pBase);
+            Marshal.Release(pDerived);
+        }
+    }
+}

--- a/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.csproj
+++ b/src/tests/Interop/COM/VirtualMethodOverride/VirtualMethodOverrideTest.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="VirtualMethodOverrideTest.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
When a COM interface is implemented by a class with a virtual method and a derived class overrides it, they share a `ComMethodTable`. With #126002, when a `ComMethodTable` lay out happens, we resolve each interface method into its target method and create a corresponding `UMEntryThunkData`. This means that if a derived class is used first, its override gets baked into the layout, so the base class will call the wrong method - and vice versa if the base class is used first.

This change prevents sharing of a `ComMethodTable` between a base/derived class if the actual targets of any interface method differ.

Found while investigating https://github.com/dotnet/runtime/issues/127512.

cc @dotnet/appmodel @AaronRobinsonMSFT

Example setup:
```c#
[ComVisible(true)]
public interface IFoo
{
    void DoWork();
}
 
[ComVisible(true), ComDefaultInterface(typeof(IFoo))]
public class Base : IFoo
{
    public virtual void DoWork() { }
}
 
[ComVisible(true), ComDefaultInterface(typeof(IFoo))]
public class Derived : Base
{
    public override void DoWork() { }
}
```
If `Derived` is created first, calling `Base.DoWork` calls `Derived.DoWork`.