### PR TITLE
[HTTP] Remove peer.address from connection OTel counters

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnectionBase.cs
@@ -75,8 +75,7 @@ namespace System.Net.Http
                         protocol,
                         _pool.IsSecure ? "https" : "http",
                         _pool.TelemetryServerAddress,
-                        _pool.OriginAuthority.Port,
-                        remoteEndPoint?.Address?.ToString());
+                        _pool.OriginAuthority.Port);
 
                     _connectionMetrics.ConnectionEstablished();
                 }

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Metrics/ConnectionMetrics.cs
@@ -14,10 +14,9 @@ namespace System.Net.Http.Metrics
         private readonly object _schemeTag;
         private readonly object _hostTag;
         private readonly object _portTag;
-        private readonly object? _peerAddressTag;
         private bool _currentlyIdle;
 
-        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int port, string? peerAddress)
+        public ConnectionMetrics(SocketsHttpHandlerMetrics metrics, string protocolVersion, string scheme, string host, int port)
         {
             _metrics = metrics;
             _openConnectionsEnabled = _metrics.OpenConnections.Enabled;
@@ -25,7 +24,6 @@ namespace System.Net.Http.Metrics
             _schemeTag = scheme;
             _hostTag = host;
             _portTag = DiagnosticsHelper.GetBoxedInt32(port);
-            _peerAddressTag = peerAddress;
         }
 
         // TagList is a huge struct, so we avoid storing it in a field to reduce the amount we allocate on the heap.
@@ -37,11 +35,6 @@ namespace System.Net.Http.Metrics
             tags.Add("url.scheme", _schemeTag);
             tags.Add("server.address", _hostTag);
             tags.Add("server.port", _portTag);
-
-            if (_peerAddressTag is not null)
-            {
-                tags.Add("network.peer.address", _peerAddressTag);
-            }
 
             return tags;
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -127,16 +127,12 @@ namespace System.Net.Http.Functional.Tests
             VerifyTag(tags, "http.connection.state", state);
         }
 
-        protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, IPAddress[] validPeerAddresses = null)
+        protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion)
         {
             Assert.Equal(InstrumentNames.ConnectionDuration, instrumentName);
             double value = Assert.IsType<double>(measurement);
 
-            // This flakes for remote requests on CI.
-            if (validPeerAddresses is null)
-            {
-                Assert.InRange(value, double.Epsilon, 60);
-            }
+            Assert.InRange(value, double.Epsilon, 60);
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
         }
@@ -373,8 +369,6 @@ namespace System.Net.Http.Functional.Tests
             Uri uri = UseVersion == HttpVersion.Version11
                 ? Test.Common.Configuration.Http.RemoteHttp11Server.EchoUri
                 : Test.Common.Configuration.Http.RemoteHttp2Server.EchoUri;
-            IPAddress[] addresses = await Dns.GetHostAddressesAsync(uri.Host);
-            addresses = addresses.Union(addresses.Select(a => a.MapToIPv6())).ToArray();
 
             using (HttpMessageInvoker client = CreateHttpMessageInvoker())
             {
@@ -387,7 +381,7 @@ namespace System.Net.Http.Functional.Tests
 
             VerifyRequestDuration(Assert.Single(requestDurationRecorder.GetMeasurements()), uri, UseVersion, 200, "GET");
             Measurement<double> cd = Assert.Single(connectionDurationRecorder.GetMeasurements());
-            VerifyConnectionDuration(InstrumentNames.ConnectionDuration, cd.Value, cd.Tags.ToArray(), uri, UseVersion, addresses);
+            VerifyConnectionDuration(InstrumentNames.ConnectionDuration, cd.Value, cd.Tags.ToArray(), uri, UseVersion);
             Measurement<long> oc = openConnectionsRecorder.GetMeasurements().First();
             VerifyOpenConnections(InstrumentNames.OpenConnections, oc.Value, oc.Tags.ToArray(), 1, uri, UseVersion, "idle");
         }

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/MetricsTest.cs
@@ -73,15 +73,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
 
-        private static void VerifyPeerAddress(KeyValuePair<string, object?>[] tags, IPAddress[] validPeerAddresses = null)
-        {
-            string ipString = (string)tags.Single(t => t.Key == "network.peer.address").Value;
-            validPeerAddresses ??= [IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback, IPAddress.IPv6Loopback];
-            IPAddress ip = IPAddress.Parse(ipString);
-            Assert.Contains(ip, validPeerAddresses);
-        }
-
-
         protected static void VerifyRequestDuration(Measurement<double> measurement,
             Uri uri,
             Version? protocolVersion = null,
@@ -127,14 +118,13 @@ namespace System.Net.Http.Functional.Tests
             Assert.Equal(method, tags.Single(t => t.Key == "http.request.method").Value);
         }
 
-        protected static void VerifyOpenConnections(string actualName, object measurement, KeyValuePair<string, object?>[] tags, long expectedValue, Uri uri, Version? protocolVersion, string state, IPAddress[] validPeerAddresses = null)
+        protected static void VerifyOpenConnections(string actualName, object measurement, KeyValuePair<string, object?>[] tags, long expectedValue, Uri uri, Version? protocolVersion, string state)
         {
             Assert.Equal(InstrumentNames.OpenConnections, actualName);
             Assert.Equal(expectedValue, Assert.IsType<long>(measurement));
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
             VerifyTag(tags, "http.connection.state", state);
-            VerifyPeerAddress(tags, validPeerAddresses);
         }
 
         protected static void VerifyConnectionDuration(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, IPAddress[] validPeerAddresses = null)
@@ -149,7 +139,6 @@ namespace System.Net.Http.Functional.Tests
             }
             VerifySchemeHostPortTags(tags, uri);
             VerifyTag(tags, "network.protocol.version", GetVersionString(protocolVersion));
-            VerifyPeerAddress(tags, validPeerAddresses);
         }
 
         protected static void VerifyTimeInQueue(string instrumentName, object measurement, KeyValuePair<string, object?>[] tags, Uri uri, Version? protocolVersion, string method = "GET")
@@ -400,7 +389,7 @@ namespace System.Net.Http.Functional.Tests
             Measurement<double> cd = Assert.Single(connectionDurationRecorder.GetMeasurements());
             VerifyConnectionDuration(InstrumentNames.ConnectionDuration, cd.Value, cd.Tags.ToArray(), uri, UseVersion, addresses);
             Measurement<long> oc = openConnectionsRecorder.GetMeasurements().First();
-            VerifyOpenConnections(InstrumentNames.OpenConnections, oc.Value, oc.Tags.ToArray(), 1, uri, UseVersion, "idle", addresses);
+            VerifyOpenConnections(InstrumentNames.OpenConnections, oc.Value, oc.Tags.ToArray(), 1, uri, UseVersion, "idle");
         }
 
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]


### PR DESCRIPTION
OTel changed specification for these 2 tags to "Opt-In". We do not have any toggles for Opt-In tags and we simply omit them. Therefore, I'm removing them from the code.

OTel change: https://github.com/open-telemetry/semantic-conventions/pull/3759
Contributes to https://github.com/dotnet/runtime/issues/122752