### PR TITLE
Skip 32-bit time_t openssl detection on linux-bionic arm

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/openssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native/openssl.c
@@ -950,7 +950,7 @@ int32_t CryptoNative_X509StoreSetVerifyTime(X509_STORE* ctx,
         return 0;
     }
 
-#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
     if (g_libSslUses32BitTime)
     {
         if (verifyTime > INT_MAX || verifyTime < INT_MIN)

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.c
@@ -21,7 +21,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef FALLBACK_FUNCTION
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
 TYPEOF(OPENSSL_gmtime) OPENSSL_gmtime_ptr;
 #endif
 
@@ -34,7 +34,7 @@ static void* volatile libssl = NULL;
 #define SONAME_BASE LIBNAME "."
 #define MAKELIB(v)  SONAME_BASE v
 
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
 // We support ARM32 linux distros that have Y2038-compatible glibc (those which support _TIME_BITS).
 // Some such distros have not yet switched to _TIME_BITS=64 by default, so we may be running against an openssl
 // that expects 32-bit time_t even though our time_t is 64-bit.
@@ -180,7 +180,7 @@ void InitializeOpenSSLShim(void)
 #undef FALLBACK_FUNCTION
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
     if (!(OPENSSL_gmtime_ptr = (TYPEOF(OPENSSL_gmtime))(dlsym(libssl, "OPENSSL_gmtime")))) { fprintf(stderr, "Cannot get required symbol OPENSSL_gmtime from libssl\n"); abort(); }
 #endif
 
@@ -195,7 +195,7 @@ void InitializeOpenSSLShim(void)
         }
     }
 
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
     c_static_assert_msg(sizeof(time_t) == 8, "Build requires 64-bit time_t.");
 
     // This value will represent a time in year 2038 if 64-bit time is used,

--- a/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
+++ b/src/native/libs/System.Security.Cryptography.Native/opensslshim.h
@@ -284,7 +284,7 @@ const EVP_CIPHER* EVP_rc2_cbc(void);
 
 #define API_EXISTS(fn) (fn != NULL)
 
-#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
 extern bool g_libSslUses32BitTime;
 #endif
 
@@ -868,7 +868,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef FALLBACK_FUNCTION
 #undef LIGHTUP_FUNCTION
 #undef REQUIRED_FUNCTION
-#if defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
 extern TYPEOF(OPENSSL_gmtime)* OPENSSL_gmtime_ptr;
 #endif
 // Redefine all calls to OpenSSL functions as calls through pointers that are set

--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -977,7 +977,7 @@ static X509VerifyStatusCode CheckOcspGetExpiry(OCSP_REQUEST* req,
             {
                 time_t currentTime = time(NULL);
                 int nextUpdComparison = 0;
-#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX)
+#if defined(FEATURE_DISTRO_AGNOSTIC_SSL) && defined(TARGET_ARM) && defined(TARGET_LINUX) && !defined(TARGET_ANDROID)
                 // If openssl uses 32-bit time_t and the current time doesn't fit in 32 bits,
                 // skip checking the status/nextupd, and fall through to return PAL_X509_V_ERR_UNABLE_TO_GET_CRL.
                 if (!g_libSslUses32BitTime || (currentTime >= INT_MIN && currentTime <= INT_MAX))


### PR DESCRIPTION
#128826 changed `eng/native/configurecompiler.cmake` to define both `TARGET_LINUX` and `TARGET_ANDROID` for Android targets. That activated a `TARGET_ARM && TARGET_LINUX` guarded `static_assert` in `opensslshim.c` requiring 64-bit `time_t`, breaking the linux-bionic shortstack arm build in the VMR because Android NDK API 24 keeps `time_t` 32-bit (the NDK only honors `_TIME_BITS=64` at API >= 32):

```
src/native/libs/System.Security.Cryptography.Native/opensslshim.c:199:25: error: static assertion failed due to requirement 'sizeof(long) == 8': Build requires 64-bit time_t.
```

The 32-bit-`time_t` libssl probe exists for distro-agnostic Linux arm builds that may load an older libssl built against a 32-bit `time_t`. linux-bionic does not build the OpenSSL crypto library at all, so the probe is dead code there. Exclude `TARGET_ANDROID` from the related guards so the assert and probe are compiled out on linux-bionic.

Fixes the `LinuxBionic_Shortstack_arm` build leg in dotnet/dotnet.