### PR TITLE
[r2r] Enable generic cycles detection by default

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -170,9 +170,12 @@ namespace ILCompiler.DependencyAnalysis
                                 }
                                 else
                                 {
-                                    GVMDependenciesNode gvmNode = factory.GVMDependencies(canonImpl);
-                                    if (gvmNode != null)
-                                        dynamicDependencies.Add(new CombinedDependencyListEntry(gvmNode, null, "ImplementingMethodInstantiation"));
+#if READYTORUN
+                                    if (!factory.CanBeInGenericCycle(canonImpl))
+#endif
+                                    {
+                                        dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(canonImpl), null, "ImplementingMethodInstantiation"));
+                                    }
                                 }
 
 #if !READYTORUN

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/GVMDependenciesNode.cs
@@ -170,7 +170,9 @@ namespace ILCompiler.DependencyAnalysis
                                 }
                                 else
                                 {
-                                    dynamicDependencies.Add(new CombinedDependencyListEntry(factory.GVMDependencies(canonImpl), null, "ImplementingMethodInstantiation"));
+                                    GVMDependenciesNode gvmNode = factory.GVMDependencies(canonImpl);
+                                    if (gvmNode != null)
+                                        dynamicDependencies.Add(new CombinedDependencyListEntry(gvmNode, null, "ImplementingMethodInstantiation"));
                                 }
 
 #if !READYTORUN
@@ -265,15 +267,7 @@ namespace ILCompiler.DependencyAnalysis
             if (!factory.CompilationModuleGroup.ContainsMethodBody(method, false))
                 return null;
 
-            try
-            {
-                factory.DetectGenericCycles(method, method);
-                return factory.CompiledMethodNode(method);
-            }
-            catch (TypeSystemException)
-            {
-                return null;
-            }
+            return factory.CompiledMethodNode(method);
 #endif
         }
     }

--- a/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
+++ b/src/coreclr/tools/Common/Compiler/GenericCycleDetection/ModuleCycleInfo.cs
@@ -230,6 +230,15 @@ namespace ILCompiler
                 }
             }
 
+            /// <summary>
+            /// Returns true if the given entity (method or type definition) could be part of a
+            /// generic cycle.
+            /// </summary>
+            public bool CanBeInCycle(TypeSystemEntity entity)
+            {
+                return FormsCycle(entity, out _);
+            }
+
             public void DetectCycle(TypeSystemEntity owner, TypeSystemEntity referent)
             {
                 // This allows to disable cycle detection completely (typically for perf reasons as the algorithm is pretty slow)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -87,8 +87,12 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 // instantiations of virtual methods that have at least one non-canonical argument (aka a valuetype).
                 if (HasNonCanonicalInstantiationArguments(canonMethod))
                 {
-                    list = list ?? new DependencyList();
-                    list.Add(factory.GVMDependencies(Method), "Virtual dispatch dependency");
+                    GVMDependenciesNode gvmNode = factory.GVMDependencies(Method);
+                    if (gvmNode != null)
+                    {
+                        list = list ?? new DependencyList();
+                        list.Add(gvmNode, "Virtual dispatch dependency");
+                    }
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/MethodFixupSignature.cs
@@ -85,14 +85,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 // Because methods with generic parameters are already compiled in their canonical form, we are only interested in finding
                 // instantiations of virtual methods that have at least one non-canonical argument (aka a valuetype).
-                if (HasNonCanonicalInstantiationArguments(canonMethod))
+                if (HasNonCanonicalInstantiationArguments(canonMethod) && !factory.CanBeInGenericCycle(Method))
                 {
-                    GVMDependenciesNode gvmNode = factory.GVMDependencies(Method);
-                    if (gvmNode != null)
-                    {
-                        list = list ?? new DependencyList();
-                        list.Add(gvmNode, "Virtual dispatch dependency");
-                    }
+                    list = list ?? new DependencyList();
+                    list.Add(factory.GVMDependencies(Method), "Virtual dispatch dependency");
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -1283,8 +1283,7 @@ namespace ILCompiler.DependencyAnalysis
                 return false;
 
             MethodDesc methodDefinition = method.GetTypicalMethodDefinition();
-            return _genericCycleDetector.CanBeInCycle(methodDefinition)
-                || _genericCycleDetector.CanBeInCycle(methodDefinition.OwningType);
+            return _genericCycleDetector.CanBeInCycle(methodDefinition);
         }
 
         public Utf8String GetSymbolAlternateName(ISymbolNode node, out bool isHidden)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -155,6 +155,13 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(method.IsVirtual);
             MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             canonMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(canonMethod);
+
+            MethodDesc methodDefinition = canonMethod.GetTypicalMethodDefinition();
+            if (CanBeInGenericCycle(methodDefinition) || CanBeInGenericCycle(methodDefinition.OwningType))
+            {
+                return null;
+            }
+
             return _gvmDependenciesNode.GetOrAdd(canonMethod);
         }
 
@@ -1275,6 +1282,11 @@ namespace ILCompiler.DependencyAnalysis
         public void DetectGenericCycles(TypeSystemEntity caller, TypeSystemEntity callee)
         {
             _genericCycleDetector?.DetectCycle(caller, callee);
+        }
+
+        public bool CanBeInGenericCycle(TypeSystemEntity entity)
+        {
+            return _genericCycleDetector?.CanBeInCycle(entity) == true;
         }
 
         public Utf8String GetSymbolAlternateName(ISymbolNode node, out bool isHidden)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -155,13 +155,6 @@ namespace ILCompiler.DependencyAnalysis
             Debug.Assert(method.IsVirtual);
             MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             canonMethod = MetadataVirtualMethodAlgorithm.FindSlotDefiningMethodForVirtualMethod(canonMethod);
-
-            MethodDesc methodDefinition = canonMethod.GetTypicalMethodDefinition();
-            if (CanBeInGenericCycle(methodDefinition) || CanBeInGenericCycle(methodDefinition.OwningType))
-            {
-                return null;
-            }
-
             return _gvmDependenciesNode.GetOrAdd(canonMethod);
         }
 
@@ -1284,9 +1277,14 @@ namespace ILCompiler.DependencyAnalysis
             _genericCycleDetector?.DetectCycle(caller, callee);
         }
 
-        public bool CanBeInGenericCycle(TypeSystemEntity entity)
+        public bool CanBeInGenericCycle(MethodDesc method)
         {
-            return _genericCycleDetector?.CanBeInCycle(entity) == true;
+            if (_genericCycleDetector is null)
+                return false;
+
+            MethodDesc methodDefinition = method.GetTypicalMethodDefinition();
+            return _genericCycleDetector.CanBeInCycle(methodDefinition)
+                || _genericCycleDetector.CanBeInCycle(methodDefinition.OwningType);
         }
 
         public Utf8String GetSymbolAlternateName(ISymbolNode node, out bool isHidden)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -43,8 +43,8 @@ namespace ILCompiler
         private CompositeImageSettings _compositeImageSettings;
         private ulong _imageBase;
         private NodeFactoryOptimizationFlags _nodeFactoryOptimizationFlags = new NodeFactoryOptimizationFlags();
-        private int _genericCycleDetectionDepthCutoff = ReadyToRunCompilerContext.DefaultGenericCycleDepthCutoff;
-        private int _genericCycleDetectionBreadthCutoff = ReadyToRunCompilerContext.DefaultGenericCycleBreadthCutoff;
+        private int _genericCycleDetectionDepthCutoff = -1;
+        private int _genericCycleDetectionBreadthCutoff = -1;
         private ReadyToRunContainerFormat _format = ReadyToRunContainerFormat.PE;
 
         private string _jitPath;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilationBuilder.cs
@@ -43,8 +43,8 @@ namespace ILCompiler
         private CompositeImageSettings _compositeImageSettings;
         private ulong _imageBase;
         private NodeFactoryOptimizationFlags _nodeFactoryOptimizationFlags = new NodeFactoryOptimizationFlags();
-        private int _genericCycleDetectionDepthCutoff = -1;
-        private int _genericCycleDetectionBreadthCutoff = -1;
+        private int _genericCycleDetectionDepthCutoff = ReadyToRunCompilerContext.DefaultGenericCycleDepthCutoff;
+        private int _genericCycleDetectionBreadthCutoff = ReadyToRunCompilerContext.DefaultGenericCycleBreadthCutoff;
         private ReadyToRunContainerFormat _format = ReadyToRunContainerFormat.PE;
 
         private string _jitPath;

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -88,8 +88,6 @@ namespace ILCompiler
             new("--imagebase") { Description = SR.ImageBase };
         public Option<string> TargetArchitecture { get; } =
             new("--targetarch") { Description = SR.TargetArchOption };
-        public Option<bool> EnableGenericCycleDetection { get; } =
-            new("--enable-generic-cycle-detection") { Description = SR.EnableGenericCycleDetection };
         public Option<int> GenericCycleDepthCutoff { get; } =
             new("--maxgenericcycle") { DefaultValueFactory = _ => ReadyToRunCompilerContext.DefaultGenericCycleDepthCutoff, Description = SR.GenericCycleDepthCutoff };
         public Option<int> GenericCycleBreadthCutoff { get; } =
@@ -197,7 +195,6 @@ namespace ILCompiler
             Options.Add(SupportIbc);
             Options.Add(Resilient);
             Options.Add(ImageBase);
-            Options.Add(EnableGenericCycleDetection);
             Options.Add(GenericCycleDepthCutoff);
             Options.Add(GenericCycleBreadthCutoff);
             Options.Add(TargetArchitecture);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -679,12 +679,9 @@ namespace ILCompiler
                         .UseCompilationRoots(compilationRoots)
                         .UseOptimizationMode(optimizationMode);
 
-                    if (Get(_command.EnableGenericCycleDetection))
-                    {
-                        builder.UseGenericCycleDetection(
-                            depthCutoff: Get(_command.GenericCycleDepthCutoff),
-                            breadthCutoff: Get(_command.GenericCycleBreadthCutoff));
-                    }
+                    builder.UseGenericCycleDetection(
+                        depthCutoff: Get(_command.GenericCycleDepthCutoff),
+                        breadthCutoff: Get(_command.GenericCycleBreadthCutoff));
 
                     builder.UsePrintReproInstructions(CreateReproArgumentString);
 

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -423,9 +423,6 @@
   <data name="TypeValidation" xml:space="preserve">
     <value>Configure the runtime's behavior around validating the correctness of types defined in assemblies compiled via crossgen2</value>
   </data>
-  <data name="EnableGenericCycleDetection" xml:space="preserve">
-    <value>Perform generic cycle detection during compilation (incurs longer compilation time)</value>
-  </data>
   <data name="GenericCycleBreadthCutoff" xml:space="preserve">
     <value>Total number of occurrences of potentially cyclic generic types within a generic type to cut off</value>
   </data>

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/param02.ilproj
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/param02.ilproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- Needed for CrossGenTest -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="param02.il" />

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/param04.ilproj
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/param04.ilproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- Needed for CrossGenTest -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="param04.il" />

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/param06.ilproj
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/param06.ilproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- Needed for CrossGenTest -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="param06.il" />

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/param08.ilproj
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/param08.ilproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
+    <!-- Needed for CrossGenTest -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <CLRTestPriority>1</CLRTestPriority>
+
+    <!-- Crossgen is not intended to serve as an IL verifier, and is not designed to provide error semantics on bad input. -->
+    <CrossGenTest>false</CrossGenTest>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="param08.il" />

--- a/src/tests/readytorun/GenericCycleDetection/Breadth1Test.csproj
+++ b/src/tests/readytorun/GenericCycleDetection/Breadth1Test.csproj
@@ -6,7 +6,7 @@
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- Without this flag Crossgen2 crashes after several minutes with arithmetic overflow -->
-    <CrossGen2TestExtraArguments>--enable-generic-cycle-detection --maxgenericcycle:1 --maxgenericcyclebreadth:1</CrossGen2TestExtraArguments>
+    <CrossGen2TestExtraArguments>--maxgenericcycle:1 --maxgenericcyclebreadth:1</CrossGen2TestExtraArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/readytorun/GenericCycleDetection/Depth1Test.csproj
+++ b/src/tests/readytorun/GenericCycleDetection/Depth1Test.csproj
@@ -6,7 +6,7 @@
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- Without this flag Crossgen2 crashes after several minutes with arithmetic overflow -->
-    <CrossGen2TestExtraArguments>--enable-generic-cycle-detection --maxgenericcycle:1 --maxgenericcyclebreadth:-1</CrossGen2TestExtraArguments>
+    <CrossGen2TestExtraArguments>--maxgenericcycle:1 --maxgenericcyclebreadth:-1</CrossGen2TestExtraArguments>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/readytorun/GenericCycleDetection/Depth3Test.csproj
+++ b/src/tests/readytorun/GenericCycleDetection/Depth3Test.csproj
@@ -6,7 +6,7 @@
     <!-- This is an explicit crossgen test -->
     <AlwaysUseCrossGen2>true</AlwaysUseCrossGen2>
     <!-- Without this flag Crossgen2 crashes after several minutes with arithmetic overflow -->
-    <CrossGen2TestExtraArguments>--enable-generic-cycle-detection --maxgenericcycle:3 --maxgenericcyclebreadth:-1</CrossGen2TestExtraArguments>
+    <CrossGen2TestExtraArguments>--maxgenericcycle:3 --maxgenericcyclebreadth:-1</CrossGen2TestExtraArguments>
     <!-- This test OOMs Crossgen2 when running in 32-bit address space -->
     <CLRTestTargetUnsupported Condition="'$(TargetBits)' == '32'">true</CLRTestTargetUnsupported>
   </PropertyGroup>


### PR DESCRIPTION
Following the addition of GVM handling in r2r via dynamic dependencies, System.Linq.Parallel.Tests fails to compile, by overflow due to excessive compilation. Enabling the scanning for generic cycles alone doesn't fix this (--enable-generic-cycle-detection). This testsuite also fails to compile on NativeAot where it is disabled. It seems like, despite having generic cycle checks inside the GVM expansion, the amount of nodes still grows at an excessive rate, breaking the compilation.

As a fix, we ensure that we have the `_genericCycleDetector` initialized by default on r2r and use it to query for types/methods that could be part of generic cycles (from the computed `ModuleCycleInfo` information). We conservatively avoid any GVM scan for these entities, to avoid excessive compilation and potential size increases, since we have the flexibility to fallback to jit/interpreter at runtime.

As a side effect, this enables the generic cycle checks for other areas of R2R, but, given we will start compiling more methods with generics, it might be a good thing to have it enabled anyway.

Also removes the previous generic cycles check from GVMDependenciesNode which no longer seem necessary.

Fixes https://github.com/dotnet/runtime/issues/128694