### PR TITLE
JIT: Fix assertion failed 'genActualType(cmp->gtGetOp1()) == genActualType(cmp->gtGetOp2())'

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -10957,12 +10957,13 @@ GenTree* Compiler::fgOptimizeBitwiseAnd(GenTreeOp* andOp)
 //
 GenTree* Compiler::fgOptimizeRelationalComparisonWithCasts(GenTreeOp* cmp)
 {
-    assert(cmp->OperIsCmpCompare());
-    assert(cmp->gtGetOp1()->OperIs(GT_CAST) || cmp->gtGetOp2()->OperIs(GT_CAST));
-    assert(genActualType(cmp->gtGetOp1()) == genActualType(cmp->gtGetOp2()));
-
     GenTree* op1 = cmp->gtGetOp1();
     GenTree* op2 = cmp->gtGetOp2();
+
+    assert(cmp->OperIsCmpCompare());
+    assert(op1->OperIs(GT_CAST) || op2->OperIs(GT_CAST));
+    assert((genActualType(op1) == genActualType(op2)) || (varTypeIsI(op1) && varTypeIsI(op2)) ||
+           (varTypeIsFloating(op1) && varTypeIsFloating(op2)));
 
     if (!op1->TypeIs(TYP_LONG))
     {


### PR DESCRIPTION
Fix https://github.com/dotnet/runtime/issues/128947

This assert is not a function specific assumption, rather a general IR validation - to my understanding.
The function uses the `supportedOp` lambda to actually cull out unsupported/uninteresting comparisons.
So it should be fine to change it.

The existing assert fired when seeing EQ(byref, long), for example:
```lua
*  NE        int   
+--*  LCL_VAR   byref  V01 arg1         
\--*  CAST      long <- ulong <- uint
   \--*  CNS_INT   int    0
```
Because it only considers `genActualType(cmp->gtGetOp1()) == genActualType(cmp->gtGetOp2())` legal.

I don't really know what we consider legal IR and there is no centralized place so as a fix I copied this existing assert from importer:
https://github.com/dotnet/runtime/blob/b0f76ec847aa48839262c4726554ea9e0f3bc4e6/src/coreclr/jit/importer.cpp#L7937-L7938