### PR TITLE
Use Utf8Span for type system names

### DIFF
--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
@@ -92,7 +92,7 @@ namespace Internal.TypeSystem.NoMetadata
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/Internal/TypeSystem/RuntimeMethodDesc.cs
@@ -4,6 +4,7 @@
 
 using System;
 
+using Internal.Text;
 using Internal.Runtime.CompilerServices;
 using Internal.Runtime.TypeLoader;
 
@@ -91,7 +92,7 @@ namespace Internal.TypeSystem.NoMetadata
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -54,6 +54,9 @@
     <Compile Include="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System\Runtime\CompilerServices\IntrinsicAttribute.cs">
       <Link>IntrinsicAttribute.cs</Link>
     </Compile>
+    <Compile Include="$(CompilerCommonPath)\Internal\Text\Utf8StringRef.cs">
+      <Link>Internal\Text\Utf8StringRef.cs</Link>
+    </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\ArrayType.Canon.cs">
       <Link>Internal\TypeSystem\ArrayType.Canon.cs</Link>
     </Compile>

--- a/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
+++ b/src/coreclr/nativeaot/System.Private.TypeLoader/src/System.Private.TypeLoader.csproj
@@ -54,8 +54,8 @@
     <Compile Include="$(LibrariesProjectRoot)\System.Private.CoreLib\src\System\Runtime\CompilerServices\IntrinsicAttribute.cs">
       <Link>IntrinsicAttribute.cs</Link>
     </Compile>
-    <Compile Include="$(CompilerCommonPath)\Internal\Text\Utf8StringRef.cs">
-      <Link>Internal\Text\Utf8StringRef.cs</Link>
+    <Compile Include="$(CompilerCommonPath)\Internal\Text\Utf8Span.cs">
+      <Link>Internal\Text\Utf8Span.cs</Link>
     </Compile>
     <Compile Include="$(CompilerCommonPath)\TypeSystem\Canon\ArrayType.Canon.cs">
       <Link>Internal\TypeSystem\ArrayType.Canon.cs</Link>

--- a/src/coreclr/tools/Common/Compiler/AsyncContinuationType.cs
+++ b/src/coreclr/tools/Common/Compiler/AsyncContinuationType.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -21,8 +22,8 @@ namespace ILCompiler
         public GCPointerMap PointerMap { get; }
 
         public override DefType[] ExplicitlyImplementedInterfaces => [];
-        public override ReadOnlySpan<byte> Name => Encoding.UTF8.GetBytes(DiagnosticName);
-        public override ReadOnlySpan<byte> Namespace => [];
+        public override Utf8StringRef Name => Encoding.UTF8.GetBytes(DiagnosticName);
+        public override Utf8StringRef Namespace => Array.Empty<byte>();
 
         // We don't lay these out using MetadataType metadata.
         // Autolayout (which we'd get due to GC pointers) would likely not match what codegen expects.
@@ -49,9 +50,9 @@ namespace ILCompiler
 
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
         public override IEnumerable<MetadataType> GetNestedTypes() => [];
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name) => null;
+        public override MetadataType GetNestedType(Utf8StringRef name) => null;
         protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => [];
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name) => [];
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => [];
 
         protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
         {

--- a/src/coreclr/tools/Common/Compiler/AsyncContinuationType.cs
+++ b/src/coreclr/tools/Common/Compiler/AsyncContinuationType.cs
@@ -22,8 +22,8 @@ namespace ILCompiler
         public GCPointerMap PointerMap { get; }
 
         public override DefType[] ExplicitlyImplementedInterfaces => [];
-        public override Utf8StringRef Name => Encoding.UTF8.GetBytes(DiagnosticName);
-        public override Utf8StringRef Namespace => Array.Empty<byte>();
+        public override Utf8Span Name => Encoding.UTF8.GetBytes(DiagnosticName);
+        public override Utf8Span Namespace => Array.Empty<byte>();
 
         // We don't lay these out using MetadataType metadata.
         // Autolayout (which we'd get due to GC pointers) would likely not match what codegen expects.
@@ -50,9 +50,9 @@ namespace ILCompiler
 
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
         public override IEnumerable<MetadataType> GetNestedTypes() => [];
-        public override MetadataType GetNestedType(Utf8StringRef name) => null;
+        public override MetadataType GetNestedType(Utf8Span name) => null;
         protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => [];
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => [];
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name) => [];
 
         protected override int CompareToImpl(TypeDesc other, TypeSystemComparer comparer)
         {

--- a/src/coreclr/tools/Common/Compiler/Dataflow/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/Dataflow/TypeExtensions.cs
@@ -53,23 +53,5 @@ namespace ILCompiler.Dataflow
             return method.OwningType.IsTypeOf(fullTypeName);
         }
 
-        public static bool StringEquals(this ReadOnlySpan<byte> utf8bytes, string value)
-        {
-            if (utf8bytes.Length < value.Length)
-                return false;
-
-            for (int i = 0; i < value.Length; i++)
-            {
-                int ch = utf8bytes[i];
-                if (ch > 0x7F)
-                    return System.Text.Encoding.UTF8.GetString(utf8bytes) == value;
-
-                // We are assuming here that valid UTF8 encoded byte > 0x7F cannot map to a character with code point <= 0x7F
-                if (ch != value[i])
-                    return false;
-            }
-
-            return utf8bytes.Length == value.Length; // All char ANSI, all matching
-        }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
+++ b/src/coreclr/tools/Common/Compiler/InstructionSetSupport.cs
@@ -61,7 +61,7 @@ namespace ILCompiler
                 return "";
 
             // 64-bit ISA variants are not included in the mapping dictionary, so we use the containing type instead
-            if (potentialType.Name.SequenceEqual("X64"u8) || potentialType.Name.SequenceEqual("Arm64"u8))
+            if (potentialType.Name == "X64"u8 || potentialType.Name == "Arm64"u8)
             {
                 if (architecture is TargetArchitecture.X64 or TargetArchitecture.ARM64)
                     potentialType = potentialType.ContainingType;
@@ -79,12 +79,12 @@ namespace ILCompiler
 
             if (architecture is TargetArchitecture.X64 or TargetArchitecture.X86)
             {
-                if (!potentialType.Namespace.SequenceEqual("System.Runtime.Intrinsics.X86"u8))
+                if (potentialType.Namespace != "System.Runtime.Intrinsics.X86"u8)
                     return "";
             }
             else if (architecture is TargetArchitecture.ARM64 or TargetArchitecture.ARM)
             {
-                if (!potentialType.Namespace.SequenceEqual("System.Runtime.Intrinsics.Arm"u8))
+                if (potentialType.Namespace != "System.Runtime.Intrinsics.Arm"u8)
                     return "";
             }
             else if (architecture is TargetArchitecture.LoongArch64)

--- a/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/Int128FieldLayoutAlgorithm.cs
@@ -84,8 +84,8 @@ namespace ILCompiler
         public static bool IsIntegerType(DefType type)
         {
             return type.IsIntrinsic
-                && type.Namespace.SequenceEqual("System"u8)
-                && (type.Name.SequenceEqual("Int128"u8) || type.Name.SequenceEqual("UInt128"u8));
+                && type.Namespace == "System"u8
+                && (type.Name == "Int128"u8 || type.Name == "UInt128"u8);
         }
     }
 }

--- a/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -142,11 +143,11 @@ namespace ILCompiler
 
             if (ret is MetadataType md
                 && md.Module == method.Context.SystemModule
-                && md.Namespace.SequenceEqual("System.Threading.Tasks"u8))
+                && md.Namespace == "System.Threading.Tasks"u8)
             {
-                ReadOnlySpan<byte> name = md.Name;
-                if (name.SequenceEqual("Task"u8) || name.SequenceEqual("Task`1"u8)
-                    || name.SequenceEqual("ValueTask"u8) || name.SequenceEqual("ValueTask`1"u8))
+                Utf8StringRef name = md.Name;
+                if (name == "Task"u8 || name == "Task`1"u8
+                    || name == "ValueTask"u8 || name == "ValueTask`1"u8)
                 {
                     return true;
                 }

--- a/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
@@ -145,7 +145,7 @@ namespace ILCompiler
                 && md.Module == method.Context.SystemModule
                 && md.Namespace == "System.Threading.Tasks"u8)
             {
-                Utf8StringRef name = md.Name;
+                Utf8Span name = md.Name;
                 if (name == "Task"u8 || name == "Task`1"u8
                     || name == "ValueTask"u8 || name == "ValueTask`1"u8)
                 {

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -40,8 +40,10 @@ namespace ILCompiler
         public override Utf8String SanitizeName(Utf8String s)
             => SanitizeName(s.AsSpan());
 
-        private static Utf8String SanitizeName(ReadOnlySpan<byte> s)
+        private static Utf8String SanitizeName(Utf8StringRef n)
         {
+            ReadOnlySpan<byte> s = n.AsSpan();
+
             Utf8StringBuilder sb = null;
             for (int i = 0; i < s.Length; i++)
             {
@@ -98,7 +100,7 @@ namespace ILCompiler
             return bytes.IndexOf(replacementCharacter) >= 0;
         }
 
-        private Utf8String SanitizeNameWithHash(Utf8String literal, byte[] hash = null)
+        private static Utf8String SanitizeNameWithHash(Utf8String literal, byte[] hash = null)
         {
             Utf8String mangledName = SanitizeName(literal);
 
@@ -242,7 +244,7 @@ namespace ILCompiler
                                 }
                                 else
                                 {
-                                    ReadOnlySpan<byte> ns = t.Namespace;
+                                    Utf8StringRef ns = t.Namespace;
                                     if (ns.Length > 0)
                                         sb.Append(SanitizeName(ns)).Append('_');
                                 }

--- a/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NativeAotNameMangler.cs
@@ -40,7 +40,7 @@ namespace ILCompiler
         public override Utf8String SanitizeName(Utf8String s)
             => SanitizeName(s.AsSpan());
 
-        private static Utf8String SanitizeName(Utf8StringRef n)
+        private static Utf8String SanitizeName(Utf8Span n)
         {
             ReadOnlySpan<byte> s = n.AsSpan();
 
@@ -244,7 +244,7 @@ namespace ILCompiler
                                 }
                                 else
                                 {
-                                    Utf8StringRef ns = t.Namespace;
+                                    Utf8Span ns = t.Namespace;
                                     if (ns.Length > 0)
                                         sb.Append(SanitizeName(ns)).Append('_');
                                 }

--- a/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
@@ -67,7 +67,7 @@ namespace ILCompiler
                 }
 
                 public TypeSystemException Exception { get; }
-                public override Utf8StringRef Name => _name;
+                public override Utf8Span Name => _name;
                 public override MethodIL EmitIL()
                 {
 #if READYTORUN

--- a/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeMapMetadata.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.IL;
 using Internal.IL.Stubs;
 using Internal.TypeSystem;
@@ -26,13 +27,13 @@ namespace ILCompiler
         private static TypeMapAttributeKind LookupTypeMapType(TypeDesc attrType)
         {
             var typeDef = attrType.GetTypeDefinition() as MetadataType;
-            if (typeDef != null && typeDef.Namespace.SequenceEqual("System.Runtime.InteropServices"u8))
+            if (typeDef != null && typeDef.Namespace == "System.Runtime.InteropServices"u8)
             {
-                if (typeDef.Name.SequenceEqual("TypeMapAssemblyTargetAttribute`1"u8))
+                if (typeDef.Name == "TypeMapAssemblyTargetAttribute`1"u8)
                     return TypeMapAttributeKind.TypeMapAssemblyTarget;
-                else if (typeDef.Name.SequenceEqual("TypeMapAttribute`1"u8))
+                else if (typeDef.Name == "TypeMapAttribute`1"u8)
                     return TypeMapAttributeKind.TypeMap;
-                else if (typeDef.Name.SequenceEqual("TypeMapAssociationAttribute`1"u8))
+                else if (typeDef.Name == "TypeMapAssociationAttribute`1"u8)
                     return TypeMapAttributeKind.TypeMapAssociation;
             }
             return TypeMapAttributeKind.None;
@@ -66,7 +67,7 @@ namespace ILCompiler
                 }
 
                 public TypeSystemException Exception { get; }
-                public override ReadOnlySpan<byte> Name => _name;
+                public override Utf8StringRef Name => _name;
                 public override MethodIL EmitIL()
                 {
 #if READYTORUN
@@ -78,7 +79,7 @@ namespace ILCompiler
 
                 protected override int CompareToImpl(MethodDesc other, TypeSystemComparer comparer)
                 {
-                    return Name.SequenceCompareTo(other.Name);
+                    return Name.AsSpan().SequenceCompareTo(other.Name.AsSpan());
                 }
 
                 public override bool IsPInvoke => false;

--- a/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/Common/Compiler/VectorFieldLayoutAlgorithm.cs
@@ -27,11 +27,11 @@ namespace ILCompiler
 
             LayoutInt alignment;
 
-            if (defType.Name.SequenceEqual("Vector64`1"u8))
+            if (defType.Name == "Vector64`1"u8)
             {
                 alignment = new LayoutInt(8);
             }
-            else if (defType.Name.SequenceEqual("Vector128`1"u8))
+            else if (defType.Name == "Vector128`1"u8)
             {
                 if (defType.Context.Target.Architecture == TargetArchitecture.ARM)
                 {
@@ -43,7 +43,7 @@ namespace ILCompiler
                     alignment = new LayoutInt(16);
                 }
             }
-            else if (defType.Name.SequenceEqual("Vector256`1"u8))
+            else if (defType.Name == "Vector256`1"u8)
             {
                 if (defType.Context.Target.Architecture == TargetArchitecture.ARM)
                 {
@@ -76,7 +76,7 @@ namespace ILCompiler
             }
             else
             {
-                Debug.Assert(defType.Name.SequenceEqual("Vector512`1"u8));
+                Debug.Assert(defType.Name == "Vector512`1"u8);
 
                 if (defType.Context.Target.Architecture == TargetArchitecture.ARM)
                 {
@@ -164,11 +164,11 @@ namespace ILCompiler
         public static bool IsVectorType(DefType type)
         {
             return type.IsIntrinsic &&
-                type.Namespace.SequenceEqual("System.Runtime.Intrinsics"u8) &&
-                (type.Name.SequenceEqual("Vector64`1"u8) ||
-                 type.Name.SequenceEqual("Vector128`1"u8) ||
-                 type.Name.SequenceEqual("Vector256`1"u8) ||
-                 type.Name.SequenceEqual("Vector512`1"u8));
+                type.Namespace == "System.Runtime.Intrinsics"u8 &&
+                (type.Name == "Vector64`1"u8 ||
+                 type.Name == "Vector128`1"u8 ||
+                 type.Name == "Vector256`1"u8 ||
+                 type.Name == "Vector512`1"u8);
         }
     }
 }

--- a/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/EETypeBuilderHelpers.cs
@@ -187,8 +187,8 @@ namespace Internal.Runtime
 
             if (type is MetadataType mdType &&
                             mdType.Module == mdType.Context.SystemModule &&
-                            (mdType.Name.SequenceEqual("WeakReference"u8) || mdType.Name.SequenceEqual("WeakReference`1"u8)) &&
-                            mdType.Namespace.SequenceEqual("System"u8))
+                            (mdType.Name == "WeakReference"u8 || mdType.Name == "WeakReference`1"u8) &&
+                            mdType.Namespace == "System"u8)
             {
                 flagsEx |= (ushort)EETypeFlagsEx.HasEagerFinalizerFlag;
             }
@@ -273,8 +273,8 @@ namespace Internal.Runtime
 
                 if (type is MetadataType mdType &&
                             mdType.Module == mdType.Context.SystemModule &&
-                            mdType.Name.SequenceEqual("CriticalFinalizerObject"u8) &&
-                            mdType.Namespace.SequenceEqual("System.Runtime.ConstrainedExecution"u8))
+                            mdType.Name == "CriticalFinalizerObject"u8 &&
+                            mdType.Namespace == "System.Runtime.ConstrainedExecution"u8)
                     return true;
 
                 type = type.BaseType;

--- a/src/coreclr/tools/Common/Internal/Text/Utf8Span.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8Span.cs
@@ -8,11 +8,11 @@ using System.Text;
 
 namespace Internal.Text
 {
-    public readonly ref struct Utf8StringRef
+    public readonly ref struct Utf8Span
     {
         private readonly ReadOnlySpan<byte> _value;
 
-        public Utf8StringRef(ReadOnlySpan<byte> value) => _value = value;
+        public Utf8Span(ReadOnlySpan<byte> value) => _value = value;
 
         public int Length => _value.Length;
 
@@ -22,9 +22,9 @@ namespace Internal.Text
 
         public byte[] ToArray() => _value.ToArray();
 
-        public bool StartsWith(Utf8StringRef value) => _value.StartsWith(value.AsSpan());
+        public bool StartsWith(Utf8Span value) => _value.StartsWith(value.AsSpan());
 
-        public bool EndsWith(Utf8StringRef value) => _value.EndsWith(value.AsSpan());
+        public bool EndsWith(Utf8Span value) => _value.EndsWith(value.AsSpan());
 
         // This is deliberately not a == operator because we don't want to make it easy
         // to accidentally do UTF-8 vs UTF-16 string comparisons.
@@ -58,12 +58,12 @@ namespace Internal.Text
 
         public override string ToString() => Encoding.UTF8.GetString(_value);
 
-        public static implicit operator Utf8StringRef(ReadOnlySpan<byte> s) => new Utf8StringRef(s);
+        public static implicit operator Utf8Span(ReadOnlySpan<byte> s) => new Utf8Span(s);
 
-        public static bool operator ==(Utf8StringRef left, Utf8StringRef right)
+        public static bool operator ==(Utf8Span left, Utf8Span right)
             => left._value.SequenceEqual(right._value);
 
-        public static bool operator !=(Utf8StringRef left, Utf8StringRef right)
+        public static bool operator !=(Utf8Span left, Utf8Span right)
             => !left._value.SequenceEqual(right._value);
     }
 }

--- a/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
@@ -29,7 +29,7 @@ namespace Internal.Text
             _value = Encoding.UTF8.GetBytes(s);
         }
 
-        public static implicit operator Utf8StringRef(Utf8String s) => s._value;
+        public static implicit operator Utf8Span(Utf8String s) => s._value;
 
         public int Length => _value.Length;
 

--- a/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
@@ -29,6 +29,8 @@ namespace Internal.Text
             _value = Encoding.UTF8.GetBytes(s);
         }
 
+        public static implicit operator Utf8StringRef(Utf8String s) => s._value;
+
         public int Length => _value.Length;
 
         public ReadOnlySpan<byte> AsSpan() => _value;

--- a/src/coreclr/tools/Common/Internal/Text/Utf8StringBuilder.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8StringBuilder.cs
@@ -43,7 +43,7 @@ namespace Internal.Text
             return Append(value.AsSpan());
         }
 
-        public Utf8StringBuilder Append(Utf8StringRef value)
+        public Utf8StringBuilder Append(Utf8Span value)
         {
             return Append(value.AsSpan());
         }

--- a/src/coreclr/tools/Common/Internal/Text/Utf8StringBuilder.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8StringBuilder.cs
@@ -43,6 +43,11 @@ namespace Internal.Text
             return Append(value.AsSpan());
         }
 
+        public Utf8StringBuilder Append(Utf8StringRef value)
+        {
+            return Append(value.AsSpan());
+        }
+
         public Utf8StringBuilder Append(ReadOnlySpan<byte> value)
         {
             Ensure(value.Length);

--- a/src/coreclr/tools/Common/Internal/Text/Utf8StringRef.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8StringRef.cs
@@ -1,0 +1,69 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Text;
+
+namespace Internal.Text
+{
+    public readonly ref struct Utf8StringRef
+    {
+        private readonly ReadOnlySpan<byte> _value;
+
+        public Utf8StringRef(ReadOnlySpan<byte> value) => _value = value;
+
+        public int Length => _value.Length;
+
+        public bool IsEmpty => _value.IsEmpty;
+
+        public ReadOnlySpan<byte> AsSpan() => _value;
+
+        public byte[] ToArray() => _value.ToArray();
+
+        public bool StartsWith(Utf8StringRef value) => _value.StartsWith(value.AsSpan());
+
+        public bool EndsWith(Utf8StringRef value) => _value.EndsWith(value.AsSpan());
+
+        // This is deliberately not a == operator because we don't want to make it easy
+        // to accidentally do UTF-8 vs UTF-16 string comparisons.
+        public bool StringEquals(string value)
+        {
+            if (_value.Length < value.Length)
+                return false;
+
+            for (int i = 0; i < value.Length; i++)
+            {
+                int ch = _value[i];
+                if (ch > 0x7F)
+                    return Encoding.UTF8.GetString(_value) == value;
+
+                // We are assuming here that valid UTF8 encoded byte > 0x7F cannot map to a character with code point <= 0x7F
+                if (ch != value[i])
+                    return false;
+            }
+
+            return _value.Length == value.Length; // All char ANSI, all matching
+        }
+
+        public override bool Equals(object obj) => false;
+
+        public override int GetHashCode()
+        {
+            HashCode h = default;
+            h.AddBytes(_value);
+            return h.ToHashCode();
+        }
+
+        public override string ToString() => Encoding.UTF8.GetString(_value);
+
+        public static implicit operator Utf8StringRef(ReadOnlySpan<byte> s) => new Utf8StringRef(s);
+
+        public static bool operator ==(Utf8StringRef left, Utf8StringRef right)
+            => left._value.SequenceEqual(right._value);
+
+        public static bool operator !=(Utf8StringRef left, Utf8StringRef right)
+            => !left._value.SequenceEqual(right._value);
+    }
+}

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -12,6 +12,8 @@ using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Text.Unicode;
 
+using Internal.Text;
+
 #if SUPPORT_JIT
 using Internal.Runtime.CompilerServices;
 #endif
@@ -1155,7 +1157,7 @@ namespace Internal.JitInterface
                 result |= CorInfoFlag.CORINFO_FLG_FORCEINLINE;
             }
 
-            if (method.OwningType.IsDelegate && method.Name.SequenceEqual("Invoke"u8))
+            if (method.OwningType.IsDelegate && method.Name == "Invoke"u8)
             {
                 // This is now used to emit efficient invoke code for any delegate invoke,
                 // including multicast.
@@ -1769,7 +1771,7 @@ namespace Internal.JitInterface
                     Debug.Assert((methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
                         (!methodContext.HasInstantiation && !owningMethod.HasInstantiation) ||
                         methodContext.GetTypicalMethodDefinition() == owningMethod.GetTypicalMethodDefinition() ||
-                        (owningMethod.Name.SequenceEqual("CreateDefaultInstance"u8) && methodContext.Name.SequenceEqual("CreateInstance"u8)));
+                        (owningMethod.Name == "CreateDefaultInstance"u8 && methodContext.Name == "CreateInstance"u8));
                     Debug.Assert(methodContext.OwningType.HasSameTypeDefinition(owningMethod.OwningType));
                     typeInst = methodContext.OwningType.Instantiation;
                     methodInst = methodContext.Instantiation;
@@ -2093,8 +2095,8 @@ namespace Internal.JitInterface
             else if (type is MetadataType mdType)
             {
                 if (namespaceName != null)
-                    *namespaceName = (byte*)GetPin(SpanToPinnableBytes(mdType.Namespace));
-                return (byte*)GetPin(SpanToPinnableBytes(mdType.Name));
+                    *namespaceName = (byte*)GetPin(Utf8StringRefToPinnableBytes(mdType.Namespace));
+                return (byte*)GetPin(Utf8StringRefToPinnableBytes(mdType.Name));
             }
 
             if (namespaceName != null)
@@ -2583,8 +2585,8 @@ namespace Internal.JitInterface
             // not care about since they are considered primitives by the JIT.
             if (type.IsIntrinsic)
             {
-                ReadOnlySpan<byte> ns = type.Namespace;
-                if (ns.SequenceEqual("System.Runtime.Intrinsics"u8) || ns.SequenceEqual("System.Numerics"u8))
+                Utf8StringRef ns = type.Namespace;
+                if (ns == "System.Runtime.Intrinsics"u8 || ns == "System.Numerics"u8)
                 {
                     parNode->simdTypeHnd = ObjectToHandle(type);
                     if (parentIndex != uint.MaxValue)
@@ -3065,9 +3067,9 @@ namespace Internal.JitInterface
             // non-candidates before we compare names.
             if (type.IsIntrinsic && type is MetadataType mdType)
             {
-                ReadOnlySpan<byte> name = mdType.Name;
-                if ((name.SequenceEqual("SZArrayHelper"u8) || name.SequenceEqual("Array`1"u8)) &&
-                    mdType.Namespace.SequenceEqual("System"u8))
+                Utf8StringRef name = mdType.Name;
+                if ((name == "SZArrayHelper"u8 || name == "Array`1"u8) &&
+                    mdType.Namespace == "System"u8)
                 {
                     return false;
                 }
@@ -3265,16 +3267,16 @@ namespace Internal.JitInterface
             var owningType = field.OwningType;
             if ((owningType.IsWellKnownType(WellKnownType.IntPtr) ||
                     owningType.IsWellKnownType(WellKnownType.UIntPtr)) &&
-                        field.Name.SequenceEqual("Zero"u8))
+                        field.Name == "Zero"u8)
             {
                 return CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INTRINSIC_ZERO;
             }
-            else if (owningType.IsString && field.Name.SequenceEqual("Empty"u8))
+            else if (owningType.IsString && field.Name == "Empty"u8)
             {
                 return CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INTRINSIC_EMPTY_STRING;
             }
-            else if (owningType.Name.SequenceEqual("BitConverter"u8) && owningType.Namespace.SequenceEqual("System"u8) &&
-                field.Name.SequenceEqual("IsLittleEndian"u8))
+            else if (owningType.Name == "BitConverter"u8 && owningType.Namespace == "System"u8 &&
+                field.Name == "IsLittleEndian"u8)
             {
                 return CORINFO_FIELD_ACCESSOR.CORINFO_FIELD_INTRINSIC_ISLITTLEENDIAN;
             }
@@ -3536,10 +3538,10 @@ namespace Internal.JitInterface
             return bytes;
         }
 
-        private static byte[] SpanToPinnableBytes(ReadOnlySpan<byte> s)
+        private static byte[] Utf8StringRefToPinnableBytes(Utf8StringRef s)
         {
             byte[] bytes = new byte[s.Length + 1];
-            s.CopyTo(bytes);
+            s.AsSpan().CopyTo(bytes);
             return bytes;
         }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -2095,8 +2095,8 @@ namespace Internal.JitInterface
             else if (type is MetadataType mdType)
             {
                 if (namespaceName != null)
-                    *namespaceName = (byte*)GetPin(Utf8StringRefToPinnableBytes(mdType.Namespace));
-                return (byte*)GetPin(Utf8StringRefToPinnableBytes(mdType.Name));
+                    *namespaceName = (byte*)GetPin(Utf8SpanToPinnableBytes(mdType.Namespace));
+                return (byte*)GetPin(Utf8SpanToPinnableBytes(mdType.Name));
             }
 
             if (namespaceName != null)
@@ -2585,7 +2585,7 @@ namespace Internal.JitInterface
             // not care about since they are considered primitives by the JIT.
             if (type.IsIntrinsic)
             {
-                Utf8StringRef ns = type.Namespace;
+                Utf8Span ns = type.Namespace;
                 if (ns == "System.Runtime.Intrinsics"u8 || ns == "System.Numerics"u8)
                 {
                     parNode->simdTypeHnd = ObjectToHandle(type);
@@ -3067,7 +3067,7 @@ namespace Internal.JitInterface
             // non-candidates before we compare names.
             if (type.IsIntrinsic && type is MetadataType mdType)
             {
-                Utf8StringRef name = mdType.Name;
+                Utf8Span name = mdType.Name;
                 if ((name == "SZArrayHelper"u8 || name == "Array`1"u8) &&
                     mdType.Namespace == "System"u8)
                 {
@@ -3538,7 +3538,7 @@ namespace Internal.JitInterface
             return bytes;
         }
 
-        private static byte[] Utf8StringRefToPinnableBytes(Utf8StringRef s)
+        private static byte[] Utf8SpanToPinnableBytes(Utf8Span s)
         {
             byte[] bytes = new byte[s.Length + 1];
             s.AsSpan().CopyTo(bytes);

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Internal.NativeFormat;
+using Internal.Text;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -35,7 +36,7 @@ namespace Internal.TypeSystem
 
         public override bool IsModuleType => false;
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
         {
             return null;
         }
@@ -45,7 +46,7 @@ namespace Internal.TypeSystem
             return default(ClassLayoutMetadata);
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             return null;
         }

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.Metadata.cs
@@ -36,7 +36,7 @@ namespace Internal.TypeSystem
 
         public override bool IsModuleType => false;
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
         {
             return null;
         }
@@ -46,7 +46,7 @@ namespace Internal.TypeSystem
             return default(ClassLayoutMetadata);
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             return null;
         }

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Internal.NativeFormat;
+using Internal.Text;
 
 using Debug = System.Diagnostics.Debug;
 
@@ -65,7 +66,7 @@ namespace Internal.TypeSystem
     {
         private int _hashcode;
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -73,7 +74,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -149,7 +150,7 @@ namespace Internal.TypeSystem
     {
         private int _hashcode;
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -157,7 +158,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Canon/CanonTypes.cs
@@ -66,7 +66,7 @@ namespace Internal.TypeSystem
     {
         private int _hashcode;
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -74,7 +74,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -150,7 +150,7 @@ namespace Internal.TypeSystem
     {
         private int _hashcode;
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -158,7 +158,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -299,7 +301,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ArrayType.cs
@@ -301,7 +301,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/CastingHelper.TypeEquivalence.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/CastingHelper.TypeEquivalence.cs
@@ -128,10 +128,10 @@ namespace Internal.TypeSystem
                 if (!data1.Equals(data2))
                     return false;
 
-                if (!type1.Name.SequenceEqual(type2.Name))
+                if (type1.Name != type2.Name)
                     return false;
 
-                if (!type1.Namespace.SequenceEqual(type2.Namespace))
+                if (type1.Namespace != type2.Namespace)
                     return false;
 
                 var containingType1 = (MetadataType)type1.ContainingType;

--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.cs
@@ -18,7 +18,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the namespace of the type.
         /// </summary>
-        public virtual Utf8StringRef Namespace => Array.Empty<byte>();
+        public virtual Utf8Span Namespace => Array.Empty<byte>();
 
         public string GetNamespace() => System.Text.Encoding.UTF8.GetString(Namespace
 #if NETSTANDARD
@@ -31,7 +31,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the name of the type as represented in the metadata.
         /// </summary>
-        public virtual Utf8StringRef Name => Array.Empty<byte>();
+        public virtual Utf8Span Name => Array.Empty<byte>();
 
         public string GetName() => System.Text.Encoding.UTF8.GetString(Name
 #if NETSTANDARD

--- a/src/coreclr/tools/Common/TypeSystem/Common/DefType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/DefType.cs
@@ -5,6 +5,8 @@ using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -16,22 +18,26 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the namespace of the type.
         /// </summary>
-        public virtual ReadOnlySpan<byte> Namespace => [];
+        public virtual Utf8StringRef Namespace => Array.Empty<byte>();
 
         public string GetNamespace() => System.Text.Encoding.UTF8.GetString(Namespace
 #if NETSTANDARD
             .ToArray()
+#else
+            .AsSpan()
 #endif
             );
 
         /// <summary>
         /// Gets the name of the type as represented in the metadata.
         /// </summary>
-        public virtual ReadOnlySpan<byte> Name => [];
+        public virtual Utf8StringRef Name => Array.Empty<byte>();
 
         public string GetName() => System.Text.Encoding.UTF8.GetString(Name
 #if NETSTANDARD
             .ToArray()
+#else
+            .AsSpan()
 #endif
             );
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
@@ -31,7 +31,7 @@ namespace Internal.TypeSystem
             return ReferenceEquals(this, o);
         }
 
-        public virtual Utf8StringRef Name
+        public virtual Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldDesc.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
-
+using Internal.Text;
 using Debug = System.Diagnostics.Debug;
 
 #if TYPE_LOADER_IMPLEMENTATION
@@ -31,18 +31,18 @@ namespace Internal.TypeSystem
             return ReferenceEquals(this, o);
         }
 
-        public virtual ReadOnlySpan<byte> Name
+        public virtual Utf8StringRef Name
         {
             get
             {
-                return [];
+                return Array.Empty<byte>();
             }
         }
 
         public string GetName()
         {
             return System.Text.Encoding.UTF8.GetString(
-                Name
+                Name.AsSpan()
 #if NETSTANDARD
                 .ToArray()
 #endif

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -40,7 +40,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/FieldForInstantiatedType.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using Debug = System.Diagnostics.Debug;
 
+using Internal.Text;
+
+using Debug = System.Diagnostics.Debug;
 #if TYPE_LOADER_IMPLEMENTATION
 using MetadataType = Internal.TypeSystem.DefType;
 #endif
@@ -38,7 +40,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/IAssemblyDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/IAssemblyDesc.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Reflection.Metadata;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -19,6 +21,6 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the simple assembly name
         /// </summary>
-        ReadOnlySpan<byte> Name { get; }
+        Utf8StringRef Name { get; }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/IAssemblyDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/IAssemblyDesc.cs
@@ -21,6 +21,6 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the simple assembly name
         /// </summary>
-        Utf8StringRef Name { get; }
+        Utf8Span Name { get; }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
@@ -44,6 +44,6 @@ namespace Internal.TypeSystem
 
         public override MarshalAsDescriptor GetMarshalAsDescriptor() => _underlyingFieldDesc.GetMarshalAsDescriptor();
 
-        public override Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes($"{_underlyingFieldDesc.GetName()}[{FieldIndex}]");
+        public override Utf8Span Name => System.Text.Encoding.UTF8.GetBytes($"{_underlyingFieldDesc.GetName()}[{FieldIndex}]");
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ImpliedRepeatedFieldDesc.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public sealed partial class ImpliedRepeatedFieldDesc : FieldDesc
@@ -42,6 +44,6 @@ namespace Internal.TypeSystem
 
         public override MarshalAsDescriptor GetMarshalAsDescriptor() => _underlyingFieldDesc.GetMarshalAsDescriptor();
 
-        public override ReadOnlySpan<byte> Name => System.Text.Encoding.UTF8.GetBytes($"{_underlyingFieldDesc.GetName()}[{FieldIndex}]");
+        public override Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes($"{_underlyingFieldDesc.GetName()}[{FieldIndex}]");
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -168,7 +168,7 @@ namespace Internal.TypeSystem
             return _methodDef.GetTypicalMethodDefinition();
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedMethod.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Diagnostics;
+
 using Internal.NativeFormat;
+using Internal.Text;
 
 namespace Internal.TypeSystem
 {
@@ -166,7 +168,7 @@ namespace Internal.TypeSystem
             return _methodDef.GetTypicalMethodDefinition();
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
@@ -95,7 +95,7 @@ namespace Internal.TypeSystem
             return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             // Return the result from the typical type definition.
             return _typeDef.GetNestedType(name);

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.Metadata.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public sealed partial class InstantiatedType : MetadataType
@@ -93,7 +95,7 @@ namespace Internal.TypeSystem
             return _typeDef.HasCustomAttribute(attributeNamespace, attributeName);
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             // Return the result from the typical type definition.
             return _typeDef.GetNestedType(name);

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.MethodImpls.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     // Implementation of MethodImpl api surface implemented without metadata access.
@@ -47,7 +49,7 @@ namespace Internal.TypeSystem
             return InstantiateMethodImpls(uninstMethodImpls);
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
         {
             MethodImplRecord[] uninstMethodImpls = _typeDef.FindMethodsImplWithMatchingDeclName(name);
             return InstantiateMethodImpls(uninstMethodImpls);

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.MethodImpls.cs
@@ -49,7 +49,7 @@ namespace Internal.TypeSystem
             return InstantiateMethodImpls(uninstMethodImpls);
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
         {
             MethodImplRecord[] uninstMethodImpls = _typeDef.FindMethodsImplWithMatchingDeclName(name);
             return InstantiateMethodImpls(uninstMethodImpls);

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -128,7 +128,7 @@ namespace Internal.TypeSystem
             return flags;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -136,7 +136,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -161,7 +161,7 @@ namespace Internal.TypeSystem
         }
 
         // TODO: Substitutions, generics, modopts, ...
-        public override MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethod(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc typicalMethodDef = _typeDef.GetMethod(name, signature, substitution);
             if (typicalMethodDef == null)
@@ -169,7 +169,7 @@ namespace Internal.TypeSystem
             return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
         }
 
-        public override MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethodWithEquivalentSignature(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc typicalMethodDef = _typeDef.GetMethodWithEquivalentSignature(name, signature, substitution);
             if (typicalMethodDef == null)
@@ -231,7 +231,7 @@ namespace Internal.TypeSystem
         }
 
         // TODO: Substitutions, generics, modopts, ...
-        public override FieldDesc GetField(Utf8StringRef name)
+        public override FieldDesc GetField(Utf8Span name)
         {
             FieldDesc fieldDef = _typeDef.GetField(name);
             if (fieldDef == null)

--- a/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/InstantiatedType.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
 #if TYPE_LOADER_IMPLEMENTATION
 using MetadataType = Internal.TypeSystem.DefType;
 #endif
@@ -127,7 +128,7 @@ namespace Internal.TypeSystem
             return flags;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -135,7 +136,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -160,7 +161,7 @@ namespace Internal.TypeSystem
         }
 
         // TODO: Substitutions, generics, modopts, ...
-        public override MethodDesc GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc typicalMethodDef = _typeDef.GetMethod(name, signature, substitution);
             if (typicalMethodDef == null)
@@ -168,7 +169,7 @@ namespace Internal.TypeSystem
             return _typeDef.Context.GetMethodForInstantiatedType(typicalMethodDef, this);
         }
 
-        public override MethodDesc GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc typicalMethodDef = _typeDef.GetMethodWithEquivalentSignature(name, signature, substitution);
             if (typicalMethodDef == null)
@@ -230,7 +231,7 @@ namespace Internal.TypeSystem
         }
 
         // TODO: Substitutions, generics, modopts, ...
-        public override FieldDesc GetField(ReadOnlySpan<byte> name)
+        public override FieldDesc GetField(Utf8StringRef name)
         {
             FieldDesc fieldDef = _typeDef.GetField(name);
             if (fieldDef == null)

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.MethodImpls.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public struct MethodImplRecord
@@ -46,6 +48,6 @@ namespace Internal.TypeSystem
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public abstract MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name);
+        public abstract MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name);
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.MethodImpls.cs
@@ -48,6 +48,6 @@ namespace Internal.TypeSystem
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        public abstract MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name);
+        public abstract MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name);
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -13,9 +15,9 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class MetadataType : DefType
     {
-        public abstract override ReadOnlySpan<byte> Name { get; }
+        public abstract override Utf8StringRef Name { get; }
 
-        public abstract override ReadOnlySpan<byte> Namespace { get; }
+        public abstract override Utf8StringRef Namespace { get; }
 
         /// <summary>
         /// Gets metadata that controls instance layout of this type.
@@ -98,7 +100,7 @@ namespace Internal.TypeSystem
         /// Get a specific type nested in this type. Returns null if the type
         /// doesn't exist.
         /// </summary>
-        public abstract MetadataType GetNestedType(ReadOnlySpan<byte> name);
+        public abstract MetadataType GetNestedType(Utf8StringRef name);
 
         /// <summary>
         /// Gets a value indicating whether this is an inline array type

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataType.cs
@@ -15,9 +15,9 @@ namespace Internal.TypeSystem
     /// </summary>
     public abstract partial class MetadataType : DefType
     {
-        public abstract override Utf8StringRef Name { get; }
+        public abstract override Utf8Span Name { get; }
 
-        public abstract override Utf8StringRef Namespace { get; }
+        public abstract override Utf8Span Namespace { get; }
 
         /// <summary>
         /// Gets metadata that controls instance layout of this type.
@@ -100,7 +100,7 @@ namespace Internal.TypeSystem
         /// Get a specific type nested in this type. Returns null if the type
         /// doesn't exist.
         /// </summary>
-        public abstract MetadataType GetNestedType(Utf8StringRef name);
+        public abstract MetadataType GetNestedType(Utf8Span name);
 
         /// <summary>
         /// Gets a value indicating whether this is an inline array type

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataTypeSystemContext.cs
@@ -106,8 +106,8 @@ namespace Internal.TypeSystem
         {
             MetadataType t = (MetadataType)type;
             return t.Module == SystemModule
-                && t.Name.SequenceEqual("IDynamicInterfaceCastable"u8)
-                && t.Namespace.SequenceEqual("System.Runtime.InteropServices"u8);
+                && t.Name == "IDynamicInterfaceCastable"u8
+                && t.Namespace == "System.Runtime.InteropServices"u8;
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public class MetadataVirtualMethodAlgorithm : VirtualMethodAlgorithm
@@ -377,14 +379,14 @@ namespace Internal.TypeSystem
         /// <returns></returns>
         private static MethodDesc FindMatchingVirtualMethodOnTypeByNameAndSig(MethodDesc targetMethod, DefType currentType, bool reverseMethodSearch, Func<MethodDesc, MethodDesc, bool> nameSigMatchMethodIsValidCandidate)
         {
-            ReadOnlySpan<byte> name = targetMethod.Name;
+            Utf8StringRef name = targetMethod.Name;
             MethodSignature sig = targetMethod.Signature;
 
             MethodDesc implMethod = null;
             MethodDesc implMethodEquivalent = null;
             foreach (MethodDesc candidate in currentType.GetAllVirtualMethods())
             {
-                if (candidate.Name.SequenceEqual(name))
+                if (candidate.Name == name)
                 {
                     if (candidate.Signature.EquivalentTo(sig))
                     {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -379,7 +379,7 @@ namespace Internal.TypeSystem
         /// <returns></returns>
         private static MethodDesc FindMatchingVirtualMethodOnTypeByNameAndSig(MethodDesc targetMethod, DefType currentType, bool reverseMethodSearch, Func<MethodDesc, MethodDesc, bool> nameSigMatchMethodIsValidCandidate)
         {
-            Utf8StringRef name = targetMethod.Name;
+            Utf8Span name = targetMethod.Name;
             MethodSignature sig = targetMethod.Signature;
 
             MethodDesc implMethod = null;

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
@@ -30,7 +30,7 @@ namespace Internal.TypeSystem
         public override bool IsDefaultConstructor => _wrappedMethod.IsDefaultConstructor;
         public override bool IsStaticConstructor => _wrappedMethod.IsStaticConstructor;
 
-        public override Utf8StringRef Name => _wrappedMethod.Name;
+        public override Utf8Span Name => _wrappedMethod.Name;
 
         public override bool IsVirtual => _wrappedMethod.IsVirtual;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDelegator.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -28,7 +30,7 @@ namespace Internal.TypeSystem
         public override bool IsDefaultConstructor => _wrappedMethod.IsDefaultConstructor;
         public override bool IsStaticConstructor => _wrappedMethod.IsStaticConstructor;
 
-        public override ReadOnlySpan<byte> Name => _wrappedMethod.Name;
+        public override Utf8StringRef Name => _wrappedMethod.Name;
 
         public override bool IsVirtual => _wrappedMethod.IsVirtual;
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Internal.NativeFormat;
+using Internal.Text;
 
 namespace Internal.TypeSystem
 {
@@ -557,7 +558,7 @@ namespace Internal.TypeSystem
             {
                 // TODO: Precise check
                 // TODO: Cache?
-                return this.Name.SequenceEqual(".ctor"u8);
+                return this.Name == ".ctor"u8;
             }
         }
 
@@ -587,11 +588,11 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the name of the method as specified in the metadata.
         /// </summary>
-        public virtual ReadOnlySpan<byte> Name
+        public virtual Utf8StringRef Name
         {
             get
             {
-                return [];
+                return Array.Empty<byte>();
             }
         }
 
@@ -600,6 +601,8 @@ namespace Internal.TypeSystem
             return System.Text.Encoding.UTF8.GetString(Name
 #if NETSTANDARD
                 .ToArray()
+#else
+                .AsSpan()
 #endif
                 );
         }
@@ -727,7 +730,7 @@ namespace Internal.TypeSystem
             get
             {
                 TypeDesc owningType = OwningType;
-                return (owningType.IsObject && Name.SequenceEqual("Finalize"u8)) || (owningType.HasFinalizer && owningType.GetFinalizer() == this);
+                return (owningType.IsObject && Name == "Finalize"u8) || (owningType.HasFinalizer && owningType.GetFinalizer() == this);
             }
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -588,7 +588,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets the name of the method as specified in the metadata.
         /// </summary>
-        public virtual Utf8StringRef Name
+        public virtual Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using Internal.Text;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
@@ -153,7 +155,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodForInstantiatedType.cs
@@ -155,7 +155,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
@@ -36,7 +36,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a type in this module or null.
         /// </summary>
-        public MetadataType GetType(Utf8StringRef nameSpace, Utf8StringRef name, bool throwIfNotFound = true)
+        public MetadataType GetType(Utf8Span nameSpace, Utf8Span name, bool throwIfNotFound = true)
         {
             return (MetadataType)GetType(nameSpace, name, throwIfNotFound ? NotFoundBehavior.Throw : NotFoundBehavior.ReturnNull);
         }
@@ -44,7 +44,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a type in this module with the specified name, a resolution failure object, or null.
         /// </summary>
-        public abstract object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior);
+        public abstract object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior);
 
         /// <summary>
         /// Gets the global &lt;Module&gt; type.

--- a/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/ModuleDesc.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
+
 #if TYPE_LOADER_IMPLEMENTATION
 using MetadataType = Internal.TypeSystem.DefType;
 #endif
@@ -34,7 +36,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a type in this module or null.
         /// </summary>
-        public MetadataType GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, bool throwIfNotFound = true)
+        public MetadataType GetType(Utf8StringRef nameSpace, Utf8StringRef name, bool throwIfNotFound = true)
         {
             return (MetadataType)GetType(nameSpace, name, throwIfNotFound ? NotFoundBehavior.Throw : NotFoundBehavior.ReturnNull);
         }
@@ -42,7 +44,7 @@ namespace Internal.TypeSystem
         /// <summary>
         /// Gets a type in this module with the specified name, a resolution failure object, or null.
         /// </summary>
-        public abstract object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior);
+        public abstract object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior);
 
         /// <summary>
         /// Gets the global &lt;Module&gt; type.

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -520,7 +522,7 @@ namespace Internal.TypeSystem
         /// If signature is not specified and there are multiple matches, the first one
         /// is returned. Returns null if method not found.
         /// </summary>
-        public MethodDesc GetMethod(ReadOnlySpan<byte> name, MethodSignature signature)
+        public MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature)
         {
             return GetMethod(name, signature, default(Instantiation));
         }
@@ -532,11 +534,11 @@ namespace Internal.TypeSystem
         /// is returned. If substitution is not null, then substitution will be applied to
         /// possible target methods before signature comparison. Returns null if method not found.
         /// </summary>
-        public virtual MethodDesc GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public virtual MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             foreach (var method in GetMethods())
             {
-                if (method.Name.SequenceEqual(name))
+                if (method.Name == name)
                 {
                     if (signature == null || signature.Equals(method.Signature.ApplySubstitution(substitution)))
                         return method;
@@ -545,11 +547,11 @@ namespace Internal.TypeSystem
             return null;
         }
 
-        public virtual MethodDesc GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public virtual MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             foreach (var method in GetMethods())
             {
-                if (method.Name.SequenceEqual(name))
+                if (method.Name == name)
                 {
                     if (signature == null || signature.EquivalentTo(method.Signature.ApplySubstitution(substitution)))
                         return method;
@@ -589,11 +591,11 @@ namespace Internal.TypeSystem
         /// </summary>
         // TODO: Substitutions, generics, modopts, ...
         // TODO: field signature
-        public virtual FieldDesc GetField(ReadOnlySpan<byte> name)
+        public virtual FieldDesc GetField(Utf8StringRef name)
         {
             foreach (var field in GetFields())
             {
-                if (field.Name.SequenceEqual(name))
+                if (field.Name == name)
                     return field;
             }
             return null;

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeDesc.cs
@@ -522,7 +522,7 @@ namespace Internal.TypeSystem
         /// If signature is not specified and there are multiple matches, the first one
         /// is returned. Returns null if method not found.
         /// </summary>
-        public MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature)
+        public MethodDesc GetMethod(Utf8Span name, MethodSignature signature)
         {
             return GetMethod(name, signature, default(Instantiation));
         }
@@ -534,7 +534,7 @@ namespace Internal.TypeSystem
         /// is returned. If substitution is not null, then substitution will be applied to
         /// possible target methods before signature comparison. Returns null if method not found.
         /// </summary>
-        public virtual MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public virtual MethodDesc GetMethod(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             foreach (var method in GetMethods())
             {
@@ -547,7 +547,7 @@ namespace Internal.TypeSystem
             return null;
         }
 
-        public virtual MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public virtual MethodDesc GetMethodWithEquivalentSignature(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             foreach (var method in GetMethods())
             {
@@ -591,7 +591,7 @@ namespace Internal.TypeSystem
         /// </summary>
         // TODO: Substitutions, generics, modopts, ...
         // TODO: field signature
-        public virtual FieldDesc GetField(Utf8StringRef name)
+        public virtual FieldDesc GetField(Utf8Span name)
         {
             foreach (var field in GetFields())
             {

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public static class TypeSystemHelpers
@@ -431,12 +433,22 @@ namespace Internal.TypeSystem
             return false;
         }
 
-        public static ReadOnlySpan<T> Append<T>(this ReadOnlySpan<T> s1, ReadOnlySpan<T> s2)
+        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2)
         {
-            Span<T> buffer = new T[s1.Length + s2.Length];
+            Span<byte> buffer = new byte[s1.Length + s2.Length];
+
+            s1.AsSpan().CopyTo(buffer);
+            s2.AsSpan().CopyTo(buffer.Slice(s1.Length));
+
+            return buffer;
+        }
+
+        public static ReadOnlySpan<byte> Append(this ReadOnlySpan<byte> s1, Utf8StringRef s2)
+        {
+            Span<byte> buffer = new byte[s1.Length + s2.Length];
 
             s1.CopyTo(buffer);
-            s2.CopyTo(buffer.Slice(s1.Length));
+            s2.AsSpan().CopyTo(buffer.Slice(s1.Length));
 
             return buffer;
         }
@@ -452,16 +464,30 @@ namespace Internal.TypeSystem
             return buffer;
         }
 
-        public static ReadOnlySpan<byte> Append(this ReadOnlySpan<byte> s1, ReadOnlySpan<byte> s2, ReadOnlySpan<byte> s3, uint i)
+        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2, Utf8StringRef s3)
+        {
+            ReadOnlySpan<byte> s1Span = s1.AsSpan();
+            ReadOnlySpan<byte> s2Span = s2.AsSpan();
+            ReadOnlySpan<byte> s3Span = s3.AsSpan();
+            Span<byte> buffer = new byte[s1Span.Length + s2Span.Length + s3Span.Length];
+
+            s1Span.CopyTo(buffer);
+            s2Span.CopyTo(buffer.Slice(s1Span.Length));
+            s3Span.CopyTo(buffer.Slice(s1Span.Length + s2Span.Length));
+
+            return buffer;
+        }
+
+        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2, Utf8StringRef s3, uint i)
         {
             Span<byte> s4 = stackalloc byte[16];
             System.Buffers.Text.Utf8Formatter.TryFormat(i, s4, out int s4length);
 
             Span<byte> buffer = new byte[s1.Length + s2.Length + s3.Length + s4length];
 
-            s1.CopyTo(buffer);
-            s2.CopyTo(buffer.Slice(s1.Length));
-            s3.CopyTo(buffer.Slice(s1.Length + s2.Length));
+            s1.AsSpan().CopyTo(buffer);
+            s2.AsSpan().CopyTo(buffer.Slice(s1.Length));
+            s3.AsSpan().CopyTo(buffer.Slice(s1.Length + s2.Length));
             s4.Slice(0, s4length).CopyTo(buffer.Slice(s1.Length + s2.Length + s3.Length));
 
             return buffer;

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeSystemHelpers.cs
@@ -433,7 +433,7 @@ namespace Internal.TypeSystem
             return false;
         }
 
-        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2)
+        public static ReadOnlySpan<byte> Append(this Utf8Span s1, Utf8Span s2)
         {
             Span<byte> buffer = new byte[s1.Length + s2.Length];
 
@@ -443,7 +443,7 @@ namespace Internal.TypeSystem
             return buffer;
         }
 
-        public static ReadOnlySpan<byte> Append(this ReadOnlySpan<byte> s1, Utf8StringRef s2)
+        public static ReadOnlySpan<byte> Append(this ReadOnlySpan<byte> s1, Utf8Span s2)
         {
             Span<byte> buffer = new byte[s1.Length + s2.Length];
 
@@ -464,7 +464,7 @@ namespace Internal.TypeSystem
             return buffer;
         }
 
-        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2, Utf8StringRef s3)
+        public static ReadOnlySpan<byte> Append(this Utf8Span s1, Utf8Span s2, Utf8Span s3)
         {
             ReadOnlySpan<byte> s1Span = s1.AsSpan();
             ReadOnlySpan<byte> s2Span = s2.AsSpan();
@@ -478,7 +478,7 @@ namespace Internal.TypeSystem
             return buffer;
         }
 
-        public static ReadOnlySpan<byte> Append(this Utf8StringRef s1, Utf8StringRef s2, Utf8StringRef s3, uint i)
+        public static ReadOnlySpan<byte> Append(this Utf8Span s1, Utf8Span s2, Utf8Span s3, uint i)
         {
             Span<byte> s4 = stackalloc byte[16];
             System.Buffers.Text.Utf8Formatter.TryFormat(i, s4, out int s4length);

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     /// <summary>
@@ -84,16 +86,16 @@ namespace Internal.TypeSystem
         public override ClassLayoutMetadata GetClassLayout() => MetadataType.GetClassLayout();
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => MetadataType.HasCustomAttribute(attributeNamespace, attributeName);
         public override IEnumerable<MetadataType> GetNestedTypes() => (IEnumerable<MetadataType>)EmptyTypes;
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name) => null;
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
+        public override MetadataType GetNestedType(Utf8StringRef name) => null;
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
         public override int GetHashCode() => MetadataType.GetHashCode();
         protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => Array.Empty<MethodImplRecord>();
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask) => MetadataType.GetTypeFlags(mask);
 
-        public override ReadOnlySpan<byte> Namespace => MetadataType.Namespace;
+        public override Utf8StringRef Namespace => MetadataType.Namespace;
 
-        public override ReadOnlySpan<byte> Name => MetadataType.Name;
+        public override Utf8StringRef Name => MetadataType.Name;
 
         public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/TypeWithRepeatedFields.cs
@@ -86,16 +86,16 @@ namespace Internal.TypeSystem
         public override ClassLayoutMetadata GetClassLayout() => MetadataType.GetClassLayout();
         public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => MetadataType.HasCustomAttribute(attributeNamespace, attributeName);
         public override IEnumerable<MetadataType> GetNestedTypes() => (IEnumerable<MetadataType>)EmptyTypes;
-        public override MetadataType GetNestedType(Utf8StringRef name) => null;
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
+        public override MetadataType GetNestedType(Utf8Span name) => null;
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name) => MetadataType.FindMethodsImplWithMatchingDeclName(name);
         public override int GetHashCode() => MetadataType.GetHashCode();
         protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => Array.Empty<MethodImplRecord>();
 
         protected override TypeFlags ComputeTypeFlags(TypeFlags mask) => MetadataType.GetTypeFlags(mask);
 
-        public override Utf8StringRef Namespace => MetadataType.Namespace;
+        public override Utf8Span Namespace => MetadataType.Namespace;
 
-        public override Utf8StringRef Name => MetadataType.Name;
+        public override Utf8Span Name => MetadataType.Name;
 
         public override DefType[] ExplicitlyImplementedInterfaces => Array.Empty<DefType>();
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/VersionResilientHashCode.TypeSystem.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/VersionResilientHashCode.TypeSystem.cs
@@ -5,12 +5,20 @@ using System;
 using System.Diagnostics;
 using System.Numerics;
 using System.Text;
+
 using Internal.TypeSystem;
+using Internal.Text;
 
 namespace Internal
 {
     internal static partial class VersionResilientHashCode
     {
+        public static int NameHashCode(Utf8StringRef src)
+            => NameHashCode(src.AsSpan());
+
+        public static int NameHashCode(Utf8StringRef namespacePart, Utf8StringRef namePart)
+            => NameHashCode(namespacePart.AsSpan(), namePart.AsSpan());
+
         /// <summary>
         /// CoreCLR <a href="https://github.com/dotnet/runtime/blob/17154bd7b8f21d6d8d6fca71b89d7dcb705ec32b/src/coreclr/vm/typehashingalgorithms.h#L87">ComputeGenericInstanceHashCode</a>
         /// </summary>

--- a/src/coreclr/tools/Common/TypeSystem/Common/VersionResilientHashCode.TypeSystem.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/VersionResilientHashCode.TypeSystem.cs
@@ -13,10 +13,10 @@ namespace Internal
 {
     internal static partial class VersionResilientHashCode
     {
-        public static int NameHashCode(Utf8StringRef src)
+        public static int NameHashCode(Utf8Span src)
             => NameHashCode(src.AsSpan());
 
-        public static int NameHashCode(Utf8StringRef namespacePart, Utf8StringRef namePart)
+        public static int NameHashCode(Utf8Span namespacePart, Utf8Span namePart)
             => NameHashCode(namespacePart.AsSpan(), namePart.AsSpan());
 
         /// <summary>

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/CustomAttributeTypeProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/CustomAttributeTypeProvider.cs
@@ -88,9 +88,9 @@ namespace Internal.TypeSystem.Ecma
         {
             var metadataType = type as MetadataType;
             return metadataType != null
-                && metadataType.Name.SequenceEqual("Type"u8)
+                && metadataType.Name == "Type"u8
                 && metadataType.Module == _module.Context.SystemModule
-                && metadataType.Namespace.SequenceEqual("System"u8);
+                && metadataType.Namespace == "System"u8;
         }
     }
 }

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaAssembly.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaAssembly.cs
@@ -6,6 +6,8 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem.Ecma
 {
     public sealed partial class EcmaAssembly : EcmaModule, IAssemblyDesc
@@ -62,7 +64,7 @@ namespace Internal.TypeSystem.Ecma
             return _assemblyName;
         }
 
-        public ReadOnlySpan<byte> Name
+        public Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaAssembly.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaAssembly.cs
@@ -64,7 +64,7 @@ namespace Internal.TypeSystem.Ecma
             return _assemblyName;
         }
 
-        public Utf8StringRef Name
+        public Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
@@ -269,7 +269,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe Utf8StringRef Name
+        public override unsafe Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaField.cs
@@ -9,6 +9,8 @@ using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem.Ecma
 {
     public sealed partial class EcmaField : FieldDesc, EcmaModule.IEntityHandleObject
@@ -267,7 +269,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe ReadOnlySpan<byte> Name
+        public override unsafe Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -407,7 +407,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe Utf8StringRef Name
+        public override unsafe Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -9,6 +9,8 @@ using System.Reflection.Metadata.Ecma335;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem.Ecma
 {
     public sealed partial class EcmaMethod : MethodDesc, EcmaModule.IEntityHandleObject
@@ -352,7 +354,7 @@ namespace Internal.TypeSystem.Ecma
                 return attributes.IsRuntimeSpecialName()
                     && attributes.IsPublic()
                     && Signature.Length == 0
-                    && Name.SequenceEqual(".ctor"u8)
+                    && Name == ".ctor"u8
                     && !_type.IsAbstract;
             }
         }
@@ -369,7 +371,7 @@ namespace Internal.TypeSystem.Ecma
         {
             get
             {
-                return Attributes.IsRuntimeSpecialName() && Name.SequenceEqual(".cctor"u8);
+                return Attributes.IsRuntimeSpecialName() && Name == ".cctor"u8;
             }
         }
 
@@ -405,7 +407,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe ReadOnlySpan<byte> Name
+        public override unsafe Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -317,7 +317,7 @@ namespace Internal.TypeSystem.Ecma
             return bucketHeads;
         }
 
-        private TypeDefinitionHandle FindDefinedType(int hashCode, Utf8StringRef nameSpace, Utf8StringRef name)
+        private TypeDefinitionHandle FindDefinedType(int hashCode, Utf8Span nameSpace, Utf8Span name)
         {
             MetadataReader reader = _metadataReader;
 
@@ -368,7 +368,7 @@ namespace Internal.TypeSystem.Ecma
             return bucketHeads;
         }
 
-        private ExportedTypeHandle FindExportedType(int hashCode, Utf8StringRef nameSpace, Utf8StringRef name)
+        private ExportedTypeHandle FindExportedType(int hashCode, Utf8Span nameSpace, Utf8Span name)
         {
             MetadataReader reader = _metadataReader;
 
@@ -389,7 +389,7 @@ namespace Internal.TypeSystem.Ecma
             return default;
         }
 
-        public sealed override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
+        public sealed override object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior)
         {
             int hashCode = VersionResilientHashCode.NameHashCode(nameSpace, name);
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaModule.cs
@@ -9,6 +9,8 @@ using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Text;
 
+using Internal.Text;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Ecma
@@ -315,7 +317,7 @@ namespace Internal.TypeSystem.Ecma
             return bucketHeads;
         }
 
-        private TypeDefinitionHandle FindDefinedType(int hashCode, ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name)
+        private TypeDefinitionHandle FindDefinedType(int hashCode, Utf8StringRef nameSpace, Utf8StringRef name)
         {
             MetadataReader reader = _metadataReader;
 
@@ -366,7 +368,7 @@ namespace Internal.TypeSystem.Ecma
             return bucketHeads;
         }
 
-        private ExportedTypeHandle FindExportedType(int hashCode, ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name)
+        private ExportedTypeHandle FindExportedType(int hashCode, Utf8StringRef nameSpace, Utf8StringRef name)
         {
             MetadataReader reader = _metadataReader;
 
@@ -387,7 +389,7 @@ namespace Internal.TypeSystem.Ecma
             return default;
         }
 
-        public sealed override object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior)
+        public sealed override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
         {
             int hashCode = VersionResilientHashCode.NameHashCode(nameSpace, name);
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.MethodImpls.cs
@@ -16,7 +16,7 @@ namespace Internal.TypeSystem.Ecma
     public sealed partial class EcmaType : MetadataType
     {
         // Virtual function related functionality
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef declName)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span declName)
         {
             MetadataReader metadataReader = _module.MetadataReader;
             ArrayBuilder<MethodImplRecord> foundRecords = default(ArrayBuilder<MethodImplRecord>);

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.MethodImpls.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.MethodImpls.cs
@@ -4,6 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection.Metadata;
+
+using Internal.Text;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Ecma
@@ -13,7 +16,7 @@ namespace Internal.TypeSystem.Ecma
     public sealed partial class EcmaType : MetadataType
     {
         // Virtual function related functionality
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> declName)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef declName)
         {
             MetadataReader metadataReader = _module.MetadataReader;
             ArrayBuilder<MethodImplRecord> foundRecords = default(ArrayBuilder<MethodImplRecord>);

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -10,6 +10,7 @@ using System.Reflection.Metadata.Ecma335;
 using System.Threading;
 
 using Internal.NativeFormat;
+using Internal.Text;
 
 namespace Internal.TypeSystem.Ecma
 {
@@ -246,7 +247,7 @@ namespace Internal.TypeSystem.Ecma
             return flags;
         }
 
-        private unsafe ReadOnlySpan<byte> InitializeName()
+        private unsafe Utf8StringRef InitializeName()
         {
             StringHandle handle = _typeDefinition.Name;
             _nameLength = MetadataReader.GetStringBytes(handle).Length;
@@ -254,7 +255,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe ReadOnlySpan<byte> Name
+        public override unsafe Utf8StringRef Name
         {
             get
             {
@@ -267,7 +268,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        private unsafe ReadOnlySpan<byte> InitializeNamespace()
+        private unsafe Utf8StringRef InitializeNamespace()
         {
             StringHandle handle = _typeDefinition.Namespace;
             _namespaceLength = MetadataReader.GetStringBytes(handle).Length;
@@ -275,7 +276,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namespacePointer, _namespaceLength);
         }
 
-        public override unsafe ReadOnlySpan<byte> Namespace
+        public override unsafe Utf8StringRef Namespace
         {
             get
             {
@@ -313,12 +314,12 @@ namespace Internal.TypeSystem.Ecma
         /// If signature is not specified and there are multiple matches, the first one
         /// is returned. Returns null if method not found.
         /// </summary>
-        public new EcmaMethod GetMethod(ReadOnlySpan<byte> name, MethodSignature signature)
+        public new EcmaMethod GetMethod(Utf8StringRef name, MethodSignature signature)
         {
             return GetMethod(name, signature, default(Instantiation));
         }
 
-        public override EcmaMethod GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override EcmaMethod GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -335,7 +336,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override EcmaMethod GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override EcmaMethod GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -461,7 +462,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override EcmaField GetField(ReadOnlySpan<byte> name)
+        public override EcmaField GetField(Utf8StringRef name)
         {
             var metadataReader = this.MetadataReader;
 
@@ -485,7 +486,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override EcmaType GetNestedType(ReadOnlySpan<byte> name)
+        public override EcmaType GetNestedType(Utf8StringRef name)
         {
             var metadataReader = this.MetadataReader;
 
@@ -501,7 +502,7 @@ namespace Internal.TypeSystem.Ecma
                 {
                     ReadOnlySpan<byte> typeName = metadataReader.GetStringBytes(type.Name);
                     typeName = metadataReader.GetStringBytes(type.Namespace).Append("."u8, typeName);
-                    nameMatched = typeName.SequenceEqual(name);
+                    nameMatched = typeName.SequenceEqual(name.AsSpan());
                 }
 
                 if (nameMatched)

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaType.cs
@@ -247,7 +247,7 @@ namespace Internal.TypeSystem.Ecma
             return flags;
         }
 
-        private unsafe Utf8StringRef InitializeName()
+        private unsafe Utf8Span InitializeName()
         {
             StringHandle handle = _typeDefinition.Name;
             _nameLength = MetadataReader.GetStringBytes(handle).Length;
@@ -255,7 +255,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namePointer, _nameLength);
         }
 
-        public override unsafe Utf8StringRef Name
+        public override unsafe Utf8Span Name
         {
             get
             {
@@ -268,7 +268,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        private unsafe Utf8StringRef InitializeNamespace()
+        private unsafe Utf8Span InitializeNamespace()
         {
             StringHandle handle = _typeDefinition.Namespace;
             _namespaceLength = MetadataReader.GetStringBytes(handle).Length;
@@ -276,7 +276,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(_namespacePointer, _namespaceLength);
         }
 
-        public override unsafe Utf8StringRef Namespace
+        public override unsafe Utf8Span Namespace
         {
             get
             {
@@ -314,12 +314,12 @@ namespace Internal.TypeSystem.Ecma
         /// If signature is not specified and there are multiple matches, the first one
         /// is returned. Returns null if method not found.
         /// </summary>
-        public new EcmaMethod GetMethod(Utf8StringRef name, MethodSignature signature)
+        public new EcmaMethod GetMethod(Utf8Span name, MethodSignature signature)
         {
             return GetMethod(name, signature, default(Instantiation));
         }
 
-        public override EcmaMethod GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override EcmaMethod GetMethod(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -336,7 +336,7 @@ namespace Internal.TypeSystem.Ecma
             return null;
         }
 
-        public override EcmaMethod GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override EcmaMethod GetMethodWithEquivalentSignature(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             var metadataReader = this.MetadataReader;
 
@@ -462,7 +462,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override EcmaField GetField(Utf8StringRef name)
+        public override EcmaField GetField(Utf8Span name)
         {
             var metadataReader = this.MetadataReader;
 
@@ -486,7 +486,7 @@ namespace Internal.TypeSystem.Ecma
             }
         }
 
-        public override EcmaType GetNestedType(Utf8StringRef name)
+        public override EcmaType GetNestedType(Utf8Span name)
         {
             var metadataReader = this.MetadataReader;
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Runtime.InteropServices;
+using Internal.Text;
 
 namespace Internal.TypeSystem.Ecma
 {
@@ -319,7 +320,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(blobReader.CurrentPointer, blobReader.Length);
         }
 
-        public static unsafe bool StringEquals(this MetadataReader reader, StringHandle handle, ReadOnlySpan<byte> otherString)
+        public static unsafe bool StringEquals(this MetadataReader reader, StringHandle handle, Utf8StringRef otherString)
         {
             int stringOffset = reader.GetHeapOffset(handle);
 
@@ -333,9 +334,10 @@ namespace Internal.TypeSystem.Ecma
                 return false;
 
             // Compare characters
+            ReadOnlySpan<byte> otherSpan = otherString.AsSpan();
             for (int i = 0; i < otherString.Length; i++)
             {
-                if (otherString[i] != *(currentChar++))
+                if (otherSpan[i] != *(currentChar++))
                     return false;
             }
 

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/MetadataExtensions.cs
@@ -320,7 +320,7 @@ namespace Internal.TypeSystem.Ecma
             return new ReadOnlySpan<byte>(blobReader.CurrentPointer, blobReader.Length);
         }
 
-        public static unsafe bool StringEquals(this MetadataReader reader, StringHandle handle, Utf8StringRef otherString)
+        public static unsafe bool StringEquals(this MetadataReader reader, StringHandle handle, Utf8Span otherString)
         {
             int stringOffset = reader.GetHeapOffset(handle);
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
@@ -51,33 +51,33 @@ namespace Internal.IL
             if (owningType == null)
                 return null;
 
-            if (owningType.Name.SequenceEqual("Unsafe"u8))
+            if (owningType.Name == "Unsafe"u8)
             {
-                if (owningType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+                if (owningType.Namespace == "System.Runtime.CompilerServices"u8)
                     return UnsafeIntrinsics.EmitIL(method);
             }
-            else if (owningType.Name.SequenceEqual("Debug"u8))
+            else if (owningType.Name == "Debug"u8)
             {
-                if (owningType.Namespace.SequenceEqual("System.Diagnostics"u8) && method.Name.SequenceEqual("DebugBreak"u8))
+                if (owningType.Namespace == "System.Diagnostics"u8 && method.Name == "DebugBreak"u8)
                     return new ILStubMethodIL(method, new byte[] { (byte)ILOpcode.break_, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
             }
-            else if (owningType.Name.SequenceEqual("RuntimeAugments"u8))
+            else if (owningType.Name == "RuntimeAugments"u8)
             {
-                if (owningType.Namespace.SequenceEqual("Internal.Runtime.Augments"u8) && method.Name.SequenceEqual("GetCanonType"u8))
+                if (owningType.Namespace == "Internal.Runtime.Augments"u8 && method.Name == "GetCanonType"u8)
                     return GetCanonTypeIntrinsic.EmitIL(method);
             }
-            else if (owningType.Name.SequenceEqual("MethodTable"u8))
+            else if (owningType.Name == "MethodTable"u8)
             {
-                if (owningType.Namespace.SequenceEqual("Internal.Runtime"u8) && method.Name.SequenceEqual("get_SupportsRelativePointers"u8))
+                if (owningType.Namespace == "Internal.Runtime"u8 && method.Name == "get_SupportsRelativePointers"u8)
                 {
                     ILOpcode value = method.Context.Target.SupportsRelativePointers ?
                         ILOpcode.ldc_i4_1 : ILOpcode.ldc_i4_0;
                     return new ILStubMethodIL(method, new byte[] { (byte)value, (byte)ILOpcode.ret }, Array.Empty<LocalVariableDefinition>(), null);
                 }
             }
-            else if (owningType.Name.SequenceEqual("Stream"u8))
+            else if (owningType.Name == "Stream"u8)
             {
-                if (owningType.Namespace.SequenceEqual("System.IO"u8))
+                if (owningType.Namespace == "System.IO"u8)
                     return StreamIntrinsics.EmitIL(method);
             }
 
@@ -97,15 +97,15 @@ namespace Internal.IL
             if (owningType == null)
                 return null;
 
-            if (owningType.Name.SequenceEqual("Interlocked"u8))
+            if (owningType.Name == "Interlocked"u8)
             {
-                if (owningType.Namespace.SequenceEqual("System.Threading"u8))
+                if (owningType.Namespace == "System.Threading"u8)
                     return InterlockedIntrinsics.EmitIL(method);
             }
-            else if (owningType.Name.SequenceEqual("Activator"u8))
+            else if (owningType.Name == "Activator"u8)
             {
                 TypeSystemContext context = owningType.Context;
-                if (method.Name.SequenceEqual("CreateInstance"u8) && method.Signature.Length == 0 && method.HasInstantiation
+                if (method.Name == "CreateInstance"u8 && method.Signature.Length == 0 && method.HasInstantiation
                     && method.Instantiation[0] is TypeDesc activatedType
                     && activatedType != context.UniversalCanonType
                     && activatedType.IsValueType
@@ -123,27 +123,27 @@ namespace Internal.IL
                     return new InstantiatedMethodIL(method, emit.Link(method.GetMethodDefinition()));
                 }
             }
-            else if (owningType.Name.SequenceEqual("RuntimeHelpers"u8))
+            else if (owningType.Name == "RuntimeHelpers"u8)
             {
-                if (owningType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+                if (owningType.Namespace == "System.Runtime.CompilerServices"u8)
                     return RuntimeHelpersIntrinsics.EmitIL(method);
             }
-            else if (owningType.Name.SequenceEqual("Comparer`1"u8))
+            else if (owningType.Name == "Comparer`1"u8)
             {
-                if (method.Name.SequenceEqual("Create"u8) && owningType.Namespace.SequenceEqual("System.Collections.Generic"u8))
+                if (method.Name == "Create"u8 && owningType.Namespace == "System.Collections.Generic"u8)
                     return ComparerIntrinsics.EmitComparerCreate(method);
             }
-            else if (owningType.Name.SequenceEqual("EqualityComparer`1"u8))
+            else if (owningType.Name == "EqualityComparer`1"u8)
             {
-                if (method.Name.SequenceEqual("Create"u8) && owningType.Namespace.SequenceEqual("System.Collections.Generic"u8))
+                if (method.Name == "Create"u8 && owningType.Namespace == "System.Collections.Generic"u8)
                     return ComparerIntrinsics.EmitEqualityComparerCreate(method);
             }
-            else if (owningType.Name.SequenceEqual("ComparerHelpers"u8))
+            else if (owningType.Name == "ComparerHelpers"u8)
             {
-                if (!owningType.Namespace.SequenceEqual("Internal.IntrinsicSupport"u8))
+                if (owningType.Namespace != "Internal.IntrinsicSupport"u8)
                     return null;
 
-                if (method.Name.SequenceEqual("EnumOnlyCompare"u8))
+                if (method.Name == "EnumOnlyCompare"u8)
                 {
                     //calls CompareTo for underlyingType to avoid boxing
 
@@ -171,12 +171,12 @@ namespace Internal.IL
                     return emitter.Link(method);
                 }
             }
-            else if (owningType.Name.SequenceEqual("EqualityComparerHelpers"u8))
+            else if (owningType.Name == "EqualityComparerHelpers"u8)
             {
-                if (!owningType.Namespace.SequenceEqual("Internal.IntrinsicSupport"u8))
+                if (owningType.Namespace != "Internal.IntrinsicSupport"u8)
                     return null;
 
-                if (method.Name.SequenceEqual("EnumOnlyEquals"u8))
+                if (method.Name == "EnumOnlyEquals"u8)
                 {
                     // EnumOnlyEquals would basically like to do this:
                     // static bool EnumOnlyEquals<T>(T x, T y) where T: struct => x == y;
@@ -211,7 +211,7 @@ namespace Internal.IL
                     },
                     Array.Empty<LocalVariableDefinition>(), null);
                 }
-                else if (method.Name.SequenceEqual("GetComparerForReferenceTypesOnly"u8))
+                else if (method.Name == "GetComparerForReferenceTypesOnly"u8)
                 {
                     TypeDesc elementType = method.Instantiation[0];
                     if (!elementType.IsRuntimeDeterminedSubtype
@@ -225,7 +225,7 @@ namespace Internal.IL
                         Array.Empty<LocalVariableDefinition>(), null);
                     }
                 }
-                else if (method.Name.SequenceEqual("StructOnlyEquals"u8))
+                else if (method.Name == "StructOnlyEquals"u8)
                 {
                     TypeDesc elementType = method.Instantiation[0];
                     if (!elementType.IsRuntimeDeterminedSubtype

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs
@@ -37,7 +39,7 @@ namespace Internal.IL.Stubs
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AssemblyGetExecutingAssemblyMethodThunk.cs
@@ -39,7 +39,7 @@ namespace Internal.IL.Stubs
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
@@ -26,7 +26,7 @@ namespace ILCompiler
             _owningType = owningType;
         }
 
-        public override Utf8StringRef Name => _targetMethod.Name;
+        public override Utf8Span Name => _targetMethod.Name;
         public override string DiagnosticName => "RESUME_" + _targetMethod.DiagnosticName;
 
         public override TypeDesc OwningType => _owningType;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
 using Internal.IL;
 using Internal.IL.Stubs;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -24,7 +26,7 @@ namespace ILCompiler
             _owningType = owningType;
         }
 
-        public override ReadOnlySpan<byte> Name => _targetMethod.Name;
+        public override Utf8StringRef Name => _targetMethod.Name;
         public override string DiagnosticName => "RESUME_" + _targetMethod.DiagnosticName;
 
         public override TypeDesc OwningType => _owningType;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
@@ -22,7 +22,7 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                Utf8StringRef prefix = RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling"u8 : "Calli"u8;
+                Utf8Span prefix = RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling"u8 : "Calli"u8;
 
                 // The target signature is expected to be normalized as MethodSignatureFlags.UnmanagedCallingConvention
                 Debug.Assert((_targetSignature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.UnmanagedCallingConvention);

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.Mangling.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Diagnostics;
-
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs
@@ -22,7 +22,7 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                ReadOnlySpan<byte> prefix = RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling"u8 : "Calli"u8;
+                Utf8StringRef prefix = RuntimeMarshallingEnabled ? "CalliWithRuntimeMarshalling"u8 : "Calli"u8;
 
                 // The target signature is expected to be normalized as MethodSignatureFlags.UnmanagedCallingConvention
                 Debug.Assert((_targetSignature.Flags & MethodSignatureFlags.UnmanagedCallingConventionMask) == MethodSignatureFlags.UnmanagedCallingConvention);
@@ -31,7 +31,7 @@ namespace Internal.IL.Stubs
                 if (_targetSignature.HasEmbeddedSignatureData)
                     prefix = prefix.Append(System.Text.Encoding.ASCII.GetBytes(_targetSignature.GetStandaloneMethodSignatureCallingConventions().ToString("x")));
 
-                return prefix;
+                return prefix.AsSpan();
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
@@ -72,7 +72,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/CalliMarshallingMethodThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs
@@ -70,7 +72,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Mangling.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.Mangling.cs
@@ -20,7 +20,7 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                return NamePrefix;
+                return NamePrefix.AsSpan();
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -221,7 +221,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        private Utf8StringRef NamePrefix
+        private Utf8Span NamePrefix
         {
             get
             {
@@ -240,7 +240,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMarshallingMethodThunk.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+
+using Internal.Text;
 using Internal.TypeSystem;
-using Internal.TypeSystem.Interop;
-using Debug = System.Diagnostics.Debug;
 using Internal.TypeSystem.Ecma;
+using Internal.TypeSystem.Interop;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL.Stubs
 {
@@ -218,7 +221,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        private ReadOnlySpan<byte> NamePrefix
+        private Utf8StringRef NamePrefix
         {
             get
             {
@@ -232,12 +235,12 @@ namespace Internal.IL.Stubs
                         return "ForwardNativeFunctionWrapper"u8;
                     default:
                         Debug.Fail("Unexpected DelegateMarshallingMethodThunkKind.");
-                        return [];
+                        return Array.Empty<byte>();
                 }
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMethodILEmitter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateMethodILEmitter.cs
@@ -17,7 +17,7 @@ namespace Internal.IL.Stubs
             Debug.Assert(method.OwningType.IsTypeDefinition);
             Debug.Assert(method.IsRuntimeImplemented);
 
-            if (method.Name.SequenceEqual("BeginInvoke"u8) || method.Name.SequenceEqual("EndInvoke"u8))
+            if (method.Name == "BeginInvoke"u8 || method.Name == "EndInvoke"u8)
             {
                 // BeginInvoke and EndInvoke are not supported on .NET Core
                 ILEmitter emit = new ILEmitter();
@@ -27,7 +27,7 @@ namespace Internal.IL.Stubs
                 return emit.Link(method);
             }
 
-            if (method.Name.SequenceEqual(".ctor"u8))
+            if (method.Name == ".ctor"u8)
             {
                 // We only support delegate creation if the IL follows the delegate creation verifiability requirements
                 // described in ECMA-335 III.4.21 (newobj - create a new object). The codegen is expected to
@@ -42,7 +42,7 @@ namespace Internal.IL.Stubs
                 return emit.Link(method);
             }
 
-            if (method.Name.SequenceEqual("Invoke"u8))
+            if (method.Name == "Invoke"u8)
             {
                 TypeSystemContext context = method.Context;
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -128,7 +130,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -221,7 +223,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -281,7 +283,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -416,7 +418,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -464,7 +466,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -641,7 +643,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -758,7 +760,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DelegateThunks.cs
@@ -130,7 +130,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -223,7 +223,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -283,7 +283,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -418,7 +418,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -466,7 +466,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -643,7 +643,7 @@ namespace Internal.IL.Stubs
             return emitter.Link(this);
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -760,7 +760,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -122,7 +122,7 @@ namespace Internal.IL.Stubs
             return base.ComputeHashCode() ^ _targetSignature.GetHashCode();
         }
 
-        public override Utf8StringRef Name => "DynamicInvoke"u8;
+        public override Utf8Span Name => "DynamicInvoke"u8;
 
         public override string DiagnosticName => "DynamicInvoke";
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/DynamicInvokeMethodThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -120,7 +122,7 @@ namespace Internal.IL.Stubs
             return base.ComputeHashCode() ^ _targetSignature.GetHashCode();
         }
 
-        public override ReadOnlySpan<byte> Name => "DynamicInvoke"u8;
+        public override Utf8StringRef Name => "DynamicInvoke"u8;
 
         public override string DiagnosticName => "DynamicInvoke";
 

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Interop;
 
@@ -62,7 +64,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/ForwardDelegateCreationThunk.cs
@@ -64,7 +64,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/GetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/GetFieldHelperMethodOverride.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 
 using ILCompiler;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -217,7 +218,7 @@ namespace Internal.IL.Stubs
 
         internal static ReadOnlySpan<byte> MetadataName => "__GetFieldHelper"u8;
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/GetFieldHelperMethodOverride.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/GetFieldHelperMethodOverride.cs
@@ -218,7 +218,7 @@ namespace Internal.IL.Stubs
 
         internal static ReadOnlySpan<byte> MetadataName => "__GetFieldHelper"u8;
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/InterlockedIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/InterlockedIntrinsics.cs
@@ -20,10 +20,10 @@ namespace Internal.IL.Stubs
 #endif // READYTORUN
             MethodDesc method)
         {
-            Debug.Assert(((MetadataType)method.OwningType).Name.SequenceEqual("Interlocked"u8));
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Interlocked"u8);
             Debug.Assert(!method.IsGenericMethodDefinition);
 
-            if (method.HasInstantiation && method.Name.SequenceEqual("CompareExchange"u8))
+            if (method.HasInstantiation && method.Name == "CompareExchange"u8)
             {
 #if READYTORUN
                 // Check to see if the tokens needed to describe the CompareExchange are naturally present within

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -37,7 +39,7 @@ namespace Internal.IL.Stubs
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/MethodBaseGetCurrentMethodThunk.cs
@@ -39,7 +39,7 @@ namespace Internal.IL.Stubs
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
@@ -126,7 +126,7 @@ namespace Internal.IL.Stubs
             return false;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeLazyFixupField.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -124,7 +126,7 @@ namespace Internal.IL.Stubs
             return false;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
@@ -56,7 +56,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/PInvokeTargetNativeMethod.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs
@@ -54,7 +56,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/RuntimeHelpersIntrinsics.cs
@@ -16,7 +16,7 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc method)
         {
-            Debug.Assert(((MetadataType)method.OwningType).Name.SequenceEqual("RuntimeHelpers"u8));
+            Debug.Assert(((MetadataType)method.OwningType).Name == "RuntimeHelpers"u8);
 
             // All the methods handled below are per-instantiation generic methods
             if (method.Instantiation.Length != 1 || method.IsTypicalMethodDefinition)
@@ -29,7 +29,7 @@ namespace Internal.IL.Stubs
                 return null;
 
             bool result;
-            if (method.Name.SequenceEqual("IsBitwiseEquatable"u8))
+            if (method.Name == "IsBitwiseEquatable"u8)
             {
                 // Ideally we could detect automatically whether a type is trivially equatable
                 // (i.e., its operator == could be implemented via memcmp). But for now we'll
@@ -57,8 +57,8 @@ namespace Internal.IL.Stubs
                         if (elementType is MetadataType mdType)
                         {
                             if (mdType.Module == mdType.Context.SystemModule &&
-                                mdType.Namespace.SequenceEqual("System.Text"u8) &&
-                                mdType.Name.SequenceEqual("Rune"u8))
+                                mdType.Namespace == "System.Text"u8 &&
+                                mdType.Name == "Rune"u8)
                             {
                                 result = true;
                             }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StreamIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StreamIntrinsics.cs
@@ -16,10 +16,10 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc method)
         {
-            Debug.Assert(((MetadataType)method.OwningType).Name.SequenceEqual("Stream"u8));
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Stream"u8);
 
-            bool isRead = method.Name.SequenceEqual("HasOverriddenBeginEndRead"u8);
-            if (!isRead && !method.Name.SequenceEqual("HasOverriddenBeginEndWrite"u8))
+            bool isRead = method.Name == "HasOverriddenBeginEndRead"u8;
+            if (!isRead && method.Name != "HasOverriddenBeginEndWrite"u8)
                 return null;
 
             TypeDesc streamClass = method.OwningType;

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.Mangling.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.Mangling.cs
@@ -20,7 +20,7 @@ namespace Internal.IL.Stubs
         {
             get
             {
-                return NamePrefix;
+                return NamePrefix.AsSpan();
             }
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -4,9 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+
 using ILCompiler;
+
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Interop;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.IL.Stubs
@@ -102,7 +106,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        private ReadOnlySpan<byte> NamePrefix
+        private Utf8StringRef NamePrefix
         {
             get
             {
@@ -116,12 +120,12 @@ namespace Internal.IL.Stubs
                         return "Cleanup"u8;
                     default:
                         Debug.Fail("Unexpected Struct marshalling thunk type");
-                        return [];
+                        return Array.Empty<byte>();
                 }
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/StructMarshallingThunk.cs
@@ -106,7 +106,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        private Utf8StringRef NamePrefix
+        private Utf8Span NamePrefix
         {
             get
             {
@@ -125,7 +125,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
@@ -36,7 +36,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/TypeGetTypeMethodThunk.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -34,7 +36,7 @@ namespace Internal.IL.Stubs
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/UnsafeIntrinsics.cs
@@ -16,7 +16,7 @@ namespace Internal.IL.Stubs
     {
         public static MethodIL EmitIL(MethodDesc method)
         {
-            Debug.Assert(((MetadataType)method.OwningType).Name.SequenceEqual("Unsafe"u8));
+            Debug.Assert(((MetadataType)method.OwningType).Name == "Unsafe"u8);
 
             switch (method.GetName())
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -3,10 +3,13 @@
 
 using System;
 using System.Collections.Generic;
-using Debug = System.Diagnostics.Debug;
-using Internal.IL.Stubs;
-using Internal.IL;
 using System.Threading;
+
+using Internal.IL;
+using Internal.IL.Stubs;
+using Internal.Text;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
 {
@@ -27,11 +30,11 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
-                return "_InlineArray__"u8.Append(ElementType.Name, "__"u8, Length);
+                return new Utf8StringRef("_InlineArray__"u8).Append(ElementType.Name, "__"u8, Length);
             }
         }
 
@@ -43,7 +46,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -199,7 +202,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             return null;
         }
@@ -209,7 +212,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
         {
             return Array.Empty<MethodImplRecord>();
         }
@@ -323,7 +326,7 @@ namespace Internal.TypeSystem.Interop
                 }
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {
@@ -493,7 +496,7 @@ namespace Internal.TypeSystem.Interop
                 return false;
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/InlineArrayType.cs
@@ -30,11 +30,11 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
-                return new Utf8StringRef("_InlineArray__"u8).Append(ElementType.Name, "__"u8, Length);
+                return new Utf8Span("_InlineArray__"u8).Append(ElementType.Name, "__"u8, Length);
             }
         }
 
@@ -46,7 +46,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -202,7 +202,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             return null;
         }
@@ -212,7 +212,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
         {
             return Array.Empty<MethodImplRecord>();
         }
@@ -326,7 +326,7 @@ namespace Internal.TypeSystem.Interop
                 }
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {
@@ -496,7 +496,7 @@ namespace Internal.TypeSystem.Interop
                 return false;
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/MarshalHelpers.cs
@@ -202,8 +202,8 @@ namespace Internal.TypeSystem.Interop
                 if (customModifierType == null)
                     continue;
 
-                if ((customModifierType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8) && customModifierType.Name.SequenceEqual("IsCopyConstructed"u8)) ||
-                    (customModifierType.Namespace.SequenceEqual("Microsoft.VisualC"u8) && customModifierType.Name.SequenceEqual("NeedsCopyConstructorModifier"u8)))
+                if ((customModifierType.Namespace == "System.Runtime.CompilerServices"u8 && customModifierType.Name == "IsCopyConstructed"u8) ||
+                    (customModifierType.Namespace == "Microsoft.VisualC"u8 && customModifierType.Name == "NeedsCopyConstructorModifier"u8))
                 {
                     return true;
                 }
@@ -946,7 +946,7 @@ namespace Internal.TypeSystem.Interop
             //   objc_msgSendSuper
             //   objc_msgSendSuper_stret
             return metadata.Module.Equals(ObjectiveCLibrary)
-                && metadata.Name.StartsWith(ObjectiveCMsgSend);
+                && metadata.Name.AsSpan().StartsWith(ObjectiveCMsgSend);
         }
 
         internal static uint? GetObjectiveCMessageSendFunction(TargetDetails target, string pinvokeModule, string pinvokeFunction)

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -3,7 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+
 using ILCompiler;
+
+using Internal.Text;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
@@ -21,7 +25,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -37,7 +41,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -255,7 +259,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             return null;
         }
@@ -265,7 +269,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
         {
             return Array.Empty<MethodImplRecord>();
         }
@@ -394,7 +398,7 @@ namespace Internal.TypeSystem.Interop
                 return false;
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/NativeStructType.cs
@@ -25,7 +25,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -41,7 +41,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -259,7 +259,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             return null;
         }
@@ -269,7 +269,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
         {
             return Array.Empty<MethodImplRecord>();
         }
@@ -398,7 +398,7 @@ namespace Internal.TypeSystem.Interop
                 return false;
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -29,7 +29,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -45,7 +45,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
@@ -183,7 +183,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             return null;
         }
@@ -193,7 +193,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
         {
             return Array.Empty<MethodImplRecord>();
         }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapper.cs
@@ -3,9 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using Internal.IL.Stubs;
-using Debug = System.Diagnostics.Debug;
 using System.Threading;
+
+using Internal.IL.Stubs;
+using Internal.Text;
+
+using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem.Interop
 {
@@ -26,7 +29,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -42,7 +45,7 @@ namespace Internal.TypeSystem.Interop
             }
         }
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
@@ -180,7 +183,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MetadataType>();
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             return null;
         }
@@ -190,7 +193,7 @@ namespace Internal.TypeSystem.Interop
             return Array.Empty<MethodImplRecord>();
         }
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
         {
             return Array.Empty<MethodImplRecord>();
         }

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
@@ -2,8 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+
 using Internal.IL;
 using Internal.IL.Stubs;
+using Internal.Text;
 
 namespace Internal.TypeSystem.Interop
 {
@@ -22,7 +24,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/IL/PInvokeDelegateWrapperConstructor.cs
@@ -24,7 +24,7 @@ namespace Internal.TypeSystem.Interop
             get;
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/InteropTypes.cs
@@ -82,8 +82,8 @@ namespace Internal.TypeSystem.Interop
         private static bool IsCoreNamedType(TypeSystemContext context, TypeDesc type, ReadOnlySpan<byte> @namespace, ReadOnlySpan<byte> name)
         {
             return type is MetadataType mdType &&
-                mdType.Name.SequenceEqual(name) &&
-                mdType.Namespace.SequenceEqual(@namespace) &&
+                mdType.Name == name &&
+                mdType.Namespace == @namespace &&
                 mdType.Module == context.SystemModule;
         }
 

--- a/src/coreclr/tools/Common/TypeSystem/Interop/UnmanagedCallingConventions.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Interop/UnmanagedCallingConventions.cs
@@ -189,24 +189,24 @@ namespace Internal.TypeSystem
 
         private static UnmanagedCallingConventions AccumulateCallingConventions(UnmanagedCallingConventions existing, MetadataType newConvention)
         {
-            if (!newConvention.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+            if (newConvention.Namespace != "System.Runtime.CompilerServices"u8)
                 return existing;
 
             UnmanagedCallingConventions? addedCallConv = null;
 
-            if (newConvention.Name.SequenceEqual("CallConvCdecl"u8))
+            if (newConvention.Name == "CallConvCdecl"u8)
                 addedCallConv = UnmanagedCallingConventions.Cdecl;
-            else if (newConvention.Name.SequenceEqual("CallConvStdcall"u8))
+            else if (newConvention.Name == "CallConvStdcall"u8)
                 addedCallConv = UnmanagedCallingConventions.Stdcall;
-            else if (newConvention.Name.SequenceEqual("CallConvFastcall"u8))
+            else if (newConvention.Name == "CallConvFastcall"u8)
                 addedCallConv = UnmanagedCallingConventions.Fastcall;
-            else if (newConvention.Name.SequenceEqual("CallConvThiscall"u8))
+            else if (newConvention.Name == "CallConvThiscall"u8)
                 addedCallConv = UnmanagedCallingConventions.Thiscall;
-            else if (newConvention.Name.SequenceEqual("CallConvSuppressGCTransition"u8))
+            else if (newConvention.Name == "CallConvSuppressGCTransition"u8)
                 addedCallConv = UnmanagedCallingConventions.IsSuppressGcTransition;
-            else if (newConvention.Name.SequenceEqual("CallConvMemberFunction"u8))
+            else if (newConvention.Name == "CallConvMemberFunction"u8)
                 addedCallConv = UnmanagedCallingConventions.IsMemberFunction;
-            else if (newConvention.Name.SequenceEqual("CallConvSwift"u8))
+            else if (newConvention.Name == "CallConvSwift"u8)
                 addedCallConv = UnmanagedCallingConventions.Swift;
 
             if (addedCallConv == null)

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Diagnostics;
 
+using Internal.Text;
+
 namespace Internal.TypeSystem
 {
     public sealed partial class MethodForRuntimeDeterminedType : MethodDesc
@@ -36,7 +38,7 @@ namespace Internal.TypeSystem
         public override bool IsAbstract => _typicalMethodDef.IsAbstract;
         public override bool IsFinal => _typicalMethodDef.IsFinal;
         public override bool IsDefaultConstructor => _typicalMethodDef.IsDefaultConstructor;
-        public override ReadOnlySpan<byte> Name => _typicalMethodDef.Name;
+        public override Utf8StringRef Name => _typicalMethodDef.Name;
         public override MethodDesc GetTypicalMethodDefinition() => _typicalMethodDef;
         public override Instantiation Instantiation => _typicalMethodDef.Instantiation;
         public override bool IsAsync => _typicalMethodDef.IsAsync;

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/MethodForRuntimeDeterminedType.cs
@@ -38,7 +38,7 @@ namespace Internal.TypeSystem
         public override bool IsAbstract => _typicalMethodDef.IsAbstract;
         public override bool IsFinal => _typicalMethodDef.IsFinal;
         public override bool IsDefaultConstructor => _typicalMethodDef.IsDefaultConstructor;
-        public override Utf8StringRef Name => _typicalMethodDef.Name;
+        public override Utf8Span Name => _typicalMethodDef.Name;
         public override MethodDesc GetTypicalMethodDefinition() => _typicalMethodDef;
         public override Instantiation Instantiation => _typicalMethodDef.Instantiation;
         public override bool IsAsync => _typicalMethodDef.IsAsync;

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -92,7 +92,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -100,11 +100,11 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override Utf8StringRef Namespace
+        public override Utf8Span Namespace
         {
             get
             {
-                return new Utf8StringRef(System.Text.Encoding.UTF8.GetBytes(_runtimeDeterminedDetailsType.Name))
+                return new Utf8Span(System.Text.Encoding.UTF8.GetBytes(_runtimeDeterminedDetailsType.Name))
                     .Append("_"u8, _rawCanonType.Namespace);
             }
         }
@@ -125,7 +125,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethod(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc method = _rawCanonType.GetMethod(name, signature, substitution);
             if (method == null)
@@ -133,7 +133,7 @@ namespace Internal.TypeSystem
             return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);
         }
 
-        public override MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethodWithEquivalentSignature(Utf8Span name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc method = _rawCanonType.GetMethodWithEquivalentSignature(name, signature, substitution);
             if (method == null)

--- a/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
+++ b/src/coreclr/tools/Common/TypeSystem/RuntimeDetermined/RuntimeDeterminedType.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
+
 using Debug = System.Diagnostics.Debug;
 
 namespace Internal.TypeSystem
@@ -90,7 +92,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -98,11 +100,11 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Namespace
+        public override Utf8StringRef Namespace
         {
             get
             {
-                return System.Text.Encoding.UTF8.GetBytes(_runtimeDeterminedDetailsType.Name)
+                return new Utf8StringRef(System.Text.Encoding.UTF8.GetBytes(_runtimeDeterminedDetailsType.Name))
                     .Append("_"u8, _rawCanonType.Namespace);
             }
         }
@@ -123,7 +125,7 @@ namespace Internal.TypeSystem
             }
         }
 
-        public override MethodDesc GetMethod(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethod(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc method = _rawCanonType.GetMethod(name, signature, substitution);
             if (method == null)
@@ -131,7 +133,7 @@ namespace Internal.TypeSystem
             return Context.GetMethodForRuntimeDeterminedType(method.GetTypicalMethodDefinition(), this);
         }
 
-        public override MethodDesc GetMethodWithEquivalentSignature(ReadOnlySpan<byte> name, MethodSignature signature, Instantiation substitution)
+        public override MethodDesc GetMethodWithEquivalentSignature(Utf8StringRef name, MethodSignature signature, Instantiation substitution)
         {
             MethodDesc method = _rawCanonType.GetMethodWithEquivalentSignature(name, signature, substitution);
             if (method == null)

--- a/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
+++ b/src/coreclr/tools/ILVerification/ILImporter.Verify.cs
@@ -1921,18 +1921,18 @@ namespace Internal.IL
             if (type is not MetadataType metadataType)
                 return false;
 
-            if (!metadataType.Namespace.SequenceEqual("System.Threading.Tasks"u8))
+            if (metadataType.Namespace != "System.Threading.Tasks"u8)
                 return false;
 
             // Check for Task (non-generic)
-            if (metadataType.Name.SequenceEqual("Task"u8) && !metadataType.HasInstantiation)
+            if (metadataType.Name == "Task"u8 && !metadataType.HasInstantiation)
             {
                 unwrappedType = _typeSystemContext.GetWellKnownType(WellKnownType.Void);
                 return true;
             }
 
             // Check for ValueTask (non-generic)
-            if (metadataType.Name.SequenceEqual("ValueTask"u8) && !metadataType.HasInstantiation)
+            if (metadataType.Name == "ValueTask"u8 && !metadataType.HasInstantiation)
             {
                 unwrappedType = _typeSystemContext.GetWellKnownType(WellKnownType.Void);
                 return true;
@@ -1941,8 +1941,8 @@ namespace Internal.IL
             // Check for Task<T> and ValueTask<T>
             if (metadataType.HasInstantiation && metadataType.Instantiation.Length == 1)
             {
-                if (metadataType.Name.SequenceEqual("Task`1"u8) || 
-                    metadataType.Name.SequenceEqual("ValueTask`1"u8))
+                if (metadataType.Name == "Task`1"u8 ||
+                    metadataType.Name == "ValueTask`1"u8)
                 {
                     unwrappedType = metadataType.Instantiation[0];
                     return true;
@@ -2784,7 +2784,7 @@ namespace Internal.IL
             {
                 foreach (var data in signature.GetEmbeddedSignatureData())
                 {
-                    if (data.type is MetadataType mdType && mdType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8) && mdType.Name.SequenceEqual("IsExternalInit"u8) &&
+                    if (data.type is MetadataType mdType && mdType.Namespace == "System.Runtime.CompilerServices"u8 && mdType.Name == "IsExternalInit"u8 &&
                         data.index == MethodSignature.IndexOfCustomModifiersOnReturnType)
                         return true;
                 }

--- a/src/coreclr/tools/ILVerification/ILVerification.projitems
+++ b/src/coreclr/tools/ILVerification/ILVerification.projitems
@@ -27,8 +27,8 @@
     <Compile Include="$(LibrariesProjectRoot)\Common\src\Internal\VersionResilientHashCode.cs">
       <Link>TypeSystem\Common\VersionResilientHashCode.cs</Link>
     </Compile>
-    <Compile Include="$(ToolsCommonPath)Internal\Text\Utf8StringRef.cs">
-      <Link>Common\Utf8StringRef.cs</Link>
+    <Compile Include="$(ToolsCommonPath)Internal\Text\Utf8Span.cs">
+      <Link>Common\Utf8Span.cs</Link>
     </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\MethodDesc.CodeGen.cs</Link>

--- a/src/coreclr/tools/ILVerification/ILVerification.projitems
+++ b/src/coreclr/tools/ILVerification/ILVerification.projitems
@@ -27,6 +27,9 @@
     <Compile Include="$(LibrariesProjectRoot)\Common\src\Internal\VersionResilientHashCode.cs">
       <Link>TypeSystem\Common\VersionResilientHashCode.cs</Link>
     </Compile>
+    <Compile Include="$(ToolsCommonPath)Internal\Text\Utf8StringRef.cs">
+      <Link>Common\Utf8StringRef.cs</Link>
+    </Compile>
     <Compile Include="$(ToolsCommonPath)TypeSystem\CodeGen\MethodDesc.CodeGen.cs">
       <Link>TypeSystem\CodeGen\MethodDesc.CodeGen.cs</Link>
     </Compile>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/SwiftLoweringTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler.Tests/SwiftLoweringTests.cs
@@ -46,7 +46,7 @@ namespace ILCompiler.Compiler.Tests
             foreach (var type in testModule.GetAllTypes())
             {
                 if (type is EcmaType { IsValueType: true } ecmaType
-                    && ecmaType.Namespace.SequenceEqual("ILCompiler.Compiler.Tests.Assets.SwiftTypes"u8)
+                    && ecmaType.Namespace == "ILCompiler.Compiler.Tests.Assets.SwiftTypes"u8
                     && ecmaType.GetDecodedCustomAttribute("ILCompiler.Compiler.Tests.Assets.SwiftTypes", "ExpectedLoweringAttribute") is { } expectedLoweringAttribute)
                 {
                     // By default, we assume that our lowered representation is meant to be naturally aligned.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -176,9 +176,9 @@ namespace ILCompiler
             if (intrinsicOwningType.Module != TypeSystemContext.SystemModule)
                 return intrinsicMethod;
 
-            if (intrinsicOwningType.Name.SequenceEqual("Type"u8) && intrinsicOwningType.Namespace.SequenceEqual("System"u8))
+            if (intrinsicOwningType.Name == "Type"u8 && intrinsicOwningType.Namespace == "System"u8)
             {
-                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name.SequenceEqual("GetType"u8))
+                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name == "GetType"u8)
                 {
                     ModuleDesc callsiteModule = (callsiteMethod.OwningType as MetadataType)?.Module;
                     if (callsiteModule != null)
@@ -188,9 +188,9 @@ namespace ILCompiler
                     }
                 }
             }
-            else if (intrinsicOwningType.Name.SequenceEqual("Assembly"u8) && intrinsicOwningType.Namespace.SequenceEqual("System.Reflection"u8))
+            else if (intrinsicOwningType.Name == "Assembly"u8 && intrinsicOwningType.Namespace == "System.Reflection"u8)
             {
-                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name.SequenceEqual("GetExecutingAssembly"u8))
+                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name == "GetExecutingAssembly"u8)
                 {
                     ModuleDesc callsiteModule = (callsiteMethod.OwningType as MetadataType)?.Module;
                     if (callsiteModule != null)
@@ -200,9 +200,9 @@ namespace ILCompiler
                     }
                 }
             }
-            else if (intrinsicOwningType.Name.SequenceEqual("MethodBase"u8) && intrinsicOwningType.Namespace.SequenceEqual("System.Reflection"u8))
+            else if (intrinsicOwningType.Name == "MethodBase"u8 && intrinsicOwningType.Namespace == "System.Reflection"u8)
             {
-                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name.SequenceEqual("GetCurrentMethod"u8))
+                if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name == "GetCurrentMethod"u8)
                 {
                     if (callsiteMethod.IsAsyncVariant())
                     {
@@ -457,11 +457,11 @@ namespace ILCompiler
             if (containingMethod.OwningType is MetadataType owningType)
             {
                 // RawCalliHelper is a way for the class library to opt out of fat calls
-                if (owningType.Name.SequenceEqual("RawCalliHelper"u8))
+                if (owningType.Name == "RawCalliHelper"u8)
                     return false;
 
                 // Delegate invocation never needs fat calls
-                if (owningType.IsDelegate && containingMethod.Name.SequenceEqual("Invoke"u8))
+                if (owningType.IsDelegate && containingMethod.Name == "Invoke"u8)
                     return false;
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -232,8 +232,8 @@ namespace ILCompiler
 
             public override ModuleDesc Module { get; }
 
-            public override Utf8StringRef Name => "Boxed_"u8.Append(ValueTypeRepresented.Name);
-            public override Utf8StringRef Namespace => ValueTypeRepresented.Namespace;
+            public override Utf8Span Name => "Boxed_"u8.Append(ValueTypeRepresented.Name);
+            public override Utf8Span Namespace => ValueTypeRepresented.Namespace;
             public override string DiagnosticName => "Boxed_" + ValueTypeRepresented.DiagnosticName;
             public override string DiagnosticNamespace => ValueTypeRepresented.DiagnosticNamespace;
             public override Instantiation Instantiation => ValueTypeRepresented.Instantiation;
@@ -274,9 +274,9 @@ namespace ILCompiler
             public override ClassLayoutMetadata GetClassLayout() => default(ClassLayoutMetadata);
             public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
             public override IEnumerable<MetadataType> GetNestedTypes() => Array.Empty<MetadataType>();
-            public override MetadataType GetNestedType(Utf8StringRef name) => null;
+            public override MetadataType GetNestedType(Utf8Span name) => null;
             protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => Array.Empty<MethodImplRecord>();
-            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => Array.Empty<MethodImplRecord>();
+            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name) => Array.Empty<MethodImplRecord>();
 
             public override int GetHashCode() => VersionResilientHashCode.NameHashCode(Namespace, Name);
 
@@ -300,7 +300,7 @@ namespace ILCompiler
                 return flags;
             }
 
-            public override FieldDesc GetField(Utf8StringRef name)
+            public override FieldDesc GetField(Utf8Span name)
             {
                 return null;
             }
@@ -370,7 +370,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {
@@ -459,7 +459,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 
 using Internal;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.IL;
 using Internal.IL.Stubs;
@@ -231,8 +232,8 @@ namespace ILCompiler
 
             public override ModuleDesc Module { get; }
 
-            public override ReadOnlySpan<byte> Name => "Boxed_"u8.Append(ValueTypeRepresented.Name);
-            public override ReadOnlySpan<byte> Namespace => ValueTypeRepresented.Namespace;
+            public override Utf8StringRef Name => "Boxed_"u8.Append(ValueTypeRepresented.Name);
+            public override Utf8StringRef Namespace => ValueTypeRepresented.Namespace;
             public override string DiagnosticName => "Boxed_" + ValueTypeRepresented.DiagnosticName;
             public override string DiagnosticNamespace => ValueTypeRepresented.DiagnosticNamespace;
             public override Instantiation Instantiation => ValueTypeRepresented.Instantiation;
@@ -273,9 +274,9 @@ namespace ILCompiler
             public override ClassLayoutMetadata GetClassLayout() => default(ClassLayoutMetadata);
             public override bool HasCustomAttribute(string attributeNamespace, string attributeName) => false;
             public override IEnumerable<MetadataType> GetNestedTypes() => Array.Empty<MetadataType>();
-            public override MetadataType GetNestedType(ReadOnlySpan<byte> name) => null;
+            public override MetadataType GetNestedType(Utf8StringRef name) => null;
             protected override MethodImplRecord[] ComputeVirtualMethodImplsForType() => Array.Empty<MethodImplRecord>();
-            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name) => Array.Empty<MethodImplRecord>();
+            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => Array.Empty<MethodImplRecord>();
 
             public override int GetHashCode() => VersionResilientHashCode.NameHashCode(Namespace, Name);
 
@@ -299,7 +300,7 @@ namespace ILCompiler
                 return flags;
             }
 
-            public override FieldDesc GetField(ReadOnlySpan<byte> name)
+            public override FieldDesc GetField(Utf8StringRef name)
             {
                 return null;
             }
@@ -369,7 +370,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {
@@ -458,7 +459,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
@@ -38,7 +38,7 @@ namespace ILCompiler
 
             public override IAssemblyDesc Assembly => this;
 
-            public Utf8StringRef Name => "System.Private.CompilerGenerated"u8;
+            public Utf8Span Name => "System.Private.CompilerGenerated"u8;
 
             public CompilerGeneratedAssembly(TypeSystemContext context)
                 : base(context, null)
@@ -61,7 +61,7 @@ namespace ILCompiler
                 return new AssemblyNameInfo("System.Private.CompilerGenerated");
             }
 
-            public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
+            public override object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior)
             {
                 Debug.Fail("Resolving a TypeRef in the compiler generated assembly?");
                 throw new NotImplementedException();
@@ -89,7 +89,7 @@ namespace ILCompiler
                 }
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {
@@ -105,7 +105,7 @@ namespace ILCompiler
                 }
             }
 
-            public override Utf8StringRef Namespace
+            public override Utf8Span Namespace
             {
                 get
                 {
@@ -163,7 +163,7 @@ namespace ILCompiler
                 return Array.Empty<MetadataType>();
             }
 
-            public override MetadataType GetNestedType(Utf8StringRef name)
+            public override MetadataType GetNestedType(Utf8Span name)
             {
                 return null;
             }
@@ -173,7 +173,7 @@ namespace ILCompiler
                 return Array.Empty<MethodImplRecord>();
             }
 
-            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
+            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name)
             {
                 return Array.Empty<MethodImplRecord>();
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GeneratedAssembly.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Reflection.Metadata;
 
 using Internal;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using TypeHashingAlgorithms = Internal.NativeFormat.TypeHashingAlgorithms;
@@ -37,7 +38,7 @@ namespace ILCompiler
 
             public override IAssemblyDesc Assembly => this;
 
-            public ReadOnlySpan<byte> Name => "System.Private.CompilerGenerated"u8;
+            public Utf8StringRef Name => "System.Private.CompilerGenerated"u8;
 
             public CompilerGeneratedAssembly(TypeSystemContext context)
                 : base(context, null)
@@ -60,7 +61,7 @@ namespace ILCompiler
                 return new AssemblyNameInfo("System.Private.CompilerGenerated");
             }
 
-            public override object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior)
+            public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
             {
                 Debug.Fail("Resolving a TypeRef in the compiler generated assembly?");
                 throw new NotImplementedException();
@@ -88,7 +89,7 @@ namespace ILCompiler
                 }
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {
@@ -104,7 +105,7 @@ namespace ILCompiler
                 }
             }
 
-            public override ReadOnlySpan<byte> Namespace
+            public override Utf8StringRef Namespace
             {
                 get
                 {
@@ -162,7 +163,7 @@ namespace ILCompiler
                 return Array.Empty<MetadataType>();
             }
 
-            public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+            public override MetadataType GetNestedType(Utf8StringRef name)
             {
                 return null;
             }
@@ -172,7 +173,7 @@ namespace ILCompiler
                 return Array.Empty<MethodImplRecord>();
             }
 
-            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name)
+            public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name)
             {
                 return Array.Empty<MethodImplRecord>();
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GetFieldMethodOverrides.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.GetFieldMethodOverrides.cs
@@ -103,7 +103,7 @@ namespace ILCompiler
                 return false;
 
             // ValueTuples override Equals/GetHashCode and don't have a `base.GetHashCode` call. So avoid the infrastructure.
-            if (valueType.Module == SystemModule && valueType.Name.StartsWith("ValueTuple`"u8) && valueType.Namespace.SequenceEqual("System"u8))
+            if (valueType.Module == SystemModule && valueType.Name.StartsWith("ValueTuple`"u8) && valueType.Namespace == "System"u8)
                 return false;
 
             return !_typeStateHashtable.GetOrCreateValue(valueType).CanCompareValueTypeBits;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.IL;
 using Internal.IL.Stubs;
@@ -196,7 +197,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
@@ -197,7 +197,7 @@ namespace ILCompiler
 
             public MethodDesc TargetMethod => _targetMethod;
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedCallGraph.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedCallGraph.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromMethod.IsTypicalMethodDefinition);
             Debug.Assert(toMethod.IsTypicalMethodDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name));
+            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name.AsSpan()));
             TrackCallInternal(fromMethod, toMethod);
         }
 
@@ -38,7 +38,7 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromMethod.IsTypicalMethodDefinition);
             Debug.Assert(toType.IsTypeDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(toType.Name));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(toType.Name.AsSpan()));
             TrackCallInternal(fromMethod, toType);
         }
 
@@ -46,8 +46,8 @@ namespace ILCompiler.Dataflow
         {
             Debug.Assert(fromType.IsTypeDefinition);
             Debug.Assert(toMethod.IsTypicalMethodDefinition);
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(fromType.Name));
-            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineType(fromType.Name.AsSpan()));
+            Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(toMethod.Name.AsSpan()));
             TrackCallInternal(fromType, toMethod);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -117,7 +117,7 @@ namespace ILCompiler.Dataflow
             internal TypeCache(MetadataType type, ILProvider ilProvider)
             {
                 Debug.Assert(type == type.GetTypeDefinition());
-                Debug.Assert(!CompilerGeneratedNames.IsStateMachineOrDisplayClass(type.Name));
+                Debug.Assert(!CompilerGeneratedNames.IsStateMachineOrDisplayClass(type.Name.AsSpan()));
 
                 Type = type;
 
@@ -138,8 +138,8 @@ namespace ILCompiler.Dataflow
                 {
                     Debug.Assert(method == method.GetTypicalMethodDefinition());
 
-                    bool isStateMachineMember = CompilerGeneratedNames.IsStateMachineType(((MetadataType)method.OwningType).Name);
-                    if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
+                    bool isStateMachineMember = CompilerGeneratedNames.IsStateMachineType(((MetadataType)method.OwningType).Name.AsSpan());
+                    if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name.AsSpan()))
                     {
                         if (!isStateMachineMember)
                         {
@@ -183,7 +183,7 @@ namespace ILCompiler.Dataflow
                                             referencedMethod.OwningType is MetadataType generatedType &&
                                             // Don't consider calls in the same/nested type, like inside a static constructor
                                             !IsSameOrNestedType(method.OwningType, generatedType) &&
-                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
+                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name.AsSpan()))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
 
@@ -196,7 +196,7 @@ namespace ILCompiler.Dataflow
                                             continue;
                                         }
 
-                                        if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(referencedMethod.Name))
+                                        if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(referencedMethod.Name.AsSpan()))
                                             continue;
 
                                         if (isStateMachineMember)
@@ -224,7 +224,7 @@ namespace ILCompiler.Dataflow
                                         if (field.OwningType is MetadataType generatedType &&
                                             // Don't consider field accesses in the same/nested type, like inside a static constructor
                                             !IsSameOrNestedType(method.OwningType, generatedType) &&
-                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name))
+                                            CompilerGeneratedNames.IsLambdaDisplayClass(generatedType.Name.AsSpan()))
                                         {
                                             Debug.Assert(generatedType.IsTypeDefinition);
 
@@ -249,7 +249,7 @@ namespace ILCompiler.Dataflow
                     if (TryGetStateMachineType(method, out MetadataType? stateMachineType))
                     {
                         Debug.Assert(stateMachineType.ContainingType == type ||
-                            (CompilerGeneratedNames.IsStateMachineOrDisplayClass(stateMachineType.ContainingType.Name) &&
+                            (CompilerGeneratedNames.IsStateMachineOrDisplayClass(stateMachineType.ContainingType.Name.AsSpan()) &&
                              stateMachineType.ContainingType.ContainingType == type));
                         Debug.Assert(stateMachineType == stateMachineType.GetTypeDefinition());
 
@@ -325,7 +325,7 @@ namespace ILCompiler.Dataflow
                         switch (compilerGeneratedMember)
                         {
                             case MethodDesc nestedFunction:
-                                Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(nestedFunction.Name));
+                                Debug.Assert(CompilerGeneratedNames.IsLambdaOrLocalFunction(nestedFunction.Name.AsSpan()));
                                 // Nested functions get suppressions from the user method only.
                                 _compilerGeneratedMethodToUserCodeMethod ??= new Dictionary<MethodDesc, MethodDesc>();
                                 if (!_compilerGeneratedMethodToUserCodeMethod.TryAdd(nestedFunction, userDefinedMethod))
@@ -340,7 +340,7 @@ namespace ILCompiler.Dataflow
                                 // are represented by the state machine type itself.
                                 // We are already tracking the association of the state machine type to the user code method
                                 // above, so no need to track it here.
-                                Debug.Assert(CompilerGeneratedNames.IsStateMachineType(stateMachineType.Name));
+                                Debug.Assert(CompilerGeneratedNames.IsStateMachineType(stateMachineType.Name.AsSpan()));
                                 break;
                             default:
                                 throw new InvalidOperationException();
@@ -392,7 +392,7 @@ namespace ILCompiler.Dataflow
                     MetadataType generatedType,
                     Dictionary<MetadataType, TypeArgumentInfo> generatedTypeToTypeArgs)
                 {
-                    Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
+                    Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name.AsSpan()));
                     Debug.Assert(generatedType == generatedType.GetTypeDefinition());
 
                     var typeInfo = generatedTypeToTypeArgs[generatedType];
@@ -432,7 +432,7 @@ namespace ILCompiler.Dataflow
                             else
                             {
                                 // Must be a type ref
-                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsStateMachineOrDisplayClass(owningType.Name))
+                                if (method.OwningType is not MetadataType owningType || !CompilerGeneratedNames.IsStateMachineOrDisplayClass(owningType.Name.AsSpan()))
                                 {
                                     userAttrs = param;
                                 }
@@ -573,7 +573,7 @@ namespace ILCompiler.Dataflow
         {
             foreach (var nestedType in type.GetNestedTypes())
             {
-                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(nestedType.Name))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(nestedType.Name.AsSpan()))
                     continue;
 
                 yield return nestedType;
@@ -585,14 +585,14 @@ namespace ILCompiler.Dataflow
 
         public static bool IsHoistedLocal(FieldDesc field)
         {
-            if (CompilerGeneratedNames.IsLambdaDisplayClass(field.OwningType.Name))
+            if (CompilerGeneratedNames.IsLambdaDisplayClass(field.OwningType.Name.AsSpan()))
                 return true;
 
-            if (CompilerGeneratedNames.IsStateMachineType(field.OwningType.Name))
+            if (CompilerGeneratedNames.IsStateMachineType(field.OwningType.Name.AsSpan()))
             {
                 // Don't track the "current" field which is used for state machine return values,
                 // because this can be expensive to track.
-                return !CompilerGeneratedNames.IsStateMachineCurrentField(field.Name);
+                return !CompilerGeneratedNames.IsStateMachineCurrentField(field.Name.AsSpan());
             }
 
             return false;
@@ -601,13 +601,13 @@ namespace ILCompiler.Dataflow
         // "Nested function" refers to lambdas and local functions.
         public static bool IsNestedFunctionOrStateMachineMember(TypeSystemEntity member)
         {
-            if (member is MethodDesc method && CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
+            if (member is MethodDesc method && CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name.AsSpan()))
                 return true;
 
             if (member.GetOwningType() is not MetadataType declaringType)
                 return false;
 
-            return CompilerGeneratedNames.IsStateMachineType(declaringType.Name);
+            return CompilerGeneratedNames.IsStateMachineType(declaringType.Name.AsSpan());
         }
 
         public static bool TryGetStateMachineType(MethodDesc method, [NotNullWhen(true)] out MetadataType? stateMachineType)
@@ -637,7 +637,7 @@ namespace ILCompiler.Dataflow
             // State machines can be emitted into display classes, so we may also need to go one more level up.
             // To avoid depending on implementation details, we go up until we see a non-compiler-generated type.
             // This is the counterpart to GetCompilerGeneratedNestedTypes.
-            while (userType != null && CompilerGeneratedNames.IsStateMachineOrDisplayClass(userType.Name))
+            while (userType != null && CompilerGeneratedNames.IsStateMachineOrDisplayClass(userType.Name.AsSpan()))
                 userType = userType.ContainingType as MetadataType;
 
             if (userType is null)
@@ -682,7 +682,7 @@ namespace ILCompiler.Dataflow
         public IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(MetadataType type)
         {
             MetadataType generatedType = (MetadataType)type.GetTypeDefinition();
-            Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name));
+            Debug.Assert(CompilerGeneratedNames.IsStateMachineOrDisplayClass(generatedType.Name.AsSpan()));
 
             // Avoid the heuristics for .NET10+, where DynamicallyAccessedMembers flows to generated code
             // because it is annotated with CompilerLoweringPreserveAttribute.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -275,16 +275,16 @@ namespace ILLink.Shared.TrimAnalysis
 
             foreach (var intf in type.RuntimeInterfaces)
             {
-                if (intf.Name.SequenceEqual("IReflect"u8) && intf.Namespace.SequenceEqual("System.Reflection"u8))
+                if (intf.Name == "IReflect"u8 && intf.Namespace == "System.Reflection"u8)
                     return true;
             }
 
-            if (metadataType.Name.SequenceEqual("IReflect"u8) && metadataType.Namespace.SequenceEqual("System.Reflection"u8))
+            if (metadataType.Name == "IReflect"u8 && metadataType.Namespace == "System.Reflection"u8)
                 return true;
 
             do
             {
-                if (metadataType.Name.SequenceEqual("Type"u8) && metadataType.Namespace.SequenceEqual("System"u8))
+                if (metadataType.Name == "Type"u8 && metadataType.Namespace == "System"u8)
                     return true;
             } while ((metadataType = metadataType.BaseType) != null);
 
@@ -509,7 +509,7 @@ namespace ILLink.Shared.TrimAnalysis
 
                     PropertyPseudoDesc property = new PropertyPseudoDesc(ecmaType, propertyHandle);
 
-                    if (CompilerGeneratedNames.IsExtensionType(ecmaType.Name))
+                    if (CompilerGeneratedNames.IsExtensionType(ecmaType.Name.AsSpan()))
                     {
                         // Annotations on extension properties are not supported.
                         _logger.LogWarning(property, DiagnosticId.DynamicallyAccessedMembersIsNotAllowedOnExtensionProperties, property.GetDisplayName());
@@ -649,7 +649,7 @@ namespace ILLink.Shared.TrimAnalysis
 
             private IReadOnlyList<GenericParameterDesc?>? GetGeneratedTypeAttributes(EcmaType typeDef)
             {
-                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(typeDef.Name))
+                if (!CompilerGeneratedNames.IsStateMachineOrDisplayClass(typeDef.Name.AsSpan()))
                 {
                     return null;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/InterproceduralState.cs
@@ -78,7 +78,7 @@ namespace ILCompiler.Dataflow
             {
                 foreach (var stateMachineMethod in stateMachineType.GetMethods())
                 {
-                    Debug.Assert(!CompilerGeneratedNames.IsLambdaOrLocalFunction(stateMachineMethod.Name));
+                    Debug.Assert(!CompilerGeneratedNames.IsLambdaOrLocalFunction(stateMachineMethod.Name.AsSpan()));
                     if (TryGetMethodBody(stateMachineMethod, out MethodIL? stateMachineMethodBody))
                     {
                         stateMachineMethodBody = GetInstantiatedMethodIL(stateMachineMethodBody);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -335,7 +335,7 @@ namespace ILCompiler.Dataflow
         {
             MethodDesc method = referencedMethod.GetTypicalMethodDefinition();
 
-            if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name))
+            if (!CompilerGeneratedNames.IsLambdaOrLocalFunction(method.Name.AsSpan()))
                 return;
 
             interproceduralState.TrackMethod(method);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/CodeBasedDependencyAlgorithm.cs
@@ -36,16 +36,16 @@ namespace ILCompiler.DependencyAnalysis
                         case "Create":
                             if (method.IsSharedByGenericInstantiations
                                 && owningType.Module == factory.TypeSystemContext.SystemModule
-                                && owningType.Namespace.SequenceEqual("System.Collections.Generic"u8))
+                                && owningType.Namespace == "System.Collections.Generic"u8)
                             {
                                 TypeDesc[] templateDependencies = null;
 
-                                if (owningType.Name.SequenceEqual("Comparer`1"u8))
+                                if (owningType.Name == "Comparer`1"u8)
                                 {
                                     templateDependencies = Internal.IL.Stubs.ComparerIntrinsics.GetPotentialComparersForType(
                                         owningType.Instantiation[0]);
                                 }
-                                else if (owningType.Name.SequenceEqual("EqualityComparer`1"u8))
+                                else if (owningType.Name == "EqualityComparer`1"u8)
                                 {
                                     templateDependencies = Internal.IL.Stubs.ComparerIntrinsics.GetPotentialEqualityComparersForType(
                                         owningType.Instantiation[0]);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -972,7 +972,7 @@ namespace ILCompiler.DependencyAnalysis
                 // Object.Finalize shouldn't get a virtual slot. Finalizer is stored in an optional field
                 // instead: most MethodTable don't have a finalizer, but all EETypes contain Object's vtable.
                 // This lets us save a pointer (+reloc) on most EETypes.
-                Debug.Assert(!declType.IsObject || !declMethod.Name.SequenceEqual("Finalize"u8));
+                Debug.Assert(!declType.IsObject || declMethod.Name != "Finalize"u8);
 
                 // No generic virtual methods can appear in the vtable!
                 Debug.Assert(!declMethod.HasInstantiation);
@@ -997,8 +997,8 @@ namespace ILCompiler.DependencyAnalysis
                 // We also null out Equals/GetHashCode - that's just a marginal size/startup optimization.
                 if (isAsyncStateMachineValueType)
                 {
-                    if ((declType.IsObject && (declMethod.Name.SequenceEqual("Equals"u8) || declMethod.Name.SequenceEqual("GetHashCode"u8)) && implMethod.OwningType.IsWellKnownType(WellKnownType.ValueType))
-                        || (declType.IsWellKnownType(WellKnownType.ValueType) && declMethod.Name.SequenceEqual(GetFieldHelperMethodOverride.MetadataName)))
+                    if ((declType.IsObject && (declMethod.Name == "Equals"u8 || declMethod.Name == "GetHashCode"u8) && implMethod.OwningType.IsWellKnownType(WellKnownType.ValueType))
+                        || (declType.IsWellKnownType(WellKnownType.ValueType) && declMethod.Name == GetFieldHelperMethodOverride.MetadataName))
                     {
                         shouldEmitImpl = false;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InlineableStringsResourceNode.cs
@@ -60,8 +60,8 @@ namespace ILCompiler.DependencyAnalysis
 
         public static void AddDependenciesDueToResourceStringUse(ref DependencyList dependencies, NodeFactory factory, MethodDesc method)
         {
-            if (method.Name.SequenceEqual(ResourceAccessorGetStringMethodName) && method.OwningType is MetadataType mdType
-                && mdType.Name.SequenceEqual(ResourceAccessorTypeName) && mdType.Namespace.SequenceEqual(ResourceAccessorTypeNamespace))
+            if (method.Name == ResourceAccessorGetStringMethodName && method.OwningType is MetadataType mdType
+                && mdType.Name == ResourceAccessorTypeName && mdType.Namespace == ResourceAccessorTypeNamespace)
             {
                 dependencies ??= new DependencyList();
                 dependencies.Add(factory.InlineableStringResource((EcmaModule)mdType.Module), "Using the System.SR class");

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -42,7 +42,7 @@ namespace ILCompiler.DependencyAnalysis
                     continue;
 
                 // Finalizers are called via a field on the MethodTable, not through the VTable
-                if (isObjectType && method.Name.SequenceEqual("Finalize"u8))
+                if (isObjectType && method.Name == "Finalize"u8)
                     continue;
 
                 // Current type doesn't define this slot.
@@ -203,7 +203,7 @@ namespace ILCompiler.DependencyAnalysis
 #endif
 
             // Finalizers are called via a field on the MethodTable, not through the VTable
-            if (_type.IsObject && virtualMethod.Name.SequenceEqual("Finalize"u8))
+            if (_type.IsObject && virtualMethod.Name == "Finalize"u8)
                 return;
 
             _usedMethods.Add(virtualMethod);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -20,7 +21,7 @@ namespace ILCompiler
             _symbolName = symbolName;
         }
 
-        public override ReadOnlySpan<byte> Name => System.Text.Encoding.UTF8.GetBytes(_symbolName);
+        public override Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes(_symbolName);
 
         public string SymbolName => _symbolName;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ExternSymbolMappedField.cs
@@ -21,7 +21,7 @@ namespace ILCompiler
             _symbolName = symbolName;
         }
 
-        public override Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes(_symbolName);
+        public override Utf8Span Name => System.Text.Encoding.UTF8.GetBytes(_symbolName);
 
         public string SymbolName => _symbolName;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicHelpers.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/HardwareIntrinsicHelpers.Aot.cs
@@ -16,7 +16,7 @@ namespace ILCompiler
     {
         public static bool IsIsSupportedMethod(MethodDesc method)
         {
-            return method.Name.SequenceEqual("get_IsSupported"u8);
+            return method.Name == "get_IsSupported"u8;
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NoMetadataBlockingPolicy.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NoMetadataBlockingPolicy.cs
@@ -54,7 +54,7 @@ namespace ILCompiler
                     return true;
 
                 // Also don't expose the ValueType.__GetFieldOverride method.
-                if (ecmaMethod.Name.SequenceEqual(Internal.IL.Stubs.GetFieldHelperMethodOverride.MetadataName)
+                if (ecmaMethod.Name == Internal.IL.Stubs.GetFieldHelperMethodOverride.MetadataName
                     && ecmaMethod.OwningType.IsWellKnownType(WellKnownType.ValueType))
                     return true;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
@@ -240,7 +240,7 @@ namespace ILCompiler
 
             public override TypeSystemContext Context => _context;
             public override TypeDesc OwningType => _context.GeneratedAssembly.GetGlobalModuleType();
-            public override Utf8StringRef Name => "InitializeReachabilityInfo"u8;
+            public override Utf8Span Name => "InitializeReachabilityInfo"u8;
             public override string DiagnosticName => "InitializeReachabilityInfo";
 
             public override MethodIL EmitIL()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ReachabilityInstrumentationProvider.cs
@@ -240,7 +240,7 @@ namespace ILCompiler
 
             public override TypeSystemContext Context => _context;
             public override TypeDesc OwningType => _context.GeneratedAssembly.GetGlobalModuleType();
-            public override ReadOnlySpan<byte> Name => "InitializeReachabilityInfo"u8;
+            public override Utf8StringRef Name => "InitializeReachabilityInfo"u8;
             public override string DiagnosticName => "InitializeReachabilityInfo";
 
             public override MethodIL EmitIL()

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutedILProvider.cs
@@ -414,8 +414,8 @@ namespace ILCompiler
                     {
                         var callee = method.GetObject(reader.ReadILToken(), NotFoundBehavior.ReturnNull) as EcmaMethod;
                         if (callee != null && callee.IsSpecialName && callee.OwningType is EcmaType calleeType
-                            && calleeType.Name.SequenceEqual(InlineableStringsResourceNode.ResourceAccessorTypeName)
-                            && calleeType.Namespace.SequenceEqual(InlineableStringsResourceNode.ResourceAccessorTypeNamespace)
+                            && calleeType.Name == InlineableStringsResourceNode.ResourceAccessorTypeName
+                            && calleeType.Namespace == InlineableStringsResourceNode.ResourceAccessorTypeNamespace
                             && callee.Signature is { Length: 0, IsStatic: true }
                             && callee.Name.StartsWith("get_"u8))
                         {
@@ -822,9 +822,9 @@ namespace ILCompiler
                         {
                             return true;
                         }
-                        else if (method.IsIntrinsic && (method.Name.SequenceEqual("get_IsValueType"u8) || method.Name.SequenceEqual("get_IsEnum"u8))
+                        else if (method.IsIntrinsic && (method.Name == "get_IsValueType"u8 || method.Name == "get_IsEnum"u8)
                             && method.OwningType is MetadataType mdt
-                            && mdt.Name.SequenceEqual("Type"u8) && mdt.Namespace.SequenceEqual("System"u8) && mdt.Module == mdt.Context.SystemModule
+                            && mdt.Name == "Type"u8 && mdt.Namespace == "System"u8 && mdt.Module == mdt.Context.SystemModule
                             && TryExpandTypeIs(methodIL, body, flags, currentOffset, method.GetName(), out constant))
                         {
                             return true;
@@ -1133,7 +1133,7 @@ namespace ILCompiler
 
             MethodDesc method = (MethodDesc)methodIL.GetObject(reader.ReadILToken());
 
-            if (!method.IsIntrinsic || !method.Name.SequenceEqual("GetTypeFromHandle"u8))
+            if (!method.IsIntrinsic || method.Name != "GetTypeFromHandle"u8)
                 return false;
 
             if ((flags[reader.Offset] & OpcodeFlags.BasicBlockStart) != 0)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutionProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/SubstitutionProvider.cs
@@ -73,7 +73,7 @@ namespace ILCompiler
                 if (featureGuardAttribute.FixedArguments is not [CustomAttributeTypedArgument<TypeDesc> { Value: EcmaType featureType }])
                     continue;
 
-                if (featureType.Namespace.SequenceEqual("System.Diagnostics.CodeAnalysis"u8))
+                if (featureType.Namespace == "System.Diagnostics.CodeAnalysis"u8)
                 {
                     switch (featureType.GetName())
                     {
@@ -135,7 +135,7 @@ namespace ILCompiler
         internal string GetResourceStringForAccessor(EcmaMethod method)
         {
             Debug.Assert(method.Name.StartsWith("get_"u8));
-            string resourceStringName = System.Text.Encoding.UTF8.GetString(method.Name.Slice(4));
+            string resourceStringName = System.Text.Encoding.UTF8.GetString(method.Name.AsSpan().Slice(4));
 
             Dictionary<string, string> dict = _hashtable.GetOrCreateValue(method.Module).InlineableResourceStrings;
             if (dict != null

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1837,8 +1837,8 @@ namespace ILCompiler
             if (type.IsByRefLike
                 && type is MetadataType maybeSpan
                 && maybeSpan.Module == type.Context.SystemModule
-                && ((isReadOnlySpan && maybeSpan.Name.SequenceEqual("ReadOnlySpan`1"u8)) || (!isReadOnlySpan && maybeSpan.Name.SequenceEqual("Span`1"u8)))
-                && maybeSpan.Namespace.SequenceEqual("System"u8)
+                && ((isReadOnlySpan && maybeSpan.Name == "ReadOnlySpan`1"u8) || (!isReadOnlySpan && maybeSpan.Name == "Span`1"u8))
+                && maybeSpan.Namespace == "System"u8
                 && maybeSpan.Instantiation[0] is MetadataType readOnlySpanElementType)
             {
                 elementType = readOnlySpanElementType;
@@ -1885,7 +1885,7 @@ namespace ILCompiler
             {
                 case "InitializeArray":
                     if (method.OwningType is MetadataType mdType
-                        && mdType.Name.SequenceEqual("RuntimeHelpers"u8) && mdType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8)
+                        && mdType.Name == "RuntimeHelpers"u8 && mdType.Namespace == "System.Runtime.CompilerServices"u8
                         && mdType.Module == mdType.Context.SystemModule
                         && parameters[0] is ArrayInstance array
                         && parameters[1] is RuntimeFieldHandleValue fieldHandle
@@ -1898,7 +1898,7 @@ namespace ILCompiler
                     return false;
                 case "CreateSpan":
                     if (method.OwningType is MetadataType createSpanType
-                        && createSpanType.Name.SequenceEqual("RuntimeHelpers"u8) && createSpanType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8)
+                        && createSpanType.Name == "RuntimeHelpers"u8 && createSpanType.Namespace == "System.Runtime.CompilerServices"u8
                         && createSpanType.Module == createSpanType.Context.SystemModule
                         && parameters[0] is RuntimeFieldHandleValue createSpanFieldHandle
                         && createSpanFieldHandle.Field.IsStatic && createSpanFieldHandle.Field.HasRva
@@ -1938,7 +1938,7 @@ namespace ILCompiler
                 }
                 case "IsReferenceOrContainsReferences" when method.Instantiation.Length == 1
                         && method.OwningType is MetadataType isReferenceOrContainsReferencesType
-                        && isReferenceOrContainsReferencesType.Name.SequenceEqual("RuntimeHelpers"u8) && isReferenceOrContainsReferencesType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8)
+                        && isReferenceOrContainsReferencesType.Name == "RuntimeHelpers"u8 && isReferenceOrContainsReferencesType.Namespace == "System.Runtime.CompilerServices"u8
                         && isReferenceOrContainsReferencesType.Module == method.Context.SystemModule:
                 {
                     bool result = method.Instantiation[0].IsGCPointer || (method.Instantiation[0] is DefType defType && defType.ContainsGCPointers);
@@ -1947,7 +1947,7 @@ namespace ILCompiler
                 }
                 case "GetArrayDataReference" when method.Instantiation.Length == 1
                         && method.OwningType is MetadataType getArrayDataReferenceType
-                        && getArrayDataReferenceType.Name.SequenceEqual("MemoryMarshal"u8) && getArrayDataReferenceType.Namespace.SequenceEqual("System.Runtime.InteropServices"u8)
+                        && getArrayDataReferenceType.Name == "MemoryMarshal"u8 && getArrayDataReferenceType.Namespace == "System.Runtime.InteropServices"u8
                         && getArrayDataReferenceType.Module == method.Context.SystemModule
                         && parameters[0] is ArrayInstance arrayData
                         && ((ArrayType)arrayData.Type).ElementType == method.Instantiation[0]:
@@ -1959,7 +1959,7 @@ namespace ILCompiler
 
             static bool IsSystemType(TypeDesc type)
                 => type is MetadataType typeType
-                        && typeType.Name.SequenceEqual("Type"u8) && typeType.Namespace.SequenceEqual("System"u8)
+                        && typeType.Name == "Type"u8 && typeType.Namespace == "System"u8
                         && typeType.Module == typeType.Context.SystemModule;
 
             return false;
@@ -2434,9 +2434,9 @@ namespace ILCompiler
 
             private static bool IsComInterfaceEntryType(TypeDesc type)
                 => type is MetadataType mdType
-                    && mdType.Name.SequenceEqual("ComInterfaceEntry"u8)
+                    && mdType.Name == "ComInterfaceEntry"u8
                     && mdType.ContainingType is MetadataType comWrappersType
-                    && comWrappersType.Name.SequenceEqual("ComWrappers"u8) && comWrappersType.Namespace.SequenceEqual("System.Runtime.InteropServices"u8)
+                    && comWrappersType.Name == "ComWrappers"u8 && comWrappersType.Namespace == "System.Runtime.InteropServices"u8
                     && comWrappersType.Module == comWrappersType.Context.SystemModule;
 
             public static bool IsCompatible(TypeDesc type, out TypeDesc entryType)
@@ -2536,14 +2536,14 @@ namespace ILCompiler
                     if (field.OwningType != _parent._entryType)
                         return false;
 
-                    if (field.Name.SequenceEqual("IID"u8)
+                    if (field.Name == "IID"u8
                         && value is ValueTypeValue guidValue
                         && guidValue.Size == _parent._guidBytes[_index].Length)
                     {
                         Array.Copy(guidValue.InstanceBytes, _parent._guidBytes[_index], _parent._guidBytes[_index].Length);
                         return true;
                     }
-                    else if (field.Name.SequenceEqual("Vtable"u8)
+                    else if (field.Name == "Vtable"u8
                         && value is ByRefValueBase byrefValue
                         && byrefValue.BackingField != null)
                     {
@@ -2982,7 +2982,7 @@ namespace ILCompiler
                     if (elementType != _value._elementType)
                         return false;
 
-                    if (field.Name.SequenceEqual("_length"u8))
+                    if (field.Name == "_length"u8)
                     {
                         _value._length = value.AsInt32() * _value._elementType.InstanceFieldSize.AsInt;
                         return true;
@@ -2990,7 +2990,7 @@ namespace ILCompiler
 
                     if (value is ByRefValue byref)
                     {
-                        Debug.Assert(field.Name.SequenceEqual("_reference"u8));
+                        Debug.Assert(field.Name == "_reference"u8);
                         _value._bytes = byref.PointedToBytes;
                         _value._index = byref.PointedToOffset;
                         return true;
@@ -3009,10 +3009,10 @@ namespace ILCompiler
                     if (elementType != _value._elementType)
                         ThrowHelper.ThrowInvalidProgramException();
 
-                    if (field.Name.SequenceEqual("_length"u8))
+                    if (field.Name == "_length"u8)
                         return ValueTypeValue.FromInt32(_value._length / elementType.InstanceFieldSize.AsInt);
 
-                    Debug.Assert(field.Name.SequenceEqual("_reference"u8));
+                    Debug.Assert(field.Name == "_reference"u8);
                     return new ByRefValue(_value._bytes, _value._index);
                 }
 
@@ -3272,7 +3272,7 @@ namespace ILCompiler
 
                 if (_methodPointed.Signature.IsStatic)
                 {
-                    Debug.Assert(creationInfo.Constructor.Method.Name.SequenceEqual("InitializeOpenStaticThunk"u8));
+                    Debug.Assert(creationInfo.Constructor.Method.Name == "InitializeOpenStaticThunk"u8);
 
                     // _firstParameter
                     builder.EmitPointerReloc(thisNode);
@@ -3289,7 +3289,7 @@ namespace ILCompiler
                 }
                 else
                 {
-                    Debug.Assert(creationInfo.Constructor.Method.Name.SequenceEqual("InitializeClosedInstance"u8));
+                    Debug.Assert(creationInfo.Constructor.Method.Name == "InitializeClosedInstance"u8);
 
                     // _firstParameter
                     _firstParameter.WriteFieldData(ref builder, factory);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedInteropStubManager.cs
@@ -60,7 +60,7 @@ namespace ILCompiler
             MetadataType metadataType = owningType as MetadataType;
             if (metadataType != null && metadataType.Module == factory.TypeSystemContext.SystemModule)
             {
-                if (metadataType.Name.SequenceEqual("Marshal"u8) && metadataType.Namespace.SequenceEqual("System.Runtime.InteropServices"u8))
+                if (metadataType.Name == "Marshal"u8 && metadataType.Namespace == "System.Runtime.InteropServices"u8)
                 {
                     string methodName = method.GetName();
                     if (methodName == "GetFunctionPointerForDelegate" ||

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/VectorOfTFieldLayoutAlgorithm.cs
@@ -98,7 +98,7 @@ namespace ILCompiler
 
         public static bool IsVectorOfTType(DefType type)
         {
-            return type.IsIntrinsic && type.Namespace.SequenceEqual("System.Numerics"u8) && type.Name.SequenceEqual("Vector`1"u8);
+            return type.IsIntrinsic && type.Namespace == "System.Numerics"u8 && type.Name == "Vector`1"u8;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -1736,7 +1736,7 @@ namespace Internal.IL
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    Utf8StringRef typeName = owningType.Name;
+                    Utf8Span typeName = owningType.Name;
                     return owningType.Module == method.Context.SystemModule
                         && owningType.Namespace == "System.Threading.Tasks"u8
                         && (typeName == "Task"u8

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -3,6 +3,7 @@
 
 using System;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.ReadyToRunConstants;
 
@@ -535,7 +536,7 @@ namespace Internal.IL
                 }
             }
 
-            if (method.OwningType.IsDelegate && method.Name.SequenceEqual("Invoke"u8) &&
+            if (method.OwningType.IsDelegate && method.Name == "Invoke"u8 &&
                 opcode != ILOpcode.ldftn && opcode != ILOpcode.ldvirtftn)
             {
                 // This call is expanded as an intrinsic; it's not an actual function call.
@@ -630,7 +631,7 @@ namespace Internal.IL
                     // null since the virtual method resolves to System.Enum's implementation and that's a reference type.
                     // We can't do this for any other method since ToString and Equals have different semantics for enums
                     // and their underlying type.
-                    if (method.OwningType.IsObject && method.Name.SequenceEqual("GetHashCode"u8))
+                    if (method.OwningType.IsObject && method.Name == "GetHashCode"u8)
                     {
                         constrained = constrained.UnderlyingType;
                     }
@@ -1154,7 +1155,7 @@ namespace Internal.IL
                 {
                     if (type.IsCanonicalDefinitionType(CanonicalFormKind.Any))
                     {
-                        Debug.Assert(_methodIL.OwningMethod.Name.SequenceEqual("GetCanonType"u8));
+                        Debug.Assert(_methodIL.OwningMethod.Name == "GetCanonType"u8);
                         helperId = ReadyToRunHelperId.NecessaryTypeHandle;
                     }
 
@@ -1630,12 +1631,12 @@ namespace Internal.IL
 
         private static bool IsTypeGetTypeFromHandle(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("GetTypeFromHandle"u8))
+            if (method.IsIntrinsic && method.Name == "GetTypeFromHandle"u8)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("Type"u8) && owningType.Namespace.SequenceEqual("System"u8);
+                    return owningType.Name == "Type"u8 && owningType.Namespace == "System"u8;
                 }
             }
 
@@ -1644,12 +1645,12 @@ namespace Internal.IL
 
         private static bool IsActivatorDefaultConstructorOf(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("DefaultConstructorOf"u8) && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && method.Name == "DefaultConstructorOf"u8 && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("Activator"u8) && owningType.Namespace.SequenceEqual("System"u8);
+                    return owningType.Name == "Activator"u8 && owningType.Namespace == "System"u8;
                 }
             }
 
@@ -1658,12 +1659,12 @@ namespace Internal.IL
 
         private static bool IsActivatorAllocatorOf(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("AllocatorOf"u8) && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && method.Name == "AllocatorOf"u8 && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("Activator"u8) && owningType.Namespace.SequenceEqual("System"u8);
+                    return owningType.Name == "Activator"u8 && owningType.Namespace == "System"u8;
                 }
             }
 
@@ -1672,12 +1673,12 @@ namespace Internal.IL
 
         private static bool IsEETypePtrOf(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("Of"u8) && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && method.Name == "Of"u8 && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("MethodTable"u8) && owningType.Namespace.SequenceEqual("Internal.Runtime"u8);
+                    return owningType.Name == "MethodTable"u8 && owningType.Namespace == "Internal.Runtime"u8;
                 }
             }
 
@@ -1686,12 +1687,12 @@ namespace Internal.IL
 
         private static bool IsRuntimeHelpersIsReferenceOrContainsReferences(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("IsReferenceOrContainsReferences"u8) && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && method.Name == "IsReferenceOrContainsReferences"u8 && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("RuntimeHelpers"u8) && owningType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8);
+                    return owningType.Name == "RuntimeHelpers"u8 && owningType.Namespace == "System.Runtime.CompilerServices"u8;
                 }
             }
 
@@ -1700,12 +1701,12 @@ namespace Internal.IL
 
         private static bool IsMemoryMarshalGetArrayDataReference(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("GetArrayDataReference"u8) && method.Instantiation.Length == 1)
+            if (method.IsIntrinsic && method.Name == "GetArrayDataReference"u8 && method.Instantiation.Length == 1)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    return owningType.Name.SequenceEqual("MemoryMarshal"u8) && owningType.Namespace.SequenceEqual("System.Runtime.InteropServices"u8);
+                    return owningType.Name == "MemoryMarshal"u8 && owningType.Namespace == "System.Runtime.InteropServices"u8;
                 }
             }
 
@@ -1714,14 +1715,14 @@ namespace Internal.IL
 
         private static bool IsAsyncHelpersAwait(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("Await"u8))
+            if (method.IsIntrinsic && method.Name == "Await"u8)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
                     return owningType.Module == method.Context.SystemModule
-                        && owningType.Name.SequenceEqual("AsyncHelpers"u8)
-                        && owningType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8);
+                        && owningType.Name == "AsyncHelpers"u8
+                        && owningType.Namespace == "System.Runtime.CompilerServices"u8;
                 }
             }
 
@@ -1730,18 +1731,18 @@ namespace Internal.IL
 
         private static bool IsTaskConfigureAwait(MethodDesc method)
         {
-            if (method.IsIntrinsic && method.Name.SequenceEqual("ConfigureAwait"u8))
+            if (method.IsIntrinsic && method.Name == "ConfigureAwait"u8)
             {
                 MetadataType owningType = method.OwningType as MetadataType;
                 if (owningType != null)
                 {
-                    ReadOnlySpan<byte> typeName = owningType.Name;
+                    Utf8StringRef typeName = owningType.Name;
                     return owningType.Module == method.Context.SystemModule
-                        && owningType.Namespace.SequenceEqual("System.Threading.Tasks"u8)
-                        && (typeName.SequenceEqual("Task"u8)
-                            || typeName.SequenceEqual("Task`1"u8)
-                            || typeName.SequenceEqual("ValueTask"u8)
-                            || typeName.SequenceEqual("ValueTask`1"u8));
+                        && owningType.Namespace == "System.Threading.Tasks"u8
+                        && (typeName == "Task"u8
+                            || typeName == "Task`1"u8
+                            || typeName == "ValueTask"u8
+                            || typeName == "ValueTask`1"u8);
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Internal.IL.Stubs.StartupCode
@@ -40,7 +41,7 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/NativeLibraryStartupMethod.cs
@@ -41,7 +41,7 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -46,7 +46,7 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
-        public override Utf8StringRef Name
+        public override Utf8Span Name
         {
             get
             {
@@ -231,7 +231,7 @@ namespace Internal.IL.Stubs.StartupCode
                 get;
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/Stubs/StartupCode/StartupCodeMainMethod.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Debug = System.Diagnostics.Debug;
 
@@ -45,7 +46,7 @@ namespace Internal.IL.Stubs.StartupCode
             }
         }
 
-        public override ReadOnlySpan<byte> Name
+        public override Utf8StringRef Name
         {
             get
             {
@@ -230,7 +231,7 @@ namespace Internal.IL.Stubs.StartupCode
                 get;
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
@@ -141,26 +141,26 @@ namespace ILCompiler
             }
 
             static bool IsSystemType(TypeDesc t)
-                => t is MetadataType mdType && mdType.Name.SequenceEqual("Type"u8) && mdType.Namespace.SequenceEqual("System"u8);
+                => t is MetadataType mdType && mdType.Name == "Type"u8 && mdType.Namespace == "System"u8;
 
             static bool IsTypeGetTypeFromHandle(ILOpcode opcode, in ILReader reader, MethodIL methodIL)
                 => opcode == ILOpcode.call && methodIL.GetObject(reader.PeekILToken()) is MethodDesc method
-                && method.IsIntrinsic && method.Name.SequenceEqual("GetTypeFromHandle"u8)
+                && method.IsIntrinsic && method.Name == "GetTypeFromHandle"u8
                 && IsSystemType(method.OwningType);
 
             static bool IsTypeEquals(ILOpcode opcode, in ILReader reader, MethodIL methodIL)
                 => opcode == ILOpcode.call && methodIL.GetObject(reader.PeekILToken()) is MethodDesc method
-                && method.IsIntrinsic && method.Name.SequenceEqual("op_Equality"u8)
+                && method.IsIntrinsic && method.Name == "op_Equality"u8
                 && IsSystemType(method.OwningType);
 
             static bool IsTypeInequals(ILOpcode opcode, in ILReader reader, MethodIL methodIL)
                 => opcode == ILOpcode.call && methodIL.GetObject(reader.PeekILToken()) is MethodDesc method
-                && method.IsIntrinsic && method.Name.SequenceEqual("op_Inequality"u8)
+                && method.IsIntrinsic && method.Name == "op_Inequality"u8
                 && IsSystemType(method.OwningType);
 
             static bool IsObjectGetType(ILOpcode opcode, in ILReader reader, MethodIL methodIL)
                 => opcode is ILOpcode.call or ILOpcode.callvirt && methodIL.GetObject(reader.PeekILToken()) is MethodDesc method
-                && method.IsIntrinsic && method.Name.SequenceEqual("GetType"u8) && method.OwningType.IsObject;
+                && method.IsIntrinsic && method.Name == "GetType"u8 && method.OwningType.IsObject;
 
             static bool IsArgumentOrLocalLoad(ILOpcode opcode)
                 => opcode is (>= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3) or (>= ILOpcode.ldarg_0 and <= ILOpcode.ldarg_3)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -84,6 +84,9 @@
     <Compile Include="$(LibrariesProjectRoot)\Common\src\Internal\VersionResilientHashCode.cs">
       <Link>TypeSystem\Common\VersionResilientHashCode.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\Common\VersionResilientHashCode.TypeSystem.cs">
+      <Link>TypeSystem\Common\VersionResilientHashCode.TypeSystem.cs</Link>
+    </Compile>
 
     <Compile Include="..\..\Common\Compiler\TypeMapManager.cs" Link="Compiler\TypeMapManager.cs" />
     <Compile Include="..\..\Common\Compiler\TypeMapMetadata.cs" Link="Compiler\TypeMapMetadata.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.CustomAttribute.cs
+++ b/src/coreclr/tools/aot/ILCompiler.MetadataTransform/ILCompiler/Metadata/Transform.CustomAttribute.cs
@@ -99,7 +99,7 @@ namespace ILCompiler.Metadata
                         return Ecma.SerializationTypeCode.String;
 
                     if (type is not Cts.MetadataType mdType
-                        || !mdType.Name.SequenceEqual("Type"u8) || !mdType.Namespace.SequenceEqual("System"u8))
+                        || mdType.Name != "Type"u8 || mdType.Namespace != "System"u8)
                         throw new UnreachableException();
 
                     return Ecma.SerializationTypeCode.Type;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/TypeValidationChecker.cs
@@ -228,7 +228,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     {
                         if (methodDef.Attributes.HasFlag(MethodAttributes.RTSpecialName))
                         {
-                            if (!method.Name.SequenceEqual(".cctor"u8) && !method.Name.StartsWith("_VtblGap"u8))
+                            if (method.Name != ".cctor"u8 && !method.Name.StartsWith("_VtblGap"u8))
                             {
                                 AddTypeValidationError(type, $"Special name method {method} defined on interface");
                                 return false;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ProfileDataManager.cs
@@ -202,7 +202,7 @@ namespace ILCompiler
                     if (targetMeth.Signature.IsStatic || !targetMeth.IsTypicalMethodDefinition)
                         continue;
 
-                    bool isDelegateInvoke = targetMeth.OwningType.IsDelegate && targetMeth.Name.SequenceEqual("Invoke"u8);
+                    bool isDelegateInvoke = targetMeth.OwningType.IsDelegate && targetMeth.Name == "Invoke"u8;
 
                     if (opcode != ILOpcode.callvirt && !isDelegateInvoke)
                         continue;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -342,7 +342,7 @@ namespace ILCompiler
 
         public static bool IsVectorOfTType(DefType type)
         {
-            return type.IsIntrinsic && type.Namespace.SequenceEqual("System.Numerics"u8) && type.Name.SequenceEqual("Vector`1"u8);
+            return type.IsIntrinsic && type.Namespace == "System.Numerics"u8 && type.Name == "Vector`1"u8;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/RuntimeDeterminedTypeHelper.cs
@@ -142,7 +142,7 @@ namespace ILCompiler
             {
                 return field1 == null && field2 == null;
             }
-            return field1.Name.SequenceEqual(field2.Name) &&
+            return field1.Name == field2.Name &&
                 RuntimeDeterminedTypeHelper.Equals(field1.OwningType, field2.OwningType) &&
                 RuntimeDeterminedTypeHelper.Equals(field1.FieldType, field2.FieldType);
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/IBCProfileParser.cs
@@ -410,7 +410,7 @@ namespace ILCompiler.IBC
 
             foreach (MethodDesc method in ecmaType.GetMethods())
             {
-                if (method.Name.SequenceEqual(methodName))
+                if (method.Name == methodName)
                 {
                     EcmaMethod ecmaCandidateMethod = method as EcmaMethod;
                     if (ecmaCandidateMethod == null)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -622,7 +622,7 @@ namespace ILCompiler.IBC
         {
             private sealed class CanonModule : ModuleDesc, IAssemblyDesc
             {
-                public Utf8StringRef Name => "System.Private.Canon"u8;
+                public Utf8Span Name => "System.Private.Canon"u8;
 
                 public CanonModule(TypeSystemContext wrappedContext) : base(wrappedContext, null)
                 {
@@ -638,7 +638,7 @@ namespace ILCompiler.IBC
                     throw new NotImplementedException();
                 }
 
-                public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
+                public override object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior)
                 {
                     TypeSystemContext context = Context;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IBC/MIbcProfileParser.cs
@@ -7,10 +7,11 @@ using System.IO.Compression;
 using System.Reflection.Metadata;
 using System.Text;
 
-using Internal.TypeSystem;
-using Internal.TypeSystem.Ecma;
 using Internal.IL;
 using Internal.Pgo;
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 using System.Linq;
 using System.IO;
@@ -621,7 +622,7 @@ namespace ILCompiler.IBC
         {
             private sealed class CanonModule : ModuleDesc, IAssemblyDesc
             {
-                public ReadOnlySpan<byte> Name => "System.Private.Canon"u8;
+                public Utf8StringRef Name => "System.Private.Canon"u8;
 
                 public CanonModule(TypeSystemContext wrappedContext) : base(wrappedContext, null)
                 {
@@ -637,19 +638,19 @@ namespace ILCompiler.IBC
                     throw new NotImplementedException();
                 }
 
-                public override object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior)
+                public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
                 {
                     TypeSystemContext context = Context;
 
-                    if (context.SupportsCanon && nameSpace.SequenceEqual(context.CanonType.Namespace) && name.SequenceEqual(context.CanonType.Name))
+                    if (context.SupportsCanon && nameSpace == context.CanonType.Namespace && name == context.CanonType.Name)
                         return Context.CanonType;
-                    if (context.SupportsUniversalCanon && nameSpace.SequenceEqual(context.UniversalCanonType.Namespace) && name.SequenceEqual(context.UniversalCanonType.Name))
+                    if (context.SupportsUniversalCanon && nameSpace == context.UniversalCanonType.Namespace && name == context.UniversalCanonType.Name)
                         return Context.UniversalCanonType;
                     else
                     {
                         if (notFoundBehavior != NotFoundBehavior.ReturnNull)
                         {
-                            var failure = ResolutionFailure.GetTypeLoadResolutionFailure(Encoding.UTF8.GetString(nameSpace), Encoding.UTF8.GetString(name), "System.Private.Canon");
+                            var failure = ResolutionFailure.GetTypeLoadResolutionFailure(Encoding.UTF8.GetString(nameSpace.AsSpan()), Encoding.UTF8.GetString(name.AsSpan()), "System.Private.Canon");
                             if (notFoundBehavior == NotFoundBehavior.Throw)
                                 failure.Throw();
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
@@ -52,7 +52,7 @@ namespace Internal.IL
         {
             if (method.Instantiation.Length == 1
                 && method.Signature.Length == 0
-                && method.Name.SequenceEqual("CreateInstance"u8))
+                && method.Name == "CreateInstance"u8)
             {
                 TypeDesc type = method.Instantiation[0];
                 if (type.IsValueType && type.GetParameterlessConstructor() == null)
@@ -77,17 +77,17 @@ namespace Internal.IL
             if (mdType == null)
                 return null;
 
-            if (mdType.Name.SequenceEqual("RuntimeHelpers"u8) && mdType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+            if (mdType.Name == "RuntimeHelpers"u8 && mdType.Namespace == "System.Runtime.CompilerServices"u8)
             {
                 return RuntimeHelpersIntrinsics.EmitIL(method);
             }
 
-            if (mdType.Name.SequenceEqual("Unsafe"u8) && mdType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+            if (mdType.Name == "Unsafe"u8 && mdType.Namespace == "System.Runtime.CompilerServices"u8)
             {
                 return UnsafeIntrinsics.EmitIL(method);
             }
 
-            if (mdType.Name.SequenceEqual("InstanceCalliHelper"u8) && mdType.Namespace.SequenceEqual("System.Reflection"u8))
+            if (mdType.Name == "InstanceCalliHelper"u8 && mdType.Namespace == "System.Reflection"u8)
             {
                 return InstanceCalliHelperIntrinsics.EmitIL(method);
             }
@@ -106,31 +106,31 @@ namespace Internal.IL
             if (mdType == null)
                 return null;
 
-            if (mdType.Name.SequenceEqual("RuntimeHelpers"u8) && mdType.Namespace.SequenceEqual("System.Runtime.CompilerServices"u8))
+            if (mdType.Name == "RuntimeHelpers"u8 && mdType.Namespace == "System.Runtime.CompilerServices"u8)
             {
                 return RuntimeHelpersIntrinsics.EmitIL(method);
             }
 
-            if (mdType.Name.SequenceEqual("Activator"u8) && mdType.Namespace.SequenceEqual("System"u8))
+            if (mdType.Name == "Activator"u8 && mdType.Namespace == "System"u8)
             {
                 return TryGetIntrinsicMethodILForActivator(method);
             }
 
-            if (mdType.Name.SequenceEqual("Interlocked"u8) && mdType.Namespace.SequenceEqual("System.Threading"u8))
+            if (mdType.Name == "Interlocked"u8 && mdType.Namespace == "System.Threading"u8)
             {
                 return InterlockedIntrinsics.EmitIL(_compilationModuleGroup, method);
             }
 
-            if (mdType.Namespace.SequenceEqual("System.Collections.Generic"u8))
+            if (mdType.Namespace == "System.Collections.Generic"u8)
             {
-                if (mdType.Name.SequenceEqual("Comparer`1"u8))
+                if (mdType.Name == "Comparer`1"u8)
                 {
-                    if (method.Name.SequenceEqual("Create"u8))
+                    if (method.Name == "Create"u8)
                         return ComparerIntrinsics.EmitComparerCreate(method);
                 }
-                else if (mdType.Name.SequenceEqual("EqualityComparer`1"u8))
+                else if (mdType.Name == "EqualityComparer`1"u8)
                 {
-                    if (method.Name.SequenceEqual("Create"u8))
+                    if (method.Name == "Create"u8)
                         return ComparerIntrinsics.EmitEqualityComparerCreate(method);
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -576,9 +576,9 @@ namespace Internal.JitInterface
             }
             if (methodNeedingCode.OwningType.IsDelegate && (
                 methodNeedingCode.IsConstructor ||
-                methodNeedingCode.Name.SequenceEqual("BeginInvoke"u8) ||
-                methodNeedingCode.Name.SequenceEqual("Invoke"u8) ||
-                methodNeedingCode.Name.SequenceEqual("EndInvoke"u8)))
+                methodNeedingCode.Name == "BeginInvoke"u8 ||
+                methodNeedingCode.Name == "Invoke"u8 ||
+                methodNeedingCode.Name == "EndInvoke"u8))
             {
                 // Special methods on delegate types
                 return true;
@@ -2041,7 +2041,7 @@ namespace Internal.JitInterface
                 // JIT compilation, and require a runtime lookup for the actual code pointer
                 // to call.
 
-                if (constrainedType.IsEnum && originalMethod.Name.SequenceEqual("GetHashCode"u8))
+                if (constrainedType.IsEnum && originalMethod.Name == "GetHashCode"u8)
                 {
                     MethodDesc methodOnUnderlyingType = constrainedType.UnderlyingType.FindVirtualFunctionTargetMethodOnObjectType(originalMethod);
                     Debug.Assert(methodOnUnderlyingType != null);
@@ -2209,8 +2209,8 @@ namespace Internal.JitInterface
                     //  2) Delegate.Invoke() - since a Delegate is a sealed class as per ECMA spec
                     //  3) JIT intrinsics - since they have pre-defined behavior
                     devirt = targetMethod.OwningType.IsValueType ||
-                        (targetMethod.OwningType.IsDelegate && targetMethod.Name.SequenceEqual("Invoke"u8)) ||
-                        (targetMethod.OwningType.IsObject && targetMethod.Name.SequenceEqual("GetType"u8));
+                        (targetMethod.OwningType.IsDelegate && targetMethod.Name == "Invoke"u8) ||
+                        (targetMethod.OwningType.IsObject && targetMethod.Name == "GetType"u8);
 
                     callVirtCrossingVersionBubble = true;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -404,7 +404,7 @@ namespace Internal.TypeSystem.Ecma
             }
             throw new ArgumentException("Invalid UserStringHandle passed to MutableModule.GetObject");
         }
-        public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior) => throw new NotImplementedException();
+        public override object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior) => throw new NotImplementedException();
         public TypeDesc GetType(EntityHandle handle)
         {
             TypeDesc type = GetObject(handle, NotFoundBehavior.Throw) as TypeDesc;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/TypeSystem/Mutable/MutableModule.cs
@@ -11,6 +11,7 @@ using System.Diagnostics;
 using System.IO;
 
 using ILCompiler;
+using Internal.Text;
 using System.Runtime.CompilerServices;
 
 namespace Internal.TypeSystem.Ecma
@@ -403,7 +404,7 @@ namespace Internal.TypeSystem.Ecma
             }
             throw new ArgumentException("Invalid UserStringHandle passed to MutableModule.GetObject");
         }
-        public override object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior) => throw new NotImplementedException();
+        public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior) => throw new NotImplementedException();
         public TypeDesc GetType(EntityHandle handle)
         {
             TypeDesc type = GetObject(handle, NotFoundBehavior.Throw) as TypeDesc;

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -1259,7 +1259,7 @@ namespace Internal.JitInterface
                     // null since the virtual method resolves to System.Enum's implementation and that's a reference type.
                     // We can't do this for any other method since ToString and Equals have different semantics for enums
                     // and their underlying type.
-                    if (method.OwningType.IsObject && method.Name.SequenceEqual("GetHashCode"u8))
+                    if (method.OwningType.IsObject && method.Name == "GetHashCode"u8)
                     {
                         constrainedType = constrainedType.UnderlyingType;
                     }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/MemberAssertionsCollector.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/MemberAssertionsCollector.cs
@@ -80,7 +80,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             if (attributeType == null)
                 return false;
 
-            if (!attributeType.Namespace.SequenceEqual("Mono.Linker.Tests.Cases.Expectations.Assertions"u8))
+            if (attributeType.Namespace != "Mono.Linker.Tests.Cases.Expectations.Assertions"u8)
                 return false;
 
             MetadataType t = attributeType;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/SyntheticVirtualOverrideTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/SyntheticVirtualOverrideTests.cs
@@ -213,7 +213,7 @@ namespace TypeSystemTests
                 }
             }
 
-            public override Utf8StringRef Name
+            public override Utf8Span Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/SyntheticVirtualOverrideTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/SyntheticVirtualOverrideTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Xunit;
@@ -143,8 +144,8 @@ namespace TypeSystemTests
             {
                 MetadataType mdType = type as MetadataType;
 
-                if (mdType.Name.SequenceEqual("StructWithNoEqualsAndGetHashCode"u8)
-                    || mdType.Name.SequenceEqual("ClassWithInjectedEqualsAndGetHashCode"u8))
+                if (mdType.Name == "StructWithNoEqualsAndGetHashCode"u8
+                    || mdType.Name == "ClassWithInjectedEqualsAndGetHashCode"u8)
                 {
                     yield return GetEqualsMethod(type);
                     yield return GetGetHashCodeMethod(type);
@@ -158,8 +159,8 @@ namespace TypeSystemTests
             {
                 MetadataType mdType = type as MetadataType;
 
-                if (mdType.Name.SequenceEqual("StructWithNoEqualsAndGetHashCode"u8)
-                    || mdType.Name.SequenceEqual("ClassWithInjectedEqualsAndGetHashCode"u8))
+                if (mdType.Name == "StructWithNoEqualsAndGetHashCode"u8
+                    || mdType.Name == "ClassWithInjectedEqualsAndGetHashCode"u8)
                 {
                     yield return GetEqualsMethod(type);
                     yield return GetGetHashCodeMethod(type);
@@ -212,7 +213,7 @@ namespace TypeSystemTests
                 }
             }
 
-            public override ReadOnlySpan<byte> Name
+            public override Utf8StringRef Name
             {
                 get
                 {

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -35,6 +35,9 @@
     <Compile Include="$(LibrariesProjectRoot)\Common\src\Internal\VersionResilientHashCode.cs">
       <Link>TypeSystem\Common\VersionResilientHashCode.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\Internal\Text\Utf8StringRef.cs">
+      <Link>Common\Utf8StringRef.cs</Link>
+    </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ArrayMethod.Diagnostic.cs">
       <Link>TypeSystem\Common\ArrayMethod.Diagnostic.cs</Link>
     </Compile>

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem/ILCompiler.TypeSystem.csproj
@@ -35,8 +35,8 @@
     <Compile Include="$(LibrariesProjectRoot)\Common\src\Internal\VersionResilientHashCode.cs">
       <Link>TypeSystem\Common\VersionResilientHashCode.cs</Link>
     </Compile>
-    <Compile Include="..\..\Common\Internal\Text\Utf8StringRef.cs">
-      <Link>Common\Utf8StringRef.cs</Link>
+    <Compile Include="..\..\Common\Internal\Text\Utf8Span.cs">
+      <Link>Common\Utf8Span.cs</Link>
     </Compile>
     <Compile Include="..\..\Common\TypeSystem\Common\ArrayMethod.Diagnostic.cs">
       <Link>TypeSystem\Common\ArrayMethod.Diagnostic.cs</Link>

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -818,7 +818,7 @@ namespace ILCompiler
                 int curIndex = 0;
                 foreach (var searchMethod in method.OwningType.GetMethods())
                 {
-                    if (!searchMethod.Name.SequenceEqual(method.Name))
+                    if (searchMethod.Name != method.Name)
                         continue;
 
                     curIndex++;

--- a/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceRuntimeDescToTypeSystemDesc.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         }
                         else
                         {
-                            if ((uninstantiatedType.Name.SequenceEqual("__Canon"u8)) && uninstantiatedType.Namespace.SequenceEqual("System"u8) && (uninstantiatedType.Module == uninstantiatedType.Context.SystemModule))
+                            if ((uninstantiatedType.Name == "__Canon"u8) && uninstantiatedType.Namespace == "System"u8 && (uninstantiatedType.Module == uninstantiatedType.Context.SystemModule))
                             {
                                 tinfo.Type = uninstantiatedType.Context.CanonType;
                             }

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             _embeddedSignatureData = embeddedSigData;
         }
 
-        public override Utf8StringRef Name => _name;
+        public override Utf8Span Name => _name;
         public override MetadataType OwningType => _type;
 
         public override TypeDesc FieldType => _fieldType;

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemField.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
@@ -25,7 +27,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             _embeddedSignatureData = embeddedSigData;
         }
 
-        public override ReadOnlySpan<byte> Name => _name;
+        public override Utf8StringRef Name => _name;
         public override MetadataType OwningType => _type;
 
         public override TypeDesc FieldType => _fieldType;

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemMethod.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemMethod.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
@@ -37,7 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             }
         }
 
-        public override ReadOnlySpan<byte> Name => _name;
+        public override Utf8StringRef Name => _name;
 
         public override Instantiation Instantiation => _instantiation;
 

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemMethod.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemMethod.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             }
         }
 
-        public override Utf8StringRef Name => _name;
+        public override Utf8Span Name => _name;
 
         public override Instantiation Instantiation => _instantiation;
 

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Reflection.Metadata;
 using System.Text;
 using System.Threading.Tasks;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
@@ -49,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override IAssemblyDesc Assembly => this;
 
-        public ReadOnlySpan<byte> Name => System.Text.Encoding.UTF8.GetBytes(_name.Name);
+        public Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes(_name.Name);
 
         public override IEnumerable<MetadataType> GetAllTypes() => _types;
         public override MetadataType GetGlobalModuleType() => throw new NotImplementedException();
@@ -73,10 +75,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             return type;
         }
 
-        public override object GetType(ReadOnlySpan<byte> nameSpace, ReadOnlySpan<byte> name, NotFoundBehavior notFoundBehavior)
+        public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
         {
-            string strns = Encoding.UTF8.GetString(nameSpace);
-            string strname = Encoding.UTF8.GetString(name);
+            string strns = Encoding.UTF8.GetString(nameSpace.AsSpan());
+            string strname = Encoding.UTF8.GetString(name.AsSpan());
             MetadataType type = GetTypeInternal(strns, strname);
             if ((type == null) && notFoundBehavior != NotFoundBehavior.ReturnNull)
             {

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemModule.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override IAssemblyDesc Assembly => this;
 
-        public Utf8StringRef Name => System.Text.Encoding.UTF8.GetBytes(_name.Name);
+        public Utf8Span Name => System.Text.Encoding.UTF8.GetBytes(_name.Name);
 
         public override IEnumerable<MetadataType> GetAllTypes() => _types;
         public override MetadataType GetGlobalModuleType() => throw new NotImplementedException();
@@ -75,7 +75,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             return type;
         }
 
-        public override object GetType(Utf8StringRef nameSpace, Utf8StringRef name, NotFoundBehavior notFoundBehavior)
+        public override object GetType(Utf8Span nameSpace, Utf8Span name, NotFoundBehavior notFoundBehavior)
         {
             string strns = Encoding.UTF8.GetString(nameSpace.AsSpan());
             string strname = Encoding.UTF8.GetString(name.AsSpan());

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -142,9 +142,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override PInvokeStringFormat PInvokeStringFormat => throw new NotImplementedException();
 
-        public override Utf8StringRef Name => _name;
+        public override Utf8Span Name => _name;
 
-        public override Utf8StringRef Namespace => _namespace;
+        public override Utf8Span Namespace => _namespace;
 
         public override bool IsExplicitLayout => throw new NotImplementedException();
 
@@ -186,7 +186,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         protected override int ClassCode => throw new NotImplementedException();
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => throw new NotImplementedException();
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8Span name) => throw new NotImplementedException();
         public override ClassLayoutMetadata GetClassLayout() => throw new NotImplementedException();
         public override int GetHashCode()
         {
@@ -197,7 +197,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
             return hash.ToHashCode();
         }
 
-        public override MetadataType GetNestedType(Utf8StringRef name)
+        public override MetadataType GetNestedType(Utf8Span name)
         {
             TypeRefTypeSystemType type = null;
             if (_nestedType != null)

--- a/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
+++ b/src/coreclr/tools/dotnet-pgo/TypeRefTypeSystem/TypeRefTypeSystemType.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
@@ -140,9 +142,9 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         public override PInvokeStringFormat PInvokeStringFormat => throw new NotImplementedException();
 
-        public override ReadOnlySpan<byte> Name => _name;
+        public override Utf8StringRef Name => _name;
 
-        public override ReadOnlySpan<byte> Namespace => _namespace;
+        public override Utf8StringRef Namespace => _namespace;
 
         public override bool IsExplicitLayout => throw new NotImplementedException();
 
@@ -184,23 +186,23 @@ namespace Microsoft.Diagnostics.Tools.Pgo.TypeRefTypeSystem
 
         protected override int ClassCode => throw new NotImplementedException();
 
-        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(ReadOnlySpan<byte> name) => throw new NotImplementedException();
+        public override MethodImplRecord[] FindMethodsImplWithMatchingDeclName(Utf8StringRef name) => throw new NotImplementedException();
         public override ClassLayoutMetadata GetClassLayout() => throw new NotImplementedException();
         public override int GetHashCode()
         {
             var hash = new HashCode();
-            hash.AddBytes(Namespace);
-            hash.AddBytes(Name);
+            hash.AddBytes(Namespace.AsSpan());
+            hash.AddBytes(Name.AsSpan());
             hash.Add(Module);
             return hash.ToHashCode();
         }
 
-        public override MetadataType GetNestedType(ReadOnlySpan<byte> name)
+        public override MetadataType GetNestedType(Utf8StringRef name)
         {
             TypeRefTypeSystemType type = null;
             if (_nestedType != null)
             {
-                _nestedType.TryGetValue(Encoding.UTF8.GetString(name), out type);
+                _nestedType.TryGetValue(Encoding.UTF8.GetString(name.AsSpan()), out type);
             }
             return type;
         }


### PR DESCRIPTION
Contributes to #122363.

This addresses two issues with the current "the exchange type for UTF-8 strings is `ReadOnlySpan<byte>`":

* Debugger now shows the strings: the `ToString` is more meaningful than the one on `ReadOnlySpan<T>`.
* We can now use `==` to compare strings, no more `x.SequenceEqual("y"u8)`

Migrate type system name surfaces and related callers from `ReadOnlySpan<byte>` to `Utf8StringRef`, adding helper APIs to keep call sites explicit and avoid unnecessary span conversions.