### PR TITLE
[HTTP] httpbin sometimes returns 503

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.RemoteServer.cs
@@ -1290,7 +1290,7 @@ namespace System.Net.Http.Functional.Tests
                 try
                 {
                     using HttpResponseMessage response = await client.GetAsync(uri);
-                    if (response.StatusCode is HttpStatusCode.GatewayTimeout or HttpStatusCode.BadGateway)
+                    if (response.StatusCode is HttpStatusCode.GatewayTimeout or HttpStatusCode.BadGateway or HttpStatusCode.ServiceUnavailable)
                     {
                         // Ignore the erroneous status code, the test depends on an external server that is out of our control.
                         _output.WriteLine(response.ToString());


### PR DESCRIPTION
Fix for httpbin returning 503, which is out of our control.
Based on Kusto, started 28.5., seen in https://github.com/dotnet/runtime/pull/128940