### PR TITLE
Simplify TryParseFormatO fractional-seconds handling

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -5171,7 +5171,11 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                 second = (int)(s1 * 10 + s2);
             }
 
-            double fraction;
+            // The "O" format always has exactly 7 fractional-second digits, which is the same precision
+            // as DateTime's ticks (TimeSpan.TicksPerSecond == 10_000_000), so the integer value formed
+            // by the seven digits is exactly the sub-second tick count. Compute it directly instead of
+            // going through a double divide/multiply/Math.Round round-trip.
+            int fractionTicks;
             {
                 uint f1 = (uint)(source[20] - '0');
                 uint f2 = (uint)(source[21] - '0');
@@ -5187,12 +5191,12 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                     return false;
                 }
 
-                fraction = (f1 * 1000000 + f2 * 100000 + f3 * 10000 + f4 * 1000 + f5 * 100 + f6 * 10 + f7) / 10000000.0;
+                fractionTicks = (int)(f1 * 1000000 + f2 * 100000 + f3 * 10000 + f4 * 1000 + f5 * 100 + f6 * 10 + f7);
             }
 
             // Per ISO 8601, 24:00:00 represents the end of a calendar day
             // (the same instant as the next day's 00:00:00), but only when minute, second, and fraction are all zero
-            if (hour == 24 && (minute != 0 || second != 0 || fraction != 0))
+            if (hour == 24 && (minute != 0 || second != 0 || fractionTicks != 0))
             {
                 result.SetBadDateTimeFailure();
                 return false;
@@ -5204,7 +5208,7 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                 return false;
             }
 
-            if (!dateTime.TryAddTicks((long)Math.Round(fraction * TimeSpan.TicksPerSecond), out result.parsedDate))
+            if (!dateTime.TryAddTicks(fractionTicks, out result.parsedDate))
             {
                 result.SetBadDateTimeFailure();
                 return false;


### PR DESCRIPTION
### Simplify `TryParseFormatO` fractional-seconds handling

The `"O"` (ISO 8601 round-trip) format always has exactly 7 fractional-second digits, which matches `DateTime`'s tick precision (`TimeSpan.TicksPerSecond == 10_000_000`). The integer formed by those seven digits is therefore *exactly* the sub-second tick count, so we can pass it straight to `TryAddTicks` instead of routing it through a `double` divide / multiply / `Math.Round` round-trip.

The change is bit-exact: every one of the 10M possible 7-digit values produces the same tick count as before (verified by brute-force).

### Tests

Existing `System.Tests.DateTimeTests` (1378 tests) and `System.Tests.DateTimeOffsetTests` (737 tests, 2 platform-skipped) pass against a CoreLib built with the change.

### Microbenchmark

Side benefit: a small (~6%) speedup on `Perf_DateTime.ParseO` on R2R'd CoreLib.

Benchmarks used (unchanged, from [`dotnet/performance`](https://github.com/dotnet/performance)):

- [`Perf_DateTime.ParseO`](https://github.com/dotnet/performance/blob/643b4e7022538b58bfc274312730a6116dc91c55/src/benchmarks/micro/libraries/System.Runtime/Perf.DateTime.cs#L52) — target
- [`Perf_DateTime.ParseR`](https://github.com/dotnet/performance/blob/643b4e7022538b58bfc274312730a6116dc91c55/src/benchmarks/micro/libraries/System.Runtime/Perf.DateTime.cs#L49) — unchanged control

Run with BenchmarkDotNet `Job.Default`, same-process A/B (both `--coreRun`s passed in one invocation so process-startup, ASLR, and thermal effects don't bias the comparison), affinity-pinned to a single P-core:

```
dotnet run -c Release -f net11.0 --project src/benchmarks/micro/MicroBenchmarks.csproj -- \
  --filter "System.Tests.Perf_DateTime.ParseO" "System.Tests.Perf_DateTime.ParseR" \
  --coreRun <baseline-testhost>\CoreRun.exe <patched-testhost>\CoreRun.exe \
  --affinity 1
```

Environment: Windows 11, Intel Core i9-14900K (P-core 0 pinned), .NET 11.0 R2R'd `System.Private.CoreLib` (Release), BenchmarkDotNet v0.16.0-nightly.

| Method | Job        | Mean     | Error    | StdDev   | Ratio | RatioSD |
|------- |----------- |---------:|---------:|---------:|------:|--------:|
| ParseR | baseline   | 11.42 ns | 0.168 ns | 0.149 ns |  1.00 |    0.00 |
| ParseR | patched    | 11.41 ns | 0.163 ns | 0.144 ns |  1.00 |    0.02 |
|        |            |          |          |          |       |         |
| ParseO | baseline   | 11.87 ns | 0.198 ns | 0.175 ns |  1.00 |    0.00 |
| ParseO | patched    | 11.14 ns | 0.125 ns | 0.111 ns |  0.94 |    0.02 |

`ParseR` (control) is identical between the two binaries, confirming the harness is stable; `ParseO` improves ~6% (~0.73 ns/call).

> [!NOTE]
> This PR was prepared with the assistance of GitHub Copilot.
