### PR TITLE
Simplify TryParseFormatO fractional-seconds handling

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -5171,7 +5171,9 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                 second = (int)(s1 * 10 + s2);
             }
 
-            double fraction;
+            // The seven fractional digits are sub-second ticks (1 tick = 100 ns = 10^-7 s),
+            // matching TimeSpan.TicksPerSecond, so we can use them directly without floating-point math.
+            int fractionTicks;
             {
                 uint f1 = (uint)(source[20] - '0');
                 uint f2 = (uint)(source[21] - '0');
@@ -5187,12 +5189,12 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                     return false;
                 }
 
-                fraction = (f1 * 1000000 + f2 * 100000 + f3 * 10000 + f4 * 1000 + f5 * 100 + f6 * 10 + f7) / 10000000.0;
+                fractionTicks = (int)(f1 * 1000000 + f2 * 100000 + f3 * 10000 + f4 * 1000 + f5 * 100 + f6 * 10 + f7);
             }
 
             // Per ISO 8601, 24:00:00 represents the end of a calendar day
             // (the same instant as the next day's 00:00:00), but only when minute, second, and fraction are all zero
-            if (hour == 24 && (minute != 0 || second != 0 || fraction != 0))
+            if (hour == 24 && (minute != 0 || second != 0 || fractionTicks != 0))
             {
                 result.SetBadDateTimeFailure();
                 return false;
@@ -5204,7 +5206,7 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                 return false;
             }
 
-            if (!dateTime.TryAddTicks((long)Math.Round(fraction * TimeSpan.TicksPerSecond), out result.parsedDate))
+            if (!dateTime.TryAddTicks(fractionTicks, out result.parsedDate))
             {
                 result.SetBadDateTimeFailure();
                 return false;


### PR DESCRIPTION
The `"O"` (ISO 8601 round-trip) format always contains exactly 7 fractional-second digits, matching `DateTime`'s tick precision (`TimeSpan.TicksPerSecond == 10_000_000`). The integer value of those seven digits is therefore already the sub-second tick count.

Today's code in `TryParseFormatO`:

```csharp
double fraction = (f1*1e6 + ... + f7) / 10000000.0;
// ...
dateTime.TryAddTicks((long)Math.Round(fraction * TimeSpan.TicksPerSecond), out result.parsedDate);
```

`/ 1e7` then `Math.Round(... * 1e7)` is identity for every value the parser will ever see. Each 7-digit fraction is `<= 9_999_999 < 2^24`, exactly representable as `double`; `1e7` is exactly representable; the two correctly-rounded ops bound absolute error well under 0.5; `Math.Round` then recovers the original integer. (The round-trip must already be exact today, since `DateTime.ToString("O")` writes the same 7 digits — otherwise format-then-parse would drift.)

So this just keeps the value as `int fractionTicks` and passes it straight to `TryAddTicks`. Bit-exact equivalent, smaller, more obvious.

### Risk

None. Existing `"O"`-format round-trip tests in `DateTimeTests` continue to pass.

### Perf

Small win on `Perf_DateTime.ParseO` micro-benchmark, but the absolute magnitude is hard to pin down precisely against R2R'd CoreLib because tiny IL changes can shift crossgen code layout: a short-job A/B showed `ParseO` at ~9% but the unmodified `ParseR` control also drifted ~8%, indicating layout noise dominates at this measurement length. The change is justified as a simplification; perf is a side benefit.