### PR TITLE
[cDAC] Multi-target managed reader to net8.0/net9.0/net10.0

### DIFF
--- a/src/native/managed/cdac/Directory.Build.props
+++ b/src/native/managed/cdac/Directory.Build.props
@@ -3,11 +3,21 @@
 
     <PropertyGroup>
       <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-      <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-      <AppendTargetFrameworkToOutputPath Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</AppendTargetFrameworkToOutputPath>
+      <!--
+        Default TFMs for the cDAC managed reader transport packages. These ship via
+        NuGet and must be consumable by diagnostic tools running on shipped runtimes
+        in addition to $(NetCoreAppToolCurrent). Projects that should not multi-target
+        (e.g. mscordaccore_universal, test harnesses) override this with TargetFramework.
+      -->
+      <CdacPackageTargetFrameworks>$(NetCoreAppToolCurrent);net10.0;net9.0;net8.0</CdacPackageTargetFrameworks>
     </PropertyGroup>
 
-    <ItemGroup>
+    <!--
+      ExperimentalAttribute is a .NET 9+ API. When multi-targeting downward
+      (e.g. net8.0 for consumption by tools that target NetCoreAppMinTargetFramework),
+      skip the injection on TFMs where the attribute type does not exist.
+    -->
+    <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
       <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExperimentalAttribute">
         <_Parameter1>NETCDAC0001</_Parameter1>
       </AssemblyAttribute>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86/X86Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86/X86Unwinder.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts.Extensions;
 using static Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.X86Context;
 
@@ -487,8 +486,9 @@ public class X86Unwinder(Target target)
             if (gcInfo.Header.DoubleAlign && (curEbp & 0x04) != 0)
                 pSavedRegs -= _pointerSize;
 
-            foreach (RegMask regMask in registerOrder.Reverse())
+            for (int i = registerOrder.Length - 1; i >= 0; i--)
             {
+                RegMask regMask = registerOrder[i];
                 if (regMask == RegMask.EBP) continue;
 
                 if (!gcInfo.SavedRegsMask.HasFlag(regMask)) continue;
@@ -570,8 +570,9 @@ public class X86Unwinder(Target target)
             /* Increment "offset" in steps to see which callee-saved
                registers have been pushed already */
 
-            foreach (RegMask regMask in registerOrder.Reverse())
+            for (int i = registerOrder.Length - 1; i >= 0; i--)
             {
+                RegMask regMask = registerOrder[i];
                 if (regMask == RegMask.EBP) continue;
 
                 if (!gcInfo.SavedRegsMask.HasFlag(regMask)) continue;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataModule.cs
@@ -91,7 +91,9 @@ public sealed unsafe partial class ClrDataModule : ICustomQueryInterface, IXCLRD
                 try
                 {
                     Guid iidMetaDataImport = typeof(IMetaDataImport).GUID;
-                    if (_legacyModulePointer != 0 && Marshal.QueryInterface(_legacyModulePointer, iidMetaDataImport, out nint ppMdi) >= 0)
+#pragma warning disable CS9191 // 'ref' is equivalent to 'in' for net9+; net8 requires 'ref'
+                    if (_legacyModulePointer != 0 && Marshal.QueryInterface(_legacyModulePointer, ref iidMetaDataImport, out nint ppMdi) >= 0)
+#pragma warning restore CS9191
                     {
                         legacyImport = ComInterfaceMarshaller<IMetaDataImport>.ConvertToManaged((void*)ppMdi);
                         Marshal.Release(ppMdi);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ISOSDacInterface.cs
@@ -758,7 +758,7 @@ public unsafe partial interface ISOSDacInterface
 
     // Frames
     [PreserveSig]
-    int GetFrameName(ClrDataAddress vtable, uint count, char* frameName, uint* pNeeded);
+    int GetFrameName(ClrDataAddress vtableAddr, uint count, char* frameName, uint* pNeeded);
 
     // PEFiles
     [PreserveSig]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader.Legacy</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1199,15 +1199,15 @@ public sealed unsafe partial class SOSDacImpl
         return hr;
     }
 
-    int ISOSDacInterface.GetFrameName(ClrDataAddress vtable, uint count, char* frameName, uint* pNeeded)
+    int ISOSDacInterface.GetFrameName(ClrDataAddress vtableAddr, uint count, char* frameName, uint* pNeeded)
     {
         int hr = HResults.S_OK;
         try
         {
-            if (vtable == 0)
+            if (vtableAddr == 0)
                 throw new ArgumentException();
             IStackWalk stackWalk = _target.Contracts.StackWalk;
-            string name = stackWalk.GetFrameName(new(vtable));
+            string name = stackWalk.GetFrameName(new(vtableAddr));
 
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException();
@@ -1234,7 +1234,7 @@ public sealed unsafe partial class SOSDacImpl
             int hrLocal;
             fixed (char* ptr = nameLocal)
             {
-                hrLocal = _legacyImpl.GetFrameName(vtable, count, ptr, &neededLocal);
+                hrLocal = _legacyImpl.GetFrameName(vtableAddr, count, ptr, &neededLocal);
             }
             Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/gen/Emitter.cs
+++ b/src/native/managed/cdac/gen/Emitter.cs
@@ -262,7 +262,7 @@ internal static class Emitter
         };
 
     private static string NameArgs(MemberModel member)
-        => string.Join(", ", Enumerate(member.Names).Select(n => $"\"{n}\""));
+        => "[" + string.Join(", ", Enumerate(member.Names).Select(n => $"\"{n}\"")) + "]";
 
     private static IEnumerable<string> Enumerate(EquatableArray<string> array)
     {

--- a/src/native/managed/cdac/gen/LayoutSetSource.cs
+++ b/src/native/managed/cdac/gen/LayoutSetSource.cs
@@ -55,7 +55,7 @@ internal readonly struct LayoutSet
         }
     }
 
-    public bool TrySelect(TargetPointer address, out Target.TypeInfo type, out TargetPointer baseAddr, out string name, params ReadOnlySpan<string> names)
+    public bool TrySelect(TargetPointer address, out Target.TypeInfo type, out TargetPointer baseAddr, out string name, ReadOnlySpan<string> names)
     {
         foreach (LazyLayout layout in _layouts)
         {
@@ -73,7 +73,7 @@ internal readonly struct LayoutSet
         return false;
     }
 
-    public void Select(TargetPointer address, out Target.TypeInfo type, out TargetPointer baseAddr, out string name, params ReadOnlySpan<string> names)
+    public void Select(TargetPointer address, out Target.TypeInfo type, out TargetPointer baseAddr, out string name, ReadOnlySpan<string> names)
     {
         if (!TrySelect(address, out type, out baseAddr, out name, names))
         {

--- a/src/native/managed/cdac/tests/TestInfrastructure/DumpInfo.cs
+++ b/src/native/managed/cdac/tests/TestInfrastructure/DumpInfo.cs
@@ -95,8 +95,10 @@ public sealed class DumpInfo
             System.Runtime.InteropServices.Architecture.X86 => "x86",
             System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
             System.Runtime.InteropServices.Architecture.Arm => "arm",
+#if NET9_0_OR_GREATER
             System.Runtime.InteropServices.Architecture.RiscV64 => "riscv64",
             System.Runtime.InteropServices.Architecture.LoongArch64 => "loongarch64",
+#endif
             _ => "unknown",
         };
 

--- a/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
+++ b/src/native/managed/cdac/tests/TestInfrastructure/Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/tests/UnitTests/MetaDataImportImplTests.cs
+++ b/src/native/managed/cdac/tests/UnitTests/MetaDataImportImplTests.cs
@@ -983,7 +983,9 @@ public unsafe class MetaDataImportImplTests
         {
             // Simulate ClrMD: QI for IMetaDataImport
             Guid iidImport = typeof(IMetaDataImport).GUID;
-            int hr = Marshal.QueryInterface(pUnk, in iidImport, out nint pImport);
+#pragma warning disable CS9191 // 'ref' is equivalent to 'in' for net9+; net8 requires 'ref'
+            int hr = Marshal.QueryInterface(pUnk, ref iidImport, out nint pImport);
+#pragma warning restore CS9191
             Assert.Equal(0, hr);
             Assert.NotEqual(nint.Zero, pImport);
 
@@ -994,7 +996,9 @@ public unsafe class MetaDataImportImplTests
                 // redirect, this would return the shorter IMetaDataImport vtable (65 slots) and accessing
                 // slot 65 (EnumGenericParams) would AV.
                 Guid iidImportAgain = typeof(IMetaDataImport).GUID;
-                hr = Marshal.QueryInterface(pImport, in iidImportAgain, out nint pImportAgain);
+#pragma warning disable CS9191 // 'ref' is equivalent to 'in' for net9+; net8 requires 'ref'
+                hr = Marshal.QueryInterface(pImport, ref iidImportAgain, out nint pImportAgain);
+#pragma warning restore CS9191
                 Assert.Equal(0, hr);
                 Assert.NotEqual(nint.Zero, pImportAgain);
 
@@ -1003,7 +1007,9 @@ public unsafe class MetaDataImportImplTests
                     // Verify the returned pointer has IMetaDataImport2 slots accessible.
                     // QI the result for IMetaDataImport2 to verify COM identity is correct.
                     Guid iidImport2 = typeof(IMetaDataImport2).GUID;
-                    hr = Marshal.QueryInterface(pImportAgain, in iidImport2, out nint pImport2);
+#pragma warning disable CS9191 // 'ref' is equivalent to 'in' for net9+; net8 requires 'ref'
+                    hr = Marshal.QueryInterface(pImportAgain, ref iidImport2, out nint pImport2);
+#pragma warning restore CS9191
                     Assert.Equal(0, hr);
                     Assert.NotEqual(nint.Zero, pImport2);
                     Marshal.Release(pImport2);

--- a/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
+++ b/src/native/managed/cdac/tests/UnitTests/Microsoft.Diagnostics.DataContractReader.Tests.csproj
@@ -1,14 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
+    <TargetFrameworks>$(CdacPackageTargetFrameworks)</TargetFrameworks>
     <JsonSerializerIsReflectionEnabledByDefault>false</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <Import Project="..\..\..\subproject.props" />
 
   <ItemGroup>
-    <ProjectReference Include="..\..\mscordaccore_universal\mscordaccore_universal.csproj" AdditionalProperties="$(SplitSubprojectProps)" />
+    <!-- mscordaccore_universal is the NativeAOT-published shim around Legacy and is built
+         only at $(NetCoreAppToolCurrent). Skip it on downlevel TFMs (the test code does
+         not import any types from it; the reference exists only to chain the NAOT publish). -->
+    <ProjectReference Include="..\..\mscordaccore_universal\mscordaccore_universal.csproj"
+                      AdditionalProperties="$(SplitSubprojectProps)"
+                      Condition="'$(TargetFramework)' == '$(NetCoreAppToolCurrent)'" />
+    <!-- On downlevel TFMs, reference Legacy directly so tests can use the Legacy COM types
+         (mscordaccore_universal provides this transitively at $(NetCoreAppToolCurrent)). -->
+    <ProjectReference Include="..\..\Microsoft.Diagnostics.DataContractReader.Legacy\Microsoft.Diagnostics.DataContractReader.Legacy.csproj"
+                      GlobalPropertiesToRemove="RuntimeIdentifier"
+                      Condition="'$(TargetFramework)' != '$(NetCoreAppToolCurrent)'" />
     <ProjectReference Include="..\TestInfrastructure\Microsoft.Diagnostics.DataContractReader.TestInfrastructure.csproj" GlobalPropertiesToRemove="RuntimeIdentifier" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> This PR description was drafted with assistance from GitHub Copilot.

Multi-targets the cDAC managed reader transport packages so the published NuGets can be consumed by diagnostic tools running on older shipped runtimes (`net8.0`, `net9.0`, `net10.0`) in addition to `$(NetCoreAppToolCurrent)`.

### Projects changed to multi-target

- `Microsoft.Diagnostics.DataContractReader`
- `Microsoft.Diagnostics.DataContractReader.Abstractions`
- `Microsoft.Diagnostics.DataContractReader.Contracts`
- `Microsoft.Diagnostics.DataContractReader.Legacy`
- `Microsoft.Diagnostics.DataContractReader.TestInfrastructure`
- `Microsoft.Diagnostics.DataContractReader.Tests`

`mscordaccore_universal` and the dump/host harnesses remain single-target at `$(NetCoreAppToolCurrent)`.

### Downlevel source-compatibility fixes

- **Directory.Build.props** — gate `ExperimentalAttribute` injection to net9+ (type does not exist on net8).
- **X86Unwinder.cs** — replace `ReadOnlySpan.Reverse()` LINQ with a manual reverse loop (LINQ `Reverse` on `ReadOnlySpan` is net9+).
- **ClrDataModule.cs / MetaDataImportImplTests.cs** — use `Marshal.QueryInterface(..., ref Guid, ...)` and suppress CS9191 (the `in Guid` overload is net9+).
- **DumpInfo.cs** — gate `Architecture.RiscV64` / `LoongArch64` to net9+ (enum members added in net9).
- **LayoutSetSource.cs / Emitter.cs** — drop `params ReadOnlySpan<T>` and emit collection-expression call sites (`params ROS` requires C# 13 / net9).
- **SOSDacImpl.cs / ISOSDacInterface.cs** — rename `vtable` parameter to `vtableAddr` to avoid downlevel codegen ambiguity.
- **Tests.csproj** — split `mscordaccore_universal` vs `Legacy` `ProjectReference` by TFM (universal is NAOT-published only at `$(NetCoreAppToolCurrent)`).
