### PR TITLE
[clr-ios] Fix Vector<T> width and R2R AVX baseline mismatch on x64 iOS/tvOS simulators

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -32,8 +32,7 @@ namespace System.CommandLine
             if ((targetArchitecture == TargetArchitecture.X86) || (targetArchitecture == TargetArchitecture.X64))
             {
                 bool isAppleOS = targetOS is TargetOS.OSX or TargetOS.MacCatalyst
-                    or TargetOS.iOS or TargetOS.iOSSimulator
-                    or TargetOS.tvOS or TargetOS.tvOSSimulator;
+                    or TargetOS.iOSSimulator or TargetOS.tvOSSimulator;
 
                 if (isReadyToRun && !isAppleOS)
                 {

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -31,7 +31,11 @@ namespace System.CommandLine
 
             if ((targetArchitecture == TargetArchitecture.X86) || (targetArchitecture == TargetArchitecture.X64))
             {
-                if (isReadyToRun && targetOS != TargetOS.OSX && targetOS != TargetOS.MacCatalyst)
+                bool isAppleOS = targetOS is TargetOS.OSX or TargetOS.MacCatalyst
+                    or TargetOS.iOS or TargetOS.iOSSimulator
+                    or TargetOS.tvOS or TargetOS.tvOSSimulator;
+
+                if (isReadyToRun && !isAppleOS)
                 {
                     // ReadyToRun can presume AVX2, BMI1, BMI2, F16C, FMA, LZCNT, and MOVBE
                     instructionSetSupportBuilder.AddSupportedInstructionSet("x86-64-v3");

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3585,7 +3585,7 @@ void Module::RunEagerFixupsUnlocked()
                 GetReadyToRunInfo()->DisableAllR2RCode();
 
 #ifndef FEATURE_DYNAMIC_CODE_COMPILED
-                if (GetReadyToRunInfo()->IsStrippedILBodies())
+                if (GetReadyToRunInfo()->HasStrippedILBodies())
                 {
                     EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE,
                         W("ReadyToRun code was disabled by a failed eager fixup, but the image has stripped IL bodies and this runtime has no JIT fallback."));

--- a/src/coreclr/vm/ceeload.cpp
+++ b/src/coreclr/vm/ceeload.cpp
@@ -3583,6 +3583,14 @@ void Module::RunEagerFixupsUnlocked()
             {
                 _ASSERTE(IsReadyToRun());
                 GetReadyToRunInfo()->DisableAllR2RCode();
+
+#ifndef FEATURE_DYNAMIC_CODE_COMPILED
+                if (GetReadyToRunInfo()->IsStrippedILBodies())
+                {
+                    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(COR_E_EXECUTIONENGINE,
+                        W("ReadyToRun code was disabled by a failed eager fixup, but the image has stripped IL bodies and this runtime has no JIT fallback."));
+                }
+#endif // !FEATURE_DYNAMIC_CODE_COMPILED
             }
             else
             {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1331,9 +1331,10 @@ void EEJitManager::SetCpuInfo()
     uint32_t maxVectorTBitWidth = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_MaxVectorTBitWidth) / 128) * 128;
 
 #if defined(FEATURE_INTERPRETER)
+#if defined(FEATURE_DYNAMIC_CODE_COMPILED)
     bool interpreterOnly = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3;
-#if !defined(FEATURE_DYNAMIC_CODE_COMPILED)
-    interpreterOnly = true;
+#else
+    bool interpreterOnly = true;
 #endif
     if (maxVectorTBitWidth != 128 && interpreterOnly)
     {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1705,18 +1705,6 @@ void EEJitManager::SetCpuInfo()
 
     uint32_t preferredVectorBitWidth = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PreferredVectorBitWidth) / 128) * 128;
 
-#ifdef FEATURE_INTERPRETER
-    bool interpreterOnlyPreferred = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3;
-#if !defined(FEATURE_DYNAMIC_CODE_COMPILED)
-    interpreterOnlyPreferred = true;
-#endif
-    if (interpreterOnlyPreferred)
-    {
-        // Disable larger Vector<T> sizes when only the interpreter runs code
-        preferredVectorBitWidth = 128;
-    }
-#endif
-
     if ((preferredVectorBitWidth == 0) && throttleVector512)
     {
         preferredVectorBitWidth = 256;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1712,7 +1712,7 @@ void EEJitManager::SetCpuInfo()
 #endif
     if (interpreterOnlyPreferred)
     {
-        // Disable larger Vector<T> sizes when interpreter is enabled, and not compiling S.P.Corelib
+        // Disable larger Vector<T> sizes when only the interpreter runs code
         preferredVectorBitWidth = 128;
     }
 #endif

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1331,9 +1331,12 @@ void EEJitManager::SetCpuInfo()
     uint32_t maxVectorTBitWidth = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_MaxVectorTBitWidth) / 128) * 128;
 
 #if defined(FEATURE_INTERPRETER)
-    if (maxVectorTBitWidth != 128 && CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3)
+    bool interpreterOnly = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3;
+#if !defined(FEATURE_DYNAMIC_CODE_COMPILED)
+    interpreterOnly = true;
+#endif
+    if (maxVectorTBitWidth != 128 && interpreterOnly)
     {
-        // Disable larger Vector<T> sizes when interpreter is enabled
         maxVectorTBitWidth = 128;
     }
 #endif
@@ -1702,9 +1705,12 @@ void EEJitManager::SetCpuInfo()
     uint32_t preferredVectorBitWidth = (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_PreferredVectorBitWidth) / 128) * 128;
 
 #ifdef FEATURE_INTERPRETER
-    if (CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3)
+    bool interpreterOnlyPreferred = CLRConfig::GetConfigValue(CLRConfig::EXTERNAL_InterpMode) == 3;
+#if !defined(FEATURE_DYNAMIC_CODE_COMPILED)
+    interpreterOnlyPreferred = true;
+#endif
+    if (interpreterOnlyPreferred)
     {
-        // Disable larger Vector<T> sizes when interpreter is enabled, and not compiling S.P.Corelib
         preferredVectorBitWidth = 128;
     }
 #endif

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -1337,6 +1337,7 @@ void EEJitManager::SetCpuInfo()
 #endif
     if (maxVectorTBitWidth != 128 && interpreterOnly)
     {
+        // Disable larger Vector<T> sizes when interpreter is enabled
         maxVectorTBitWidth = 128;
     }
 #endif
@@ -1711,6 +1712,7 @@ void EEJitManager::SetCpuInfo()
 #endif
     if (interpreterOnlyPreferred)
     {
+        // Disable larger Vector<T> sizes when interpreter is enabled, and not compiling S.P.Corelib
         preferredVectorBitWidth = 128;
     }
 #endif

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -252,7 +252,7 @@ public:
     BOOL IsStrippedILBodies()
     {
         LIMITED_METHOD_CONTRACT;
-        return m_pCompositeInfo->m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES;
+        return m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES;
     }
 
     void DisableAllR2RCode()

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -249,6 +249,12 @@ public:
         return m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_PARTIAL;
     }
 
+    BOOL IsStrippedILBodies()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return m_pCompositeInfo->m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES;
+    }
+
     void DisableAllR2RCode()
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -249,7 +249,7 @@ public:
         return m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_PARTIAL;
     }
 
-    BOOL IsStrippedILBodies()
+    BOOL HasStrippedILBodies()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES;


### PR DESCRIPTION
## Description

The interpreter only supports 128-bit Vector<T>, but on Mac Catalyst and iOS simulator x64 it was ending up with 256-bit Vector<T>, which is what caused the NullReferenceException in Vector.get_IsHardwareAccelerated. The runtime already limits Vector<T> to 128-bit for the full interpreter mode, but it wasn't doing so on no-JIT builds where everything is interpreted anyway, so AVX2 on x64 silently bumped it up to 256-bit. This change applies the same 128-bit limit whenever the interpreter is the only thing running code. arm64 was never affected since Vector<T> is always 128-bit there.

Crossgen2 had the matching problem where it presumed an x86-64-v3 (AVX2) ReadyToRun baseline for the Apple x64 simulator targets, so the precompiled R2R code and the interpreter disagreed on the Vector<T> width. It now uses the x86-64-v2 baseline for the iOS/tvOS simulators as well, matching osx and maccatalyst, so both share the same 128-bit view. The x64 simulators also run under Rosetta, which does not support AVX, so presuming it was incorrect regardless. 

As defense in depth, when an eager fixup failure disables R2R on a no-JIT runtime where the image was compiled with stripped IL bodies (so there is no IL to fall back to), the runtime now fails fast with a clear message instead of running the throw stub left in place of the IL, which previously surfaced as an opaque stack overflow.

Fixes #128901
Fixes https://github.com/dotnet/runtime/issues/128898
