### PR TITLE
Compute all checksums before emitting into image stream

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ISymbolNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/ISymbolNode.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
 using ILCompiler.DependencyAnalysisFramework;
 using Internal.Text;
 
@@ -97,7 +98,14 @@ namespace ILCompiler.DependencyAnalysis
     {
         int ChecksumSize { get; }
 
-        void EmitChecksum(ReadOnlySpan<byte> outputBlob, Span<byte> checksumLocation);
+        /// <summary>
+        /// Computes the checksum over the complete output image. <paramref name="outputStream"/>
+        /// is a seekable stream positioned at the start of the image and contains the image as it
+        /// is before any checksums are written, so the result must only depend on those original
+        /// bytes. The method may read the stream and leave its position changed, but must not
+        /// modify the stream contents; the caller writes the result.
+        /// </summary>
+        void EmitChecksum(Stream outputStream, Span<byte> checksumLocation);
     }
 
     /// <summary>

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ObjectWriter.cs
@@ -668,15 +668,20 @@ namespace ILCompiler.ObjectWriter
 
         private void EmitChecksums(Stream outputFileStream, List<ChecksumsToCalculate> checksumRelocations)
         {
-            MemoryStream originalOutputStream = new();
-            outputFileStream.Seek(0, SeekOrigin.Begin);
-            outputFileStream.CopyTo(originalOutputStream);
-            byte[] originalOutput = originalOutputStream.ToArray();
-            EmitChecksumsForObject(outputFileStream, checksumRelocations, originalOutput);
+            // Defer writing the computed values until all checksums are computed so each one is
+            // calculated over the original image and not a value written by an earlier checksum.
+            List<(long Offset, byte[] Value)> pendingWrites = ComputeChecksums(outputFileStream, checksumRelocations);
+
+            foreach ((long offset, byte[] value) in pendingWrites)
+            {
+                outputFileStream.Seek(offset, SeekOrigin.Begin);
+                outputFileStream.Write(value);
+            }
         }
 
-        private protected virtual void EmitChecksumsForObject(Stream outputFileStream, List<ChecksumsToCalculate> checksumRelocations, ReadOnlySpan<byte> originalOutput)
+        private protected virtual List<(long Offset, byte[] Value)> ComputeChecksums(Stream outputFileStream, List<ChecksumsToCalculate> checksumRelocations)
         {
+            List<(long Offset, byte[] Value)> pendingWrites = [];
             foreach (var block in checksumRelocations)
             {
                 foreach (var reloc in block.ChecksumRelocations)
@@ -684,13 +689,15 @@ namespace ILCompiler.ObjectWriter
                     IChecksumNode checksum = (IChecksumNode)reloc.Target;
 
                     byte[] checksumValue = new byte[checksum.ChecksumSize];
-                    checksum.EmitChecksum(originalOutput, checksumValue);
+                    outputFileStream.Seek(0, SeekOrigin.Begin);
+                    checksum.EmitChecksum(outputFileStream, checksumValue);
 
                     var checksumOffset = (long)_outputSectionLayout[block.SectionIndex].FilePosition + block.Offset + reloc.Offset;
-                    outputFileStream.Seek(checksumOffset, SeekOrigin.Begin);
-                    outputFileStream.Write(checksumValue);
+                    pendingWrites.Add((checksumOffset, checksumValue));
                 }
             }
+
+            return pendingWrites;
         }
 
         partial void HandleControlFlowForRelocation(ISymbolNode relocTarget, Utf8String relocSymbolName);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
@@ -11,7 +11,6 @@ using System.Numerics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
-using System.Text;
 
 using ILCompiler.DependencyAnalysis;
 
@@ -868,17 +867,25 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private protected override void EmitChecksumsForObject(Stream outputFileStream, List<ChecksumsToCalculate> checksumRelocations, ReadOnlySpan<byte> originalOutput)
+        private protected override List<(long Offset, byte[] Value)> ComputeChecksums(Stream outputFileStream, List<ChecksumsToCalculate> checksumRelocations)
         {
-            base.EmitChecksumsForObject(outputFileStream, checksumRelocations, originalOutput);
+            List<(long Offset, byte[] Value)> pendingWrites = base.ComputeChecksums(outputFileStream, checksumRelocations);
 
             if (_coffTimestamp is null)
             {
                 // If we were not provided a deterministic timestamp, generate one from a hash of the content.
-                outputFileStream.Seek(_coffHeaderOffset + CoffHeader.TimeDateStampOffset(bigObj: false), SeekOrigin.Begin);
-                using BinaryWriter writer = new(outputFileStream, Encoding.UTF8, leaveOpen: true);
-                writer.Write(BlobContentId.FromHash(SHA256.HashData(originalOutput)).Stamp);
+                outputFileStream.Seek(0, SeekOrigin.Begin);
+                Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+                SHA256.HashData(outputFileStream, hash);
+
+                byte[] timestamp = new byte[sizeof(uint)];
+                BinaryPrimitives.WriteUInt32LittleEndian(timestamp, BlobContentId.FromHash(hash.ToArray()).Stamp);
+
+                long timestampOffset = _coffHeaderOffset + CoffHeader.TimeDateStampOffset(bigObj: false);
+                pendingWrites.Add((timestampOffset, timestamp));
             }
+
+            return pendingWrites;
         }
 
         private unsafe void ResolveRelocations(int sectionIndex, List<SymbolicRelocation> symbolicRelocations, long imageBase, MemoryStream stream)

--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -1,16 +1,6 @@
 <Project>
   <PropertyGroup>
-    <!-- crossgen2/ilc run as the build host architecture when cross-building (CrossHostArch),
-         otherwise as TargetArchitecture. This is the architecture of the compiler process itself. -->
-    <_AotCompilerHostArch Condition="'$(CrossHostArch)' != ''">$(CrossHostArch)</_AotCompilerHostArch>
-    <_AotCompilerHostArch Condition="'$(CrossHostArch)' == ''">$(TargetArchitecture)</_AotCompilerHostArch>
-
-    <!-- Server GC reserves per-heap address-space segments up front. On a 32-bit host the ~2 GB
-         user-mode address space is largely consumed by those reservations, so compiling a very
-         large method can fail to allocate the contiguous output image buffer and crash with
-         OutOfMemory. Use Workstation GC on 32-bit hosts. See https://github.com/dotnet/runtime/issues/128531. -->
-    <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == '' and '$(_AotCompilerHostArch)' != 'x86' and '$(_AotCompilerHostArch)' != 'arm' and '$(_AotCompilerHostArch)' != 'armel'">true</ServerGarbageCollection>
-    <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == ''">false</ServerGarbageCollection>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
     <TieredCompilation>false</TieredCompilation>
     <EventSourceSupport>true</EventSourceSupport>
     <OptimizationPreference>Speed</OptimizationPreference>

--- a/src/coreclr/tools/aot/AotCompilerCommon.props
+++ b/src/coreclr/tools/aot/AotCompilerCommon.props
@@ -1,6 +1,16 @@
 <Project>
   <PropertyGroup>
-    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <!-- crossgen2/ilc run as the build host architecture when cross-building (CrossHostArch),
+         otherwise as TargetArchitecture. This is the architecture of the compiler process itself. -->
+    <_AotCompilerHostArch Condition="'$(CrossHostArch)' != ''">$(CrossHostArch)</_AotCompilerHostArch>
+    <_AotCompilerHostArch Condition="'$(CrossHostArch)' == ''">$(TargetArchitecture)</_AotCompilerHostArch>
+
+    <!-- Server GC reserves per-heap address-space segments up front. On a 32-bit host the ~2 GB
+         user-mode address space is largely consumed by those reservations, so compiling a very
+         large method can fail to allocate the contiguous output image buffer and crash with
+         OutOfMemory. Use Workstation GC on 32-bit hosts. See https://github.com/dotnet/runtime/issues/128531. -->
+    <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == '' and '$(_AotCompilerHostArch)' != 'x86' and '$(_AotCompilerHostArch)' != 'arm' and '$(_AotCompilerHostArch)' != 'armel'">true</ServerGarbageCollection>
+    <ServerGarbageCollection Condition="'$(ServerGarbageCollection)' == ''">false</ServerGarbageCollection>
     <TieredCompilation>false</TieredCompilation>
     <EventSourceSupport>true</EventSourceSupport>
     <OptimizationPreference>Speed</OptimizationPreference>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/DebugDirectoryEntryNode.cs
@@ -244,11 +244,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
         {
             public int ChecksumSize => 16;
 
-            public void EmitChecksum(ReadOnlySpan<byte> outputBlob, Span<byte> checksumLocation)
+            public void EmitChecksum(Stream outputStream, Span<byte> checksumLocation)
             {
                 Debug.Assert(checksumLocation.Length == ChecksumSize);
-                // Take the first 16 bytes of the SHA256 hash as the RSDS checksum.
-                SHA256.HashData(outputBlob)[0..ChecksumSize].CopyTo(checksumLocation);
+                // Take the first 16 bytes of the SHA256 hash of the image as the RSDS checksum.
+                Span<byte> hash = stackalloc byte[SHA256.HashSizeInBytes];
+                SHA256.HashData(outputStream, hash);
+                hash[0..ChecksumSize].CopyTo(checksumLocation);
             }
 
             public override bool InterestingForDynamicDependencyAnalysis => false;


### PR DESCRIPTION
Instead of creating a copy of the entire image in-memory, use the existing stream to compute the checksum before emitting the checksum relocs into the final image. This avoids a large allocation and should prevent some of the OOMs we're seeing in 32-bit CI.

> [!NOTE]
> This pull request was authored with assistance from GitHub Copilot.
