### PR TITLE
Change jit fuzzer build to pull Antigen from jitutils

### DIFF
--- a/src/coreclr/scripts/exploratory.md
+++ b/src/coreclr/scripts/exploratory.md
@@ -1,6 +1,6 @@
 # Documentation of Exploratory tools Antigen and Fuzzlyn
 
-[Antigen](https://github.com/kunalspathak/antigen) and [Fuzzlyn](https://github.com/jakobbotsch/Fuzzlyn) are exploratory fuzzing tools used to test the JIT compiler.
+[Antigen](https://github.com/dotnet/jitutils/tree/main/src/Antigen) and [Fuzzlyn](https://github.com/jakobbotsch/Fuzzlyn) are exploratory fuzzing tools used to test the JIT compiler.
 
 ## Overview
 

--- a/src/coreclr/scripts/fuzzer_setup.py
+++ b/src/coreclr/scripts/fuzzer_setup.py
@@ -95,14 +95,16 @@ def main(main_args):
     helix_source_prefix = "official"
     creator = ""
 
+    # (repro url, proj path, sparse path)
+    # sparse_path is needed when the tool lives in a subtree of a larger repo, to avoid pulling the entire repo.
     build_repos = {
-        "Antigen": ("https://github.com/kunalspathak/Antigen.git", "Antigen/Antigen.csproj"),
-        "Fuzzlyn": ("https://github.com/jakobbotsch/Fuzzlyn.git", "Fuzzlyn/Fuzzlyn.csproj"),
+        "Antigen": ("https://github.com/dotnet/jitutils.git", "src/Antigen/Antigen/Antigen.csproj", "src/Antigen"),
+        "Fuzzlyn": ("https://github.com/jakobbotsch/Fuzzlyn.git", "Fuzzlyn/Fuzzlyn.csproj", None),
     }
 
     # tool_name is verifed in setup_args
     assert coreclr_args.tool_name in build_repos
-    (repo_url, proj_path) = build_repos[coreclr_args.tool_name]
+    (repo_url, proj_path, sparse_path) = build_repos[coreclr_args.tool_name]
 
     # create exploratory directory
     print('Copying {} -> {}'.format(scripts_src_directory, coreroot_directory))
@@ -121,8 +123,17 @@ def main(main_args):
     try:
         with TempDir() as tool_code_directory:
             # clone the tool
-            run_command(
-                ["git", "clone", "--quiet", "--depth", "1", repo_url, tool_code_directory])
+            if sparse_path is None:
+                run_command(
+                    ["git", "clone", "--quiet", "--depth", "1", repo_url, tool_code_directory])
+            else:
+                # sparse checkout so we don't pull all of jitutils
+                run_command(
+                    ["git", "clone", "--quiet", "--no-checkout", "--filter=blob:none",
+                     "--depth", "1", "--sparse", repo_url, tool_code_directory])
+                with ChangeDir(tool_code_directory):
+                    run_command(["git", "sparse-checkout", "set", "--cone", sparse_path])
+                    run_command(["git", "checkout"])
 
             publish_dir = path.join(tool_code_directory, "publish")
 

--- a/src/coreclr/scripts/fuzzer_setup.py
+++ b/src/coreclr/scripts/fuzzer_setup.py
@@ -95,7 +95,7 @@ def main(main_args):
     helix_source_prefix = "official"
     creator = ""
 
-    # (repro url, proj path, sparse path)
+    # (repo url, proj path, sparse path)
     # sparse_path is needed when the tool lives in a subtree of a larger repo, to avoid pulling the entire repo.
     build_repos = {
         "Antigen": ("https://github.com/dotnet/jitutils.git", "src/Antigen/Antigen/Antigen.csproj", "src/Antigen"),


### PR DESCRIPTION
Point Antigen fuzzing pipeline at the source in jitutils rather than external.

Use sparse-checkout so we don't pull all of jitutils.