### PR TITLE
SuperPMI: re-apply JitWasmNyiToR2RUnsupported when ignoring stored config

### DIFF
--- a/src/coreclr/scripts/superpmi.py
+++ b/src/coreclr/scripts/superpmi.py
@@ -2280,6 +2280,17 @@ class SuperPMIReplayAsmDiffs:
                     # two Release compilers, so this is safest.
                     flags += [ "-ignoreStoredConfig" ]
 
+                    # `-ignoreStoredConfig` drops any codegenopt the collection recorded into the
+                    # MCH stored config. For wasm we need to re-supply
+                    # `JitWasmNyiToR2RUnsupported=1` (set by crossgen-corelib.proj during collection)
+                    # so that unimplemented opcodes turn into R2R-unsupported skips rather than
+                    # asserts. FIXME: remove once wasm codegen covers all cases.
+                    if self.coreclr_args.target_arch == "wasm":
+                        flags += [
+                            "-jitoption", "force", "JitWasmNyiToR2RUnsupported=1",
+                            "-jit2option", "force", "JitWasmNyiToR2RUnsupported=1"
+                        ]
+
                 # Change the working directory to the Core_Root we will call SuperPMI from.
                 # This is done to allow libcoredistools to be loaded correctly on unix
                 # as the loadlibrary path will be relative to the current directory.


### PR DESCRIPTION
The asmdiffs-checked-release leg uses -ignoreStoredConfig, which drops the JitWasmNyiToR2RUnsupported=1 recorded into the MCH stored config at collection time. The wasm JIT then asserts on unimplemented opcodes (e.g. GT_ASYNC_CONTINUATION) instead of cleanly skipping them as R2R-unsupported. 

So add back the option externally for wasm whenever we pass -ignoreStoredConfig.

Fixes #129014