### PR TITLE
Never attempt to process an RSA 16K key on Android

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/EncryptDecrypt.cs
@@ -644,7 +644,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             Assert.Equal(TestData.HelloBytes, output);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
         public void LargeKeyCryptRoundtrip()
         {
             byte[] output;

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -69,7 +69,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             RSATestHelpers.AssertKeyEquals(diminishedDPParameters, exported);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
         public static void LargeKeyImportExport()
         {
             RSAParameters imported = TestData.RSA16384Params;
@@ -367,6 +367,13 @@ namespace System.Security.Cryptography.Rsa.Tests
 
         private static bool TestRsa16384()
         {
+            if (PlatformDetection.IsAndroid)
+            {
+                // We cannot detect this on Android at the moment. Even attempting to generate or import a 16K RSA key
+                // may leave the error queue in the incorrect state. See https://github.com/google/conscrypt/issues/1507
+                return false;
+            }
+
             try
             {
                 using (RSA rsa = RSAFactory.Create())

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/SignVerify.cs
@@ -1022,7 +1022,7 @@ namespace System.Security.Cryptography.Rsa.Tests
                 modulus2048Signature);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
         public void VerifyExpectedSignature_PssSha256_RSA16384()
         {
             byte[] modulus2048Signature = (
@@ -1098,7 +1098,7 @@ namespace System.Security.Cryptography.Rsa.Tests
                 modulus2048Signature);
         }
 
-        [Fact]
+        [ConditionalFact(typeof(ImportExport), nameof(ImportExport.Supports16384))]
         public void VerifyExpectedSignature_PssSha384()
         {
             byte[] bigModulusSignature = (


### PR DESCRIPTION
Android's Conscrypt does not appear to process RSA 16K keys. It also does not appropriately clear BoringSSL's error queue, so when you attempt to import an RSA 16K key, the error may appear elsewhere, which can produce nonsense errors.

For example, attempting to import an RSA 16K key, then doing ChaCha20Poly1305 with a bad tag would raise an `java.security.InvalidKeyException: error:04000080:RSA routines:OPENSSL_internal:MODULUS_TOO_LARGE`, which is of course an incorrect exception for Cipher's ChaCha20/Poly1305 to raise.

The "best" fix for this currently is to simply never touch an RSA 16K key from our unit tests. We don't have direct access to BoringSSL's error queue, so we can't manage it or inspect it to fix the problem on the RSA side.

Actual APIs that clear the error queue are somewhat costly. We can investigate some of those but we are relying on side effects that may not always hold.

This is the easiest fix so far that doesn't require somewhat undesirable changes in actual product code.

Fixes https://github.com/dotnet/runtime/issues/128888